### PR TITLE
Adds: Flag and Helper function to identify the new disabled state 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -125,6 +125,7 @@ android {
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_THREE", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_PHASE_FOUR", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_NEW_USERS", "false"
+        buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_STATIC_POSTERS", "false"
         buildConfigField "boolean", "JETPACK_FEATURE_REMOVAL_SELF_HOSTED_USERS", "false"
         buildConfigField "boolean", "PREVENT_DUPLICATE_NOTIFS_REMOTE_FIELD", "false"
         buildConfigField "boolean", "OPEN_WEB_LINKS_WITH_JETPACK_FLOW", "false"

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseO
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseStaticPosters
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.BuildConfigWrapper
@@ -85,7 +86,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
                 when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
                     null -> false
                     PhaseOne, PhaseTwo, PhaseThree -> true
-                    PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+                    PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
                 }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -56,7 +56,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
-            is PhaseFour, PhaseStaticPosters,  PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
+            is PhaseFour, PhaseStaticPosters, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
@@ -64,14 +64,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> PHASE_ONE
-            is PhaseFour ,  PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
     fun shouldRemoveJetpackFeatures(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false
         return when (currentPhase) {
-            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers-> true
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> true
             is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> false
         }
     }
@@ -79,8 +79,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     fun shouldShowNotifications(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true
         return when (currentPhase) {
-            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
-            is PhaseOne, PhaseTwo, PhaseThree -> true
+            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> true
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -76,6 +76,15 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    @Suppress("Unused")
+    fun shouldShowStaticPage(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return false
+        return when (currentPhase) {
+            is PhaseStaticPosters -> true
+            is PhaseOne, PhaseTwo, PhaseThree, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+        }
+    }
+
     fun shouldShowNotifications(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true
         return when (currentPhase) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseO
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseStaticPosters
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
 import org.wordpress.android.util.BuildConfigWrapper
@@ -15,6 +16,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalStaticPostersConfig
 import javax.inject.Inject
 
 private const val PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
@@ -35,12 +37,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalPhaseThreeConfig: JetpackFeatureRemovalPhaseThreeConfig,
     private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
     private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig,
-    private val jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig
+    private val jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig,
+    private val jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig
 ) {
     fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
         else if (jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()) PhaseSelfHostedUsers
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
+        else if (jetpackFeatureRemovalStaticPostersConfig.isEnabled()) PhaseStaticPosters
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
         else if (jetpackFeatureRemovalPhaseThreeConfig.isEnabled()) PhaseThree
         else if (jetpackFeatureRemovalPhaseTwoConfig.isEnabled()) PhaseTwo
@@ -52,15 +56,15 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
             is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
-            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
+            is PhaseFour, PhaseStaticPosters,  PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
     fun getDeepLinkPhase(): JetpackFeatureRemovalSiteCreationPhase? {
         val currentPhase = getCurrentPhase() ?: return null
         return when (currentPhase) {
-            is PhaseOne, PhaseTwo, PhaseThree -> PHASE_ONE
-            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
+            is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> PHASE_ONE
+            is PhaseFour ,  PhaseNewUsers, PhaseSelfHostedUsers -> PHASE_TWO
         }
     }
 
@@ -68,14 +72,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         val currentPhase = getCurrentPhase() ?: return false
         return when (currentPhase) {
             is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers-> true
-            is PhaseOne, PhaseTwo, PhaseThree -> false
+            is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> false
         }
     }
 
     fun shouldShowNotifications(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true
         return when (currentPhase) {
-            is PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
             is PhaseOne, PhaseTwo, PhaseThree -> true
         }
     }
@@ -108,6 +112,7 @@ sealed class JetpackFeatureRemovalPhase(
         "three"
     )
 
+    object PhaseStaticPosters : JetpackFeatureRemovalPhase(trackingName = "static_posters")
     object PhaseFour : JetpackFeatureRemovalPhase(trackingName = "four")
     object PhaseNewUsers : JetpackFeatureRemovalPhase(trackingName = "new_users")
     object PhaseSelfHostedUsers : JetpackFeatureRemovalPhase(trackingName = "self_hosted")

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalStaticPostersConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalStaticPostersConfig.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.JetpackFeatureRemovalStaticPostersConfig.Companion.JETPACK_FEATURE_REMOVAL_STATIC_POSTERS_REMOTE_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration for Jetpack feature removal phase new users
+ */
+@Feature(JETPACK_FEATURE_REMOVAL_STATIC_POSTERS_REMOTE_FIELD, false)
+class JetpackFeatureRemovalStaticPostersConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.JETPACK_FEATURE_REMOVAL_NEW_USERS,
+    JETPACK_FEATURE_REMOVAL_STATIC_POSTERS_REMOTE_FIELD
+) {
+    companion object {
+        const val JETPACK_FEATURE_REMOVAL_STATIC_POSTERS_REMOTE_FIELD = "jp_removal_static_posters"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalStaticPostersConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalStaticPostersConfig.kt
@@ -13,7 +13,7 @@ class JetpackFeatureRemovalStaticPostersConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
     appConfig,
-    BuildConfig.JETPACK_FEATURE_REMOVAL_NEW_USERS,
+    BuildConfig.JETPACK_FEATURE_REMOVAL_STATIC_POSTERS,
     JETPACK_FEATURE_REMOVAL_STATIC_POSTERS_REMOTE_FIELD
 ) {
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
+import org.wordpress.android.util.config.JetpackFeatureRemovalStaticPostersConfig
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -49,6 +50,9 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
     @Mock
     private lateinit var jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig
 
+    @Mock
+    private lateinit var jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig
+
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Before
@@ -60,7 +64,8 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
             jetpackFeatureRemovalPhaseThreeConfig,
             jetpackFeatureRemovalPhaseFourConfig,
             jetpackFeatureRemovalNewUsersConfig,
-            jetpackFeatureRemovalSelfHostedUsersConfig
+            jetpackFeatureRemovalSelfHostedUsersConfig,
+            jetpackFeatureRemovalStaticPostersConfig
         )
     }
 
@@ -128,6 +133,15 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
         assertEquals(currentPhase, PhaseSelfHostedUsers)
     }
 
+    @Test
+    fun `given static posters config true, when current phase is fetched, then return static posters config`() {
+        whenever(jetpackFeatureRemovalStaticPostersConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase()
+
+        assertEquals(currentPhase, JetpackFeatureRemovalPhase.PhaseStaticPosters)
+    }
+
     // site creation phase tests
     @Test
     fun `given jetpack app, when current site creation phase is fetched, then return null`() {
@@ -150,6 +164,15 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
     @Test
     fun `given phase four config true, when current site creation phase is fetched, then return phase two`() {
         whenever(jetpackFeatureRemovalNewUsersConfig.isEnabled()).thenReturn(true)
+
+        val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
+
+        assertEquals(currentPhase, PHASE_TWO)
+    }
+
+    @Test
+    fun `given static posters config true, when current site creation phase is fetched, then return phase two`() {
+        whenever(jetpackFeatureRemovalStaticPostersConfig.isEnabled()).thenReturn(true)
 
         val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
 


### PR DESCRIPTION
Fixes #18116 


## Description
This PR adds the feature flag `jp_removal_static_posters`

<img src="https://user-images.githubusercontent.com/17463767/225364795-b5f5585f-72f5-43ec-9fe5-f92e55a2fb69.png" width="250" height="480">

## To test:
- Go to jetpack app 
- Login with a wp account with Administor privileges 
- Go to **app settings** → **Debug settings** 
- Verify that the flag `jp_removal_static_posters` is visible

## Regression Notes
1. Potential unintended areas of impact

2. What did I to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
