### PR TITLE
[Dependency Updates] Update `androidDesugarVersion` to 1.1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ ext {
     wiremockHttpClientVersion = '4.3.5.1'
 
     // other
-    androidDesugarVersion = '1.1.5'
+    androidDesugarVersion = '1.1.8'
     wordPressLintVersion = '1.1.0'
 }
 


### PR DESCRIPTION
Parent #17559

This PR updates `androidDesugarVersion` to [1.1.8](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs:1.1.8).

FYI:
- Release Notes: [N/A](https://github.com/google/desugar_jdk_libs/releases)
- [Documentation](https://developer.android.com/studio/write/java8-support)
- [Google Maven Repository](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs)

-----

Since [1.1.5](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs:1.1.5) is outdated, with the latest v1 release ([1.2.2](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs:1.2.2)) requiring an update to AGP `7.3.0` and above (see [docs](https://developer.android.com/studio/write/java8-support#library-desugaring-versions)), while the latest v2 release ([2.0.2](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs:2.0.2)) requiring an update to AGP `7.4.0` and above (see [docs](https://developer.android.com/studio/write/java8-support#library-desugaring-versions)), the only possible update at this point is the [1.1.8](https://maven.google.com/web/index.html?q=desug#com.android.tools:desugar_jdk_libs:1.1.8).

-----

PS: @ravishanker I added you as the main reviewer, randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

## To test:

- See the dependency tree diff result and verify correctness.
- Smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.
- In addition to the above smoke test, you can focus on testing push notifications and/or blogging reminders since this was why this library was introduced to this project in the first place (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14698) and [here](https://github.com/orgs/wordpress-mobile/projects/95)).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Not that I can think of, maybe push notifications and/or blogging reminders misbehaviour somehow, but I doubt it.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
