### PR TITLE
Fix blaze animation and click behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
@@ -10,8 +10,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester.Companion.createRefs
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -49,7 +50,6 @@ fun PreviewDrawButton() {
     )
 }
 
-
 @Composable
 fun ImageButton(
     modifier: Modifier = Modifier,
@@ -60,7 +60,8 @@ fun ImageButton(
     button: Button,
     onClick: () -> Unit
 ) {
-    ConstraintLayout(modifier = modifier) {
+    ConstraintLayout(modifier = modifier
+        .clickable { onClick.invoke() }) {
         val (buttonTextRef) = createRefs()
         Box(modifier = Modifier
             .constrainAs(buttonTextRef) {
@@ -70,7 +71,6 @@ fun ImageButton(
                 end.linkTo(parent.end, drawableRight?.iconSize ?: 0.dp)
                 width = Dimension.wrapContent
             }
-            .clickable { onClick.invoke() }
         ) {
             val buttonTextValue: String = uiStringText(button.text)
             Text(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ImageButton.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource

--- a/WordPress/src/main/res/layout/promote_with_blaze_card.xml
+++ b/WordPress/src/main/res/layout/promote_with_blaze_card.xml
@@ -18,7 +18,6 @@
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_alignParentEnd="true"
-            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/content_description_more"
             android:scaleType="fitEnd"
             android:src="@drawable/img_blaze_flame" />


### PR DESCRIPTION
Fixes #18091 and #18092 

This PR address two issues with Blaze:
(1) Blaze Card: Eliminates the second ripple animation around the flame regardless of where the card is tapped
(2) Makes the “Blaze a Post now 🔥” button tappable across the entire width

**To test:**
- Install and launch the app
- Login with a wp.com account that has blaze access 

**Test: No more second ripple animation**
- Navigate to the dashboard
- Tap on the Blaze Card
- ✅ Verify there is no longer a second ripple on the flame image

**Test: Entire button is clickable**
- Navigate to the dashboard
- Tap on the Blaze Card
- Tap the "Blaze a post Now" button
- ✅ Verify the entire button is tappable by tapping anywhere except the text (although tapping on the text will also work)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
