### PR TITLE
Blaze: Fix view not scrolling for large font size/displays

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -19,8 +19,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -106,9 +107,7 @@ class BlazeOverlayFragment : Fragment() {
         }
         Scaffold(
             topBar = { OverlayTopBar(blazeUIModel) },
-        ) {
-            ScrollableBox(blazeUIModel, isDarkTheme)
-        }
+        ) { BlazeOverlayContent(blazeUIModel, isDarkTheme) }
     }
 
     @Composable
@@ -146,11 +145,10 @@ class BlazeOverlayFragment : Fragment() {
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(
-                top = Margin.ExtraLarge.value,
-                start = Margin.ExtraLarge.value,
-                end = Margin.ExtraLarge.value
-            )
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(Margin.ExtraLarge.value)
         ) {
             Image(
                 painterResource(id = R.drawable.ic_blaze_overlay_image),
@@ -202,18 +200,6 @@ class BlazeOverlayFragment : Fragment() {
                 drawableRight = Drawable(R.drawable.ic_promote_with_blaze),
                 onClick = { viewModel.onPromoteWithBlazeClicked() },
             )
-        }
-    }
-
-    @Composable
-    fun ScrollableBox(uiModel: BlazeUIModel?,
-                      isDarkTheme: Boolean) {
-        Box(Modifier.fillMaxSize()) {
-            LazyColumn(Modifier.fillMaxSize()) {
-                items(1) {
-                    BlazeOverlayContent(uiModel, isDarkTheme)
-                }
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -108,7 +108,6 @@ class BlazeOverlayFragment : Fragment() {
             topBar = { OverlayTopBar(blazeUIModel) },
         ) {
             ScrollableBox(blazeUIModel, isDarkTheme)
-         //   BlazeOverlayContent(blazeUIModel, isDarkTheme)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -13,13 +13,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -107,7 +107,8 @@ class BlazeOverlayFragment : Fragment() {
         Scaffold(
             topBar = { OverlayTopBar(blazeUIModel) },
         ) {
-            BlazeOverlayContent(blazeUIModel, isDarkTheme)
+            ScrollableBox(blazeUIModel, isDarkTheme)
+         //   BlazeOverlayContent(blazeUIModel, isDarkTheme)
         }
     }
 
@@ -205,6 +206,18 @@ class BlazeOverlayFragment : Fragment() {
         }
     }
 
+    @Composable
+    fun ScrollableBox(uiModel: BlazeUIModel?,
+                      isDarkTheme: Boolean) {
+        Box(Modifier.fillMaxSize()) {
+            LazyColumn(Modifier.fillMaxSize()) {
+                items(1) {
+                    BlazeOverlayContent(uiModel, isDarkTheme)
+                }
+            }
+        }
+    }
+
     private fun getPrimaryButtonColor(isInDarkTheme: Boolean): Color {
         return if (isInDarkTheme) darkModePrimaryButtonColor
         else AppColor.Black
@@ -244,8 +257,23 @@ class BlazeOverlayFragment : Fragment() {
                     end.linkTo(postContainer.end, 15.dp)
                 })
             Title(
-                title = uiModel.title, modifier = Modifier.constrainAs(title) {
-                    top.linkTo(postContainer.top, 15.dp)
+                title = uiModel.title, modifier = Modifier
+                    .constrainAs(title) {
+                        top.linkTo(postContainer.top, 15.dp)
+                        start.linkTo(postContainer.start, 20.dp)
+                        uiModel.featuredImageUrl?.run {
+                            end.linkTo(featuredImage.start, margin = 15.dp)
+                        } ?: run {
+                            end.linkTo(postContainer.end, margin = 20.dp)
+                        }
+                        width = Dimension.fillToConstraints
+                    }
+                    .wrapContentHeight()
+            )
+            val url = createRef()
+            Url(url = uiModel.url, modifier = Modifier
+                .constrainAs(url) {
+                    top.linkTo(title.bottom)
                     start.linkTo(postContainer.start, 20.dp)
                     uiModel.featuredImageUrl?.run {
                         end.linkTo(featuredImage.start, margin = 15.dp)
@@ -253,20 +281,9 @@ class BlazeOverlayFragment : Fragment() {
                         end.linkTo(postContainer.end, margin = 20.dp)
                     }
                     width = Dimension.fillToConstraints
-                }.wrapContentHeight()
-            )
-            val url = createRef()
-            Url(url = uiModel.url, modifier = Modifier.constrainAs(url) {
-                top.linkTo(title.bottom)
-                start.linkTo(postContainer.start, 20.dp)
-                uiModel.featuredImageUrl?.run {
-                    end.linkTo(featuredImage.start, margin = 15.dp)
-                } ?: run {
-                    end.linkTo(postContainer.end, margin = 20.dp)
+                    height = Dimension.wrapContent
                 }
-                width = Dimension.fillToConstraints
-                height = Dimension.wrapContent
-            }.padding(bottom = 15.dp))
+                .padding(bottom = 15.dp))
         }
     }
 
@@ -320,16 +337,14 @@ class BlazeOverlayFragment : Fragment() {
 
     @Composable
     fun Subtitles(list: List<Int>, modifier: Modifier = Modifier) {
-        LazyColumn(
+        Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = modifier.padding(
                 top = Margin.ExtraLarge.value,
                 bottom = Margin.ExtraLarge.value
             )
         ) {
-            items(list) {
-                BulletedText(it)
-            }
+            list.forEach { BulletedText(it) }
         }
     }
 


### PR DESCRIPTION
Fixes #18048 

This PR fixes an issue in the Blaze overlay. The view prohibited the user from accessing the action button when using a larger font/display sizes.

- Added a scrollable box the around `BlazeOverlayContent`
- Changed `Subtitles` from a `LazyColumn` to `Column`
Note: Apologies for the "reformat code" - <shakes fist> at Android Studio.

I'm still learning Compose, so if there is a better way to do this please lmk!

**To test:**
- Install and launch the app
- Login with a wp.com account that has blaze access 
- Navigate to posts or pages list
- Choose a post/page and tap the More menu 
- From the more menu, tap "Promote with Blaze"
- ✅ Verify the overlay page is shown
- Navigate to the Device settings
- And set the display size and text to their highest settings
- Repeat the above steps
- ✅ Verify the overlay page is shown and the content is scrollable. Ensure you can see the action button

## Regression Notes
1. Potential unintended areas of impact
The blaze overlay doesn't scroll properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
