### PR TITLE
[Gutenberg] Allow audio upload to premium users after Jetpack features removal

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2378,7 +2378,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     false,
                     true,
                     false,
-                    false,
+                    !isFreeWPCom,
                     shouldUseFastImage,
                     false,
                     wpcomLocaleSlug,


### PR DESCRIPTION
This PR fixes a bug where premium users can't upload Audio files after the Jetpack features are removed. This issue was introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/17587.

**NOTE:** The issue addressed in this PR is only affecting the WordPress app as the removal of Jetpack features is only applied in that app.

## To test
**Preparation:**
1. Open the WordPress app.
2. Go to "Debug settings" screen via "Me -> App Settings" screen.
3. Enable "jp_removal_four" (this flag will remove Jetpack features)

### Simple site - **Paid plan**
1. Go to a Simple site with a paid plan.
2. Open/create a post.
4. Add an Audio block.
5. In the "Choose audio" picker, observe that it displays the following options:
  - WordPress Media Library
  - Insert from URL
  - Other Apps

### Simple site - **Free site**
1. Go to a Simple site with the free plan.
2. Open/create a post.
3. Add an Audio block.
4. In the "Choose audio" picker, observe that it only displays the option "Insert from URL".

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
