### PR TITLE
[UI Tests] Adjust "e2eAllDayStatsLoad" for JP

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -19,9 +18,6 @@ import org.wordpress.android.util.StatsVisitsData
 class StatsTests : BaseTest() {
     @Before
     fun setUp() {
-        // Ignore the test for JP because of the bug with stats card load.
-        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
-        org.junit.Assume.assumeTrue(!BuildConfig.IS_JETPACK_APP)
         logoutIfNecessary()
         wpLogin()
     }
@@ -45,7 +41,6 @@ class StatsTests : BaseTest() {
         val countriesList: List<StatsKeyValueData> = StatsMocksReader().readDayCountriesToList()
         val videosList: List<StatsKeyValueData> = StatsMocksReader().readDayVideoPlaysToList()
         val downloadsList: List<StatsKeyValueData> = StatsMocksReader().readDayFileDownloadsToList()
-
         MySitesPage()
             .go()
             .goToStats()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -18,6 +19,7 @@ import org.wordpress.android.util.StatsVisitsData
 class StatsTests : BaseTest() {
     @Before
     fun setUp() {
+        org.junit.Assume.assumeTrue("jetpack" in BuildConfig.FLAVOR)
         logoutIfNecessary()
         wpLogin()
     }
@@ -41,6 +43,7 @@ class StatsTests : BaseTest() {
         val countriesList: List<StatsKeyValueData> = StatsMocksReader().readDayCountriesToList()
         val videosList: List<StatsKeyValueData> = StatsMocksReader().readDayVideoPlaysToList()
         val downloadsList: List<StatsKeyValueData> = StatsMocksReader().readDayFileDownloadsToList()
+
         MySitesPage()
             .go()
             .goToStats()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -19,7 +19,9 @@ import org.wordpress.android.util.StatsVisitsData
 class StatsTests : BaseTest() {
     @Before
     fun setUp() {
-        org.junit.Assume.assumeTrue("jetpack" in BuildConfig.FLAVOR)
+        // Ignore the test for JP because of the bug with stats card load.
+        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
+        org.junit.Assume.assumeTrue(!BuildConfig.IS_JETPACK_APP)
         logoutIfNecessary()
         wpLogin()
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -69,41 +69,39 @@ class StatsPage {
     fun assertVisits(visitsData: StatsVisitsData): StatsPage {
         // Skip this check for JP because of the bug with Stats card load.
         // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
-        if (BuildConfig.IS_JETPACK_APP) {
-            return this
-        }
-
-        val cardStructure = Espresso.onView(
-            Matchers.allOf(
-                ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),
-                ViewMatchers.withId(R.id.stats_block_list),
-                ViewMatchers.hasDescendant(
-                    Matchers.allOf(
-                        ViewMatchers.withText("Views"),
-                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.views))
-                    )
-                ),
-                ViewMatchers.hasDescendant(
-                    Matchers.allOf(
-                        ViewMatchers.withText("Visitors"),
-                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.visitors))
-                    )
-                ),
-                ViewMatchers.hasDescendant(
-                    Matchers.allOf(
-                        ViewMatchers.withText("Likes"),
-                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.likes))
-                    )
-                ),
-                ViewMatchers.hasDescendant(
-                    Matchers.allOf(
-                        ViewMatchers.withText("Comments"),
-                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.comments))
+        if (!BuildConfig.IS_JETPACK_APP) {
+            val cardStructure = Espresso.onView(
+                Matchers.allOf(
+                    ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),
+                    ViewMatchers.withId(R.id.stats_block_list),
+                    ViewMatchers.hasDescendant(
+                        Matchers.allOf(
+                            ViewMatchers.withText("Views"),
+                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.views))
+                        )
+                    ),
+                    ViewMatchers.hasDescendant(
+                        Matchers.allOf(
+                            ViewMatchers.withText("Visitors"),
+                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.visitors))
+                        )
+                    ),
+                    ViewMatchers.hasDescendant(
+                        Matchers.allOf(
+                            ViewMatchers.withText("Likes"),
+                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.likes))
+                        )
+                    ),
+                    ViewMatchers.hasDescendant(
+                        Matchers.allOf(
+                            ViewMatchers.withText("Comments"),
+                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.comments))
+                        )
                     )
                 )
             )
-        )
-        cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
+            cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
+        }
         return this
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -5,6 +5,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.Matchers
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.support.WPSupportUtils
 import org.wordpress.android.util.StatsKeyValueData
@@ -66,6 +67,12 @@ class StatsPage {
     }
 
     fun assertVisits(visitsData: StatsVisitsData): StatsPage {
+        // Skip this check for JP because of the bug with Stats card load.
+        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
+        if (BuildConfig.IS_JETPACK_APP) {
+            return this
+        }
+
         val cardStructure = Espresso.onView(
             Matchers.allOf(
                 ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),


### PR DESCRIPTION
### What
Even though the initial intention of this PR was to fix a test in question, it appeared that the fail is caused by a kind of real issue with an app: #18065 

I wrote "kind of" because it's reproducible on Emulators only, so far, which lowers the chances that it will be fixed, but still causes `e2eAllDayStatsLoad ` test to fail on Jetpack.

### How
~I disabled the test only for Jetpack. I see no better measure as long as the bug mentioned above exists~
After some thought, I disabled only the `assertVisits` call for JP (this is where the content of the card with loading issue is checked). #18065 might not be fixed for a long time, so IMO it makes sense to still have 90% of the test running on JP rather than 0%.

### To test
- Execution is green on CI ([JP](https://buildkite.com/automattic/wordpress-android/builds/9847#0186c809-a38e-440c-82df-c152bf78ad01), [WP](https://buildkite.com/automattic/wordpress-android/builds/9847#0186c809-a38b-4345-8311-9f8593855a87))