### PR TITLE
Update my site dashboard cards styles

### DIFF
--- a/WordPress/src/jetpack/res/drawable/ic_splash.xml
+++ b/WordPress/src/jetpack/res/drawable/ic_splash.xml
@@ -1,12 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="25dp"
-    android:height="24dp"
-    android:viewportHeight="24"
-    android:viewportWidth="25">
+    android:width="44dp"
+    android:height="44dp"
+    android:viewportWidth="44"
+    android:viewportHeight="44">
   <path
-      android:fillColor="#ffffff"
-      android:pathData="M12.5,0L12.5,0A12,12 0,0 1,24.5 12L24.5,12A12,12 0,0 1,12.5 24L12.5,24A12,12 0,0 1,0.5 12L0.5,12A12,12 0,0 1,12.5 0z" />
+      android:pathData="M22,44C34.15,44 44,34.15 44,22C44,9.85 34.15,0 22,0C9.85,0 0,9.85 0,22C0,34.15 9.85,44 22,44Z"
+      android:fillColor="#069E08"/>
   <path
-      android:fillColor="#069E08"
-      android:pathData="M12.5,0C5.889,0 0.5,5.374 0.5,12C0.5,18.626 5.874,24 12.5,24C19.126,24 24.5,18.626 24.5,12C24.5,5.374 19.126,0 12.5,0ZM11.882,13.988H5.904L11.882,2.356V13.988ZM13.104,21.615V9.983H19.067L13.104,21.615Z" />
+      android:pathData="M23.092,18.305V39.633L34.092,18.305H23.092Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M20.867,25.653V4.366L9.908,25.653H20.867Z"
+      android:fillColor="#ffffff"/>
 </vector>

--- a/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
@@ -1,15 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="44dp"
-    android:height="44dp"
-    android:viewportWidth="44"
-    android:viewportHeight="44">
+    android:width="25dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="25">
   <path
-      android:pathData="M22,44C34.15,44 44,34.15 44,22C44,9.85 34.15,0 22,0C9.85,0 0,9.85 0,22C0,34.15 9.85,44 22,44Z"
-      android:fillColor="#069E08"/>
+      android:fillColor="#ffffff"
+      android:pathData="M12.5,0L12.5,0A12,12 0,0 1,24.5 12L24.5,12A12,12 0,0 1,12.5 24L12.5,24A12,12 0,0 1,0.5 12L0.5,12A12,12 0,0 1,12.5 0z" />
   <path
-      android:pathData="M23.092,18.305V39.633L34.092,18.305H23.092Z"
-      android:fillColor="#ffffff"/>
-  <path
-      android:pathData="M20.867,25.653V4.366L9.908,25.653H20.867Z"
-      android:fillColor="#ffffff"/>
+      android:fillColor="#069E08"
+      android:pathData="M12.5,0C5.889,0 0.5,5.374 0.5,12C0.5,18.626 5.874,24 12.5,24C19.126,24 24.5,18.626 24.5,12C24.5,5.374 19.126,0 12.5,0ZM11.882,13.988H5.904L11.882,2.356V13.988ZM13.104,21.615V9.983H19.067L13.104,21.615Z" />
 </vector>

--- a/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_jetpack_logo_green_24dp.xml
@@ -1,12 +1,15 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="25dp"
-    android:height="24dp"
-    android:viewportHeight="24"
-    android:viewportWidth="25">
+    android:width="44dp"
+    android:height="44dp"
+    android:viewportWidth="44"
+    android:viewportHeight="44">
   <path
-      android:fillColor="#ffffff"
-      android:pathData="M12.5,0L12.5,0A12,12 0,0 1,24.5 12L24.5,12A12,12 0,0 1,12.5 24L12.5,24A12,12 0,0 1,0.5 12L0.5,12A12,12 0,0 1,12.5 0z" />
+      android:pathData="M22,44C34.15,44 44,34.15 44,22C44,9.85 34.15,0 22,0C9.85,0 0,9.85 0,22C0,34.15 9.85,44 22,44Z"
+      android:fillColor="#069E08"/>
   <path
-      android:fillColor="#069E08"
-      android:pathData="M12.5,0C5.889,0 0.5,5.374 0.5,12C0.5,18.626 5.874,24 12.5,24C19.126,24 24.5,18.626 24.5,12C24.5,5.374 19.126,0 12.5,0ZM11.882,13.988H5.904L11.882,2.356V13.988ZM13.104,21.615V9.983H19.067L13.104,21.615Z" />
+      android:pathData="M23.092,18.305V39.633L34.092,18.305H23.092Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M20.867,25.653V4.366L9.908,25.653H20.867Z"
+      android:fillColor="#ffffff"/>
 </vector>

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -14,28 +14,17 @@
         android:paddingEnd="@dimen/my_site_card_row_padding"
         android:paddingBottom="@dimen/margin_small">
 
-        <ImageView
-            android:id="@+id/title_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:importantForAccessibility="no"
-            android:src="@drawable/ic_outline_lightbulb_white_24dp"
-            android:tint="?attr/colorOnSurface"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/card_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_small_medium"
             android:ellipsize="end"
             android:maxLines="1"
             android:text="@string/my_site_blogging_prompt_card_title"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceSubtitle1"
             app:layout_constraintEnd_toStartOf="@+id/blogging_prompt_card_menu"
-            app:layout_constraintStart_toEndOf="@+id/title_icon"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <ImageView

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -23,6 +23,8 @@
             android:text="@string/my_site_blogging_prompt_card_title"
             android:textAlignment="viewStart"
             android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textSize="@dimen/text_sz_medium"
+            android:textStyle="bold"
             app:layout_constraintEnd_toStartOf="@+id/blogging_prompt_card_menu"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/WordPress/src/main/res/layout/my_site_card_toolbar.xml
+++ b/WordPress/src/main/res/layout/my_site_card_toolbar.xml
@@ -10,18 +10,6 @@
     android:paddingTop="@dimen/my_site_card_row_top_padding"
     tools:showIn="@layout/quick_start_card">
 
-    <ImageView
-        android:id="@+id/my_site_card_toolbar_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="@null"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="?attr/wpColorOnSurfaceMedium"
-        android:src="@drawable/ic_posts_white_24dp"
-        tools:visibility="visible"/>
-
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/my_site_card_toolbar_title"
         android:layout_width="0dp"
@@ -34,10 +22,8 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/my_site_card_toolbar_more"
-        app:layout_constraintStart_toEndOf="@+id/my_site_card_toolbar_icon"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:paddingStart="@dimen/margin_medium"
-        android:paddingEnd="@dimen/margin_medium"
         tools:text="@string/quick_start_sites" />
 
     <ImageView

--- a/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
+++ b/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
@@ -106,32 +106,18 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <ImageView
-            android:id="@+id/title_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@null"
-            android:visibility="visible"
-            android:layout_marginTop="@dimen/margin_medium_large"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/wpColorOnSurfaceMedium"
-            android:src="@drawable/ic_stats_alt_white_24dp" />
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/title"
             style="@style/MySiteTodaysStatsCardTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/my_site_todays_stat_card_title"
-            app:layout_constraintBottom_toBottomOf="@+id/title_icon"
+            android:layout_marginTop="@dimen/margin_medium_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toEndOf="@+id/title_icon"
-            app:layout_constraintTop_toTopOf="@+id/title_icon" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/get_more_views_message"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -727,7 +727,7 @@
     <!-- quick link ribbon -->
     <dimen name="quick_link_ribbon_padding_start">18dp</dimen>
     <dimen name="quick_link_ribbon_icon_size">24dp</dimen>
-    <dimen name="quick_link_ribbon_corner_radius">4dp</dimen>
+    <dimen name="quick_link_ribbon_corner_radius">10dp</dimen>
     <dimen name="quick_link_ribbon_icon_padding">16dp</dimen>
 
     <!-- Jetpack Migration Flow -->

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1441,6 +1441,7 @@
         <item name="strokeColor">@color/on_surface_divider</item>
         <item name="strokeWidth">@dimen/unelevated_card_stroke_width</item>
         <item name="contentPadding">@dimen/unelevated_card_stroke_width</item>
+        <item name="cardCornerRadius">@dimen/quick_start_task_card_view_corner_radius</item>
     </style>
 
     <style name="FullScreenDialogFragmentAnimation" parent="@android:style/Theme.Panel">
@@ -1840,7 +1841,7 @@
         <item name="android:paddingStart">@dimen/quick_link_ribbon_padding_start</item>
         <item name="android:paddingTop">@dimen/margin_large</item>
         <item name="android:paddingBottom">@dimen/margin_large</item>
-        <item name="android:fontFamily">serif</item>
+        <item name="android:fontFamily">san-serif</item>
         <item name="android:letterSpacing">0</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textColor">?attr/colorOnSurface</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -453,7 +453,6 @@
         <item name="android:maxLines">1</item>
         <item name="android:ellipsize">end</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:fontFamily">serif</item>
         <item name="android:alpha">@dimen/material_emphasis_high_type</item>
     </style>
 
@@ -828,7 +827,6 @@
         <item name="android:textSize">@dimen/text_sz_double_extra_large</item>
         <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:fontFamily">serif</item>
         <item name="android:layout_marginTop">@dimen/margin_extra_small</item>
         <item name="android:layout_marginBottom">@dimen/margin_large</item>
         <item name="android:alpha">@dimen/material_emphasis_high_type</item>


### PR DESCRIPTION
This PR updates the MySite dashboard card styles for Stats card, Posts card, Prompts card
- Remove icon in the title
- Update font to sans-serif
- Update cardCornerRadius to 10dp
- Update Jetpack logo


<img width=320 src="https://user-images.githubusercontent.com/990349/224586948-18a0620e-ae72-4512-add1-e5eaf37a1849.png" />


To test:

- Launch WP or JP app
- Go to MySite and select Home
- Verify that the Stats, Posts and Prompts cards now do not show icon in the title, and font is sans-serif

>**Note**
> **Work on a draft post** on Android has **Go to drafts** action link on the card at the bottom

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
