### PR TITLE
Blaze: Enable the native back swipe gesture for certain steps in the flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
@@ -184,7 +184,7 @@ class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
             viewLifecycleOwner,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    // no op
+                    blazeWebViewViewModel.handleOnBackPressed()
                 }
             }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
@@ -218,6 +218,20 @@ class BlazeWebViewViewModel @Inject constructor(
         }?: return false
     }
 
+    fun handleOnBackPressed() {
+        val nonDismissableStep = nonDismissableHashConfig.getValue<String>()
+        val completedStep = completedStepHashConfig.getValue<String>()
+
+        if (blazeFlowStep.label == nonDismissableStep) return
+
+        if (blazeFlowStep.label == completedStep || blazeFlowStep == BlazeFlowStep.CAMPAIGNS_LIST) {
+            blazeFeatureUtils.trackBlazeFlowCompleted(blazeFlowSource)
+        } else {
+            blazeFeatureUtils.trackFlowCanceled(blazeFlowSource, blazeFlowStep)
+        }
+        postActionEvent(BlazeActionEvent.FinishActivity)
+    }
+
     companion object {
         const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
         const val WPCOM_DOMAIN = ".wordpress.com"


### PR DESCRIPTION
This PR:
- Pushes the handleOnBackPressed to the viewModel `handleOnBackPressed`. This ensures that only the non-dismissable steps are prohibited from using the native back gesture.
- Tracks the cancel or done when using the back swipe gesture to cancel/complete the flow

For more information see:  p5T066-3Ue-p2#comment-14501
**To test:**
- Install and launch the app
- Login with a wp.com account that has blaze access 
- Navigate to the dashboard
- Tap on the Blaze Card
- Tap the "Blaze a Post now" button within the blaze overlay
- On the posts list, swipe back to cancel the flow
- ✅ Verify that the back swipe worked and you are returned to the dashboard
- Repeat this process by navigating through you will need to enter a fake CC number or your own to submit the campaign.
- ✅ Verify that the back swipe gesture is disabled when on the payment processing step (the header action bar will have the Cancel button grayed out)

FYI: @hypest 

## Regression Notes
1. Potential unintended areas of impact
The back button doesn't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.