### PR TITLE
Refactor: Replace mutex.lock() with mutex.withLock()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -148,7 +148,6 @@ class UploadStarter @Inject constructor(
     private suspend fun upload(site: SiteModel) = coroutineScope {
         try {
             mutex.withLock {
-
                 val posts = async { postStore.getPostsWithLocalChanges(site) }
                 val pages = async { pageStore.getPagesWithLocalChanges(site) }
                 val list = posts.await() + pages.await()

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ProcessLifecycleOwner
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -13,6 +14,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.UploadActionBuilder
@@ -145,46 +147,45 @@ class UploadStarter @Inject constructor(
      */
     private suspend fun upload(site: SiteModel) = coroutineScope {
         try {
-            mutex.lock()
+            mutex.withLock {
 
-            val posts = async { postStore.getPostsWithLocalChanges(site) }
-            val pages = async { pageStore.getPagesWithLocalChanges(site) }
-            val list = posts.await() + pages.await()
+                val posts = async { postStore.getPostsWithLocalChanges(site) }
+                val pages = async { pageStore.getPagesWithLocalChanges(site) }
+                val list = posts.await() + pages.await()
 
-            list.asSequence()
-                .map { post ->
-                    val action = uploadActionUseCase.getAutoUploadAction(post, site)
-                    Pair(post, action)
-                }
-                .filter { (_, action) ->
-                    action != DO_NOTHING
-                }
-                .toList()
-                .forEach { (post, action) ->
-                    trackAutoUploadAction(action, post.status, post.isPage)
-                    AppLog.d(
-                        AppLog.T.POSTS,
-                        "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
-                    )
-                    dispatcher.dispatch(
-                        UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(
-                            post
+                list.asSequence()
+                    .map { post ->
+                        val action = uploadActionUseCase.getAutoUploadAction(post, site)
+                        Pair(post, action)
+                    }
+                    .filter { (_, action) ->
+                        action != DO_NOTHING
+                    }
+                    .toList()
+                    .forEach { (post, action) ->
+                        trackAutoUploadAction(action, post.status, post.isPage)
+                        AppLog.d(
+                            AppLog.T.POSTS,
+                            "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
                         )
-                    )
-                    uploadServiceFacade.uploadPost(
-                        context = context,
-                        post = post,
-                        trackAnalytics = false
-                    )
-                }
-        } finally {
-            // If the job of the current coroutine is cancelled while the `lock()` call is suspended,
-            // it results in the mutex ending up unlocked.
-            // We introduced this check to prevent IllegalStateExceptions when `unlock` is called in those cases.
-            // See: https://github.com/wordpress-mobile/WordPress-Android/issues/17463
-            if (mutex.isLocked) {
-                mutex.unlock()
+                        dispatcher.dispatch(
+                            UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(
+                                post
+                            )
+                        )
+                        uploadServiceFacade.uploadPost(
+                            context = context,
+                            post = post,
+                            trackAnalytics = false
+                        )
+                    }
             }
+        } catch (e: CancellationException) {
+            AppLog.e(T.MEDIA, e)
+            // Do any needed actions while we are still holding the mutex lock, then release it and rethrow the
+            // exception so it can be handled upstream
+            mutex.unlock()
+            throw e
         }
     }
 


### PR DESCRIPTION
Parent #17463 
(CompletionHandlerException: Exception in resume onCancellation handler for CancellableContinuation(DispatchedContinuation[Dis...)

The goal of this PR is to try and fix the `IllegalStateException: Mutex is not locked` issue that occurs when uploading local changes. 

The intent is to change from using `mutex.lock()` to `mutex.withLocking()`. This should ensure that we have access to the locked mutex before trying to unlock it. The theory behind this is that we may be experiencing a race condition since `mutex.isLocked()` only gives us the "at this moment" answer, another process could have come in before we get to the unlock. 

Using `withLock` should automatically manage the locking/unlocking of the mutex, and in addition, we can call mutex.unlock() when we experience a `CancellationException` without needing to check the `isLocked` beforehand.

If anyone thinks this is a bad idea, we can nix it. Figured it was worth a try. :)

To test:
There is nothing specific to test; as we haven't been able to reproduce this crash. 
Please take the apps out for a generic spin - create/update some posts, turn networking on/off, etc.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
