### PR TITLE
Blaze: Show blaze menu item even when blaze dashboard card is hidden

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -36,12 +36,13 @@ class BlazeFeatureUtils @Inject constructor(
                 postModel.password.isEmpty()
     }
 
-    fun shouldShowBlazeEntryPoint(blazeStatusModel: BlazeStatusModel?, siteId: Long): Boolean {
-        val isEligible = blazeStatusModel?.isEligible == true
-        return isBlazeEnabled() &&
-                isEligible &&
-                !isPromoteWithBlazeCardHiddenByUser(siteId)
-    }
+    fun shouldShowBlazeCardEntryPoint(blazeStatusModel: BlazeStatusModel?, siteId: Long) =
+        isBlazeEnabled() &&
+                blazeStatusModel?.isEligible == true &&
+                    !isPromoteWithBlazeCardHiddenByUser(siteId)
+
+    fun shouldShowBlazeMenuEntryPoint(blazeStatusModel: BlazeStatusModel?) =
+        isBlazeEnabled() &&  blazeStatusModel?.isEligible == true
 
     fun track(stat: AnalyticsTracker.Stat, source: BlazeFlowSource) {
         analyticsTrackerWrapper.track(

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
@@ -184,7 +184,7 @@ class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
             viewLifecycleOwner,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    // no op
+                    blazeWebViewViewModel.handleOnBackPressed()
                 }
             }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewViewModel.kt
@@ -218,6 +218,20 @@ class BlazeWebViewViewModel @Inject constructor(
         }?: return false
     }
 
+    fun handleOnBackPressed() {
+        val nonDismissableStep = nonDismissableHashConfig.getValue<String>()
+        val completedStep = completedStepHashConfig.getValue<String>()
+
+        if (blazeFlowStep.label == nonDismissableStep) return
+
+        if (blazeFlowStep.label == completedStep || blazeFlowStep == BlazeFlowStep.CAMPAIGNS_LIST) {
+            blazeFeatureUtils.trackBlazeFlowCompleted(blazeFlowSource)
+        } else {
+            blazeFeatureUtils.trackFlowCanceled(blazeFlowSource, blazeFlowStep)
+        }
+        postActionEvent(BlazeActionEvent.FinishActivity)
+    }
+
     companion object {
         const val WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php"
         const val WPCOM_DOMAIN = ".wordpress.com"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -574,7 +574,7 @@ class MySiteViewModel @Inject constructor(
                     onRemoveClick = this::onBloggingPromptRemoveClick
                 ),
                 promoteWithBlazeCardBuilderParams = PromoteWithBlazeCardBuilderParams(
-                    isEligible = blazeFeatureUtils.shouldShowBlazeEntryPoint(
+                    isEligible = blazeFeatureUtils.shouldShowBlazeCardEntryPoint(
                         promoteWithBlazeUpdate?.blazeStatusModel,
                         site.siteId
                     ),
@@ -614,7 +614,7 @@ class MySiteViewModel @Inject constructor(
                 enableMediaFocusPoint = shouldEnableSiteItemsFocusPoints(),
                 onClick = this::onItemClick,
                 isBlazeEligible =
-                    blazeFeatureUtils.shouldShowBlazeEntryPoint(promoteWithBlazeUpdate?.blazeStatusModel, site.siteId)
+                blazeFeatureUtils.shouldShowBlazeMenuEntryPoint(promoteWithBlazeUpdate?.blazeStatusModel)
             )
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -3375,7 +3375,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsSocialEnabled)
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsEnabled)
         whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
-        whenever(blazeFeatureUtils.shouldShowBlazeEntryPoint(any(), any())).thenReturn(isBlazeEnabled)
+        whenever(blazeFeatureUtils.shouldShowBlazeCardEntryPoint(any(), any())).thenReturn(isBlazeEnabled)
         if (isSiteUsingWpComRestApi) {
             site.setIsWPCom(true)
             site.setIsJetpackConnected(true)
@@ -3548,7 +3548,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                     add(initPostCard(mockInvocation))
                     add(initTodaysStatsCard(mockInvocation))
                     if (bloggingPromptsFeatureConfig.isEnabled()) add(initBloggingPromptCard(mockInvocation))
-                    if (blazeFeatureUtils.shouldShowBlazeEntryPoint(
+                    if (blazeFeatureUtils.shouldShowBlazeCardEntryPoint(
                             BlazeStatusModel(1, true), 1)
                     ) add(
                         initPromoteWithBlazeCard(mockInvocation)


### PR DESCRIPTION
Fixes #18099 

This PR ensures that the Blaze menu item is not hidden when the Blaze dashboard card is.

**Merge Instructions**
- Ensure that #18100 has been merged
- Remove label
- Merge as normal

**To test:**
- Install and launch the app
- Login with a wp.com account that has blaze access 
- Navigate to the dashboard
- Tap on the Blaze Card more Menu
- Tap on the Hide this option
- ✅ Verify the Blaze dashboard card is hidden
- Tap on the Menu tab
- ✅ Verify the Blaze menu item is visible

## Regression Notes
1. Potential unintended areas of impact
The blaze menu item continues to show when dashboard card is hidden

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and MySiteViewModelTest

3. What automated tests I added (or what prevented me from doing so)
Updated MySiteViewModelTest

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
