### PR TITLE
Adds: Messaging for the Jp features in Static Posters Phase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseF
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseStaticPosters
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringPluralRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -39,6 +40,7 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
             PhaseOne,
             PhaseTwo,
             PhaseThree,
+            PhaseStaticPosters,
             PhaseFour -> true
             else -> false
         }
@@ -48,6 +50,7 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
             PhaseTwo,
             PhaseThree,
+            PhaseStaticPosters,
             PhaseFour -> true
             else -> false
         }
@@ -55,6 +58,7 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
 
     fun getBrandingTextByPhase(screen: JetpackPoweredScreen): UiString {
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
+            PhaseStaticPosters -> UiStringRes(R.string.wp_jetpack_feature_removal_static_posters_phase)
             PhaseThree -> (screen as? JetpackPoweredScreen.WithDynamicText)?.let { screenWithDynamicText ->
                 getDynamicBrandingForScreen(screenWithDynamicText)
             } ?: UiStringRes(JetpackBrandingUiState.RES_JP_POWERED)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4372,6 +4372,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_phase_new_users_notifications_description">Get notifications for new comments, likes, views, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_description">The Jetpack mobile app is designed to work in companion with the Jetpack plugin. Switch now to get access to stats, notifications, reader, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_title">Your site has the Jetpack plugin</string>
+    <string name="wp_jetpack_feature_removal_static_posters_phase">Moving to the Jetpack app in a few days.</string>
+
 
     <!-- Deep Linking Activity Aliases -->
     <string name="deep_linking_urilinks_alias_label">urilinks</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -296,6 +296,16 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyNoInteractions(dateTimeUtilsWrapper)
     }
 
+    @Test
+    fun `given static posters phase started, all banners and badges should be Jetpack powered`() {
+        givenPhase(JetpackFeatureRemovalPhase.PhaseStaticPosters)
+
+        val actual = allJpScreens.map(classToTest::getBrandingTextByPhase)
+
+        actual.assertAllMatch(R.string.wp_jetpack_feature_removal_static_posters_phase)
+        verifyNoInteractions(dateTimeUtilsWrapper)
+    }
+
     // endregion
 
     // region Helpers


### PR DESCRIPTION
Closes #18112 

## Description
As titled, this adds a new string to be displayed in the Jetpack banners and badges during the static screens phase.

## To test
- ### Pre-requisistes 
- Go to Wordpress app 
- Login with a wp account
- Go to **app settings** → **Debug settings** 
- enable feature flag → `jp_removal_static_posters`
- Go to Activity Log from the Site menu.
-  🔎 Verify that the Jetpack banner is shown with the new string: **Moving to the Jetpack app in a few days.**

Since the change is centralized, verifying the change in one place should be enough. 


## Regression Notes
1. Potential unintended areas of impact
Banner/Badges text is not correct. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran existing unit tests, added Unit tests for the change and Manual testing 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
