### PR TITLE
Update deprecated PackageManager functions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PackageManagerWrapper.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.extensions.getActivityInfoCompat
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,7 +39,7 @@ class PackageManagerWrapper @Inject constructor(
         intent.component?.let {
             try {
                 val context = contextProvider.getContext()
-                val activityInfo = context.packageManager.getActivityInfo(it, PackageManager.GET_META_DATA)
+                val activityInfo = context.packageManager.getActivityInfoCompat(it, PackageManager.GET_META_DATA)
                 return activityInfo.labelRes
             } catch (ex: PackageManager.NameNotFoundException) {
                 AppLog.e(T.UTILS, "Unable to extract label res from activity info")

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -1,6 +1,10 @@
 package org.wordpress.android.util.extensions
 
+import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcel
@@ -108,3 +112,19 @@ inline fun <reified T> Parcel.readListCompat(outVal: MutableList<T?>, loader: Cl
         readList(outVal, loader)
     }
 }
+
+fun PackageManager.getActivityInfoCompat(componentName: ComponentName, flags: Int): ActivityInfo =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getActivityInfo(componentName, PackageManager.ComponentInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getActivityInfo(componentName, flags)
+    }
+
+fun PackageManager.getPackageInfoCompat(packageName: String, flags: Int): PackageInfo? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getPackageInfo(packageName, flags)
+    }

--- a/WordPress/src/main/java/org/wordpress/android/util/publicdata/PackageManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/publicdata/PackageManagerWrapper.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.util.publicdata
 
 import android.content.pm.PackageInfo
+import org.wordpress.android.util.extensions.getPackageInfoCompat
 import org.wordpress.android.viewmodel.ContextProvider
 import javax.inject.Inject
 
 class PackageManagerWrapper @Inject constructor(private val contextProvider: ContextProvider) {
     fun getPackageInfo(packageName: String, flags: Int = 0): PackageInfo? =
-        contextProvider.getContext().packageManager.getPackageInfo(packageName, flags)
+        contextProvider.getContext().packageManager.getPackageInfoCompat(packageName, flags)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/signature/SignatureUtils.kt
@@ -4,6 +4,7 @@ import android.annotation.TargetApi
 import android.content.pm.PackageManager
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import org.wordpress.android.util.extensions.getPackageInfoCompat
 import org.wordpress.android.viewmodel.ContextProvider
 import java.security.MessageDigest
 import javax.inject.Inject
@@ -28,8 +29,11 @@ class SignatureUtils @Inject constructor(
         trustedPackageId: String,
         trustedSignatureHash: String
     ): Boolean = try {
-        val signingInfo = contextProvider.getContext().packageManager.getPackageInfo(
-            trustedPackageId, PackageManager.GET_SIGNING_CERTIFICATES
+        val signingInfo = requireNotNull(
+            contextProvider.getContext().packageManager.getPackageInfoCompat(
+                trustedPackageId,
+                PackageManager.GET_SIGNING_CERTIFICATES
+            )
         ).signingInfo
         if (signingInfo.hasMultipleSigners()) {
             throw SignatureNotFoundException()


### PR DESCRIPTION
This PR is part of a [parent PR](https://github.com/wordpress-mobile/WordPress-Android/pull/17947) to update compileSdk to 33.

`PackageManager#getActivityInfo(ComponentName, int)` and `PackageManager#getPackageInfo(String, int)` were deprecated on Android 13. Extension functions have been added to `CopatExtensions` to replace deprecated functions.

To test:
Being able to build and basic smoke test should be enough.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
This doesn't introduce any change, so no tests added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
