### PR TITLE
Fixes: Post info overlay background color 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -73,6 +73,9 @@ private val darkModePrimaryButtonColor = Color(0xFF1C1C1E)
 private val lightModePostThumbnailBackground = Color(0xD000000)
 
 @Stable
+private val darkModePostThumbnailBackground = Color(0xDFFFFFF)
+
+@Stable
 private val bulletedTextColor = Color(0xFF666666)
 
 @AndroidEntryPoint
@@ -273,7 +276,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     private fun getThumbnailBackground(isInDarkTheme: Boolean): Color {
-        return if (isInDarkTheme) AppColor.DarkGray
+        return if (isInDarkTheme) darkModePostThumbnailBackground
         else lightModePostThumbnailBackground
     }
 


### PR DESCRIPTION
Fixes #18051

## What? 
This PR fixes the background color of the post info on dark mode. 

Note: no changes to the color on Light Mode

 ## Screenshots 
| Before fix  | After fix | 
|---|---|
| ![before-fix](https://user-images.githubusercontent.com/42008628/222824118-e583123c-6045-4ee4-8998-1903f9345ec9.png)| ![screenshot_darkmode_background_color_](https://user-images.githubusercontent.com/17463767/224927515-b775c38b-6b26-46ed-95ea-8d3d1f978e69.png)  |  

## To test:
1. Go to the **Jetpack** app
2. 🚪 Login with a wp account having blaze eligibility 
3. 👉🏻Go to Pages → Published Pages 
4. 👆🏻Click on the more icon ⁞ → 
5. ✅ Verify that the **🔥 Promote with Blaze** is shown
6. 👆🏻 Turn on Dark mode 
7. ✅ Verify that the Post info background color is as per the Design spec 

## Regression Notes
1. Potential unintended areas of impact
Post info background color is not correct as per design on Light Mode or DarkMode

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
