### PR TITLE
Find available url for new sites with paid domains

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -99,7 +99,8 @@ class SiteCreationProgressViewModel @Inject constructor(
                     segmentIdentifier,
                     siteDesign,
                     urlWithoutScheme,
-                    siteTitle
+                    siteTitle,
+                    requireNotNull(siteCreationState.domain?.isFree) { "domain required to create a site" },
                 )
                 _startCreateSiteService.value = StartServiceData(serviceData, previousState)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -55,6 +55,7 @@ class SiteCreationProgressViewModel @Inject constructor(
 
     private var urlWithoutScheme: String? = null
     private var siteTitle: String? = null
+
     private var lastReceivedServiceState: SiteCreationServiceState? = null
     private var serviceStateForRetry: SiteCreationServiceState? = null
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceData.kt
@@ -10,5 +10,6 @@ data class SiteCreationServiceData(
     val segmentId: Long?,
     val siteDesign: String?,
     val domain: String?,
-    val title: String?
+    val title: String?,
+    val isFree: Boolean,
 ) : Parcelable

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
@@ -105,7 +105,7 @@ class SiteCreationServiceManager @Inject constructor(
         launch {
             AppLog.i(
                 T.SITE_CREATION,
-                "Dispatching Create Site Action, SiteName: ${siteData.domain}"
+                "Dispatching Create Site Action, SiteName: ${siteData.domain}, isFree: ${siteData.isFree}"
             )
             val createSiteEvent: OnNewSiteCreated
             try {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -60,7 +60,8 @@ class CreateSiteUseCase @Inject constructor(
                 siteVisibility,
                 siteData.segmentId,
                 siteData.siteDesign,
-                dryRun
+                dryRun,
+                findAvailableUrl = siteData.isFree.takeIf { !it }
             )
             continuation = cont
             dispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload))

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/CreateSiteUseCase.kt
@@ -61,7 +61,7 @@ class CreateSiteUseCase @Inject constructor(
                 siteData.segmentId,
                 siteData.siteDesign,
                 dryRun,
-                findAvailableUrl = siteData.isFree.takeIf { !it }
+                findAvailableUrl = if (siteData.isFree) null else true
             )
             continuation = cont
             dispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -14,8 +14,9 @@ import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 
 const val SUB_DOMAIN = "test"
 const val URL = "$SUB_DOMAIN.wordpress.com"
+const val URL_CUSTOM = "$SUB_DOMAIN.host.com"
 val FREE_DOMAIN = DomainModel(URL, true, "", 1)
-val PAID_DOMAIN = DomainModel(URL, false, "$1", 2)
+val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2)
 
 const val SITE_REMOTE_ID = 1L
 private const val SITE_LOCAL_ID = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 const val SUB_DOMAIN = "test"
 const val URL = "$SUB_DOMAIN.wordpress.com"
 val FREE_DOMAIN = DomainModel(URL, true, "", 1)
+val PAID_DOMAIN = DomainModel(URL, false, "$1", 2)
 
 const val SITE_REMOTE_ID = 1L
 private const val SITE_LOCAL_ID = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
+import org.wordpress.android.ui.sitecreation.FREE_DOMAIN
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceData
 import org.wordpress.android.ui.sitecreation.usecases.CreateSiteUseCase
 import org.wordpress.android.util.UrlUtilsWrapper
@@ -28,9 +29,9 @@ private const val SITE_TITLE = "site title"
 private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
     123,
     "slug",
-    "domain",
+    FREE_DOMAIN.domainName,
     SITE_TITLE,
-    false,
+    FREE_DOMAIN.isFree,
 )
 private const val LANGUAGE_ID = "lang_id"
 private const val TIMEZONE_ID = "timezone_id"

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -22,13 +23,15 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceData
 import org.wordpress.android.ui.sitecreation.usecases.CreateSiteUseCase
 import org.wordpress.android.util.UrlUtilsWrapper
+import kotlin.test.assertFalse
 
 private const val SITE_TITLE = "site title"
 private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
     123,
     "slug",
     "domain",
-    SITE_TITLE
+    SITE_TITLE,
+    false,
 )
 private const val LANGUAGE_ID = "lang_id"
 private const val TIMEZONE_ID = "timezone_id"
@@ -75,6 +78,14 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
         assertThat(payload.siteName).isEqualTo(DUMMY_SITE_DATA.domain)
         assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
         assertThat(payload.siteTitle).isEqualTo(SITE_TITLE)
+        assertFalse(payload.findAvailableUrl!!)
+    }
+
+    @Test
+    fun verifySiteDataWhenFreePropagatesNoFindAvailableUrl() = test {
+        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
+        useCase.createSite(DUMMY_SITE_DATA.copy(isFree = true), LANGUAGE_ID, TIMEZONE_ID)
+        verify(dispatcher).dispatch(argWhere { (it.payload as NewSitePayload).findAvailableUrl == null })
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceData
 import org.wordpress.android.ui.sitecreation.usecases.CreateSiteUseCase
 import org.wordpress.android.util.UrlUtilsWrapper
-import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 private const val SITE_TITLE = "site title"
 private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
@@ -78,7 +78,7 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
         assertThat(payload.siteName).isEqualTo(DUMMY_SITE_DATA.domain)
         assertThat(payload.segmentId).isEqualTo(DUMMY_SITE_DATA.segmentId)
         assertThat(payload.siteTitle).isEqualTo(SITE_TITLE)
-        assertFalse(payload.findAvailableUrl!!)
+        assertTrue(payload.findAvailableUrl!!)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/CreateSiteUseCaseTest.kt
@@ -54,11 +54,11 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
     fun setUp() {
         useCase = CreateSiteUseCase(dispatcher, store, urlUtilsWrapper)
         event = OnNewSiteCreated(newSiteRemoteId = 123)
+        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
     }
 
     @Test
     fun coroutineResumedWhenResultEventDispatched() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         val resultEvent = useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         assertThat(resultEvent).isEqualTo(event)
@@ -66,7 +66,6 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
 
     @Test
     fun verifySiteDataPropagated() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
@@ -83,14 +82,12 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
 
     @Test
     fun verifySiteDataWhenFreePropagatesNoFindAvailableUrl() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA.copy(isFree = true), LANGUAGE_ID, TIMEZONE_ID)
         verify(dispatcher).dispatch(argWhere { (it.payload as NewSitePayload).findAvailableUrl == null })
     }
 
     @Test
     fun verifyDryRunIsFalse() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
@@ -102,7 +99,6 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
 
     @Test
     fun verifyCreatesPublicSite() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
@@ -114,7 +110,6 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
 
     @Test
     fun verifyPropagatesLanguageId() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
@@ -126,7 +121,6 @@ class CreateSiteUseCaseTest : BaseUnitTest() {
 
     @Test
     fun verifyPropagatesTimeZoneId() = test {
-        whenever(dispatcher.dispatch(any())).then { useCase.onNewSiteCreated(event) }
         useCase.createSite(DUMMY_SITE_DATA, LANGUAGE_ID, TIMEZONE_ID)
 
         val captor = ArgumentCaptor.forClass(Action::class.java)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -17,10 +17,12 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.sitecreation.PAID_DOMAIN
 import org.wordpress.android.ui.sitecreation.SERVICE_ERROR
 import org.wordpress.android.ui.sitecreation.SERVICE_SUCCESS
 import org.wordpress.android.ui.sitecreation.SITE_CREATION_STATE
 import org.wordpress.android.ui.sitecreation.SITE_REMOTE_ID
+import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState.Error.ConnectionError
@@ -29,8 +31,10 @@ import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewMo
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.StartServiceData
 import org.wordpress.android.util.NetworkUtilsWrapper
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -72,6 +76,20 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     fun `on start emits service event`() = test {
         startViewModel()
         assertNotNull(viewModel.startCreateSiteService.value)
+    }
+
+    @Test
+    fun `on start emits service event for free domains with isFree true`() = test {
+        startViewModel(SITE_CREATION_STATE)
+        val request = assertNotNull(viewModel.startCreateSiteService.value).serviceData
+        assertTrue(request.isFree)
+    }
+
+    @Test
+    fun `on start emits service event for paid domains with isFree false`() = test {
+        startViewModel(SITE_CREATION_STATE.copy(domain = PAID_DOMAIN))
+        val request = assertNotNull(viewModel.startCreateSiteService.value).serviceData
+        assertFalse(request.isFree)
     }
 
     @Test
@@ -151,8 +169,8 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
 
     // region Helpers
 
-    private fun startViewModel() {
-        viewModel.start( SITE_CREATION_STATE)
+    private fun startViewModel(state: SiteCreationState = SITE_CREATION_STATE) {
+        viewModel.start(state)
     }
 
     // endregion

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
@@ -34,7 +34,8 @@ private val DUMMY_SITE_DATA: SiteCreationServiceData = SiteCreationServiceData(
     123,
     "slug",
     "domain",
-    null
+    null,
+    true,
 )
 
 private val IDLE_STATE = SiteCreationServiceState(IDLE)

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.90.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = 'trunk-314cad0eed02a26dd51b7b17a2813de097f0c43e'
+    wordPressFluxCVersion = 'trunk-aff6f17db9549bc47bc4e6372c8d8f32e62b65bb'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.90.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2.17.0'
+    wordPressFluxCVersion = '2676-5b0dc33a1b574192660a032900642e19874192a3'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.90.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2676-5b0dc33a1b574192660a032900642e19874192a3'
+    wordPressFluxCVersion = 'trunk-314cad0eed02a26dd51b7b17a2813de097f0c43e'
     wordPressLoginVersion = '1.0.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'


### PR DESCRIPTION
Resolves partially #17905
Relies on wordpress-mobile/WordPress-FluxC-Android#2676

This PR:
- ★ Integrates with the above fluxC PR to receive an available wpcom url during site creation for a paid domain choice

<details><summary><b>Merging Strategy</b></summary>

1. Merge the FluxC PR
2. Update the `wordPressFluxCVersion` of this PR
   1. After the [post-merge BuildKite job for trunk](https://buildkite.com/automattic/wordpress-fluxc-android) completes open its sub-job named:
      `Publish :fluxc`
   2. Search for `is succesfully published` and copy the FluxC version before it:
       `trunk-{commit_sha}`
   3. Paste the FluxC version in `./build.gradle` at:
      `wordPressFluxCVersion`
   5. Commit and push this change
3. Auto-merge this PR
---
</details>

## To Test

<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
---
</details>

### ● Treatment Variation

- **Verify** sites are created with your free domain of choice
- **Verify** sites with paid domains are created with a free domain, expecting the preview to show the paid domain and the next screen to show the matching free domain found

### ○ Control Variation

- **Verify** sites are created with your domain of choice

### Previews

| ● |
| - |
| <video src="https://user-images.githubusercontent.com/4588074/225266445-2da64f13-f9f0-42ce-a7a4-26fe8c0b0c8b.mp4" style="max-width: 315px;"></video> |

## Regression Notes

1. Potential unintended areas of impact
   `Site Creation` → `Progress` and the url of created sites

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
   Unit tests in `CreateSiteUseCaseTest`, `SiteCreationProgressViewModelTest` and `SiteCreationServiceManagerTest` as well as in the FluxC PR

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
