### PR TITLE
[Dependency Updates] Update `jsoupVersion` to 1.15.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
     googleMLKitBarcodeScanningVersion = '17.0.0'
     googlePlayServicesAuthVersion = '20.4.1'
     googlePlayServicesCodeScannerVersion = '16.0.0-beta3'
-    jsoupVersion = '1.10.3'
+    jsoupVersion = '1.15.4'
     kotlinxCoroutinesVersion = '1.6.4'
     lottieVersion = '5.2.0'
     philjayMpAndroidChartVersion = 'v3.1.0'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -89,9 +89,6 @@ dependencies {
         exclude module: 'react-native'
     }
 
-    // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
-    implementation "org.jsoup:jsoup:$jsoupVersion"
-
     implementation "org.wordpress:utils:$wordPressUtilsVersion"
 
     implementation "androidx.lifecycle:lifecycle-common:$androidxLifecycleVersion"


### PR DESCRIPTION
Parent #17569

This PR updates `jsoupVersion` to [1.15.4](https://github.com/jhy/jsoup/releases/tag/jsoup-1.15.4).

-----

PS: @geriux @fluiddot I added you both as the main reviewers, [not so randomly](https://github.com/wordpress-mobile/WordPress-Android/pull/17066/files#r1135813549), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

PS: You might want to do a similar update on both, the [Aztec](https://github.com/wordpress-mobile/AztecEditor-Android/blob/23983f83a710ba5471c79416e6ce96febc63d6b9/aztec/build.gradle#L52) and [Gutenberg](https://github.com/WordPress/gutenberg/blob/b3a66dbc044d8c273744520161ea6436e07c1aaf/packages/react-native-aztec/android/build.gradle#L9) libraries, at some point too.

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any JSoup related functionality, which is mainly parsing `HTLM` into a `Document` and selecting an `Element` from it, on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>1. Classic Editor [Aztec]</summary>

ℹ️ Disable the `Block Editor` before testing this.

- Go to `Posts` screen and create a new post.
- Add an `Image`, `Video` and any other entry (like `Paragraph`, `Ordered List`, `Quote`, etc).
- Publish this newly created post.
- Verify that this newly created `Classic Editor` related post of yours is being displayed as expected, both when previewing it from within the `Posts` and `Reader` screens. FYI: On `Reader`, you will find you post within the `FOLLOWING` tab. 

</details>

<details>
    <summary>2. Block Editor [Gutenberg]</summary>

ℹ️ Enable the `Block Editor` before testing this.

- Go to `Posts` screen and create a new post.
- Add an `Image`, `Gallery`, `Video`, `Audio`, `File`, `Media Text` and `Cover` blocks to the post.
- Publish this newly created post.
- Verify that this newly created `Block Editor` related post of yours is being displayed as expected, both when previewing it from within the `Posts` and `Reader` screens. FYI: On `Reader`, you will find you post within the `FOLLOWING` tab. 

</details>

<details>
    <summary>3. Reader Post Details [ReaderPostRenderer.java]</summary>

- Go to `Reader` screen and click on various posts.
- Verify that each and every post, along with all their details is being displayed as expected.

</details>

<details>
    <summary>4. Stats Insights - Latest Post Summary [LatestPostSummaryMapper.kt]</summary>

ℹ️ If the `Latest Post Summary` card is not being displayed, navigate to the bottom of the `Stats` screen and click on the `Add new stats card`. Then, enabled the `Latest Post Summary` from within the `Posts and Pages` group.

- Go to `Stats` screen and its `INSIGHTS` tab.
- Scroll to the `Latest Post Summary` card and verify that it is being displayed as expected.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all JSoup related app functionalities, like parsing `HTLM` into a `Document` and selecting an `Element` from it.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
