### PR TITLE
Enable forum support for all on WP

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -103,8 +103,7 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP &&
-                !SiteUtils.hasSiteWithPaidPlan(siteStore)
+            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
             ) {
                 showSupportForum()
             } else {
@@ -198,7 +197,10 @@ class HelpActivity : LocaleAwareActivity() {
             AnalyticsTracker.track(Stat.SUPPORT_MIGRATION_FAQ_VIEWED)
             JpFaqContainer.setOnClickListener { showMigrationFaq() }
         }
+        showContactSupport()
+    }
 
+    private fun HelpActivityBinding.showContactSupport() {
         contactUsButton.setOnClickListener { createNewZendeskTicket() }
         ticketsButton.setOnClickListener { showZendeskTickets() }
 
@@ -226,9 +228,13 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun HelpActivityBinding.showSupportForum() {
-        contactUsButton.isVisible = false
-        ticketsButton.isVisible = false
-        contactEmailContainer.isVisible = false
+        if (SiteUtils.hasSiteWithPaidPlan(siteStore)) {
+            showContactSupport()
+        } else {
+            contactUsButton.isVisible = false
+            ticketsButton.isVisible = false
+            contactEmailContainer.isVisible = false
+        }
 
         forumContainer.run {
             isVisible = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -103,8 +103,7 @@ class HelpActivity : LocaleAwareActivity() {
                 actionBar.elevation = 0f // remove shadow
             }
 
-            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP
-            ) {
+            if (wpSupportForumFeatureConfig.isEnabled() && !BuildConfig.IS_JETPACK_APP) {
                 showSupportForum()
             } else {
                 showContactUs()
@@ -197,10 +196,6 @@ class HelpActivity : LocaleAwareActivity() {
             AnalyticsTracker.track(Stat.SUPPORT_MIGRATION_FAQ_VIEWED)
             JpFaqContainer.setOnClickListener { showMigrationFaq() }
         }
-        showContactSupport()
-    }
-
-    private fun HelpActivityBinding.showContactSupport() {
         contactUsButton.setOnClickListener { createNewZendeskTicket() }
         ticketsButton.setOnClickListener { showZendeskTickets() }
 
@@ -228,13 +223,9 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun HelpActivityBinding.showSupportForum() {
-        if (SiteUtils.hasSiteWithPaidPlan(siteStore)) {
-            showContactSupport()
-        } else {
-            contactUsButton.isVisible = false
-            ticketsButton.isVisible = false
-            contactEmailContainer.isVisible = false
-        }
+        contactUsButton.isVisible = false
+        ticketsButton.isVisible = false
+        contactEmailContainer.isVisible = false
 
         forumContainer.run {
             isVisible = true

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -368,16 +368,6 @@ public class SiteUtils {
         return site.getPlanId() == PlansConstants.FREE_PLAN_ID;
     }
 
-    public static boolean hasSiteWithPaidPlan(SiteStore siteStore) {
-        for (SiteModel site : siteStore.getSites()) {
-            if (site.getPlanId() != 0 && !site.getHasFreePlan()) {
-                // The plan id is 0 if a self-hosted site is added without logging in.
-                return true;
-            }
-        }
-        return false;
-    }
-
     public static boolean onBloggerPlan(@NonNull SiteModel site) {
         return site.getPlanId() == PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
                || site.getPlanId() == PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID;

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -9,7 +9,6 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
 import org.wordpress.android.ui.plans.PlansConstants.BLOGGER_PLAN_TWO_YEARS_ID
@@ -30,9 +29,6 @@ class SiteUtilsTest {
     @Mock
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
-    @Mock
-    private lateinit var siteStore: SiteStore
-
     @Test
     fun `onFreePlan returns true when site is on free plan`() {
         val site = SiteModel()
@@ -42,23 +38,6 @@ class SiteUtilsTest {
 
         site.planId = PREMIUM_PLAN_ID
         assertFalse(SiteUtils.onFreePlan(site))
-    }
-
-    @Test
-    fun `hasSiteWithPaidPlan returns true when site is on a paid plan`() {
-        val site1 = SiteModel()
-        val site2 = SiteModel()
-        whenever(siteStore.sites).thenReturn(listOf(site1, site2))
-
-        site1.hasFreePlan = true
-        site2.hasFreePlan = true
-        site1.planId = FREE_PLAN_ID
-        site2.planId = FREE_PLAN_ID
-        assertFalse(SiteUtils.hasSiteWithPaidPlan(siteStore))
-
-        site2.hasFreePlan = false
-        site2.planId = BLOGGER_PLAN_ONE_YEAR_ID
-        assertTrue(SiteUtils.hasSiteWithPaidPlan(siteStore))
     }
 
     @Test


### PR DESCRIPTION
Enable showing forum for all

Fixes #18042 

|before |after|
|-|-|
|![Screenshot_20230309_115544](https://user-images.githubusercontent.com/990349/223892501-cff04743-a571-4601-a3e8-cffd38998dfe.png)|![Screenshot_20230310_111033](https://user-images.githubusercontent.com/990349/224190815-7af99601-8843-4b6b-949f-4202d9754be6.png)|


To test:
**WordPress**
1. Launch the WP app and log in.
2. Ensure you have selected a site with a paid plan.
3. Navigate to "Me → Help & Support".
4. Verify that  only Community forums is shown.
5. Tap the various options and ensure they're all working

**Jetpack** 
Repeat the tests above on Jetpack app. You should see only "Contact Support" for both cases.

## Regression Notes
1. Potential unintended areas of impact
check with both free and paid plans

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
