### PR TITLE
Update deprecated Intent and Bundle functions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.databinding.JetpackRemoteInstallActivityBinding
 import org.wordpress.android.ui.JetpackConnectionUtils.trackWithSource
 import org.wordpress.android.ui.JetpackRemoteInstallFragment.Companion.TRACKING_SOURCE_KEY
 import org.wordpress.android.util.extensions.onBackPressedCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,7 +22,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
         onBackPressedDispatcher.addCallback(this) {
             trackWithSource(
                 INSTALL_JETPACK_CANCELLED,
-                intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
+                intent.getSerializableExtraCompat(TRACKING_SOURCE_KEY)
             )
             onBackPressedDispatcher.onBackPressedCompat(this)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallActivity.kt
@@ -22,7 +22,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
         onBackPressedDispatcher.addCallback(this) {
             trackWithSource(
                 INSTALL_JETPACK_CANCELLED,
-                intent.getSerializableExtraCompat(TRACKING_SOURCE_KEY)
+                requireNotNull(intent.getSerializableExtraCompat(TRACKING_SOURCE_KEY))
             )
             onBackPressedDispatcher.onBackPressedCompat(this)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -52,7 +52,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
                 savedInstanceState?.getSerializableCompat<JetpackRemoteInstallViewState.Type>(VIEW_STATE)
             viewModel = ViewModelProvider(
                 this@JetpackRemoteInstallFragment, viewModelFactory
-            ).get(JetpackRemoteInstallViewModel::class.java)
+            )[JetpackRemoteInstallViewModel::class.java]
             viewModel.start(site, retrievedState)
 
             initLiveViewStateObserver()

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -22,6 +22,8 @@ import org.wordpress.android.ui.JetpackRemoteInstallViewModel.JetpackResultActio
 import org.wordpress.android.ui.RequestCodes.JETPACK_LOGIN
 import org.wordpress.android.ui.accounts.LoginActivity
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fragment) {
@@ -44,9 +46,10 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
     private fun JetpackRemoteInstallFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
         requireActivity().let { activity ->
             val intent = activity.intent
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val source = intent.getSerializableExtra(TRACKING_SOURCE_KEY) as JetpackConnectionSource
-            val retrievedState = savedInstanceState?.getSerializable(VIEW_STATE) as? JetpackRemoteInstallViewState.Type
+            val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
+            val source = requireNotNull(intent.getSerializableExtraCompat<JetpackConnectionSource>(TRACKING_SOURCE_KEY))
+            val retrievedState =
+                savedInstanceState?.getSerializableCompat<JetpackRemoteInstallViewState.Type>(VIEW_STATE)
             viewModel = ViewModelProvider(
                 this@JetpackRemoteInstallFragment, viewModelFactory
             ).get(JetpackRemoteInstallViewModel::class.java)
@@ -139,7 +142,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == JETPACK_LOGIN && resultCode == Activity.RESULT_OK) {
-            val site = requireActivity().intent!!.getSerializableExtra(WordPress.SITE) as SiteModel
+            val site = requireNotNull(activity?.intent?.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
             viewModel.onLogin(site.id)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -51,7 +51,8 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
             val retrievedState =
                 savedInstanceState?.getSerializableCompat<JetpackRemoteInstallViewState.Type>(VIEW_STATE)
             viewModel = ViewModelProvider(
-                this@JetpackRemoteInstallFragment, viewModelFactory
+                this@JetpackRemoteInstallFragment,
+                viewModelFactory
             )[JetpackRemoteInstallViewModel::class.java]
             viewModel.start(site, retrievedState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackRemoteInstallFragment.kt
@@ -57,7 +57,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
 
             initLiveViewStateObserver()
 
-            viewModel.liveActionOnResult.observe(viewLifecycleOwner, Observer { result ->
+            viewModel.liveActionOnResult.observe(viewLifecycleOwner) { result ->
                 if (result != null) {
                     when (result.action) {
                         MANUAL_INSTALL -> onManualInstallResultAction(activity, source, result)
@@ -65,7 +65,7 @@ class JetpackRemoteInstallFragment : Fragment(R.layout.jetpack_remote_install_fr
                         CONNECT -> onConnectResultAction(activity, source, result)
                     }
                 }
-            })
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.UnifiedLoginTracker.Step
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.NoUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.ShowUser
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import java.io.Serializable
@@ -58,8 +59,9 @@ class LoginNoSitesViewModel @Inject constructor(
         _uiModel.postValue(UiModel(state = state))
     }
 
-    private fun buildStateFromSavedInstanceState(savedInstanceState: Bundle) =
-        savedInstanceState.getSerializable(KEY_STATE) as State
+    private fun buildStateFromSavedInstanceState(savedInstanceState: Bundle) = requireNotNull(
+        savedInstanceState.getSerializableCompat<State>(KEY_STATE)
+    )
 
     private fun buildStateFromAccountStore() =
         accountStore.account?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
@@ -221,7 +223,9 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
 
     private fun sideAndActivityId(savedInstanceState: Bundle?, intent: Intent?) = when {
         savedInstanceState != null -> {
-            val site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            val site = requireNotNull(
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
+            )
             val activityLogId = requireNotNull(
                 savedInstanceState.getString(
                     ACTIVITY_LOG_ID_KEY
@@ -230,7 +234,9 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
             site to activityLogId
         }
         intent != null -> {
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+            val site = requireNotNull(
+                intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            )
             val activityLogId = intent.getStringExtra(ACTIVITY_LOG_ID_KEY) as String
             site to activityLogId
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -89,12 +89,12 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
                 }
             }
 
-            val site: SiteModel = requireNotNull(
+            val site = requireNotNull(
                 if (savedInstanceState == null) {
                     val nonNullIntent = checkNotNull(nonNullActivity.intent)
-                    nonNullIntent.getSerializableExtraCompat(WordPress.SITE)
+                    nonNullIntent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
                 } else {
-                    savedInstanceState.getSerializableCompat(WordPress.SITE)
+                    savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
                 }
             )
             val rewindableOnly = nonNullActivity.intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -75,7 +75,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         viewModel = ViewModelProvider(
             this@ActivityLogListFragment,
             viewModelFactory
-        ).get(ActivityLogViewModel::class.java)
+        )[ActivityLogViewModel::class.java]
 
         with(ActivityLogListFragmentBinding.bind(view)) {
             listView = logListView

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -29,6 +29,8 @@ import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_REWINDABLE_ONLY_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogViewModel
@@ -87,12 +89,14 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
                 }
             }
 
-            val site = if (savedInstanceState == null) {
-                val nonNullIntent = checkNotNull(nonNullActivity.intent)
-                nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
-            } else {
-                savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-            }
+            val site: SiteModel = requireNotNull(
+                if (savedInstanceState == null) {
+                    val nonNullIntent = checkNotNull(nonNullActivity.intent)
+                    nonNullIntent.getSerializableExtraCompat(WordPress.SITE)
+                } else {
+                    savedInstanceState.getSerializableCompat(WordPress.SITE)
+                }
+            )
             val rewindableOnly = nonNullActivity.intent.getBooleanExtra(ACTIVITY_LOG_REWINDABLE_ONLY_KEY, false)
 
             logListView.setEmptyView(actionableEmptyView)

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeParentActivity.kt
@@ -8,6 +8,8 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.blaze.ui.blazeoverlay.BlazeOverlayFragment
 import org.wordpress.android.ui.blaze.ui.blazeoverlay.BlazeViewModel
 import org.wordpress.android.ui.blaze.ui.blazewebview.BlazeWebViewFragment
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 const val ARG_EXTRA_BLAZE_UI_MODEL = "blaze_ui_model"
 const val ARG_BLAZE_FLOW_SOURCE = "blaze_flow_source"
@@ -45,10 +47,10 @@ class BlazeParentActivity : AppCompatActivity() {
     }
 
     private fun getSource(): BlazeFlowSource {
-        return intent.getSerializableExtra(ARG_BLAZE_FLOW_SOURCE) as BlazeFlowSource
+        return requireNotNull(intent.getSerializableExtraCompat(ARG_BLAZE_FLOW_SOURCE))
     }
 
     private fun getBlazeUiModel(): BlazeUIModel? {
-        return intent.getParcelableExtra(ARG_EXTRA_BLAZE_UI_MODEL)
+        return intent.getParcelableExtraCompat(ARG_EXTRA_BLAZE_UI_MODEL)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -96,9 +97,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
     @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        arguments?.let {
-            dialogType = it.getSerializable(KEY_DIALOG_TYPE) as DialogType
-        }
+        arguments?.let { dialogType = requireNotNull(it.getSerializableCompat(KEY_DIALOG_TYPE)) }
         (requireActivity().applicationContext as WordPress).component().inject(this)
         if (dialogType == ONBOARDING && context !is BloggingPromptsReminderSchedulerListener) {
             throw IllegalStateException(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingDialogFragment.kt
@@ -97,7 +97,7 @@ class BloggingPromptsOnboardingDialogFragment : FeatureIntroductionDialogFragmen
     @Suppress("UseCheckOrError")
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        arguments?.let { dialogType = requireNotNull(it.getSerializableCompat(KEY_DIALOG_TYPE)) }
+        arguments?.let { dialogType = requireNotNull(it.getSerializableCompat<DialogType>(KEY_DIALOG_TYPE)) }
         (requireActivity().applicationContext as WordPress).component().inject(this)
         if (dialogType == ONBOARDING && context !is BloggingPromptsReminderSchedulerListener) {
             throw IllegalStateException(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingreminders/BloggingRemindersViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTrac
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersAnalyticsTracker.Source.PUBLISH_FLOW
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.merge
 import org.wordpress.android.util.perform
 import org.wordpress.android.viewmodel.Event
@@ -220,9 +221,7 @@ class BloggingRemindersViewModel @Inject constructor(
     }
 
     fun restoreState(state: Bundle) {
-        state.getSerializable(SELECTED_SCREEN)?.let {
-            _selectedScreen.value = it as Screen
-        }
+        state.getSerializableCompat<Screen>(SELECTED_SCREEN)?.let { _selectedScreen.value = it }
         val siteId = state.getInt(SITE_ID)
         if (siteId != 0) {
             val enabledDays = state.getStringArrayList(SELECTED_DAYS)?.map { DayOfWeek.valueOf(it) }?.toSet() ?: setOf()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -71,11 +71,11 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        viewModel = ViewModelProvider(this, viewModelFactory).get(UnifiedCommentListViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[UnifiedCommentListViewModel::class.java]
         activityViewModel = ViewModelProvider(
             requireActivity(),
             viewModelFactory
-        ).get(UnifiedCommentActivityViewModel::class.java)
+        )[UnifiedCommentActivityViewModel::class.java]
         arguments?.let {
             commentListFilter = requireNotNull(it.getSerializableCompat(KEY_COMMENT_LIST_FILTER))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -33,6 +33,7 @@ import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.config.UnifiedCommentsDetailFeatureConfig
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import javax.inject.Inject
 
@@ -76,7 +77,7 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
             viewModelFactory
         ).get(UnifiedCommentActivityViewModel::class.java)
         arguments?.let {
-            commentListFilter = it.getSerializable(KEY_COMMENT_LIST_FILTER) as CommentFilter
+            commentListFilter = requireNotNull(it.getSerializableCompat(KEY_COMMENT_LIST_FILTER))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -77,7 +77,7 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
             viewModelFactory
         )[UnifiedCommentActivityViewModel::class.java]
         arguments?.let {
-            commentListFilter = requireNotNull(it.getSerializableCompat(KEY_COMMENT_LIST_FILTER))
+            commentListFilter = requireNotNull(it.getSerializableCompat<CommentFilter>(KEY_COMMENT_LIST_FILTER))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
@@ -20,8 +20,9 @@ class UnifiedCommentsEditActivity : LocaleAwareActivity() {
         }
 
         val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
-        val commentIdentifier =
-            requireNotNull(intent.getParcelableExtraCompat<CommentIdentifier>(KEY_COMMENT_IDENTIFIER))
+        val commentIdentifier = requireNotNull(
+            intent.getParcelableExtraCompat<CommentIdentifier>(KEY_COMMENT_IDENTIFIER)
+        )
 
         val fm = supportFragmentManager
         var editCommentFragment = fm.findFragmentByTag(

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditActivity.kt
@@ -8,6 +8,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.UnifiedCommentsEditActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 class UnifiedCommentsEditActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,8 +19,9 @@ class UnifiedCommentsEditActivity : LocaleAwareActivity() {
             setContentView(root)
         }
 
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        val commentIdentifier = requireNotNull(intent.getParcelableExtra<CommentIdentifier>(KEY_COMMENT_IDENTIFIER))
+        val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
+        val commentIdentifier =
+            requireNotNull(intent.getParcelableExtraCompat<CommentIdentifier>(KEY_COMMENT_IDENTIFIER))
 
         val fm = supportFragmentManager
         var editCommentFragment = fm.findFragmentByTag(

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -34,6 +34,8 @@ import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarItem.Action
 import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -61,9 +63,9 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
         super.onViewCreated(view, savedInstanceState)
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
 
-        val site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        val site = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
         val commentIdentifier = requireNotNull(
-            requireArguments().getParcelable<CommentIdentifier>(
+            requireArguments().getParcelableCompat<CommentIdentifier>(
                 KEY_COMMENT_IDENTIFIER
             )
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditFragment.kt
@@ -65,9 +65,7 @@ class UnifiedCommentsEditFragment : Fragment(R.layout.unified_comments_edit_frag
 
         val site = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
         val commentIdentifier = requireNotNull(
-            requireArguments().getParcelableCompat<CommentIdentifier>(
-                KEY_COMMENT_IDENTIFIER
-            )
+            requireArguments().getParcelableCompat<CommentIdentifier>(KEY_COMMENT_IDENTIFIER)
         )
 
         UnifiedCommentsEditFragmentBinding.bind(view).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverViewModel.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.deeplinks.handlers.ServerTrackingHandler
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -147,12 +148,11 @@ class DeepLinkingIntentReceiverViewModel
 
     private fun extractSavedInstanceStateIfNeeded(savedInstanceState: Bundle?) {
         savedInstanceState?.let {
-            val uri: Uri? = savedInstanceState.getParcelable(URI_KEY)
+            val uri = savedInstanceState.getParcelableCompat<Uri>(URI_KEY)
             uriWrapper = uri?.let { UriWrapper(it) }
-            deepLinkEntryPoint =
-                DeepLinkEntryPoint.valueOf(
-                    savedInstanceState.getString(DEEP_LINK_ENTRY_POINT_KEY, DeepLinkEntryPoint.DEFAULT.name)
-                )
+            deepLinkEntryPoint = DeepLinkEntryPoint.valueOf(
+                savedInstanceState.getString(DEEP_LINK_ENTRY_POINT_KEY, DeepLinkEntryPoint.DEFAULT.name)
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationActivity.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenD
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationDetails
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainRegistrationResult
 import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction.OpenDomainSuggestions
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -50,9 +51,10 @@ class DomainRegistrationActivity : LocaleAwareActivity(), ScrollableViewInitiali
             setContentView(root)
             binding = this
 
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
-                    as DomainRegistrationPurpose
+            val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
+            val domainRegistrationPurpose = requireNotNull(
+                intent.getSerializableExtraCompat<DomainRegistrationPurpose>(DOMAIN_REGISTRATION_PURPOSE_KEY)
+            )
 
             setupToolbar()
             setupViewModel(site, domainRegistrationPurpose)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -90,8 +90,10 @@ class DomainRegistrationDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mainViewModel =
-            ViewModelProvider(requireActivity(), viewModelFactory)[DomainRegistrationMainViewModel::class.java]
+        mainViewModel = ViewModelProvider(
+            requireActivity(),
+            viewModelFactory
+        )[DomainRegistrationMainViewModel::class.java]
         viewModel = ViewModelProvider(this, viewModelFactory)[DomainRegistrationDetailsViewModel::class.java]
         with(DomainRegistrationDetailsFragmentBinding.bind(view)) {
             binding = this

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -90,10 +90,9 @@ class DomainRegistrationDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mainViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-            .get(DomainRegistrationMainViewModel::class.java)
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(DomainRegistrationDetailsViewModel::class.java)
+        mainViewModel =
+            ViewModelProvider(requireActivity(), viewModelFactory)[DomainRegistrationMainViewModel::class.java]
+        viewModel = ViewModelProvider(this, viewModelFactory)[DomainRegistrationDetailsViewModel::class.java]
         with(DomainRegistrationDetailsFragmentBinding.bind(view)) {
             binding = this
             setupObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsFragment.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationDetailsViewModel.Domai
 import org.wordpress.android.util.StringUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPUrlUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 class DomainRegistrationDetailsFragment : Fragment() {
@@ -100,7 +101,7 @@ class DomainRegistrationDetailsFragment : Fragment() {
             val domainProductDetails = requireNotNull(
                 arguments?.getParcelable<DomainProductDetails?>(EXTRA_DOMAIN_PRODUCT_DETAILS)
             )
-            val site = requireActivity().intent?.getSerializableExtra(WordPress.SITE) as SiteModel
+            val site = requireNotNull(activity?.intent?.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
 
             viewModel.start(site, domainProductDetails)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.DOMAIN_REGISTRATION_PURPOSE_KEY
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -46,9 +47,10 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
 
         with(DomainSuggestionsFragmentBinding.bind(view)) {
             val intent = requireActivity().intent
-            val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-            val domainRegistrationPurpose = intent.getSerializableExtra(DOMAIN_REGISTRATION_PURPOSE_KEY)
-                    as DomainRegistrationPurpose
+            val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
+            val domainRegistrationPurpose = requireNotNull(
+                intent.getSerializableExtraCompat<DomainRegistrationPurpose>(DOMAIN_REGISTRATION_PURPOSE_KEY)
+            )
 
             setupViews()
             setupObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -39,8 +39,10 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         super.onViewCreated(view, savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
 
-        mainViewModel =
-            ViewModelProvider(requireActivity(), viewModelFactory)[DomainRegistrationMainViewModel::class.java]
+        mainViewModel = ViewModelProvider(
+            requireActivity(),
+            viewModelFactory
+        )[DomainRegistrationMainViewModel::class.java]
 
         viewModel = ViewModelProvider(this, viewModelFactory)[DomainSuggestionsViewModel::class.java]
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsFragment.kt
@@ -39,11 +39,10 @@ class DomainSuggestionsFragment : Fragment(R.layout.domain_suggestions_fragment)
         super.onViewCreated(view, savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
 
-        mainViewModel = ViewModelProvider(requireActivity(), viewModelFactory)
-            .get(DomainRegistrationMainViewModel::class.java)
+        mainViewModel =
+            ViewModelProvider(requireActivity(), viewModelFactory)[DomainRegistrationMainViewModel::class.java]
 
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(DomainSuggestionsViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[DomainSuggestionsViewModel::class.java]
 
         with(DomainSuggestionsFragmentBinding.bind(view)) {
             val intent = requireActivity().intent

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -48,7 +48,7 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
     private fun setupViewModel() {
         val intent = requireActivity().intent
         val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
-        viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(DomainsDashboardViewModel::class.java)
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)[DomainsDashboardViewModel::class.java]
         viewModel.start(site)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -46,7 +47,7 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
 
     private fun setupViewModel() {
         val intent = requireActivity().intent
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
         viewModel = ViewModelProvider(requireActivity(), viewModelFactory).get(DomainsDashboardViewModel::class.java)
         viewModel.start(site)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListActivity.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.EngagedPeopleListActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 import javax.inject.Inject
 
 class EngagedPeopleListActivity : LocaleAwareActivity() {
@@ -22,7 +23,7 @@ class EngagedPeopleListActivity : LocaleAwareActivity() {
             setSupportActionBar(toolbarMain)
         }
 
-        val listScenario = intent.getParcelableExtra<ListScenario>(KEY_LIST_SCENARIO)
+        val listScenario = intent.getParcelableExtraCompat<ListScenario>(KEY_LIST_SCENARIO)
             ?: throw IllegalArgumentException(
                 "List Scenario cannot be null. Make sure to pass a valid List Scenario in the intent"
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -104,7 +104,7 @@ class EngagedPeopleListFragment : Fragment() {
 
         recycler.layoutManager = layoutManager
 
-        userProfileViewModel.onBottomSheetAction.observeEvent(viewLifecycleOwner, { state ->
+        userProfileViewModel.onBottomSheetAction.observeEvent(viewLifecycleOwner) { state ->
             var bottomSheet = childFragmentManager.findFragmentByTag(USER_PROFILE_BOTTOM_SHEET_TAG)
                     as? UserProfileBottomSheetFragment
 
@@ -119,31 +119,31 @@ class EngagedPeopleListFragment : Fragment() {
                     bottomSheet?.apply { this.dismiss() }
                 }
             }
-        })
+        }
 
-        viewModel.uiState.observe(viewLifecycleOwner, { state ->
+        viewModel.uiState.observe(viewLifecycleOwner) { state ->
             if (!isAdded) return@observe
 
             updateUiState(state)
-        })
+        }
 
-        viewModel.onNavigationEvent.observeEvent(viewLifecycleOwner, { event ->
+        viewModel.onNavigationEvent.observeEvent(viewLifecycleOwner) { event ->
             if (!isAdded) return@observeEvent
 
             manageNavigation(event)
-        })
+        }
 
-        viewModel.onSnackbarMessage.observeEvent(viewLifecycleOwner, { messageHolder ->
+        viewModel.onSnackbarMessage.observeEvent(viewLifecycleOwner) { messageHolder ->
             if (!isAdded || !lifecycle.currentState.isAtLeast(State.RESUMED)) return@observeEvent
 
             showSnackbar(messageHolder)
-        })
+        }
 
-        viewModel.onServiceRequestEvent.observeEvent(viewLifecycleOwner, { serviceRequest ->
+        viewModel.onServiceRequestEvent.observeEvent(viewLifecycleOwner) { serviceRequest ->
             if (!isAdded) return@observeEvent
 
             manageServiceRequest(serviceRequest)
-        })
+        }
 
         viewModel.start(listScenario)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.util.SnackbarItem.Info
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.ResourceProvider
 import org.wordpress.android.viewmodel.observeEvent
@@ -93,11 +94,11 @@ class EngagedPeopleListFragment : Fragment() {
         loadingView = view.findViewById(R.id.loading_view)
         emptyView = view.findViewById(R.id.actionable_empty_view)
 
-        val listScenario = requireArguments().getParcelable<ListScenario>(KEY_LIST_SCENARIO)
+        val listScenario = requireNotNull(arguments?.getParcelableCompat<ListScenario>(KEY_LIST_SCENARIO))
 
         val layoutManager = LinearLayoutManager(activity)
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -144,7 +145,7 @@ class EngagedPeopleListFragment : Fragment() {
             manageServiceRequest(serviceRequest)
         })
 
-        viewModel.start(listScenario!!)
+        viewModel.start(listScenario)
     }
 
     @Suppress("ForbiddenComment")

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailActivity.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.HistoryDetailActivityBinding
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.onBackPressedCompat
 
 class HistoryDetailActivity : LocaleAwareActivity() {
@@ -30,7 +31,7 @@ class HistoryDetailActivity : LocaleAwareActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val extras = requireNotNull(intent.extras)
-        val revision = extras.getParcelable<Revision>(HistoryDetailContainerFragment.EXTRA_CURRENT_REVISION)
+        val revision = extras.getParcelableCompat<Revision>(HistoryDetailContainerFragment.EXTRA_CURRENT_REVISION)
         val previousRevisionsIds =
             extras.getLongArray(HistoryDetailContainerFragment.EXTRA_PREVIOUS_REVISIONS_IDS)
         val postId = extras.getLong(HistoryDetailContainerFragment.EXTRA_POST_ID)

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import org.wordpress.android.R
 import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.widgets.DiffView
 
 class HistoryDetailFragment : Fragment() {
@@ -16,9 +17,9 @@ class HistoryDetailFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         mRevision = if (savedInstanceState != null) {
-            savedInstanceState.getParcelable(KEY_REVISION)
+            savedInstanceState.getParcelableCompat(KEY_REVISION)
         } else {
-            arguments?.getParcelable(EXTRA_REVISION)
+            arguments?.getParcelableCompat(EXTRA_REVISION)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -76,7 +76,7 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         viewModel = ViewModelProvider(
             this@BackupDownloadFragment,
             viewModelFactory
-        ).get(BackupDownloadViewModel::class.java)
+        )[BackupDownloadViewModel::class.java]
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -79,7 +80,9 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
-                val site = requireNotNull(requireActivity().intent.extras).getSerializable(WordPress.SITE) as SiteModel
+                val site = requireNotNull(
+                    requireActivity().intent.extras?.getSerializableCompat<SiteModel>(WordPress.SITE)
+                )
                 val activityId = requireNotNull(requireActivity().intent.extras).getString(
                     KEY_BACKUP_DOWNLOAD_ACTIVITY_ID_KEY
                 ) as String

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModel.kt
@@ -58,6 +58,7 @@ import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -139,7 +140,7 @@ class BackupDownloadViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            backupDownloadState = requireNotNull(savedInstanceState.getParcelable(KEY_BACKUP_DOWNLOAD_STATE))
+            backupDownloadState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_BACKUP_DOWNLOAD_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -73,7 +74,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {
-                val site = requireNotNull(requireActivity().intent.extras).getSerializable(WordPress.SITE) as SiteModel
+                val site = requireNotNull(activity?.intent?.extras?.getSerializableCompat<SiteModel>(WordPress.SITE))
                 val activityId = requireNotNull(requireActivity().intent.extras).getString(
                     KEY_RESTORE_ACTIVITY_ID_KEY
                 ) as String

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -70,7 +70,7 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
     }
 
     private fun JetpackBackupRestoreFragmentBinding.initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this@RestoreFragment, viewModelFactory).get(RestoreViewModel::class.java)
+        viewModel = ViewModelProvider(this@RestoreFragment, viewModelFactory)[RestoreViewModel::class.java]
 
         val (site, activityId) = when {
             requireActivity().intent?.extras != null -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModel.kt
@@ -61,6 +61,7 @@ import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -142,7 +143,7 @@ class RestoreViewModel @Inject constructor(
             // Show the next step only if it's a fresh activity so we can handle the navigation
             wizardManager.showNextStep()
         } else {
-            restoreState = requireNotNull(savedInstanceState.getParcelable(KEY_RESTORE_STATE))
+            restoreState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_RESTORE_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_RESTORE_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanActivity.kt
@@ -11,13 +11,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ScanActivityBinding
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.models.JetpackPoweredScreen
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -87,7 +87,7 @@ class ScanActivity : AppCompatActivity(), ScrollableViewInitializedListener {
             return true
         } else if (item.itemId == R.id.menu_scan_history) {
             // todo malinjir is it worth introducing a vm?
-            ActivityLauncher.viewScanHistory(this, intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+            ActivityLauncher.viewScanHistory(this, intent.getSerializableExtraCompat(WordPress.SITE))
         }
         return super.onOptionsItemSelected(item)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -30,6 +30,8 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.EmptyViewRecyclerView
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -175,11 +177,12 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site: SiteModel? = if (savedInstanceState == null) {
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
+        return requireNotNull(site)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/ScanFragment.kt
@@ -177,12 +177,14 @@ class ScanFragment : Fragment(R.layout.scan_fragment) {
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        val site: SiteModel? = if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
-        } else {
-            savedInstanceState.getSerializableCompat(WordPress.SITE)
-        }
-        return requireNotNull(site)
+        val site = requireNotNull(
+            if (savedInstanceState == null) {
+                requireActivity().intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            } else {
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
+            }
+        )
+        return site
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -69,37 +69,33 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
 
     private fun ThreatDetailsFragmentBinding.setupObservers() {
         viewModel.uiState.observe(
-            viewLifecycleOwner,
-            { uiState ->
-                if (uiState is Content) {
-                    refreshContentScreen(uiState)
-                }
+            viewLifecycleOwner
+        ) { uiState ->
+            if (uiState is Content) {
+                refreshContentScreen(uiState)
             }
-        )
+        }
 
-        viewModel.snackbarEvents.observeEvent(viewLifecycleOwner, { it.showSnackbar() })
+        viewModel.snackbarEvents.observeEvent(viewLifecycleOwner) { it.showSnackbar() }
 
-        viewModel.navigationEvents.observeEvent(
-            viewLifecycleOwner,
-            { events ->
-                when (events) {
-                    is OpenThreatActionDialog -> showThreatActionDialog(events)
+        viewModel.navigationEvents.observeEvent(viewLifecycleOwner) { events ->
+            when (events) {
+                is OpenThreatActionDialog -> showThreatActionDialog(events)
 
-                    is ShowUpdatedScanStateWithMessage -> {
-                        val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
-                        ActivityLauncher.viewScanRequestScanState(requireActivity(), site, events.messageRes)
-                    }
-                    is ShowUpdatedFixState -> {
-                        val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
-                        ActivityLauncher.viewScanRequestFixState(requireActivity(), site, events.threatId)
-                    }
-                    is ShowGetFreeEstimate -> {
-                        ActivityLauncher.openUrlExternal(context, events.url())
-                    }
-                    is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
+                is ShowUpdatedScanStateWithMessage -> {
+                    val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
+                    ActivityLauncher.viewScanRequestScanState(requireActivity(), site, events.messageRes)
                 }
+                is ShowUpdatedFixState -> {
+                    val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
+                    ActivityLauncher.viewScanRequestFixState(requireActivity(), site, events.threatId)
+                }
+                is ShowGetFreeEstimate -> {
+                    ActivityLauncher.openUrlExternal(context, events.url())
+                }
+                is ShowJetpackSettings -> ActivityLauncher.openUrlExternal(context, events.url)
             }
-        )
+        }
     }
 
     private fun ThreatDetailsFragmentBinding.refreshContentScreen(content: Content) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsViewModel.UiSt
 import org.wordpress.android.ui.jetpack.scan.details.adapters.ThreatDetailsAdapter
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -85,13 +86,11 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
                     is OpenThreatActionDialog -> showThreatActionDialog(events)
 
                     is ShowUpdatedScanStateWithMessage -> {
-                        val site = requireNotNull(requireActivity().intent.extras)
-                            .getSerializable(WordPress.SITE) as SiteModel
+                        val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
                         ActivityLauncher.viewScanRequestScanState(requireActivity(), site, events.messageRes)
                     }
                     is ShowUpdatedFixState -> {
-                        val site = requireNotNull(requireActivity().intent.extras)
-                            .getSerializable(WordPress.SITE) as SiteModel
+                        val site = requireNotNull(activity?.intent?.extras).getSerializableCompat<SiteModel>(WordPress.SITE)
                         ActivityLauncher.viewScanRequestFixState(requireActivity(), site, events.threatId)
                     }
                     is ShowGetFreeEstimate -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.FullscreenErrorWithRetryBinding
 import org.wordpress.android.databinding.ScanHistoryFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.ui.ScrollableViewInitializedListener
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.TabUiState
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.UiState.ContentUiState
@@ -27,8 +28,9 @@ import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.UiStat
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
-import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -121,11 +123,12 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site: SiteModel? = if (savedInstanceState == null) {
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
+        return requireNotNull(site)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryFragment.kt
@@ -123,12 +123,14 @@ class ScanHistoryFragment : Fragment(R.layout.scan_history_fragment), MenuProvid
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        val site: SiteModel? = if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
-        } else {
-            savedInstanceState.getSerializableCompat(WordPress.SITE)
-        }
-        return requireNotNull(site)
+        val site = requireNotNull(
+            if (savedInstanceState == null) {
+                requireActivity().intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            } else {
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
+            }
+        )
+        return site
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -17,6 +17,9 @@ import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel.Sc
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryListViewModel.ScanHistoryUiState.EmptyUiState.EmptyHistory
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryViewModel.ScanHistoryTabType
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -78,14 +81,15 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site: SiteModel? = if (savedInstanceState == null) {
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
+        return requireNotNull(site)
     }
 
-    private fun getTabType(): ScanHistoryTabType = requireNotNull(arguments?.getParcelable(ARG_TAB_TYPE))
+    private fun getTabType() = requireNotNull(arguments?.getParcelableCompat<ScanHistoryTabType>(ARG_TAB_TYPE))
 
     override fun getScrollableViewForUniqueIdProvision(): View? = binding?.recyclerView
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/history/ScanHistoryListFragment.kt
@@ -81,12 +81,14 @@ class ScanHistoryListFragment : ViewPagerFragment(R.layout.scan_history_list_fra
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        val site: SiteModel? = if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
-        } else {
-            savedInstanceState.getSerializableCompat(WordPress.SITE)
-        }
-        return requireNotNull(site)
+        val site = requireNotNull(
+            if (savedInstanceState == null) {
+                requireActivity().intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            } else {
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
+            }
+        )
+        return site
     }
 
     private fun getTabType() = requireNotNull(arguments?.getParcelableCompat<ScanHistoryTabType>(ARG_TAB_TYPE))

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.setVisible
 import javax.inject.Inject
 
@@ -93,8 +94,7 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
-    private fun getSiteScreen() =
-        arguments?.getSerializable(OVERLAY_SCREEN_TYPE) as JetpackFeatureOverlayScreenType?
+    private fun getSiteScreen() = arguments?.getSerializableCompat<JetpackFeatureOverlayScreenType>(OVERLAY_SCREEN_TYPE)
 
     private fun getIfSiteCreationOverlay() =
         arguments?.getSerializable(IS_SITE_CREATION_OVERLAY) as Boolean
@@ -102,14 +102,16 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
     private fun getIfDeepLinkOverlay() =
         arguments?.getSerializable(IS_DEEP_LINK_OVERLAY) as Boolean
 
-    private fun getSiteCreationSource() =
-        arguments?.getSerializable(SITE_CREATION_OVERLAY_SOURCE) as SiteCreationSource
+    private fun getSiteCreationSource() = requireNotNull(
+        arguments?.getSerializableCompat<SiteCreationSource>(SITE_CREATION_OVERLAY_SOURCE)
+    )
 
     private fun getIfFeatureCollectionOverlay() =
         arguments?.getSerializable(IS_FEATURE_COLLECTION_OVERLAY) as Boolean
 
-    private fun getFeatureCollectionOverlaysSource() =
-        arguments?.getSerializable(FEATURE_COLLECTION_OVERLAY_SOURCE) as JetpackFeatureCollectionOverlaySource
+    private fun getFeatureCollectionOverlaysSource() = requireNotNull(
+        arguments?.getSerializableCompat<JetpackFeatureCollectionOverlaySource>(FEATURE_COLLECTION_OVERLAY_SOURCE)
+    )
 
     private fun JetpackFeatureRemovalOverlayBinding.setupObservers() {
         viewModel.uiState.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -96,18 +96,15 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
 
     private fun getSiteScreen() = arguments?.getSerializableCompat<JetpackFeatureOverlayScreenType>(OVERLAY_SCREEN_TYPE)
 
-    private fun getIfSiteCreationOverlay() =
-        arguments?.getSerializable(IS_SITE_CREATION_OVERLAY) as Boolean
+    private fun getIfSiteCreationOverlay() = arguments?.getBoolean(IS_SITE_CREATION_OVERLAY) ?: false
 
-    private fun getIfDeepLinkOverlay() =
-        arguments?.getSerializable(IS_DEEP_LINK_OVERLAY) as Boolean
+    private fun getIfDeepLinkOverlay() = arguments?.getBoolean(IS_DEEP_LINK_OVERLAY) ?: false
 
     private fun getSiteCreationSource() = requireNotNull(
         arguments?.getSerializableCompat<SiteCreationSource>(SITE_CREATION_OVERLAY_SOURCE)
     )
 
-    private fun getIfFeatureCollectionOverlay() =
-        arguments?.getSerializable(IS_FEATURE_COLLECTION_OVERLAY) as Boolean
+    private fun getIfFeatureCollectionOverlay() = arguments?.getBoolean(IS_FEATURE_COLLECTION_OVERLAY) ?: false
 
     private fun getFeatureCollectionOverlaysSource() = requireNotNull(
         arguments?.getSerializableCompat<JetpackFeatureCollectionOverlaySource>(FEATURE_COLLECTION_OVERLAY_SOURCE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -15,6 +15,8 @@ import org.wordpress.android.ui.PreviewModeHandler
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Content
 import org.wordpress.android.ui.layoutpicker.LayoutPickerUiState.Error
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -307,11 +309,11 @@ abstract class LayoutPickerViewModel(
 
     fun loadSavedState(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) return
-        val layouts = savedInstanceState.getParcelableArrayList<LayoutModel>(FETCHED_LAYOUTS)
-        val categories = savedInstanceState.getParcelableArrayList<LayoutCategoryModel>(FETCHED_CATEGORIES)
+        val layouts = savedInstanceState.getParcelableArrayListCompat<LayoutModel>(FETCHED_LAYOUTS)
+        val categories = savedInstanceState.getParcelableArrayListCompat<LayoutCategoryModel>(FETCHED_CATEGORIES)
         val selected = savedInstanceState.getString(SELECTED_LAYOUT)
-        val selectedCategories = (savedInstanceState.getSerializable(SELECTED_CATEGORIES) as? List<*>)
-            ?.filterIsInstance<String>() ?: listOf()
+        val selectedCategories = (savedInstanceState.getSerializableCompat<ArrayList<String>>(SELECTED_CATEGORIES))
+            ?: listOf()
         val previewMode = savedInstanceState.getString(PREVIEW_MODE, MOBILE.name)
         resetState(selected, ArrayList(selectedCategories.toMutableList()), previewMode)
         if (layouts == null || categories == null || layouts.isEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsRowViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutsRowViewHolder.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import org.wordpress.android.R
 import org.wordpress.android.R.dimen
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.setVisible
 
 sealed class LayoutsRowViewHolder(view: View) : RecyclerView.ViewHolder(view)
@@ -100,7 +101,7 @@ class LayoutsItemViewHolder(
 
     private fun restoreScrollState(recyclerView: RecyclerView, key: String) {
         recyclerView.layoutManager?.apply {
-            val scrollState = nestedScrollStates.getParcelable<Parcelable>(key)
+            val scrollState = nestedScrollStates.getParcelableCompat<Parcelable>(key)
             if (scrollState != null) {
                 onRestoreInstanceState(scrollState)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationActivity.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.databinding.ActivityJetpackMigrationBinding
 import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 
 @AndroidEntryPoint
 class JetpackMigrationActivity : AppCompatActivity() {
@@ -18,7 +19,7 @@ class JetpackMigrationActivity : AppCompatActivity() {
             setContentView(root)
             if (savedInstanceState == null) {
                 val showDeleteWpState = intent.getBooleanExtra(KEY_SHOW_DELETE_WP_STATE, false)
-                val deepLinkData = intent.getParcelableExtra<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
+                val deepLinkData = intent.getParcelableExtraCompat<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
                 val fragment = JetpackMigrationFragment.newInstance(showDeleteWpState, deepLinkData)
                 supportFragmentManager.beginTransaction()
                     .replace(R.id.fragment_container, fragment)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -77,7 +78,7 @@ class JetpackMigrationFragment : Fragment() {
         observeViewModelEvents()
         observeRefreshAppThemeEvents()
         val showDeleteWpState = arguments?.getBoolean(KEY_SHOW_DELETE_WP_STATE, false) ?: false
-        val deepLinkData = arguments?.getParcelable<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
+        val deepLinkData = arguments?.getParcelableCompat<PreMigrationDeepLinkData>(KEY_DEEP_LINK_DATA)
         initBackPressHandler(showDeleteWpState)
         viewModel.start(
             showDeleteWpState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -50,6 +50,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
 import org.wordpress.android.util.WPMediaUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import java.io.File
 import javax.inject.Inject
 
@@ -118,11 +120,11 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
         }
         if (savedInstanceState == null) {
             mediaPickerSetup = MediaPickerSetup.fromIntent(intent)
-            site = intent.getSerializableExtra(WordPress.SITE) as? SiteModel
+            site = intent.getSerializableExtraCompat(WordPress.SITE)
             localPostId = intent.getIntExtra(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
         } else {
             mediaPickerSetup = MediaPickerSetup.fromBundle(savedInstanceState)
-            site = savedInstanceState.getSerializable(WordPress.SITE) as? SiteModel
+            site = savedInstanceState.getSerializableCompat(WordPress.SITE)
             localPostId = savedInstanceState.getInt(LOCAL_POST_ID, EMPTY_LOCAL_POST_ID)
         }
         var fragment = pickerFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerFragment.kt
@@ -74,6 +74,9 @@ import org.wordpress.android.util.WPLinkMovementMethod
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -224,13 +227,13 @@ class MediaPickerFragment : Fragment(), MenuProvider {
         requireActivity().addMenuProvider(this, viewLifecycleOwner)
 
         val mediaPickerSetup = MediaPickerSetup.fromBundle(requireArguments())
-        val site = requireArguments().getSerializable(WordPress.SITE) as? SiteModel
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         var selectedIds: List<Identifier>? = null
         var lastTappedIcon: MediaPickerIcon? = null
         if (savedInstanceState != null) {
             lastTappedIcon = MediaPickerIcon.fromBundle(savedInstanceState)
             if (savedInstanceState.containsKey(KEY_SELECTED_IDS)) {
-                selectedIds = savedInstanceState.getParcelableArrayList<Identifier>(KEY_SELECTED_IDS)?.map { it }
+                selectedIds = savedInstanceState.getParcelableArrayListCompat<Identifier>(KEY_SELECTED_IDS)?.map { it }
             }
         }
 
@@ -239,7 +242,7 @@ class MediaPickerFragment : Fragment(), MenuProvider {
             NUM_COLUMNS
         )
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         with(MediaPickerFragmentBinding.bind(view)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/dynamiccards/quickstart/QuickStartDynamicCardViewHolder.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DynamicCard.QuickStartD
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ColorUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.viewBinding
 
 private const val Y_BUFFER = 10
@@ -90,7 +91,7 @@ class QuickStartDynamicCardViewHolder(
 
     private fun restoreScrollState(recyclerView: RecyclerView, key: String) {
         recyclerView.layoutManager?.apply {
-            val scrollState = nestedScrollStates.getParcelable<Parcelable>(key)
+            val scrollState = nestedScrollStates.getParcelableCompat<Parcelable>(key)
             if (scrollState != null) {
                 onRestoreInstanceState(scrollState)
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
@@ -14,8 +14,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.R.raw
-import org.wordpress.android.R.string
 import org.wordpress.android.databinding.JetpackPoweredBottomSheetBinding
 import org.wordpress.android.databinding.JetpackPoweredExpandedBottomSheetBinding
 import org.wordpress.android.ui.ActivityLauncherWrapper
@@ -27,6 +25,7 @@ import org.wordpress.android.ui.main.WPMainNavigationView.PageType.READER
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.DismissDialog
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredDialogAction.OpenPlayStore
 import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -85,27 +84,27 @@ class JetpackPoweredBottomSheetFragment : BottomSheetDialogFragment() {
 
     private fun setupFullScreenViews(view: View) {
         with(JetpackPoweredExpandedBottomSheetBinding.bind(view)) {
-            when (arguments?.getSerializable(KEY_SITE_SCREEN) as? PageType ?: MY_SITE) {
+            when (arguments?.getSerializableCompat(KEY_SITE_SCREEN) ?: MY_SITE) {
                 MY_SITE -> {
-                    val animRes = if (rtlLayout(view)) raw.jp_stats_rtl else raw.jp_stats_left
+                    val animRes = if (rtlLayout(view)) R.raw.jp_stats_rtl else R.raw.jp_stats_left
                     illustrationView.setAnimation(animRes)
-                    title.text = getString(string.wp_jetpack_powered_stats_powered_by_jetpack)
-                    caption.text = getString(string.wp_jetpack_powered_stats_powered_by_jetpack_caption)
-                    secondaryButton.text = getString(string.wp_jetpack_continue_to_stats)
+                    title.text = getString(R.string.wp_jetpack_powered_stats_powered_by_jetpack)
+                    caption.text = getString(R.string.wp_jetpack_powered_stats_powered_by_jetpack_caption)
+                    secondaryButton.text = getString(R.string.wp_jetpack_continue_to_stats)
                 }
                 READER -> {
-                    val animRes = if (rtlLayout(view)) raw.jp_reader_rtl else raw.jp_reader_left
+                    val animRes = if (rtlLayout(view)) R.raw.jp_reader_rtl else R.raw.jp_reader_left
                     illustrationView.setAnimation(animRes)
-                    title.text = getString(string.wp_jetpack_powered_reader_powered_by_jetpack)
-                    caption.text = getString(string.wp_jetpack_powered_reader_powered_by_jetpack_caption)
-                    secondaryButton.text = getString(string.wp_jetpack_continue_to_reader)
+                    title.text = getString(R.string.wp_jetpack_powered_reader_powered_by_jetpack)
+                    caption.text = getString(R.string.wp_jetpack_powered_reader_powered_by_jetpack_caption)
+                    secondaryButton.text = getString(R.string.wp_jetpack_continue_to_reader)
                 }
                 NOTIFS -> {
-                    val animRes = if (rtlLayout(view)) raw.jp_notifications_rtl else raw.jp_notifications_left
+                    val animRes = if (rtlLayout(view)) R.raw.jp_notifications_rtl else R.raw.jp_notifications_left
                     illustrationView.setAnimation(animRes)
-                    title.text = getString(string.wp_jetpack_powered_notifications_powered_by_jetpack)
-                    caption.text = getString(string.wp_jetpack_powered_notifications_powered_by_jetpack_caption)
-                    secondaryButton.text = getString(string.wp_jetpack_continue_to_notifications)
+                    title.text = getString(R.string.wp_jetpack_powered_notifications_powered_by_jetpack)
+                    caption.text = getString(R.string.wp_jetpack_powered_notifications_powered_by_jetpack_caption)
+                    secondaryButton.text = getString(R.string.wp_jetpack_continue_to_notifications)
                 }
             }
             primaryButton.setOnClickListener { viewModel.openJetpackAppDownloadLink() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
@@ -84,7 +84,7 @@ class JetpackPoweredBottomSheetFragment : BottomSheetDialogFragment() {
 
     private fun setupFullScreenViews(view: View) {
         with(JetpackPoweredExpandedBottomSheetBinding.bind(view)) {
-            when (arguments?.getSerializableCompat(KEY_SITE_SCREEN) ?: MY_SITE) {
+            when (arguments?.getSerializableCompat<PageType>(KEY_SITE_SCREEN) ?: MY_SITE) {
                 MY_SITE -> {
                     val animRes = if (rtlLayout(view)) R.raw.jp_stats_rtl else R.raw.jp_stats_left
                     illustrationView.setAnimation(animRes)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -87,6 +87,7 @@ import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
@@ -737,7 +738,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
     }
 
     override fun onConfirm(result: Bundle?) {
-        val task = result?.getSerializable(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
+        val task = result?.getSerializableCompat(QuickStartFullScreenDialogFragment.RESULT_TASK) as? QuickStartTask
         task?.let { viewModel.onQuickStartTaskCardClick(it) }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/DismissNotificationReceiver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/DismissNotificationReceiver.kt
@@ -7,6 +7,7 @@ import androidx.core.app.NotificationManagerCompat
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 class DismissNotificationReceiver : BroadcastReceiver() {
@@ -21,7 +22,7 @@ class DismissNotificationReceiver : BroadcastReceiver() {
     }
 
     private fun trackAnalyticsEvent(intent: Intent) {
-        val stat = intent.getSerializableExtra(EXTRA_STAT_TO_TRACK) as Stat?
+        val stat = intent.getSerializableExtraCompat<Stat>(EXTRA_STAT_TO_TRACK)
         if (stat != null) {
             analyticsTrackerWrapper.track(stat)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -93,8 +93,10 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
         val pagesViewModel = ViewModelProvider(activity, viewModelFactory)[PagesViewModel::class.java]
 
         val listType = requireNotNull(arguments?.getSerializableCompat<PageListType>(typeKey))
-        viewModel =
-            ViewModelProvider(this@PageListFragment, viewModelFactory)[listType.name, PageListViewModel::class.java]
+        viewModel = ViewModelProvider(
+            this@PageListFragment,
+            viewModelFactory
+        )[listType.name, PageListViewModel::class.java]
 
         viewModel.start(listType, pagesViewModel)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -90,7 +90,7 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     }
 
     private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
-        val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
+        val pagesViewModel = ViewModelProvider(activity, viewModelFactory)[PagesViewModel::class.java]
 
         val listType = requireNotNull(arguments?.getSerializableCompat<PageListType>(typeKey))
         viewModel =

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageListFragment.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.pages.PageListViewModel
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
@@ -90,9 +92,9 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
     private fun PagesListFragmentBinding.initializeViewModels(activity: FragmentActivity) {
         val pagesViewModel = ViewModelProvider(activity, viewModelFactory).get(PagesViewModel::class.java)
 
-        val listType = arguments?.getSerializable(typeKey) as PageListType
-        viewModel = ViewModelProvider(this@PageListFragment, viewModelFactory)
-            .get(listType.name, PageListViewModel::class.java)
+        val listType = requireNotNull(arguments?.getSerializableCompat<PageListType>(typeKey))
+        viewModel =
+            ViewModelProvider(this@PageListFragment, viewModelFactory)[listType.name, PageListViewModel::class.java]
 
         viewModel.start(listType, pagesViewModel)
 
@@ -101,7 +103,7 @@ class PageListFragment : ViewPagerFragment(R.layout.pages_list_fragment) {
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -180,8 +180,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
         pageId: Long,
         isFirstStart: Boolean
     ) {
-        viewModel = ViewModelProvider(activity, viewModelFactory)
-            .get(PageParentViewModel::class.java)
+        viewModel = ViewModelProvider(activity, viewModelFactory)[PageParentViewModel::class.java]
 
         setupObservers()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentFragment.kt
@@ -25,6 +25,8 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PageParentFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.pages.PageParentViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
@@ -158,7 +160,7 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
 
     private fun PageParentFragmentBinding.initializeViews(activity: FragmentActivity, savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -184,9 +186,8 @@ class PageParentFragment : Fragment(R.layout.page_parent_fragment), MenuProvider
         setupObservers()
 
         if (isFirstStart) {
-            val site = activity.intent?.getSerializableExtra(WordPress.SITE) as SiteModel?
-            val nonNullSite = checkNotNull(site)
-            viewModel.start(nonNullSite, pageId)
+            val site = requireNotNull(activity.intent?.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
+            viewModel.start(site, pageId)
         } else {
             restorePreviousSearch = true
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageParentSearchFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.pages.PageParentSearchViewModel
 import org.wordpress.android.viewmodel.pages.PageParentViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
@@ -71,7 +72,7 @@ class PageParentSearchFragment : Fragment(R.layout.pages_list_fragment), Corouti
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 const val EXTRA_PAGE_REMOTE_ID_KEY = "extra_page_remote_id_key"
@@ -39,8 +40,9 @@ class PagesActivity : LocaleAwareActivity(),
 
     private fun handleIntent(intent: Intent) {
         if (intent.hasExtra(ARG_NOTIFICATION_TYPE)) {
-            val notificationType: NotificationType =
-                intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
+            val notificationType = requireNotNull(
+                intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)
+            )
             systemNotificationTracker.trackTappedNotification(notificationType)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -318,13 +318,13 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         setupActions(activity)
         setupMlpObservers(activity)
 
-        val site: SiteModel = requireNotNull(
+        val site = requireNotNull(
             if (savedInstanceState == null) {
                 val nonNullIntent = checkNotNull(activity.intent)
-                nonNullIntent.getSerializableExtraCompat(WordPress.SITE)
+                nonNullIntent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
             } else {
                 restorePreviousSearch = true
-                savedInstanceState.getSerializableCompat(WordPress.SITE)
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
             }
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -56,6 +56,8 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.redirectContextClickToLongPressListener
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
@@ -316,13 +318,15 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         setupActions(activity)
         setupMlpObservers(activity)
 
-        val site = if (savedInstanceState == null) {
-            val nonNullIntent = checkNotNull(activity.intent)
-            nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel
-        } else {
-            restorePreviousSearch = true
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-        }
+        val site: SiteModel = requireNotNull(
+            if (savedInstanceState == null) {
+                val nonNullIntent = checkNotNull(activity.intent)
+                nonNullIntent.getSerializableExtraCompat(WordPress.SITE)
+            } else {
+                restorePreviousSearch = true
+                savedInstanceState.getSerializableCompat(WordPress.SITE)
+            }
+        )
 
         viewModel.authorUIState.observe(activity, Observer { state ->
             state?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/SearchListFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PagesListFragmentBinding
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DisplayUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.pages.PagesViewModel
 import org.wordpress.android.viewmodel.pages.SearchListViewModel
 import org.wordpress.android.widgets.RecyclerItemDecoration
@@ -66,7 +67,7 @@ class SearchListFragment : Fragment(R.layout.pages_list_fragment) {
 
     private fun PagesListFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.people.PeopleInviteDialogFragment.DialogMode.DISABLE_INVITE_LINKS_CONFIRMATION
 import org.wordpress.android.ui.people.PeopleInviteDialogFragment.DialogMode.INVITE_LINKS_ROLE_SELECTION
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
@@ -45,7 +46,7 @@ class PeopleInviteDialogFragment : DialogFragment() {
             targetFragment as ViewModelStoreOwner, viewModelFactory
         ).get(PeopleInviteViewModel::class.java)
 
-        val dialogMode = arguments?.getSerializable(ARG_DIALOG_MODE) as? DialogMode
+        val dialogMode = arguments?.getSerializableCompat<DialogMode>(ARG_DIALOG_MODE)
         val roles = arguments?.getStringArray(ARG_ROLES)
         val builder = MaterialAlertDialogBuilder(requireActivity())
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
@@ -44,7 +44,7 @@ class PeopleInviteDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         viewModel = ViewModelProvider(
             targetFragment as ViewModelStoreOwner, viewModelFactory
-        ).get(PeopleInviteViewModel::class.java)
+        )[PeopleInviteViewModel::class.java]
 
         val dialogMode = arguments?.getSerializableCompat<DialogMode>(ARG_DIALOG_MODE)
         val roles = arguments?.getStringArray(ARG_ROLES)

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteDialogFragment.kt
@@ -43,7 +43,8 @@ class PeopleInviteDialogFragment : DialogFragment() {
     @Suppress("DEPRECATION")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         viewModel = ViewModelProvider(
-            targetFragment as ViewModelStoreOwner, viewModelFactory
+            targetFragment as ViewModelStoreOwner,
+            viewModelFactory
         )[PeopleInviteViewModel::class.java]
 
         val dialogMode = arguments?.getSerializableCompat<DialogMode>(ARG_DIALOG_MODE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.kt
@@ -35,6 +35,8 @@ import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.ViewWrapper
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -90,8 +92,10 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val browserType = requireArguments().getSerializable(MediaBrowserActivity.ARG_BROWSER_TYPE) as MediaBrowserType
-        val site = requireArguments().getSerializable(WordPress.SITE) as? SiteModel
+        val browserType = requireNotNull(
+            arguments?.getSerializableCompat<MediaBrowserType>(MediaBrowserActivity.ARG_BROWSER_TYPE)
+        )
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         var selectedIds: List<Long>? = null
         var lastTappedIcon: PhotoPickerIcon? = null
         if (savedInstanceState != null) {
@@ -111,7 +115,7 @@ class PhotoPickerFragment : Fragment(R.layout.photo_picker_fragment) {
                 NUM_COLUMNS
             )
 
-            savedInstanceState?.getParcelable<Parcelable>(KEY_LIST_STATE)?.let {
+            savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIST_STATE)?.let {
                 layoutManager.onRestoreInstanceState(it)
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanDetailsFragment.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.plans.PlanOffersModel
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogContent
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogController
 import org.wordpress.android.util.StringUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 import javax.inject.Inject
@@ -42,9 +43,9 @@ class PlanDetailsFragment : Fragment(), FullScreenDialogContent {
         (requireActivity().application as WordPress).component().inject(this)
 
         plan = if (savedInstanceState != null) {
-            savedInstanceState.getParcelable(KEY_PLAN)
+            savedInstanceState.getParcelableCompat(KEY_PLAN)
         } else {
-            arguments?.getParcelable(EXTRA_PLAN)
+            arguments?.getParcelableCompat(EXTRA_PLAN)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/BasicDialog.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.AndroidSupportInjection
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 /**
@@ -34,7 +35,7 @@ class BasicDialog : AppCompatDialogFragment() {
         setStyle(STYLE_NORMAL, theme)
 
         if (savedInstanceState != null) {
-            model = requireNotNull(savedInstanceState.getParcelable(STATE_KEY_MODEL))
+            model = requireNotNull(savedInstanceState.getParcelableCompat(STATE_KEY_MODEL))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.history.HistoryAdapter
 import org.wordpress.android.ui.history.HistoryListItem
 import org.wordpress.android.ui.history.HistoryListItem.Revision
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.history.HistoryViewModel
 import org.wordpress.android.viewmodel.history.HistoryViewModel.HistoryListStatus
@@ -85,9 +86,10 @@ class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
             (nonNullActivity.application as WordPress).component().inject(this@HistoryListFragment)
 
             viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory).get(HistoryViewModel::class.java)
+            val site = requireNotNull(arguments?.getSerializableCompat<SiteModel>(KEY_SITE))
             viewModel.create(
                 localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,
-                site = arguments?.get(KEY_SITE) as SiteModel
+                site = site
             )
             updatePostOrPageEmptyView()
             setObservers()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/HistoryListFragment.kt
@@ -85,7 +85,7 @@ class HistoryListFragment : Fragment(R.layout.history_list_fragment) {
 
             (nonNullActivity.application as WordPress).component().inject(this@HistoryListFragment)
 
-            viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory).get(HistoryViewModel::class.java)
+            viewModel = ViewModelProvider(this@HistoryListFragment, viewModelFactory)[HistoryViewModel::class.java]
             val site = requireNotNull(arguments?.getSerializableCompat<SiteModel>(KEY_SITE))
             viewModel.create(
                 localPostId = arguments?.getInt(KEY_POST_LOCAL_ID) ?: 0,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostDatePickerDialogFragment : DialogFragment() {
@@ -18,7 +19,7 @@ class PostDatePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostDatePickerDialogFragment.kt
@@ -24,10 +24,14 @@ class PostDatePickerDialogFragment : DialogFragment() {
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -127,13 +127,13 @@ class PostListFragment : ViewPagerFragment() {
             }
         })
 
-        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner, Observer {
+        mainViewModel.authorSelectionUpdated.observe(viewLifecycleOwner) {
             if (it != null) {
                 if (viewModel.updateAuthorFilterIfNotSearch(it)) {
                     recyclerView?.scrollToPosition(0)
                 }
             }
-        })
+        }
 
         actionableEmptyView?.updateLayoutForSearch(postListType == SEARCH, 0)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -105,8 +105,7 @@ class PostListFragment : ViewPagerFragment() {
             recyclerView?.id = R.id.posts_search_recycler_view_id
         }
 
-        mainViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)
-            .get(PostListMainViewModel::class.java)
+        mainViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)[PostListMainViewModel::class.java]
 
         mainViewModel.viewLayoutType.observe(viewLifecycleOwner, Observer { optionaLayoutType ->
             optionaLayoutType?.let { layoutType ->
@@ -140,7 +139,7 @@ class PostListFragment : ViewPagerFragment() {
 
         val postListViewModelConnector = mainViewModel.getPostListViewModelConnector(postListType)
 
-        viewModel = ViewModelProvider(this, viewModelFactory).get(PostListViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[PostListViewModel::class.java]
 
         val displayWidth = DisplayUtils.getWindowPixelWidth(requireContext())
         val contentSpacing = nonNullActivity.resources.getDimensionPixelSize(R.dimen.content_margin)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
@@ -80,7 +82,7 @@ class PostListFragment : ViewPagerFragment() {
         (nonNullActivity.application as WordPress).component().inject(this)
 
         val nonNullIntent = checkNotNull(nonNullActivity.intent)
-        val site: SiteModel? = nonNullIntent.getSerializableExtra(WordPress.SITE) as SiteModel?
+        val site = nonNullIntent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
 
         if (site == null) {
             ToastUtils.showToast(nonNullActivity, R.string.blog_not_found, ToastUtils.Duration.SHORT)
@@ -97,7 +99,7 @@ class PostListFragment : ViewPagerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        postListType = requireNotNull(arguments).getSerializable(EXTRA_POST_LIST_TYPE) as PostListType
+        postListType = requireNotNull(arguments?.getSerializableCompat(EXTRA_POST_LIST_TYPE))
 
         if (postListType == SEARCH) {
             recyclerView?.id = R.id.posts_search_recycler_view_id

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.Schedul
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.TEN_MINUTES
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel.Period.WHEN_PUBLISHED
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
@@ -23,7 +24,7 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostNotificationScheduleTimeDialogFragment.kt
@@ -29,10 +29,14 @@ class PostNotificationScheduleTimeDialogFragment : DialogFragment() {
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.R.style
 import org.wordpress.android.WordPress
 
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettingsViewModel
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 class PostTimePickerDialogFragment : DialogFragment() {
@@ -21,7 +22,7 @@ class PostTimePickerDialogFragment : DialogFragment() {
     private lateinit var viewModel: PublishSettingsViewModel
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val publishSettingsFragmentType = arguments?.getParcelable<PublishSettingsFragmentType>(
+        val publishSettingsFragmentType = arguments?.getParcelableCompat<PublishSettingsFragmentType>(
             ARG_PUBLISH_SETTINGS_FRAGMENT_TYPE
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostTimePickerDialogFragment.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.posts
 
 import android.app.Dialog
 import android.app.TimePickerDialog
-import android.app.TimePickerDialog.OnTimeSetListener
 import android.content.Context
 import android.os.Bundle
 import android.text.format.DateFormat
@@ -27,25 +26,26 @@ class PostTimePickerDialogFragment : DialogFragment() {
         )
 
         viewModel = when (publishSettingsFragmentType) {
-            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(EditPostPublishSettingsViewModel::class.java)
-            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(requireActivity(), viewModelFactory)
-                .get(PrepublishingPublishSettingsViewModel::class.java)
+            PublishSettingsFragmentType.EDIT_POST -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[EditPostPublishSettingsViewModel::class.java]
+            PublishSettingsFragmentType.PREPUBLISHING_NUDGES -> ViewModelProvider(
+                requireActivity(),
+                viewModelFactory
+            )[PrepublishingPublishSettingsViewModel::class.java]
             null -> error("PublishSettingsViewModel not initialized")
         }
 
         val is24HrFormat = DateFormat.is24HourFormat(activity)
         val context = ContextThemeWrapper(activity, style.PostSettingsCalendar)
-        val timePickerDialog = TimePickerDialog(
+        return TimePickerDialog(
             context,
-            OnTimeSetListener { _, selectedHour, selectedMinute ->
-                viewModel.onTimeSelected(selectedHour, selectedMinute)
-            },
+            { _, selectedHour, selectedMinute -> viewModel.onTimeSelected(selectedHour, selectedMinute) },
             viewModel.hour ?: 0,
             viewModel.minute ?: 0,
             is24HrFormat
         )
-        return timePickerDialog
     }
 
     override fun onAttach(context: Context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -60,6 +60,8 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.redirectContextClickToLongPressListener
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.viewmodel.observeEvent
@@ -165,7 +167,7 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     private fun restartWhenSiteHasChanged(intent: Intent) {
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site = requireNotNull(intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE))
         if (site.id != this.site.id) {
             finish()
             startActivity(intent)
@@ -180,14 +182,14 @@ class PostsListActivity : LocaleAwareActivity(),
             setContentView(root)
             binding = this
 
-            site = if (savedInstanceState == null) {
-                checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                    "SiteModel cannot be null, check the PendingIntent starting PostsListActivity"
+            site = requireNotNull(
+                if (savedInstanceState == null) {
+                    intent.getSerializableExtraCompat(WordPress.SITE)
+                } else {
+                    restorePreviousSearch = true
+                    savedInstanceState.getSerializableCompat(WordPress.SITE)
                 }
-            } else {
-                restorePreviousSearch = true
-                savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
-            }
+            ) { "SiteModel cannot be null, check the PendingIntent starting PostsListActivity" }
 
             val initPreviewState = if (savedInstanceState == null) {
                 PostListRemotePreviewState.NONE
@@ -477,8 +479,9 @@ class PostsListActivity : LocaleAwareActivity(),
 
     private fun loadIntentData(intent: Intent) {
         if (intent.hasExtra(ARG_NOTIFICATION_TYPE)) {
-            val notificationType: NotificationType =
-                intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
+            val notificationType = requireNotNull(
+                intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)
+            )
             systemNotificationTracker.trackTappedNotification(notificationType)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -145,7 +146,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
         startObserving()
 
         val needsRequestLayout = requireArguments().getBoolean(PrepublishingTagsFragment.NEEDS_REQUEST_LAYOUT)
-        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        val siteModel = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
         viewModel.start(siteModel, !needsRequestLayout)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -142,8 +142,10 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
             this@PrepublishingAddCategoryFragment,
             viewModelFactory
         )[PrepublishingAddCategoryViewModel::class.java]
-        parentViewModel =
-            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
+        parentViewModel = ViewModelProvider(
+            requireParentFragment(),
+            viewModelFactory
+        )[PrepublishingViewModel::class.java]
 
         startObserving()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingAddCategoryFragment.kt
@@ -138,10 +138,12 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
     }
 
     private fun PrepublishingAddCategoryFragmentBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@PrepublishingAddCategoryFragment, viewModelFactory)
-            .get(PrepublishingAddCategoryViewModel::class.java)
-        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(
+            this@PrepublishingAddCategoryFragment,
+            viewModelFactory
+        )[PrepublishingAddCategoryViewModel::class.java]
+        parentViewModel =
+            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
 
         startObserving()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -135,8 +135,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
 
         viewModel.navigationTarget.observeEvent(this, { navigationState ->
             navigateToScreen(navigationState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -137,21 +137,21 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     private fun initViewModel(savedInstanceState: Bundle?) {
         viewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
 
-        viewModel.navigationTarget.observeEvent(this, { navigationState ->
+        viewModel.navigationTarget.observeEvent(this) { navigationState ->
             navigateToScreen(navigationState)
-        })
+        }
 
-        viewModel.dismissBottomSheet.observeEvent(this, {
+        viewModel.dismissBottomSheet.observeEvent(this) {
             dismiss()
-        })
+        }
 
-        viewModel.triggerOnSubmitButtonClickedListener.observeEvent(this, { publishPost ->
+        viewModel.triggerOnSubmitButtonClickedListener.observeEvent(this) { publishPost ->
             prepublishingBottomSheetListener?.onSubmitButtonClicked(publishPost)
-        })
+        }
 
-        viewModel.dismissKeyboard.observeEvent(this, {
+        viewModel.dismissKeyboard.observeEvent(this) {
             ActivityUtils.hideKeyboardForced(view)
-        })
+        }
 
         val prepublishingScreenState = savedInstanceState?.getParcelableCompat<PrepublishingScreen>(
             KEY_SCREEN_STATE

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingBottomSheetFragment.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.posts.prepublishing.PrepublishingPublishSettings
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.KeyboardResizeViewUtil
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -152,11 +154,10 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             ActivityUtils.hideKeyboardForced(view)
         })
 
-        val prepublishingScreenState = savedInstanceState?.getParcelable<PrepublishingScreen>(
+        val prepublishingScreenState = savedInstanceState?.getParcelableCompat<PrepublishingScreen>(
             KEY_SCREEN_STATE
         )
-        val site = arguments?.getSerializable(SITE) as SiteModel
-
+        val site = requireNotNull(arguments?.getSerializableCompat<SiteModel>(SITE))
         viewModel.start(site, prepublishingScreenState)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -117,10 +117,12 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     private fun PrepublishingCategoriesFragmentBinding.initViewModel() {
-        viewModel = ViewModelProvider(this@PrepublishingCategoriesFragment, viewModelFactory)
-            .get(PrepublishingCategoriesViewModel::class.java)
-        parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
-            .get(PrepublishingViewModel::class.java)
+        viewModel = ViewModelProvider(
+            this@PrepublishingCategoriesFragment,
+            viewModelFactory
+        )[PrepublishingCategoriesViewModel::class.java]
+        parentViewModel =
+            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
         startObserving()
         val siteModel = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
         val addCategoryRequest = arguments?.getSerializableCompat<PrepublishingAddCategoryRequest>(ADD_CATEGORY_REQUEST)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.posts.PrepublishingHomeItemUiState.ActionType.AD
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
@@ -121,9 +122,8 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         parentViewModel = ViewModelProvider(requireParentFragment(), viewModelFactory)
             .get(PrepublishingViewModel::class.java)
         startObserving()
-        val siteModel = requireArguments().getSerializable(WordPress.SITE) as SiteModel
-        val addCategoryRequest: PrepublishingAddCategoryRequest? =
-            arguments?.getSerializable(ADD_CATEGORY_REQUEST) as? PrepublishingAddCategoryRequest
+        val siteModel = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
+        val addCategoryRequest = arguments?.getSerializableCompat<PrepublishingAddCategoryRequest>(ADD_CATEGORY_REQUEST)
         val selectedCategoryIds: List<Long> =
             arguments?.getLongArray(SELECTED_CATEGORY_IDS)?.toList() ?: listOf()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PrepublishingCategoriesFragment.kt
@@ -121,8 +121,10 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
             this@PrepublishingCategoriesFragment,
             viewModelFactory
         )[PrepublishingCategoriesViewModel::class.java]
-        parentViewModel =
-            ViewModelProvider(requireParentFragment(), viewModelFactory)[PrepublishingViewModel::class.java]
+        parentViewModel = ViewModelProvider(
+            requireParentFragment(),
+            viewModelFactory
+        )[PrepublishingViewModel::class.java]
         startObserving()
         val siteModel = requireNotNull(arguments?.getSerializableCompat<SiteModel>(WordPress.SITE))
         val addCategoryRequest = arguments?.getSerializableCompat<PrepublishingAddCategoryRequest>(ADD_CATEGORY_REQUEST)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.prefs.categories.list.CategoryDetailNavigation.E
 import org.wordpress.android.ui.prefs.categories.list.UiState.Content
 import org.wordpress.android.ui.prefs.categories.list.UiState.Loading
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -68,11 +70,12 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        return if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        val site: SiteModel? = if (savedInstanceState == null) {
+            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
+        return requireNotNull(site)
     }
 
     private fun SiteSettingsCategoriesListFragmentBinding.setupObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/list/CategoriesListFragment.kt
@@ -70,12 +70,14 @@ class CategoriesListFragment : Fragment(R.layout.site_settings_categories_list_f
     }
 
     private fun getSite(savedInstanceState: Bundle?): SiteModel {
-        val site: SiteModel? = if (savedInstanceState == null) {
-            requireActivity().intent.getSerializableExtraCompat(WordPress.SITE)
-        } else {
-            savedInstanceState.getSerializableCompat(WordPress.SITE)
-        }
-        return requireNotNull(site)
+        val site = requireNotNull(
+            if (savedInstanceState == null) {
+                requireActivity().intent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
+            } else {
+                savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
+            }
+        )
+        return site
     }
 
     private fun SiteSettingsCategoriesListFragmentBinding.setupObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -39,9 +39,9 @@ class HomepageSettingsDialog : DialogFragment() {
         var pageForPostsId: Long? = null
         (arguments ?: savedInstanceState)?.let { bundle ->
             siteId = bundle.getInt(KEY_SITE_ID)
-            isClassicBlog = bundle.get(KEY_IS_CLASSIC_BLOG)?.let { it as Boolean }
-            pageOnFrontId = bundle.get(KEY_PAGE_ON_FRONT)?.let { it as Long }
-            pageForPostsId = bundle.get(KEY_PAGE_FOR_POSTS)?.let { it as Long }
+            isClassicBlog = bundle.getBoolean(KEY_IS_CLASSIC_BLOG)
+            pageOnFrontId = bundle.getLong(KEY_PAGE_ON_FRONT)
+            pageForPostsId = bundle.getLong(KEY_PAGE_FOR_POSTS)
         } ?: throw IllegalArgumentException("Site has to be initialized")
         val builder = MaterialAlertDialogBuilder(requireActivity())
         builder.setPositiveButton(R.string.site_settings_accept_homepage) { _, _ -> }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -55,8 +55,10 @@ class HomepageSettingsDialog : DialogFragment() {
             }
             builder.setView(root)
 
-            viewModel =
-                ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)[HomepageSettingsViewModel::class.java]
+            viewModel = ViewModelProvider(
+                this@HomepageSettingsDialog,
+                viewModelFactory
+            )[HomepageSettingsViewModel::class.java]
             viewModel.uiState.observe(this@HomepageSettingsDialog) { uiState ->
                 uiState?.let {
                     loadingPages.visibility = if (uiState.isLoading) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/homepage/HomepageSettingsDialog.kt
@@ -55,8 +55,8 @@ class HomepageSettingsDialog : DialogFragment() {
             }
             builder.setView(root)
 
-            viewModel = ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)
-                .get(HomepageSettingsViewModel::class.java)
+            viewModel =
+                ViewModelProvider(this@HomepageSettingsDialog, viewModelFactory)[HomepageSettingsViewModel::class.java]
             viewModel.uiState.observe(this@HomepageSettingsDialog) { uiState ->
                 uiState?.let {
                     loadingPages.visibility = if (uiState.isLoading) View.VISIBLE else View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartFullScreenDialogFragment.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.CREATE_SITE
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
-import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.UNKNOWN
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogContent
 import org.wordpress.android.ui.FullScreenDialogFragment.FullScreenDialogController
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -28,6 +27,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.QuickStartUtils.getQuickStartListSkippedTracker
 import org.wordpress.android.util.QuickStartUtils.getQuickStartListTappedTracker
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.widgets.WPSnackbar.Companion.make
 import java.io.Serializable
 import javax.inject.Inject
@@ -74,7 +74,7 @@ class QuickStartFullScreenDialogFragment : Fragment(R.layout.quick_start_dialog_
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        tasksType = arguments?.getSerializable(EXTRA_TYPE) as QuickStartTaskType? ?: QuickStartTaskType.UNKNOWN
+        tasksType = arguments?.getSerializableCompat(EXTRA_TYPE) ?: QuickStartTaskType.UNKNOWN
         quickStartTracker.trackQuickStartListViewed(tasksType)
         binding.setupQuickStartList()
     }
@@ -150,7 +150,7 @@ class QuickStartFullScreenDialogFragment : Fragment(R.layout.quick_start_dialog_
     )
 
     private fun buildTaskCards(): List<QuickStartTaskCard> {
-        val tasks = QuickStartTask.getTasksByTaskType(tasksType).filterNot { it.taskType == UNKNOWN }
+        val tasks = QuickStartTask.getTasksByTaskType(tasksType).filterNot { it.taskType == QuickStartTaskType.UNKNOWN }
         val selectedSiteLocalId = selectedSiteRepository.getSelectedSiteLocalId().toLong()
         val tasksCompleted = quickStartStore.getCompletedTasksByType(selectedSiteLocalId, tasksType)
         return tasks.mapToQuickStartTaskCard(tasksCompleted)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -132,6 +132,8 @@ import org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelp
 import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
 import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.isDarkTheme
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
@@ -317,12 +319,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (args != null) {
             blogId = args.getLong(ReaderConstants.ARG_BLOG_ID)
             postId = args.getLong(ReaderConstants.ARG_POST_ID)
-            directOperation = args.getSerializable(ReaderConstants.ARG_DIRECT_OPERATION) as? DirectOperation
+            directOperation = args.getSerializableCompat(ReaderConstants.ARG_DIRECT_OPERATION)
             commentId = args.getInt(ReaderConstants.ARG_COMMENT_ID)
             isRelatedPost = args.getBoolean(ReaderConstants.ARG_IS_RELATED_POST)
             interceptedUri = args.getString(ReaderConstants.ARG_INTERCEPTED_URI)
             if (args.containsKey(ReaderConstants.ARG_POST_LIST_TYPE)) {
-                this.postListType = args.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE) as ReaderPostListType
+                postListType = requireNotNull(
+                    args.getSerializableCompat(ReaderConstants.ARG_POST_LIST_TYPE)
+                )
             }
             postSlugsResolutionUnderway = args.getBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY)
         }
@@ -499,7 +503,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun initLikeFacesRecycler(savedInstanceState: Bundle?) {
         if (!likesEnhancementsFeatureConfig.isEnabled()) return
         val layoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
-        savedInstanceState?.getParcelable<Parcelable>(KEY_LIKERS_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_LIKERS_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -518,7 +522,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         if (!commentsSnippetFeatureConfig.isEnabled()) return
         val layoutManager = LinearLayoutManager(activity)
 
-        savedInstanceState?.getParcelable<Parcelable>(KEY_COMMENTS_SNIPPET_LIST_STATE)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(KEY_COMMENTS_SNIPPET_LIST_STATE)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 
@@ -1082,8 +1086,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         savedInstanceState?.let {
             blogId = it.getLong(ReaderConstants.ARG_BLOG_ID)
             postId = it.getLong(ReaderConstants.ARG_POST_ID)
-            directOperation = it
-                .getSerializable(ReaderConstants.ARG_DIRECT_OPERATION) as? DirectOperation
+            directOperation = it.getSerializableCompat(ReaderConstants.ARG_DIRECT_OPERATION)
             commentId = it.getInt(ReaderConstants.ARG_COMMENT_ID)
             isRelatedPost = it.getBoolean(ReaderConstants.ARG_IS_RELATED_POST)
             interceptedUri = it.getString(ReaderConstants.ARG_INTERCEPTED_URI)
@@ -1092,7 +1095,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             hasTrackedGlobalRelatedPosts = it.getBoolean(ReaderConstants.KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS)
             hasTrackedLocalRelatedPosts = it.getBoolean(ReaderConstants.KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS)
             if (it.containsKey(ReaderConstants.ARG_POST_LIST_TYPE)) {
-                this.postListType = it.getSerializable(ReaderConstants.ARG_POST_LIST_TYPE) as ReaderPostListType
+                postListType = requireNotNull(it.getSerializableCompat(ReaderConstants.ARG_POST_LIST_TYPE))
             }
             if (it.containsKey(ReaderConstants.KEY_ERROR_MESSAGE)) {
                 errorMessage = it.getString(ReaderConstants.KEY_ERROR_MESSAGE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.subfilter.SubfilterPagerAdapter
+import org.wordpress.android.util.extensions.getParcelableArrayListCompat
 import javax.inject.Inject
 
 class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
@@ -66,8 +67,9 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
 
         val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
         val bottomSheetTitle = requireArguments().getCharSequence(SUBFILTER_TITLE_KEY)!!
-        val categories: ArrayList<SubfilterCategory> = requireArguments()
-            .getParcelableArrayList(SUBFILTER_CATEGORIES_KEY)!!
+        val categories = requireNotNull(
+            requireArguments().getParcelableArrayListCompat<SubfilterCategory>(SUBFILTER_CATEGORIES_KEY)
+        )
 
         viewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory)
             .get(subfilterVmKey, SubFilterViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -71,8 +71,10 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
             requireArguments().getParcelableArrayListCompat<SubfilterCategory>(SUBFILTER_CATEGORIES_KEY)
         )
 
-        viewModel = ViewModelProvider(parentFragment as ViewModelStoreOwner, viewModelFactory)
-            .get(subfilterVmKey, SubFilterViewModel::class.java)
+        viewModel = ViewModelProvider(
+            parentFragment as ViewModelStoreOwner,
+            viewModelFactory
+        )[subfilterVmKey, SubFilterViewModel::class.java]
 
         val pager = view.findViewById<ViewPager>(R.id.view_pager)
         val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewMod
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
@@ -37,7 +38,7 @@ class ReaderInterestsFragment : Fragment(R.layout.reader_interests_fragment_layo
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val entryPoint = requireActivity().intent.getSerializableExtra(READER_INTEREST_ENTRY_POINT) as? EntryPoint
+        val entryPoint = requireActivity().intent.getSerializableExtraCompat(READER_INTEREST_ENTRY_POINT)
             ?: EntryPoint.DISCOVER
         with(ReaderInterestsFragmentLayoutBinding.bind(view)) {
             initDoneButton()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverJobService.kt
@@ -37,7 +37,7 @@ class ReaderDiscoverJobService : JobService(), ServiceCompletionListener, Corout
     override fun onStartJob(params: JobParameters): Boolean {
         AppLog.i(READER, "reader discover job service > started")
 
-        val task = DiscoverTasks.values()[(params.extras[ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK] as Int)]
+        val task = DiscoverTasks.values()[params.extras.getInt(ReaderDiscoverServiceStarter.ARG_DISCOVER_TASK)]
 
         readerDiscoverLogic.performTasks(task, params, this, this)
         return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverService.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverServiceSt
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
 import org.wordpress.android.util.LocaleManager
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -56,7 +57,7 @@ class ReaderDiscoverService : Service(), ServiceCompletionListener, CoroutineSco
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent != null && intent.hasExtra(ARG_DISCOVER_TASK)) {
-            val task = intent.getSerializableExtra(ARG_DISCOVER_TASK) as DiscoverTasks
+            val task = requireNotNull(intent.getSerializableExtraCompat<DiscoverTasks>(ARG_DISCOVER_TASK))
             readerDiscoverLogic.performTasks(task, null, this, this)
         }
         return START_NOT_STICKY

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -16,7 +16,6 @@ import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -100,7 +99,7 @@ class SubfilterPageFragment : DaggerFragment() {
             viewModelFactory
         ).get(subfilterVmKey, SubFilterViewModel::class.java)
 
-        subFilterViewModel.subFilters.observe(viewLifecycleOwner, Observer {
+        subFilterViewModel.subFilters.observe(viewLifecycleOwner) {
             (recyclerView.adapter as? SubfilterListAdapter)?.let { adapter ->
                 var items = it?.filter { it.type == category.type } ?: listOf()
 
@@ -117,9 +116,9 @@ class SubfilterPageFragment : DaggerFragment() {
                 adapter.update(items)
                 subFilterViewModel.onSubfilterPageUpdated(category, items.size)
             }
-        })
+        }
 
-        viewModel.emptyState.observe(viewLifecycleOwner, Observer { uiState ->
+        viewModel.emptyState.observe(viewLifecycleOwner) { uiState ->
             if (isAdded) {
                 when (uiState) {
                     HiddenEmptyUiState -> emptyStateContainer.visibility = View.GONE
@@ -133,7 +132,7 @@ class SubfilterPageFragment : DaggerFragment() {
                     }
                 }
             }
-        })
+        }
     }
 
     fun setNestedScrollBehavior(enable: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -84,7 +84,7 @@ class SubfilterPageFragment : DaggerFragment() {
         val category = requireNotNull(arguments?.getSerializableCompat<SubfilterCategory>(CATEGORY_KEY))
         val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
 
-        viewModel = ViewModelProvider(this, viewModelFactory).get(SubfilterPageViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[SubfilterPageViewModel::class.java]
         viewModel.start(category)
 
         recyclerView = view.findViewById(R.id.content_recycler_view)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.widgets.WPTextView
 import java.lang.ref.WeakReference
 import javax.inject.Inject
@@ -80,7 +81,7 @@ class SubfilterPageFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val category = requireArguments().getSerializable(CATEGORY_KEY) as SubfilterCategory
+        val category = requireNotNull(arguments?.getSerializableCompat<SubfilterCategory>(CATEGORY_KEY))
         val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
 
         viewModel = ViewModelProvider(this, viewModelFactory).get(SubfilterPageViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.SiteCreationDomainPurchasingFeatureConfig
 import org.wordpress.android.util.experiments.SiteCreationDomainPurchasingExperiment
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -128,7 +129,7 @@ class SiteCreationMainVM @Inject constructor(
                 showSiteCreationNextStep()
         } else {
             siteCreationCompleted = savedInstanceState.getBoolean(KEY_SITE_CREATION_COMPLETED, false)
-            siteCreationState = requireNotNull(savedInstanceState.getParcelable(KEY_SITE_CREATION_STATE))
+            siteCreationState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_SITE_CREATION_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
             wizardManager.setCurrentStepIndex(currentStepIndex)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AutoForeground.ServiceEventConnection
 import org.wordpress.android.util.ErrorManagedWebViewClient.ErrorManagedWebViewClientListener
 import org.wordpress.android.util.URLFilteredWebViewClient
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 private const val ARG_DATA = "arg_site_creation_data"
@@ -97,7 +98,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         super.onViewCreated(view, savedInstanceState)
         (requireActivity() as AppCompatActivity).supportActionBar?.hide()
 
-        viewModel.start(requireArguments()[ARG_DATA] as SiteCreationState, savedInstanceState)
+        viewModel.start(requireNotNull(arguments?.getParcelableCompat(ARG_DATA)), savedInstanceState)
     }
 
     override fun getContentLayout(): Int {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
@@ -137,7 +138,7 @@ class SitePreviewViewModel @Inject constructor(
         urlWithoutScheme = siteCreationState.domain
         siteTitle = siteCreationState.siteName
 
-        val restoredState = savedState?.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)
+        val restoredState = savedState?.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)
 
         init(restoredState ?: SiteNotCreated)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationService.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationService.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AutoForeground
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
 import javax.inject.Inject
 
 private val INITIAL_STATE = IDLE
@@ -47,7 +48,7 @@ class SiteCreationService : AutoForeground<SiteCreationServiceState>(SiteCreatio
             return Service.START_NOT_STICKY
         }
 
-        val data = intent.getParcelableExtra<SiteCreationServiceData>(ARG_DATA)!!
+        val data = requireNotNull(intent.getParcelableExtraCompat<SiteCreationServiceData>(ARG_DATA))
         manager.onStart(
             LocaleManager.getLanguageWordPressId(this),
             localeManagerWrapper.getTimeZone().id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.WPUrlUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
 
 /**
@@ -72,14 +73,18 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
             if (TextUtils.isEmpty(mAccountStore.account.userName)) {
                 mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction())
             } else {
-                startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+                startJetpackConnectionFlow(
+                    requireNotNull(intent.getSerializableExtraCompat(WordPress.SITE))
+                )
             }
         }
     }
 
     private fun StatsJetpackConnectionActivityBinding.initViews() {
         jetpackSetup.setOnClickListener {
-            startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+            startJetpackConnectionFlow(
+                requireNotNull(intent.getSerializableExtraCompat(WordPress.SITE))
+            )
         }
         jetpackFaq.setOnClickListener {
             WPWebViewActivity.openURL(this@StatsConnectJetpackActivity, FAQ_URL)
@@ -133,7 +138,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
                 event.causeOfChange == FETCH_ACCOUNT &&
                 !TextUtils.isEmpty(mAccountStore.account.userName)
             ) {
-                startJetpackConnectionFlow(intent.getSerializableExtra(WordPress.SITE) as SiteModel)
+                startJetpackConnectionFlow(requireNotNull(intent.getSerializableExtraCompat(WordPress.SITE)))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -157,11 +157,11 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         savedInstanceState: Bundle?
     ) {
         val nonNullIntent = checkNotNull(activity.intent)
-        val type: StatsViewType = requireNotNull(
+        val type = requireNotNull(
             if (savedInstanceState == null) {
-                nonNullIntent.getSerializableExtraCompat(ARGS_VIEW_TYPE)
+                nonNullIntent.getSerializableExtraCompat<StatsViewType>(ARGS_VIEW_TYPE)
             } else {
-                savedInstanceState.getSerializableCompat(ARGS_VIEW_TYPE)
+                savedInstanceState.getSerializableCompat<StatsViewType>(ARGS_VIEW_TYPE)
             }
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -34,6 +34,10 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
@@ -78,13 +82,13 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
             if (intent.hasExtra(ARGS_VIEW_TYPE)) {
                 outState.putSerializable(
                     ARGS_VIEW_TYPE,
-                    intent.getSerializableExtra(ARGS_VIEW_TYPE)
+                    intent.getSerializableExtraCompat(ARGS_VIEW_TYPE)
                 )
             }
             if (intent.hasExtra(ARGS_TIMEFRAME)) {
                 outState.putSerializable(
                     ARGS_TIMEFRAME,
-                    intent.getSerializableExtra(ARGS_TIMEFRAME)
+                    intent.getSerializableExtraCompat(ARGS_TIMEFRAME)
                 )
             }
             outState.putInt(WordPress.LOCAL_SITE_ID, intent.getIntExtra(WordPress.LOCAL_SITE_ID, 0))
@@ -96,7 +100,7 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
     private fun StatsViewAllFragmentBinding.initializeViews(savedInstanceState: Bundle?) {
         val layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
 
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
         with(statsListFragment) {
@@ -153,16 +157,18 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         savedInstanceState: Bundle?
     ) {
         val nonNullIntent = checkNotNull(activity.intent)
-        val type = if (savedInstanceState == null) {
-            nonNullIntent.getSerializableExtra(ARGS_VIEW_TYPE) as StatsViewType
-        } else {
-            savedInstanceState.getSerializable(ARGS_VIEW_TYPE) as StatsViewType
-        }
+        val type: StatsViewType = requireNotNull(
+            if (savedInstanceState == null) {
+                nonNullIntent.getSerializableExtraCompat(ARGS_VIEW_TYPE)
+            } else {
+                savedInstanceState.getSerializableCompat(ARGS_VIEW_TYPE)
+            }
+        )
 
-        val granularity = if (savedInstanceState == null) {
-            nonNullIntent.getSerializableExtra(ARGS_TIMEFRAME) as StatsGranularity?
+        val granularity: StatsGranularity? = if (savedInstanceState == null) {
+            nonNullIntent.getSerializableExtraCompat(ARGS_TIMEFRAME)
         } else {
-            savedInstanceState.getSerializable(ARGS_TIMEFRAME) as StatsGranularity?
+            savedInstanceState.getSerializableCompat(ARGS_TIMEFRAME)
         }
 
         val siteId = savedInstanceState?.getInt(WordPress.LOCAL_SITE_ID, 0)
@@ -172,10 +178,10 @@ class StatsViewAllFragment : DaggerFragment(R.layout.stats_view_all_fragment) {
         val viewModelFactory = viewModelFactoryBuilder.build(type, granularity)
         viewModel = ViewModelProvider(activity, viewModelFactory).get(StatsViewAllViewModel::class.java)
 
-        val selectedDate = if (savedInstanceState == null) {
-            nonNullIntent.getParcelableExtra(ARGS_SELECTED_DATE) as SelectedDate?
+        val selectedDate: SelectedDate? = if (savedInstanceState == null) {
+            nonNullIntent.getParcelableExtraCompat(ARGS_SELECTED_DATE)
         } else {
-            savedInstanceState.getParcelable(ARGS_SELECTED_DATE) as SelectedDate?
+            savedInstanceState.getParcelableCompat(ARGS_SELECTED_DATE)
         }
         setupObservers(activity)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.viewmodel.Event
@@ -114,10 +115,10 @@ class StatsViewModel
     fun start(intent: Intent, restart: Boolean = false) {
         val localSiteId = intent.getIntExtra(WordPress.LOCAL_SITE_ID, 0)
 
-        val launchedFrom = intent.getSerializableExtra(StatsActivity.ARG_LAUNCHED_FROM)
+        val launchedFrom = intent.getSerializableExtraCompat<Serializable>(StatsActivity.ARG_LAUNCHED_FROM)
         val initialTimeFrame = getInitialTimeFrame(intent)
         val initialSelectedPeriod = intent.getStringExtra(StatsActivity.INITIAL_SELECTED_PERIOD_KEY)
-        val notificationType = intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as? NotificationType
+        val notificationType = intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)
         start(localSiteId, launchedFrom, initialTimeFrame, initialSelectedPeriod, restart, notificationType)
     }
 
@@ -135,7 +136,7 @@ class StatsViewModel
     }
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {
-        return when (intent.getSerializableExtra(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
+        return when (intent.getSerializableExtraCompat<Serializable>(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
             StatsTimeframe.INSIGHTS -> StatsSection.INSIGHTS
             DAY -> StatsSection.DAYS
             WEEK -> StatsSection.WEEKS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -27,6 +27,9 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
@@ -68,8 +71,8 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        statsSection = arguments?.getSerializable(LIST_TYPE) as? StatsSection
-            ?: activity?.intent?.getSerializableExtra(LIST_TYPE) as? StatsSection
+        statsSection = arguments?.getSerializableCompat(LIST_TYPE)
+            ?: activity?.intent?.getSerializableExtraCompat(LIST_TYPE)
                     ?: StatsSection.INSIGHTS
 
         setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
@@ -80,7 +83,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         layoutManager?.let {
             outState.putParcelable(listStateKey, it.onSaveInstanceState())
         }
-        (activity?.intent?.getSerializableExtra(LIST_TYPE) as? StatsSection)?.let { sectionFromIntent ->
+        (activity?.intent?.getSerializableExtraCompat<StatsSection>(LIST_TYPE))?.let { sectionFromIntent ->
             outState.putSerializable(LIST_TYPE, sectionFromIntent)
         }
         super.onSaveInstanceState(outState)
@@ -110,7 +113,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         } else {
             StaggeredGridLayoutManager(columns, StaggeredGridLayoutManager.VERTICAL)
         }
-        savedInstanceState?.getParcelable<Parcelable>(listStateKey)?.let {
+        savedInstanceState?.getParcelableCompat<Parcelable>(listStateKey)?.let {
             layoutManager.onRestoreInstanceState(it)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/InsightsDetailFragment.kt
@@ -13,7 +13,9 @@ import org.wordpress.android.databinding.StatsDetailFragmentBinding
 import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.util.WPSwipeToRefreshHelper
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
+import java.io.Serializable
 
 @AndroidEntryPoint
 class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
@@ -29,7 +31,9 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
         super.onViewCreated(view, savedInstanceState)
 
         val nonNullActivity = requireActivity()
-        val listType = nonNullActivity.intent.extras?.get(StatsListFragment.LIST_TYPE) as StatsSection
+        val listType = requireNotNull(
+            nonNullActivity.intent.extras?.getSerializableCompat<StatsSection>(StatsListFragment.LIST_TYPE)
+        )
         with(StatsDetailFragmentBinding.bind(view)) {
             with(nonNullActivity as AppCompatActivity) {
                 setSupportActionBar(toolbar)
@@ -52,7 +56,7 @@ class InsightsDetailFragment : Fragment(R.layout.stats_detail_fragment) {
 
     private fun initializeViewModels(activity: FragmentActivity) {
         val siteId = activity.intent?.getIntExtra(WordPress.LOCAL_SITE_ID, 0) ?: 0
-        val listType = activity.intent.extras?.get(StatsListFragment.LIST_TYPE)
+        val listType = activity.intent.extras?.getSerializableCompat<Serializable>(StatsListFragment.LIST_TYPE)
 
         viewModel = when (listType) {
             StatsSection.INSIGHT_DETAIL -> viewsVisitorsDetailViewModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailActivity.kt
@@ -20,6 +20,8 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListFragment
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
+import java.io.Serializable
 
 const val POST_ID = "POST_ID"
 const val POST_TYPE = "POST_TYPE"
@@ -33,7 +35,7 @@ class StatsDetailActivity : LocaleAwareActivity() {
         val binding = StatsDetailActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val listType = intent.extras?.get(StatsListFragment.LIST_TYPE)
+        val listType = intent.extras?.getSerializableCompat<Serializable>(StatsListFragment.LIST_TYPE)
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/StatsDetailFragment.kt
@@ -94,9 +94,9 @@ class StatsDetailFragment : DaggerFragment(R.layout.stats_detail_fragment) {
         statsSiteProvider.start(siteId)
 
         val postId = activity.intent?.getLongExtra(POST_ID, 0L)
-        val postType = activity.intent?.getSerializableExtra(POST_TYPE) as String?
-        val postTitle = activity.intent?.getSerializableExtra(POST_TITLE) as String?
-        val postUrl = activity.intent?.getSerializableExtra(POST_URL) as String?
+        val postType = activity.intent?.getStringExtra(POST_TYPE)
+        val postTitle = activity.intent?.getStringExtra(POST_TITLE)
+        val postUrl = activity.intent?.getStringExtra(POST_URL)
 
         viewModel = ViewModelProvider(this, viewModelFactory)
             .get(StatsSection.DETAIL.name, StatsDetailViewModel::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.toStatsSection
 import org.wordpress.android.ui.stats.refresh.utils.trackWithSection
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.filter
 import java.util.Date
 import javax.inject.Inject
@@ -172,7 +173,7 @@ class SelectedDateProvider
 
     fun onRestoreInstanceState(savedState: Bundle) {
         for (period in listOf(DAYS, WEEKS, MONTHS, YEARS)) {
-            val selectedDate: SelectedDate? = savedState.getParcelable(buildStateKey(period)) as SelectedDate?
+            val selectedDate = savedState.getParcelableCompat<SelectedDate>(buildStateKey(period))
             if (selectedDate != null) {
                 mutableDates[period] = selectedDate
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesMediaPickerResultHandler.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.AddNewStoryWithMedia
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.UTILS
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
@@ -109,8 +110,10 @@ class StoriesMediaPickerResultHandler
 
     private fun isWPStoriesMediaBrowserTypeResult(data: Intent): Boolean {
         if (data.hasExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)) {
-            val browserType = data.getSerializableExtra(MediaBrowserActivity.ARG_BROWSER_TYPE)
-            return (browserType as MediaBrowserType).isWPStoriesPicker
+            val browserType = requireNotNull(
+                data.getSerializableExtraCompat<MediaBrowserType>(MediaBrowserActivity.ARG_BROWSER_TYPE)
+            )
+            return browserType.isWPStoriesPicker
         }
         return false
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.analytics.AnalyticsUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
 
 class StoriesTrackerHelper @Inject constructor() {
@@ -33,7 +34,7 @@ class StoriesTrackerHelper @Inject constructor() {
         val properties = getCommonProperties(event)
         var siteModel: SiteModel? = null
         event.metadata?.let {
-            siteModel = it.getSerializable(WordPress.SITE) as SiteModel
+            siteModel = it.getSerializableCompat(WordPress.SITE)
         }
 
         siteModel?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoriesTrackerHelper.kt
@@ -34,7 +34,7 @@ class StoriesTrackerHelper @Inject constructor() {
         val properties = getCommonProperties(event)
         var siteModel: SiteModel? = null
         event.metadata?.let {
-            siteModel = it.getSerializableCompat(WordPress.SITE)
+            siteModel = it.getSerializableCompat<SiteModel>(WordPress.SITE)
         }
 
         siteModel?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -86,6 +86,10 @@ import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
+import org.wordpress.android.util.extensions.getParcelableExtraCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
@@ -197,10 +201,10 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
     }
 
     private fun initSite(savedInstanceState: Bundle?) {
-        if (savedInstanceState == null) {
-            site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        site = if (savedInstanceState == null) {
+            intent.getSerializableExtraCompat(WordPress.SITE)
         } else {
-            site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+            savedInstanceState.getSerializableCompat(WordPress.SITE)
         }
     }
 
@@ -211,10 +215,10 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
 
         if (savedInstanceState == null) {
             localPostId = getBackingPostIdFromIntent()
-            originalStorySaveResult = intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
+            originalStorySaveResult = intent.getParcelableExtraCompat(KEY_STORY_SAVE_RESULT)
 
             if (intent.hasExtra(ARG_NOTIFICATION_TYPE)) {
-                notificationType = intent.getSerializableExtra(ARG_NOTIFICATION_TYPE) as NotificationType
+                notificationType = intent.getSerializableExtraCompat(ARG_NOTIFICATION_TYPE)
             }
         } else {
             if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
@@ -222,7 +226,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             }
             if (savedInstanceState.containsKey(STATE_KEY_ORIGINAL_STORY_SAVE_RESULT)) {
                 originalStorySaveResult =
-                    savedInstanceState.getParcelable(STATE_KEY_ORIGINAL_STORY_SAVE_RESULT) as StorySaveResult?
+                    savedInstanceState.getParcelableCompat(STATE_KEY_ORIGINAL_STORY_SAVE_RESULT)
             }
         }
 
@@ -370,8 +374,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
         var localPostId = intent.getIntExtra(KEY_POST_LOCAL_ID, 0)
         if (localPostId == 0) {
             if (intent.hasExtra(KEY_STORY_SAVE_RESULT)) {
-                val storySaveResult =
-                    intent.getParcelableExtra(KEY_STORY_SAVE_RESULT) as StorySaveResult?
+                val storySaveResult = intent.getParcelableExtraCompat<StorySaveResult>(KEY_STORY_SAVE_RESULT)
                 storySaveResult?.let {
                     localPostId = it.metadata?.getInt(KEY_POST_LOCAL_ID, 0) ?: 0
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerActivity.kt
@@ -234,8 +234,7 @@ class StoryComposerActivity : ComposeLoopFrameActivity(),
             PostEditorAnalyticsSession.fromBundle(bundle, STATE_KEY_EDITOR_SESSION_DATA, analyticsTrackerWrapper)
         }
 
-        viewModel = ViewModelProvider(this, viewModelFactory)
-            .get(StoryComposerViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[StoryComposerViewModel::class.java]
 
         site?.let {
             val postInitialized = viewModel.start(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.databinding.StoriesIntroDialogFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.setStatusBarAsSurfaceColor
 import javax.inject.Inject
 
@@ -59,7 +60,7 @@ class StoriesIntroDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val site = requireArguments().getSerializable(WordPress.SITE) as SiteModel
+        val site = requireArguments().getSerializableCompat<SiteModel>(WordPress.SITE)
         with(StoriesIntroDialogFragmentBinding.bind(view)) {
             createStoryIntroButton.setOnClickListener { viewModel.onCreateStoryButtonPressed() }
             storiesIntroBackButton.setOnClickListener { viewModel.onBackButtonPressed() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroDialogFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -68,20 +67,20 @@ class StoriesIntroDialogFragment : DialogFragment() {
             storyImageFirst.setOnClickListener { viewModel.onStoryPreviewTapped1() }
             storyImageSecond.setOnClickListener { viewModel.onStoryPreviewTapped2() }
         }
-        viewModel.onCreateButtonClicked.observe(this, Observer {
+        viewModel.onCreateButtonClicked.observe(this) {
             activity?.let {
                 mediaPickerLauncher.showStoriesPhotoPickerForResultAndTrack(it, site)
             }
             dismiss()
-        })
+        }
 
-        viewModel.onDialogClosed.observe(this, Observer {
+        viewModel.onDialogClosed.observe(this) {
             dismiss()
-        })
+        }
 
-        viewModel.onStoryOpenRequested.observe(this, Observer { storyUrl ->
+        viewModel.onStoryOpenRequested.observe(this) { storyUrl ->
             ActivityLauncher.openUrlExternal(context, storyUrl)
-        })
+        }
 
         viewModel.start()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.LONG
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.helpers.MediaFile
 import javax.inject.Inject
 import javax.inject.Named
@@ -239,7 +240,7 @@ class StoryMediaSaveUploadBridge @Inject constructor(
         storiesTrackerHelper.trackStorySaveResultEvent(event)
 
         event.metadata?.let {
-            val site = it.getSerializable(WordPress.SITE) as SiteModel
+            val site = requireNotNull(it.getSerializableCompat<SiteModel>(WordPress.SITE))
             val story = storyRepositoryWrapper.getStoryAtIndex(event.storyIndex)
             saveStoryGutenbergBlockUseCase.saveNewLocalFilesToStoriesPrefsTempSlides(
                 site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.ToastUtils
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.SuggestionAutoCompleteText
 import javax.inject.Inject
@@ -49,8 +50,8 @@ class SuggestionActivity : LocaleAwareActivity() {
             onBackPressedDispatcher.onBackPressedCompat(this)
         }
 
-        val siteModel = intent.getSerializableExtra(INTENT_KEY_SITE_MODEL) as? SiteModel
-        val suggestionType = intent.getSerializableExtra(INTENT_KEY_SUGGESTION_TYPE) as? SuggestionType
+        val siteModel = intent.getSerializableExtraCompat<SiteModel>(INTENT_KEY_SITE_MODEL)
+        val suggestionType = intent.getSerializableExtraCompat<SuggestionType>(INTENT_KEY_SUGGESTION_TYPE)
         when {
             siteModel == null -> abortDueToMissingIntentExtra(INTENT_KEY_SITE_MODEL)
             suggestionType == null -> abortDueToMissingIntentExtra(INTENT_KEY_SUGGESTION_TYPE)

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -36,6 +36,9 @@ inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String)
         getParcelableExtra(key) as T?
     }
 
+/**
+ * This is an Android 13 compatibility function that is not included in IntentCompat.
+ */
 inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializableExtra(key, T::class.java)
@@ -68,6 +71,9 @@ inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: Str
         getParcelableArrayList(key)
     }
 
+/**
+ * This is an Android 13 compatibility function that is not included in BundleCompat.
+ */
 inline fun <reified T : Serializable?> Bundle.getSerializableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getSerializable(key, T::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -57,7 +57,7 @@ inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? 
     }
 
 /**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
  */
 @Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -1,7 +1,12 @@
 package org.wordpress.android.util.extensions
 
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
+import java.io.Serializable
 
 /**
  * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
@@ -18,3 +23,55 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressed()
     onBackPressedCallback.isEnabled = true
 }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(key) as T?
+    }
+
+inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializableExtra(key) as T?
+    }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(key)
+    }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableArrayList(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableArrayList(key)
+    }
+
+inline fun <reified T : Serializable?> Bundle.getSerializableCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializable(key) as T
+    }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/plugins/PluginBrowserViewModel.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.ListDiffCallback
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.FEATURED
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.NEW
 import org.wordpress.android.viewmodel.plugins.PluginBrowserViewModel.PluginListType.POPULAR
@@ -138,7 +139,7 @@ class PluginBrowserViewModel @Inject constructor(
             // read from the bundle
             return
         }
-        site = savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        site = requireNotNull(savedInstanceState.getSerializableCompat(WordPress.SITE))
         searchQuery = requireNotNull(savedInstanceState.getString(KEY_SEARCH_QUERY))
         setTitle(savedInstanceState.getString(KEY_TITLE))
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.NoUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.State.ShowUser
 import org.wordpress.android.ui.accounts.login.jetpack.LoginNoSitesViewModel.UiModel
+import org.wordpress.android.util.extensions.getSerializableCompat
 
 private const val USERNAME = "username"
 private const val DISPLAY_NAME = "display_name"
@@ -152,11 +153,11 @@ class LoginNoSitesViewModelTest : BaseUnitTest() {
     }
 
     private fun setupInstanceStateForNoUser() {
-        whenever(savedInstanceState.getSerializable(KEY_STATE)).thenReturn(NoUser)
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State?>(KEY_STATE)).thenReturn(NoUser)
     }
 
     private fun setupInstanceStateForShowUser() {
-        whenever(savedInstanceState.getSerializable(KEY_STATE)).thenReturn(
+        whenever(savedInstanceState.getSerializableCompat<LoginNoSitesViewModel.State?>(KEY_STATE)).thenReturn(
             ShowUser(
                 userName = USERNAME,
                 displayName = DISPLAY_NAME,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.jetpack.common.providers.JetpackAvailableItemsPr
 import org.wordpress.android.ui.jetpack.usecases.GetActivityLogItemUseCase
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -426,7 +427,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForProgress() {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.PROGRESS.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         whenever(percentFormatter.format(30))
             .thenReturn("30%")
@@ -439,7 +440,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForComplete(backupDownloadState: BackupDownloadState? = null) {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.COMPLETE.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         startViewModel(savedInstanceState)
     }
@@ -447,7 +448,7 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private fun startViewModelForError() {
         whenever(savedInstanceState.getInt(KEY_BACKUP_DOWNLOAD_CURRENT_STEP))
             .thenReturn(BackupDownloadStep.ERROR.id)
-        whenever(savedInstanceState.getParcelable<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
+        whenever(savedInstanceState.getParcelableCompat<BackupDownloadState>(KEY_BACKUP_DOWNLOAD_STATE))
             .thenReturn(backupDownloadState)
         startViewModel(savedInstanceState)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -60,6 +60,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.HtmlMessageUtils
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.text.PercentFormatter
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.util.wizard.WizardNavigationTarget
@@ -459,7 +460,7 @@ class RestoreViewModelTest : BaseUnitTest() {
     private fun startViewModelForStep(step: RestoreStep, restoreState: RestoreState? = null) {
         whenever(savedInstanceState.getInt(KEY_RESTORE_CURRENT_STEP))
             .thenReturn(step.id)
-        whenever(savedInstanceState.getParcelable<RestoreState>(KEY_RESTORE_STATE))
+        whenever(savedInstanceState.getParcelableCompat<RestoreState>(KEY_RESTORE_STATE))
             .thenReturn(restoreState ?: this.restoreState)
         startViewModel(savedInstanceState)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCas
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.SiteCreationDomainPurchasingFeatureConfig
 import org.wordpress.android.util.experiments.SiteCreationDomainPurchasingExperiment
+import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -245,7 +246,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         /* we need to model a real use case of data only existing for steps the user has visited (Segment only in
         this case). Otherwise, subsequent steps' state will be cleared and make the test fail. (issue #10189)*/
         val expectedState = SiteCreationState(segmentId = SEGMENT_ID)
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(expectedState)
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
@@ -266,7 +267,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         whenever(savedInstanceState.getInt(KEY_CURRENT_STEP)).thenReturn(index)
 
         // siteCreationState is not nullable - we need to set it
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(SiteCreationState())
 
         // we need to create a new instance of the VM as the `viewModel` has already been started in setUp()
@@ -290,7 +291,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Test
     fun `given instance state is not null, when start, then site creation accessed is not tracked`() {
         val expectedState = SiteCreationState(segmentId = SEGMENT_ID)
-        whenever(savedInstanceState.getParcelable<SiteCreationState>(KEY_SITE_CREATION_STATE))
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
             .thenReturn(expectedState)
 
         val newViewModel = getNewViewModel()

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.S
 import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.extensions.getParcelableCompat
 
 private const val SUB_DOMAIN = "test"
 private const val DOMAIN = ".wordpress.com"
@@ -302,7 +303,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show fullscreen progress when restoring from SiteNotCreated state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
@@ -311,7 +312,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `service started when restoring from SiteNotCreated state`() {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.startCreateSiteService.value).isNotNull
@@ -319,7 +320,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `show fullscreen progress when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE)).thenReturn(SiteNotCreated)
         initViewModel(bundle)
 
         assertThat(viewModel.uiState.value).isInstanceOf(SitePreviewFullscreenProgressUiState::class.java)
@@ -328,7 +329,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `start pre-loading WebView when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
@@ -337,7 +338,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `fetch newly created SiteModel when restoring from SiteNotInLocalDb state`() = testWithSuccessResponse {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteNotInLocalDb(REMOTE_SITE_ID, false))
         initViewModel(bundle)
 
@@ -346,7 +347,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `start pre-loading WebView when restoring from SiteCreationCompleted state`() {
-        whenever(bundle.getParcelable<CreateSiteState>(KEY_CREATE_SITE_STATE))
+        whenever(bundle.getParcelableCompat<CreateSiteState>(KEY_CREATE_SITE_STATE))
             .thenReturn(SiteCreationCompleted(LOCAL_SITE_ID, false))
         initViewModel(bundle)
 

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/crop/CropViewModel.kt
@@ -23,6 +23,8 @@ import org.wordpress.android.imageeditor.crop.CropViewModel.ImageCropAndSaveStat
 import org.wordpress.android.imageeditor.crop.CropViewModel.UiState.UiLoadedState
 import org.wordpress.android.imageeditor.crop.CropViewModel.UiState.UiStartLoadingWithBundleState
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.OutputData
+import org.wordpress.android.imageeditor.utils.getParcelableCompat
+import org.wordpress.android.imageeditor.utils.getParcelableExtraCompat
 import org.wordpress.android.imageeditor.viewmodel.Event
 import java.io.File
 import java.io.Serializable
@@ -158,10 +160,10 @@ class CropViewModel : ViewModel() {
     private fun createCropResult(cropResultCode: Int, cropData: Intent) = CropResult(cropResultCode, cropData)
 
     private fun getOutputPath(): String =
-        cropOptionsBundleWithFilesInfo.getParcelable<Uri?>(UCrop.EXTRA_OUTPUT_URI)?.path ?: ""
+        cropOptionsBundleWithFilesInfo.getParcelableCompat<Uri>(UCrop.EXTRA_OUTPUT_URI)?.path ?: ""
 
     fun getOutputData(cropResult: CropResult): ArrayList<OutputData> {
-        val imageUri: Uri? = cropResult.data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI)
+        val imageUri = cropResult.data.getParcelableExtraCompat<Uri>(UCrop.EXTRA_OUTPUT_URI)
 
         return if (imageUri != null) {
             arrayListOf(OutputData(imageUri.toString()))

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/preview/PreviewImageFragment.kt
@@ -40,6 +40,8 @@ import org.wordpress.android.imageeditor.preview.PreviewImageViewModel.UiState
 import org.wordpress.android.imageeditor.utils.ToastUtils
 import org.wordpress.android.imageeditor.utils.ToastUtils.Duration
 import org.wordpress.android.imageeditor.utils.UiHelpers
+import org.wordpress.android.imageeditor.utils.getParcelableArrayListExtraCompat
+import org.wordpress.android.imageeditor.utils.getParcelableExtraCompat
 import java.io.File
 
 class PreviewImageFragment : Fragment(R.layout.preview_image_fragment), MenuProvider {
@@ -150,7 +152,7 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment), MenuProv
         viewModel = ViewModelProvider(this@PreviewImageFragment).get(PreviewImageViewModel::class.java)
         parentViewModel = ViewModelProvider(requireActivity()).get(EditImageViewModel::class.java)
         setupObservers()
-        val inputData = nonNullIntent.getParcelableArrayListExtra<EditImageData.InputData>(ARG_EDIT_IMAGE_DATA)
+        val inputData = nonNullIntent.getParcelableArrayListExtraCompat<EditImageData.InputData>(ARG_EDIT_IMAGE_DATA)
 
         inputData?.let { viewModel.onCreateView(it, ImageEditor.instance) }
     }
@@ -186,7 +188,7 @@ class PreviewImageFragment : Fragment(R.layout.preview_image_fragment), MenuProv
                 if (it.resultCode == RESULT_OK) {
                     val data: Intent = it.data
                     if (data.hasExtra(UCrop.EXTRA_OUTPUT_URI)) {
-                        val imageUri = data.getParcelableExtra(UCrop.EXTRA_OUTPUT_URI) as? Uri
+                        val imageUri = data.getParcelableExtraCompat<Uri>(UCrop.EXTRA_OUTPUT_URI)
                         imageUri?.let { uri ->
                             viewModel.onCropResult(uri.toString())
                         }

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
@@ -1,5 +1,9 @@
 package org.wordpress.android.imageeditor.utils
 
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
 
@@ -18,3 +22,39 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressed()
     onBackPressedCallback.isEnabled = true
 }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(key) as T?
+    }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Intent.getParcelableArrayListExtraCompat(key: String): ArrayList<T>? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableArrayListExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableArrayListExtra(key)
+    }
+
+/**
+ * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
+ */
+@Suppress("ForbiddenComment")
+inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelable(key)
+    }


### PR DESCRIPTION
This PR is part of a [parent PR](https://github.com/wordpress-mobile/WordPress-Android/pull/17947) to update compileSdk to 33.

The functions below were deprecated on Android 13. 
`Intent.getParcelableExtra()`
`Intent.getSerializableExtra()`
`Bundle.getParcelable()`
`Bundle.getParcelableArrayList()`
`Bundle.getSerializable()`
To update these functions for Android 13, there are ready-to-use functions in [IntentCompat](https://developer.android.com/reference/androidx/core/content/IntentCompat) and [BundleCompat](https://developer.android.com/reference/androidx/core/app/BundleCompat), but they're available on the `androidx.core:1.10.0-beta01` version, which is not stable yet. I used `CompatExtensions` that I created to update deprecated functions.

To test:
Being able to build and basic smoke test should be enough. 

## Regression Notes
1. Potential unintended areas of impact
Navigation between screens may result in unintended behaviors.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I debugged suspicious changes manually. 

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
