### PR TITLE
Remove large titles

### DIFF
--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -19,15 +19,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/prominent_toolbar_with_tabs_height">
-
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsing_toolbar"
-            style="@style/WordPress.CollapsedToolbarLayout"
-            android:layout_width="match_parent"
-            app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
-            app:expandedTitleTextAppearance="@style/TextAppearance.App.Toolbar.Title"
-            android:layout_height="@dimen/prominent_toolbar_height">
+        android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar_main"
@@ -35,8 +27,6 @@
                 android:layout_height="@dimen/toolbar_height"
                 app:layout_collapseMode="pin"
                 app:theme="@style/WordPress.ActionBar" />
-
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -25,7 +25,7 @@
                 android:id="@+id/toolbar_main"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/toolbar_height"
-                app:layout_collapseMode="pin"
+                app:layout_scrollFlags="scroll|enterAlways"
                 app:theme="@style/WordPress.ActionBar" />
 
         <com.google.android.material.tabs.TabLayout

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -26,6 +26,7 @@
             style="@style/WordPress.CollapsedToolbarLayout"
             android:layout_width="match_parent"
             app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
+            app:expandedTitleTextAppearance="@style/TextAppearance.App.Toolbar.Title"
             android:layout_height="@dimen/prominent_toolbar_height">
 
             <com.google.android.material.appbar.MaterialToolbar

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -8,15 +8,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/prominent_toolbar_with_tabs_height">
-
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsing_toolbar"
-            style="@style/WordPress.CollapsedToolbarLayout"
-            android:layout_width="match_parent"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed"
-            app:expandedTitleTextAppearance="@style/TextAppearance.App.Toolbar.Title"
-            android:layout_height="@dimen/prominent_toolbar_height">
+        android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
@@ -24,8 +16,6 @@
                 app:layout_collapseMode="pin"
                 android:layout_height="@dimen/toolbar_height"
                 app:theme="@style/WordPress.ActionBar" />
-
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -13,7 +13,7 @@
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                app:layout_collapseMode="pin"
+                app:layout_scrollFlags="scroll|enterAlways"
                 android:layout_height="@dimen/toolbar_height"
                 app:theme="@style/WordPress.ActionBar" />
 

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -15,6 +15,7 @@
             style="@style/WordPress.CollapsedToolbarLayout"
             android:layout_width="match_parent"
             app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            app:expandedTitleTextAppearance="@style/TextAppearance.App.Toolbar.Title"
             android:layout_height="@dimen/prominent_toolbar_height">
 
             <com.google.android.material.appbar.MaterialToolbar

--- a/WordPress/src/main/res/layout/reader_home_settings_menu_action_layout.xml
+++ b/WordPress/src/main/res/layout/reader_home_settings_menu_action_layout.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_medium_large"
         android:layout_marginStart="@dimen/margin_medium_large"
-        android:src="@drawable/ic_cog_white_24dp"
+        android:src="@drawable/ic_reader_following_white_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -11,8 +11,6 @@
     <dimen name="me_menu_width">64dp</dimen>
     <dimen name="me_menu_avatar_end_offset">11dp</dimen>
     <dimen name="toolbar_height">56dp</dimen>
-    <dimen name="prominent_toolbar_height">112dp</dimen>
-    <dimen name="prominent_toolbar_with_tabs_height">168dp</dimen>
     <dimen name="toolbar_content_offset">72dp</dimen>
     <dimen name="toolbar_content_offset_end">0dp</dimen>
     <dimen name="collapsible_toolbar_expanded_bottom_margin">28dp</dimen>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -39,19 +39,16 @@
 
     <!-- TextAppearance -->
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
-        <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="fontFamily">serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 


### PR DESCRIPTION
This PR updates the following
- Update the icon Reader from cog to following
- Removes collapsing toolbar and large title with it on Reader
- Removes collapsing toolbar and large title with it on Notifications
- Removes serif on title fonts

|Before|Rader|Notifications|
|-|-|-|
|![Screenshot_20230309_155059](https://user-images.githubusercontent.com/990349/223920813-6d28b2c4-8a82-458f-98b9-7b5435df0465.png)|![Screenshot_20230310_120015](https://user-images.githubusercontent.com/990349/224197415-175cbdd3-d5dd-4445-900f-1ae7218b2c85.png)|![Screenshot_20230310_120035](https://user-images.githubusercontent.com/990349/224197461-e0260c46-b973-4c99-a642-b98fb05ba607.png)|


Fixes #

To test:

- Launch WP/JP app
- Navigate to Reader
- Compare the title is smaller with sans-serif, and icon is following
- Navigate to Notifications
- Compare that title is now smaller and with sans-serif font

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
