### PR TITLE
Adds: Logic for navigating to Static pages 

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1064,6 +1064,12 @@
             android:label="@string/blaze_activity_title"
             android:screenOrientation="portrait"
             android:theme="@style/WordPress.NoActionBar"/>
+
+        <activity android:name=".ui.jetpackoverlay.JetpackStaticPosterActivity"
+            android:exported="false"
+            android:label="@string/stats"
+            android:theme="@style/WordPress.NoActionBar"/>
+
     </application>
     <queries>
         <intent>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -69,6 +69,7 @@ import org.wordpress.android.ui.jetpack.restore.RestoreActivity;
 import org.wordpress.android.ui.jetpack.scan.ScanActivity;
 import org.wordpress.android.ui.jetpack.scan.details.ThreatDetailsActivity;
 import org.wordpress.android.ui.jetpack.scan.history.ScanHistoryActivity;
+import org.wordpress.android.ui.jetpackoverlay.JetpackStaticPosterActivity;
 import org.wordpress.android.ui.main.MeActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.ui.main.SitePickerAdapter.SitePickerMode;
@@ -1847,6 +1848,11 @@ public class ActivityLauncher {
                 null);
         intent.putExtra(ARG_EXTRA_BLAZE_UI_MODEL, pageUIModel);
         intent.putExtra(ARG_BLAZE_FLOW_SOURCE, source);
+        context.startActivity(intent);
+    }
+
+    public static void showJetpackStaticPoster(@NonNull Context context) {
+        Intent intent = new Intent(context, JetpackStaticPosterActivity.class);
         context.startActivity(intent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
@@ -32,8 +32,13 @@ public class ShortcutsNavigator {
             case OPEN_STATS:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_STATS_CLICKED);
                 if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
-                    ActivityLauncher.viewBlogStats(activity, currentSite);
-                } 
+                    if (mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+                        // todo: JetpackFocus - Send to static posters fragment when ready
+                        ActivityLauncher.viewBlogStats(activity, currentSite);
+                    } else {
+                        ActivityLauncher.viewBlogStats(activity, currentSite);
+                    }
+                }
                 break;
             case CREATE_NEW_POST:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_NEW_POST_CLICKED);
@@ -47,6 +52,8 @@ public class ShortcutsNavigator {
                 );
                 break;
             case OPEN_NOTIFICATIONS:
+                // todo: JetpackFocus - Send to static posters fragment when ready, but this
+                // will go through WPMainActivity.handleOpenPageIntent, so it doesn't have to be handled here
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_NOTIFICATIONS_CLICKED);
                 if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
                     ActivityLauncher.viewNotifications(activity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
@@ -33,8 +33,7 @@ public class ShortcutsNavigator {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_STATS_CLICKED);
                 if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
                     if (mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-                        // todo: JetpackFocus - Send to static posters fragment when ready
-                        ActivityLauncher.viewBlogStats(activity, currentSite);
+                        ActivityLauncher.showJetpackStaticPoster(activity);
                     } else {
                         ActivityLauncher.viewBlogStats(activity, currentSite);
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShortcutsNavigator.java
@@ -51,8 +51,6 @@ public class ShortcutsNavigator {
                 );
                 break;
             case OPEN_NOTIFICATIONS:
-                // todo: JetpackFocus - Send to static posters fragment when ready, but this
-                // will go through WPMainActivity.handleOpenPageIntent, so it doesn't have to be handled here
                 AnalyticsTracker.track(AnalyticsTracker.Stat.SHORTCUT_NOTIFICATIONS_CLICKED);
                 if (!mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
                     ActivityLauncher.viewNotifications(activity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -81,6 +81,8 @@ class DeepLinkNavigator
             OpenLoginPrologue -> ActivityLauncher.showLoginPrologue(activity)
             is OpenJetpackForDeepLink ->
                 ActivityLauncher.openJetpackForDeeplink(activity, navigateAction.action, navigateAction.uri)
+            is NavigateAction.OpenJetpackStaticPosterView ->
+                ActivityLauncher.showJetpackStaticPoster(activity)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -111,5 +113,6 @@ class DeepLinkNavigator
         object OpenMySite : NavigateAction()
         object OpenLoginPrologue : NavigateAction()
         data class OpenJetpackForDeepLink(val action: String?, val uri: UriWrapper) : NavigateAction()
+        object OpenJetpackStaticPosterView : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/StatsLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/StatsLinkHandler.kt
@@ -6,17 +6,20 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenS
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStatsForSite
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStatsForSiteAndTimeframe
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenStatsForTimeframe
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenJetpackStaticPosterView
 import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel.Companion.APPLINK_SCHEME
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel.Companion.HOST_WORDPRESS_COM
 import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel.Companion.SITE_DOMAIN
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
 
 class StatsLinkHandler
 @Inject constructor(
-    private val deepLinkUriUtils: DeepLinkUriUtils
+    private val deepLinkUriUtils: DeepLinkUriUtils,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) : DeepLinkHandler {
     /**
      * Builds navigate action from URL like:
@@ -31,6 +34,7 @@ class StatsLinkHandler
         val site = pathSegments.getOrNull(length - 1)?.toSite()
         val statsTimeframe = pathSegments.getOrNull(length - 2)?.toStatsTimeframe()
         return when {
+            jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage() -> OpenJetpackStaticPosterView
             site != null && statsTimeframe != null -> {
                 OpenStatsForSiteAndTimeframe(site, statsTimeframe)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -84,6 +84,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowStoryPost(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -76,6 +76,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowDashboard(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalWidgetHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalWidgetHelper.kt
@@ -13,7 +13,8 @@ class JetpackFeatureRemovalWidgetHelper @Inject constructor(
     )
 
     fun disableWidgetReceiversIfNeeded() {
-        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+        if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() ||
+            jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
             widgetReceivers.forEach { packageManagerWrapper.disableComponentEnabledSetting(it) }
         } else {
             widgetReceivers.forEach { packageManagerWrapper.enableComponentEnabledSetting(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackStaticPosterActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackStaticPosterActivity.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.ui.jetpackoverlay
+
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.ViewCompat
+import androidx.fragment.app.commit
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.models.JetpackPoweredScreen
+import org.wordpress.android.ui.main.jetpack.staticposter.JetpackStaticPosterFragment
+import org.wordpress.android.util.extensions.setContent
+
+@AndroidEntryPoint
+class JetpackStaticPosterActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent { ComposeFrame() }
+    }
+
+    @Composable
+    fun ComposeFrame() {
+        AndroidView(
+            factory = { context ->
+                FrameLayout(context).apply {
+                    id = ViewCompat.generateViewId()
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                    )
+                }
+            },
+            update = { fragment ->
+                supportFragmentManager.commit {
+                    replace(
+                        fragment.id,
+                        JetpackStaticPosterFragment.newInstance(JetpackPoweredScreen.WithStaticPoster.STATS)
+                    )
+                }
+            }
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -366,13 +366,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         launchWithNoteId();
                     }
                 } else if (openedFromShortcut) {
-                    // todo: JetpackFocus - We need to intercept this here for static posters
                     initSelectedSite();
-                    Toast.makeText(this, "JetpackFocus via shortcut", Toast.LENGTH_LONG).show();
-                    mShortcutsNavigator.showTargetScreen(getIntent().getStringExtra(
-                            ShortcutsNavigator.ACTION_OPEN_SHORTCUT), this, getSelectedSite());
-                    showJetpackOverlayIfNeeded(getIntent().getStringExtra(
-                            ShortcutsNavigator.ACTION_OPEN_SHORTCUT));
+                        mShortcutsNavigator.showTargetScreen(getIntent().getStringExtra(
+                                ShortcutsNavigator.ACTION_OPEN_SHORTCUT), this, getSelectedSite());
+                        showJetpackOverlayIfNeeded(getIntent().getStringExtra(
+                                ShortcutsNavigator.ACTION_OPEN_SHORTCUT));
                 } else if (openRequestedPage) {
                     handleOpenPageIntent(getIntent());
                 } else if (isQuickStartRequestedFromPush) {
@@ -506,8 +504,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
         Map<String, String> trackingProperties = new HashMap<>();
         trackingProperties.put("calling_function", "shortcut_" + shortcut.name());
 
-        // todo: JetpackFocus - I don't believe we need a change here, since static posters
-        // won't get past the first check since they are not considered part of shouldHideJetpackFeatures
         switch (shortcut) {
             case CREATE_NEW_POST:
                 break;
@@ -833,8 +829,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         showJetpackFeatureOverlayAccessedInCorrectly(trackingProperties);
                         break;
                     }
-                    // todo: JetpackFocus - if we reuse the "NOTIFS" and "READER" then
-                    // remembering parts will stay the same, we just need to switch out the fragment
                     if (mBottomNav != null) mBottomNav.setCurrentSelectedPage(PageType.NOTIFS);
                     break;
                 case ARG_READER:
@@ -845,8 +839,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         showJetpackFeatureOverlayAccessedInCorrectly(trackingProperties);
                         break;
                     }
-                    // todo: JetpackFocus -  this shouldn't need to change, if the fragment is not reader, it
-                    // will move forward with navigation to "READER"
                     if (intent.getBooleanExtra(ARG_READER_BOOKMARK_TAB, false) && mBottomNav != null && mBottomNav
                             .getActiveFragment() instanceof ReaderFragment) {
                         ((ReaderFragment) mBottomNav.getActiveFragment()).requestBookmarkTab();
@@ -873,10 +865,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         break;
                     }
                     if (mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-                        // todo: JetpackFocus - redirect to the static poster fragment when ready
-                        Toast.makeText(this,
-                                "todo: JetpackFocus - redirect to the static poster fragment when ready",
-                                LENGTH_LONG).show();
+                        ActivityLauncher.showJetpackStaticPoster(this);
                         break;
                     }
                     if (intent.hasExtra(ARG_STATS_TIMEFRAME)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -165,6 +165,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import static android.widget.Toast.LENGTH_LONG;
 import static androidx.lifecycle.Lifecycle.State.STARTED;
 import static org.wordpress.android.WordPress.SITE;
 import static org.wordpress.android.editor.gutenberg.GutenbergEditorFragment.ARG_STORY_BLOCK_ID;
@@ -328,7 +329,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         boolean canShowAppRatingPrompt = savedInstanceState != null;
 
         mBottomNav = findViewById(R.id.bottom_navigation);
-        mBottomNav.init(getSupportFragmentManager(), this);
+        mBottomNav.init(getSupportFragmentManager(), this, mJetpackFeatureRemovalPhaseHelper);
 
         if (savedInstanceState == null) {
             if (!AppPrefs.isInstallationReferrerObtained()) {
@@ -365,7 +366,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         launchWithNoteId();
                     }
                 } else if (openedFromShortcut) {
+                    // todo: JetpackFocus - We need to intercept this here for static posters
                     initSelectedSite();
+                    Toast.makeText(this, "JetpackFocus via shortcut", Toast.LENGTH_LONG).show();
                     mShortcutsNavigator.showTargetScreen(getIntent().getStringExtra(
                             ShortcutsNavigator.ACTION_OPEN_SHORTCUT), this, getSelectedSite());
                     showJetpackOverlayIfNeeded(getIntent().getStringExtra(
@@ -503,6 +506,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
         Map<String, String> trackingProperties = new HashMap<>();
         trackingProperties.put("calling_function", "shortcut_" + shortcut.name());
 
+        // todo: JetpackFocus - I don't believe we need a change here, since static posters
+        // won't get past the first check since they are not considered part of shouldHideJetpackFeatures
         switch (shortcut) {
             case CREATE_NEW_POST:
                 break;
@@ -828,6 +833,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         showJetpackFeatureOverlayAccessedInCorrectly(trackingProperties);
                         break;
                     }
+                    // todo: JetpackFocus - if we reuse the "NOTIFS" and "READER" then
+                    // remembering parts will stay the same, we just need to switch out the fragment
                     if (mBottomNav != null) mBottomNav.setCurrentSelectedPage(PageType.NOTIFS);
                     break;
                 case ARG_READER:
@@ -838,6 +845,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         showJetpackFeatureOverlayAccessedInCorrectly(trackingProperties);
                         break;
                     }
+                    // todo: JetpackFocus -  this shouldn't need to change, if the fragment is not reader, it
+                    // will move forward with navigation to "READER"
                     if (intent.getBooleanExtra(ARG_READER_BOOKMARK_TAB, false) && mBottomNav != null && mBottomNav
                             .getActiveFragment() instanceof ReaderFragment) {
                         ((ReaderFragment) mBottomNav.getActiveFragment()).requestBookmarkTab();
@@ -861,6 +870,13 @@ public class WPMainActivity extends LocaleAwareActivity implements
                         Map<String, String> trackingProperties = new HashMap<>();
                         trackingProperties.put("calling_function", "deeplink_stats");
                         showJetpackFeatureOverlayAccessedInCorrectly(trackingProperties);
+                        break;
+                    }
+                    if (mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+                        // todo: JetpackFocus - redirect to the static poster fragment when ready
+                        Toast.makeText(this,
+                                "todo: JetpackFocus - redirect to the static poster fragment when ready",
+                                LENGTH_LONG).show();
                         break;
                     }
                     if (intent.hasExtra(ARG_STATS_TIMEFRAME)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -165,7 +165,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import static android.widget.Toast.LENGTH_LONG;
 import static androidx.lifecycle.Lifecycle.State.STARTED;
 import static org.wordpress.android.WordPress.SITE;
 import static org.wordpress.android.editor.gutenberg.GutenbergEditorFragment.ARG_STORY_BLOCK_ID;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -320,10 +320,10 @@ class WPMainNavigationView @JvmOverloads constructor(
             return pages().getOrNull(position)?.let { pageType ->
                 val currentFragment = fragmentManager?.findFragmentByTag(getTagForPageType(pageType))
                 return currentFragment?.let {
-                    when(it){
+                    when (it) {
                         is ReaderFragment, is NotificationsListFragment -> checkAndCreateForStaticPage(it, pageType)
                         is JetpackStaticPosterFragment -> checkAndCreateForNonStaticPage(it, pageType)
-                        else -> { it}
+                        else -> it
                     }
                 } ?: createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -315,31 +315,35 @@ class WPMainNavigationView @JvmOverloads constructor(
             return fragment
         }
 
+
         internal fun getFragment(position: Int): Fragment? {
             return pages().getOrNull(position)?.let { pageType ->
-                val fragment = fragmentManager?.findFragmentByTag(getTagForPageType(pageType))
-                if (fragment != null) {
-                    when(fragment){
-                        is ReaderFragment, is NotificationsListFragment -> {
-                            return if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-                                fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
-                                createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
-                            } else {
-                                fragment
-                            }
-                        }
-                        is JetpackStaticPosterFragment -> {
-                            return if (!jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-                                fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
-                                createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
-                            } else {
-                                fragment
-                            }
-                        }
+                val currentFragment = fragmentManager?.findFragmentByTag(getTagForPageType(pageType))
+                return currentFragment?.let {
+                    when(it){
+                        is ReaderFragment, is NotificationsListFragment -> checkAndCreateForStaticPage(it, pageType)
+                        is JetpackStaticPosterFragment -> checkAndCreateForNonStaticPage(it, pageType)
+                        else -> { it}
                     }
-                    return fragment
-                }
-                return createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
+                } ?: createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
+            }
+        }
+
+        private fun checkAndCreateForStaticPage(fragment: Fragment, pageType: PageType) : Fragment {
+            return if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+                fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
+                createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
+            } else {
+                fragment
+            }
+        }
+
+        private fun checkAndCreateForNonStaticPage(fragment: Fragment, pageType: PageType) : Fragment {
+            return if (!jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+                fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
+                createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
+            } else {
+                fragment
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -19,7 +19,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView
 import com.google.android.material.navigation.NavigationBarView.OnItemReselectedListener
 import com.google.android.material.navigation.NavigationBarView.OnItemSelectedListener
-import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
@@ -43,7 +42,6 @@ import org.wordpress.android.util.extensions.getColorStateListFromAttribute
  * four primary views - note that we ignore the built-in icons and labels and
  * insert our own custom views so we have more control over their appearance
  */
-@AndroidEntryPoint
 class WPMainNavigationView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -735,7 +735,7 @@ class MySiteViewModel @Inject constructor(
 
     private fun onTodaysStatsCardFooterLinkClick() {
         cardsTracker.trackTodaysStatsCardFooterLinkClicked()
-         navigateToTodaysStats()
+        navigateToTodaysStats()
     }
 
     private fun onTodaysStatsCardClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1236,7 +1236,8 @@ class MySiteViewModel @Inject constructor(
 
     private fun getStatsNavigationActionForSite(site: SiteModel): SiteNavigationAction = when {
         // if we are in static posters phase - we don't want to show any connection/login messages
-        jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage() -> SiteNavigationAction.ShowJetpackRemovalStaticPostersView
+        jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage() ->
+            SiteNavigationAction.ShowJetpackRemovalStaticPostersView
 
         // If the user is not logged in and the site is already connected to Jetpack, ask to login.
         !accountStore.hasAccessToken() && site.isJetpackConnected -> SiteNavigationAction.StartWPComLoginForJetpackStats

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -724,9 +724,8 @@ class MySiteViewModel @Inject constructor(
     @Suppress("EmptyFunctionBlock")
     private fun onGetMoreViewsClick() {
         cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
-        // todo: JetpackFocus
         if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView())
+            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
         } else {
             _onNavigation.value = Event(
                 SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(URL_GET_MORE_VIEWS_AND_TRAFFIC)
@@ -736,29 +735,18 @@ class MySiteViewModel @Inject constructor(
 
     private fun onTodaysStatsCardFooterLinkClick() {
         cardsTracker.trackTodaysStatsCardFooterLinkClicked()
-        // todo: JetpackFocus
-        if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView())
-        } else {
-            navigateToTodaysStats()
-        }
+         navigateToTodaysStats()
     }
 
     private fun onTodaysStatsCardClick() {
         cardsTracker.trackTodaysStatsCardClicked()
-        // todo: JetpackFocus
-        if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView())
-        } else {
-            navigateToTodaysStats()
-        }
+        navigateToTodaysStats()
     }
 
     private fun navigateToTodaysStats() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
-        // todo: JetpackFocus
         if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
-            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView(selectedSite))
+            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
         } else {
             _onNavigation.value = Event(SiteNavigationAction.OpenStatsInsights(selectedSite))
         }
@@ -1246,19 +1234,18 @@ class MySiteViewModel @Inject constructor(
         return fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, site.id)
     }
 
-    // todo: JetpackFocus - We need to intercept this here for static posters
     private fun getStatsNavigationActionForSite(site: SiteModel): SiteNavigationAction = when {
-            // if we are in static posters phase, then ignore the rest
-            jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage() -> SiteNavigationAction.ShowJetpackRemovalStaticPostersView(site)
+        // if we are in static posters phase - we don't want to show any connection/login messages
+        jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage() -> SiteNavigationAction.ShowJetpackRemovalStaticPostersView
 
-            // If the user is not logged in and the site is already connected to Jetpack, ask to login.
-            !accountStore.hasAccessToken() && site.isJetpackConnected -> SiteNavigationAction.StartWPComLoginForJetpackStats
+        // If the user is not logged in and the site is already connected to Jetpack, ask to login.
+        !accountStore.hasAccessToken() && site.isJetpackConnected -> SiteNavigationAction.StartWPComLoginForJetpackStats
 
-            // If it's a WordPress.com or Jetpack site, show the Stats screen.
-            site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> SiteNavigationAction.OpenStats(site)
+        // If it's a WordPress.com or Jetpack site, show the Stats screen.
+        site.isWPCom || site.isJetpackInstalled && site.isJetpackConnected -> SiteNavigationAction.OpenStats(site)
 
-            // If it's a self-hosted site, ask to connect to Jetpack.
-            else -> SiteNavigationAction.ConnectJetpackForStats(site)
+        // If it's a self-hosted site, ask to connect to Jetpack.
+        else -> SiteNavigationAction.ConnectJetpackForStats(site)
     }
 
     fun onAvatarPressed() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -248,7 +248,7 @@ class MySiteViewModel @Inject constructor(
     val isMySiteTabsEnabled: Boolean
         get() = isMySiteDashboardTabsEnabled &&
                 buildConfigWrapper.isMySiteTabsEnabled &&
-                !jetpackFeatureRemovalUtils.shouldHideJetpackFeatures() &&
+                jetpackFeatureRemovalPhaseHelper.shouldShowDashboard() &&
                 selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi ?: true
 
     val orderedTabTypes: List<MySiteTabType>
@@ -528,7 +528,7 @@ class MySiteViewModel @Inject constructor(
         )
         val jetpackInstallFullPluginCard = jetpackInstallFullPluginCardBuilder.build(jetpackInstallFullPluginCardParams)
 
-        val cardsResult = if (jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()) emptyList()
+        val cardsResult = if (!jetpackFeatureRemovalPhaseHelper.shouldShowDashboard()) emptyList()
         else cardsBuilder.build(
             QuickActionsCardBuilderParams(
                 siteModel = site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -84,4 +84,5 @@ sealed class SiteNavigationAction {
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
     data class OpenPromoteWithBlazeOverlay(val source: BlazeFlowSource) : SiteNavigationAction()
+    data class ShowJetpackRemovalStaticPostersView(val site: SiteModel? = null) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -84,5 +84,5 @@ sealed class SiteNavigationAction {
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
     data class OpenPromoteWithBlazeOverlay(val source: BlazeFlowSource) : SiteNavigationAction()
-    data class ShowJetpackRemovalStaticPostersView(val site: SiteModel? = null) : SiteNavigationAction()
+    object ShowJetpackRemovalStaticPostersView : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -42,7 +42,6 @@ class SiteItemsBuilder @Inject constructor(
         return jetpackSiteItems + publishSiteItems + lookAndFeelSiteItems + configurationSiteItems + externalSiteItems
     }
 
-    // todo: JetpackFocus - should we be showing the quick start for static posters?
     private fun getJetpackDependantSiteItems(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
         return if (!jetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
             val checkStatsTask = quickStartRepository.quickStartType

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -42,6 +42,7 @@ class SiteItemsBuilder @Inject constructor(
         return jetpackSiteItems + publishSiteItems + lookAndFeelSiteItems + configurationSiteItems + externalSiteItems
     }
 
+    // todo: JetpackFocus - should we be showing the quick start for static posters?
     private fun getJetpackDependantSiteItems(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
         return if (!jetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
             val checkStatsTask = quickStartRepository.quickStartType

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -437,6 +437,12 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             null,
             action.source
         )
+        is SiteNavigationAction.ShowJetpackRemovalStaticPostersView -> {
+            // todo: JetpackFocus - implement when static posters fragment is ready
+            showSnackbar(SnackbarMessageHolder(
+                message = UiStringText("TODO: JetpackFeatureRemoval for stats"),
+                isImportant = true))
+        }
     }
 
     private fun showJetpackPoweredBottomSheet() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -438,10 +438,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             action.source
         )
         is SiteNavigationAction.ShowJetpackRemovalStaticPostersView -> {
-            // todo: JetpackFocus - implement when static posters fragment is ready
-            showSnackbar(SnackbarMessageHolder(
-                message = UiStringText("TODO: JetpackFeatureRemoval for stats"),
-                isImportant = true))
+            ActivityLauncher.showJetpackStaticPoster(requireActivity())
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -52,7 +52,7 @@ import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
-import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.ToastUtils.Duration
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
@@ -92,7 +92,8 @@ class PostListMainViewModel @Inject constructor(
     private val uploadStarter: UploadStarter,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
     private val blazeFeatureUtils: BlazeFeatureUtils,
-    private val blazeStore: BlazeStore
+    private val blazeStore: BlazeStore,
+    private val siteUtilsWrapper: SiteUtilsWrapper
 ) : ViewModel(), CoroutineScope {
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
@@ -401,7 +402,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun fabClicked() {
-        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             _onFabClicked.postValue(Event(Unit))
         } else {
             newPost()
@@ -643,7 +644,7 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun onFabLongPressed() {
-        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             _onFabLongPressedForCreateMenu.postValue(Event(Unit))
         } else {
             _onFabLongPressedForPostList.postValue(Event(Unit))

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayVi
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.ForwardToJetpack;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
+import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -93,6 +94,9 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+
+import static org.wordpress.android.ui.main.WPMainActivity.ARG_OPEN_PAGE;
+import static org.wordpress.android.ui.main.WPMainActivity.ARG_READER;
 
 /*
  * shows reader post detail fragments in a ViewPager - primarily used for easy swiping between
@@ -299,12 +303,22 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
             host = uri.getHost();
         }
 
-        if (uri == null || mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+        if (uri == null
+            || mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+            || mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
             mReaderTracker.trackDeepLink(AnalyticsTracker.Stat.DEEP_LINKED, action, host, uri);
             // invalid uri so, just show the entry screen
-            Intent intent = new Intent(this, WPLaunchActivity.class);
-            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(intent);
+            if (mJetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+                Intent intent = new Intent(this, WPMainActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.putExtra(ARG_OPEN_PAGE, ARG_READER);
+                startActivity(intent);
+            } else {
+                Intent intent = new Intent(this, WPLaunchActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.putExtra(ARG_OPEN_PAGE, ARG_READER);
+                startActivity(intent);
+            }
             finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -11,7 +11,9 @@ import org.wordpress.android.databinding.StatsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.util.JetpackBrandingUtils
@@ -24,12 +26,19 @@ class StatsActivity : LocaleAwareActivity() {
 
     @Inject
     lateinit var jetpackBrandingUtils: JetpackBrandingUtils
+
+    @Inject
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
     private val viewModel: StatsViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setContentView(StatsListActivityBinding.inflate(layoutInflater).root)
+        if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+            ActivityLauncher.showJetpackStaticPoster(this)
+            finish()
+        } else {
+            setContentView(StatsListActivityBinding.inflate(layoutInflater).root)
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -331,9 +331,10 @@ public class SiteUtils {
         return VersionUtils.checkMinimalVersion(site.getSoftwareVersion(), minVersion);
     }
 
+    // todo: annmarie
     public static boolean supportsStoriesFeature(SiteModel site, JetpackFeatureRemovalPhaseHelper helper) {
-        return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION))
-               && !helper.shouldRemoveJetpackFeatures();
+       return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION))
+               && helper.shouldShowStoryPost();
     }
 
     public static boolean supportsContactInfoFeature(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -331,7 +331,6 @@ public class SiteUtils {
         return VersionUtils.checkMinimalVersion(site.getSoftwareVersion(), minVersion);
     }
 
-    // todo: annmarie
     public static boolean supportsStoriesFeature(SiteModel site, JetpackFeatureRemovalPhaseHelper helper) {
        return site != null && (site.isWPCom() || checkMinimalJetpackVersion(site, WP_STORIES_JETPACK_VERSION))
                && helper.shouldShowStoryPost();

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.DimenRes
 import dagger.Reusable
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.reader.utils.SiteAccessibilityInfo
 import javax.inject.Inject
 
@@ -26,5 +27,8 @@ class SiteUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun getHomeURLOrHostName(site: SiteModel): String = SiteUtils.getHomeURLOrHostName(site)
     fun getSiteIconUrlOfResourceSize(site: SiteModel, @DimenRes sizeRes: Int): String {
         return SiteUtils.getSiteIconUrl(site, appContext.resources.getDimensionPixelSize(sizeRes))
+    }
+    fun supportsStoriesFeature(site: SiteModel, helper: JetpackFeatureRemovalPhaseHelper): Boolean {
+        return SiteUtils.supportsStoriesFeature(site, helper)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtilsWrapper.kt
@@ -28,7 +28,7 @@ class SiteUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun getSiteIconUrlOfResourceSize(site: SiteModel, @DimenRes sizeRes: Int): String {
         return SiteUtils.getSiteIconUrl(site, appContext.resources.getDimensionPixelSize(sizeRes))
     }
-    fun supportsStoriesFeature(site: SiteModel, helper: JetpackFeatureRemovalPhaseHelper): Boolean {
+    fun supportsStoriesFeature(site: SiteModel?, helper: JetpackFeatureRemovalPhaseHelper): Boolean {
         return SiteUtils.supportsStoriesFeature(site, helper)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -41,8 +41,8 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementProvider
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.FluxCUtils
-import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.map
 import org.wordpress.android.util.mapNullable
@@ -73,7 +73,8 @@ class WPMainActivityViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
     private val blazeFeatureUtils: BlazeFeatureUtils,
-    private val blazeStore: BlazeStore
+    private val blazeStore: BlazeStore,
+    private val siteUtilsWrapper: SiteUtilsWrapper
 ) : ScopedViewModel(mainDispatcher) {
     private var isStarted = false
 
@@ -186,7 +187,7 @@ class WPMainActivityViewModel @Inject constructor(
                 onClickAction = null
             )
         )
-        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             actionsList.add(
                 CreateAction(
                     actionType = CREATE_NEW_STORY,
@@ -269,7 +270,7 @@ class WPMainActivityViewModel @Inject constructor(
 
         _showQuickStarInBottomSheet.postValue(quickStartRepository.activeTask.value == PUBLISH_POST)
 
-        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper) || hasFullAccessToContent(site)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper) || hasFullAccessToContent(site)) {
             launch {
                 // The user has at least two create options available for this site (pages and/or story posts),
                 // so we should show a bottom sheet.
@@ -355,7 +356,7 @@ class WPMainActivityViewModel @Inject constructor(
     }
 
     fun getCreateContentMessageId(site: SiteModel?): Int {
-        return if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        return if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             getCreateContentMessageIdStoriesFlagOn(hasFullAccessToContent(site))
         } else {
             getCreateContentMessageIdStoriesFlagOff(hasFullAccessToContent(site))

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -270,7 +270,11 @@ class WPMainActivityViewModel @Inject constructor(
 
         _showQuickStarInBottomSheet.postValue(quickStartRepository.activeTask.value == PUBLISH_POST)
 
-        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper) || hasFullAccessToContent(site)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(
+            site,
+            jetpackFeatureRemovalPhaseHelper) ||
+            hasFullAccessToContent(site)
+        ) {
             launch {
                 // The user has at least two create options available for this site (pages and/or story posts),
                 // so we should show a bottom sheet.

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.main.MainFabUiState
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -25,7 +25,8 @@ import javax.inject.Inject
 class PostListCreateMenuViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+    private val siteUtilsWrapper: SiteUtilsWrapper
 ) : ViewModel() {
     private var isStarted = false
     private lateinit var site: SiteModel
@@ -67,7 +68,7 @@ class PostListCreateMenuViewModel @Inject constructor(
                 onClickAction = null
             )
         )
-        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             actionsList.add(
                 CreateAction(
                     actionType = CREATE_NEW_STORY,
@@ -147,7 +148,7 @@ class PostListCreateMenuViewModel @Inject constructor(
     }
 
     private fun getCreateContentMessageId(): Int {
-        return if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+        return if (siteUtilsWrapper.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
             R.string.create_post_story_fab_tooltip
         } else {
             R.string.create_post_fab_tooltip

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModel.kt
@@ -67,15 +67,17 @@ class PostListCreateMenuViewModel @Inject constructor(
                 onClickAction = null
             )
         )
-        actionsList.add(
-            CreateAction(
-                actionType = CREATE_NEW_STORY,
-                iconRes = R.drawable.ic_story_icon_24dp,
-                labelRes = R.string.my_site_bottom_sheet_add_story,
-                onClickAction = ::onCreateActionClicked
+        if (SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)) {
+            actionsList.add(
+                CreateAction(
+                    actionType = CREATE_NEW_STORY,
+                    iconRes = R.drawable.ic_story_icon_24dp,
+                    labelRes = R.string.my_site_bottom_sheet_add_story,
+                    onClickAction = ::onCreateActionClicked
 
+                )
             )
-        )
+        }
         actionsList.add(
             CreateAction(
                 actionType = CREATE_NEW_POST,

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/StatsLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/StatsLinkHandlerTest.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
 import org.wordpress.android.ui.deeplinks.buildUri
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.stats.StatsTimeframe.DAY
 import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
 import org.wordpress.android.ui.stats.StatsTimeframe.MONTH
@@ -26,9 +27,12 @@ class StatsLinkHandlerTest {
     lateinit var site: SiteModel
     private lateinit var statsLinkHandler: StatsLinkHandler
 
+    @Mock
+    private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     @Before
     fun setUp() {
-        statsLinkHandler = StatsLinkHandler(deepLinkUriUtils)
+        statsLinkHandler = StatsLinkHandler(deepLinkUriUtils, jetpackFeatureRemovalPhaseHelper)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -493,6 +493,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartType.getTaskFromString(QuickStartStore.QUICK_START_VIEW_SITE_LABEL))
             .thenReturn(QuickStartNewSiteTask.VIEW_SITE)
         whenever(jetpackBrandingUtils.getBrandingTextForScreen(any())).thenReturn(mock())
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowDashboard()).thenReturn(true)
         viewModel = MySiteViewModel(
             networkUtilsWrapper,
             testDispatcher(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -57,6 +57,7 @@ import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsPostTagProvider
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.jpfullplugininstall.GetShowJetpackFullPluginInstallOnboardingUseCase
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
@@ -323,6 +324,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var blazeFeatureUtils: BlazeFeatureUtils
 
+    @Mock
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<UiModel>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -540,7 +544,8 @@ class MySiteViewModelTest : BaseUnitTest() {
             bloggingPromptsCardTrackHelper,
             getShowJetpackFullPluginInstallOnboardingUseCase,
             jetpackInstallFullPluginShownTracker,
-            blazeFeatureUtils
+            blazeFeatureUtils,
+            jetpackFeatureRemovalPhaseHelper
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
@@ -75,7 +75,8 @@ class PostListMainViewModelCopyPostTest : BaseUnitTest() {
             savePostToDbUseCase = mock(),
             jetpackFeatureRemovalPhaseHelper = mock(),
             blazeFeatureUtils = mock(),
-            blazeStore = mock()
+            blazeStore = mock(),
+            siteUtilsWrapper = mock()
         )
         viewModel.postListAction.observeForever(onPostListActionObserver)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -18,10 +18,12 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.posts.PostListViewLayoutType.COMPACT
 import org.wordpress.android.ui.posts.PostListViewLayoutType.STANDARD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.viewmodel.Event
 
 @ExperimentalCoroutinesApi
@@ -41,6 +43,12 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var savePostToDbUseCase: SavePostToDbUseCase
+
+    @Mock
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    @Mock
+    lateinit var siteUtilsWrapper: SiteUtilsWrapper
     private lateinit var viewModel: PostListMainViewModel
 
     @Before
@@ -50,6 +58,7 @@ class PostListMainViewModelTest : BaseUnitTest() {
         }
 
         whenever(editPostRepository.postChanged).thenReturn(MutableLiveData(Event(PostModel())))
+        whenever(siteUtilsWrapper.supportsStoriesFeature(any(), any())).thenReturn(true)
 
         viewModel = PostListMainViewModel(
             dispatcher = dispatcher,
@@ -69,7 +78,8 @@ class PostListMainViewModelTest : BaseUnitTest() {
             savePostToDbUseCase = savePostToDbUseCase,
             jetpackFeatureRemovalPhaseHelper = mock(),
             blazeFeatureUtils = mock(),
-            blazeStore = mock()
+            blazeStore = mock(),
+            siteUtilsWrapper = siteUtilsWrapper
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/SiteUtilsTest.kt
@@ -201,6 +201,7 @@ class SiteUtilsTest {
 
     @Test
     fun `supportsStoriesFeature returns true when origin is wpcom rest`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowStoryPost()).thenReturn(true)
         val site = SiteModel().apply {
             origin = SiteModel.ORIGIN_WPCOM_REST
             setIsWPCom(true)
@@ -213,6 +214,7 @@ class SiteUtilsTest {
 
     @Test
     fun `supportsStoriesFeature returns true when Jetpack site meets requirement`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowStoryPost()).thenReturn(true)
         val site = initJetpackSite().apply {
             jetpackVersion = SiteUtils.WP_STORIES_JETPACK_VERSION
         }
@@ -239,7 +241,7 @@ class SiteUtilsTest {
             origin = SiteModel.ORIGIN_WPCOM_REST
             setIsWPCom(true)
         }
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowStoryPost()).thenReturn(false)
 
         val supportsStoriesFeature = SiteUtils.supportsStoriesFeature(site, jetpackFeatureRemovalPhaseHelper)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -173,7 +173,6 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
         whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(false)
         whenever(bloggingPromptsStore.getPromptForDate(any(), any())).thenReturn(flowOf(bloggingPrompt))
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
         whenever(siteUtilsWrapper.supportsStoriesFeature(any(), any())).thenReturn(true)
         viewModel = WPMainActivityViewModel(
             featureAnnouncementProvider,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListCreateMenuViewModelTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -18,6 +19,7 @@ import org.wordpress.android.ui.main.MainActionListItem.ActionType.CREATE_NEW_ST
 import org.wordpress.android.ui.main.MainActionListItem.ActionType.NO_ACTION
 import org.wordpress.android.ui.main.MainActionListItem.CreateAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @ExperimentalCoroutinesApi
@@ -36,13 +38,16 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
     @Mock
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
+    @Mock lateinit var siteUtilsWrapper: SiteUtilsWrapper
+
     @Before
     fun setUp() {
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(false)
+        whenever(siteUtilsWrapper.supportsStoriesFeature(any(), any())).thenReturn(true)
         viewModel = PostListCreateMenuViewModel(
             appPrefsWrapper,
             analyticsTrackerWrapper,
-            jetpackFeatureRemovalPhaseHelper
+            jetpackFeatureRemovalPhaseHelper,
+            siteUtilsWrapper
         )
     }
 
@@ -132,8 +137,6 @@ class PostListCreateMenuViewModelTest : BaseUnitTest() {
 
     @Test
     fun `start set expected content message`() {
-        whenever(site.isWPCom).thenReturn(true)
-
         viewModel.start(site, false)
         Assertions.assertThat(viewModel.fabUiState.value!!.CreateContentMessageId)
             .isEqualTo(R.string.create_post_story_fab_tooltip)


### PR DESCRIPTION
Parents #18109 , #18110 , #18111 

## Description
### Navigating to Static Posters
This PR covers the core parts for managing Jetpack Static Posters phase:
- Show the Static Page when:
-- Tapping on the Reader tab
-- Tapping on the Notification tab
-- Tapping on the Stats menu item
-- Wen navigating into the app from a Stats shortcut, widget, or deep link
-- When navigating into the app from a Notification shortcut or widget

### Disables the ability to Add Stories in Static posters phase

## **TestSetup**
- Remove all other versions of WP & JP from your device
- Install WP from this PR
- Set up WP to handle deep links
    - Navigate to the device app settings for WP > Open by default
    - Tap on the Add link > Select all 3 supported links
    - Click Add
- Login to the app
- Navigate to Me > App Settings > Privacy Settings  and enable Collect Information
- Do not enable/disable the `jp_removal_static_posters`, it should be off after fresh install
- Locate the app icon on your device and long press on it
- Add a stats widget to your homescreen

 
**Test - Non Static Poster state  is not enabled**

- Tap on MySite tab
- ✅ Verify the dashboard is visible 
- Tap on the reader and notification tabs
- ✅ Verify the reader and notification content are shown
- Tap on the FAB
- ✅ Verify Story Post option is visible
- Tap on the “Stats” feature (either through the menu item, stats card, or quick links)
- ✅ Verify you are taken to the Stats area
- Navigate back to My Site
- Tap on Posts
- Tap on FAB
- ✅ Verify Story Post option is visible
- Background the app 
- Locate the stats widget you created during setup and tap on it
- ✅ Verify the app is launched and you are taken to the Stats area
- Background the app 
- Locate the app icon and long press on it
- Tap on the stats shortcut
- ✅ Verify the app is launched and you are taken to the Stats area
- Background the app 
- Locate the app icon and long press on it
- Tap on the notifications shortcut
- ✅ Verify the app is launched and you are taken to the Notifications tab showing notification content
- Deep link into the app using the following 
`<p><a href="intent://stats/#Intent;scheme=wordpress;package=org.wordpress.android.prealpha;end;">WordPress Stats</a></p>`
- ✅ Verify the app is launched and you are taken to the Stats area

**Test - Static Poster state is enabled**

- Navigate to Me > App Settings > Debug Settings
- Enable `jp_removal_static_posters`
- Navigate back to My Site Tab
- ✅ Verify the dashboard is not visible 
- Tap on the reader and notification tabs
- ✅ Verify the reader and notification content are not shown, but rather the static page is shown
- Tap on the FAB
- ✅ Verify Story Post option is not visible
- Tap on the “Stats” menu item 
- ✅ Verify you are shown the static page
- Navigate back to My Site
- Tap on Posts
- Tap on FAB
- ✅ Verify Story Post option is not visible (You should be taken straight into the editor)
- Background the app 
- Locate the stats widget you created during setup and tap on it
- ✅ Verify the app is launched and you are shown the static page
- Background the app 
- Locate the app icon and long press on it
- Tap on the stats shortcut
- ✅ Verify the app is launched and you are shown the static page
- Background the app 
- Locate the app icon and long press on it
- Tap on the notifications shortcut
- ✅ Verify the app is launched and you are taken to the Notification tab showing the static page
- Deep link into the app using the following:
``<p><a href="intent://stats/#Intent;scheme=wordpress;package=org.wordpress.android.prealpha;end;">WordPress Stats</a></p>``
- ✅ Verify the app is launched and you are taken to the static page

## Regression Notes
1. Potential unintended areas of impact
The tabs don't work as expected, the stats view shows when it shouldn't, there are overlapping fragments in the main view.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and individual unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
