### PR TITLE
Disable features on static posters phase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -132,6 +132,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
             else -> true
         }
     }
+
+    fun shouldShowHelpAndSupportOnEditor(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
 }
 // Global overlay frequency is the frequency at which the overlay is shown across the features
 // no matter which feature was accessed last time

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -92,6 +92,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowJetpackPoweredEditorFeatures(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     fun shouldShowTemplateSelectionInPages(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true
         return when (currentPhase) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -92,6 +92,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowTemplateSelectionInPages(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -124,6 +124,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
             is PhaseOne, PhaseTwo, PhaseThree, PhaseStaticPosters -> true
         }
     }
+
+    fun shouldShowQuickStart(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
 }
 // Global overlay frequency is the frequency at which the overlay is shown across the features
 // no matter which feature was accessed last time

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -665,7 +665,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     break;
                 case CREATE_NEW_PAGE:
                     if (mMLPViewModel.canShowModalLayoutPicker()
-                        && !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+                        && mJetpackFeatureRemovalPhaseHelper.shouldShowTemplateSelectionInPages()) {
                         mMLPViewModel.createPageFlowTriggered();
                     } else {
                         handleNewPageAction("", "", null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1322,6 +1322,7 @@ class MySiteViewModel @Inject constructor(
         isSiteTitleTaskCompleted: Boolean,
         isNewSite: Boolean
     ) {
+        if (!jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()) return
         quickStartRepository.checkAndSetQuickStartType(isNewSite = isNewSite)
         if (quickStartDynamicCardsFeatureConfig.isEnabled()) {
             startQuickStart(siteLocalId, isSiteTitleTaskCompleted)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -377,7 +377,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
 
         viewModel.createNewPage.observe(viewLifecycleOwner, {
             if (mlpViewModel.canShowModalLayoutPicker()
-                && !jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) {
+                && jetpackFeatureRemovalPhaseHelper.shouldShowTemplateSelectionInPages()) {
                 mlpViewModel.createPageFlowTriggered()
             } else {
                 createNewPage()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2360,7 +2360,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         String hostAppNamespace = mBuildConfigWrapper.isJetpackApp() ? "Jetpack" : "WordPress";
 
         // Disable Jetpack-powered editor features in WordPress app based on Jetpack Features Removal Phase helper
-        boolean jetpackFeaturesRemoved = mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures();
+        boolean jetpackFeaturesRemoved = !mJetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures();
         if (jetpackFeaturesRemoved) {
             return new GutenbergPropsBuilder(
                     false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1335,8 +1335,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         if (helpMenuItem != null) {
             // Support section will be disabled in WordPress app when Jetpack-powered features are removed.
             // Therefore, we have to update the Help menu item accordingly.
-            boolean jetpackFeaturesRemoved = mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures();
-            int helpMenuTitle = jetpackFeaturesRemoved ? R.string.help : R.string.help_and_support;
+            boolean showHelpAndSupport = mJetpackFeatureRemovalPhaseHelper.shouldShowHelpAndSupportOnEditor();
+            int helpMenuTitle = showHelpAndSupport ? R.string.help_and_support : R.string.help;
             helpMenuItem.setTitle(helpMenuTitle);
 
             if (mEditorFragment instanceof GutenbergEditorFragment
@@ -2272,7 +2272,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                                 gutenbergWebViewAuthorizationData,
                                 gutenbergPropsBuilder,
                                 RequestCodes.EDIT_STORY,
-                                !mJetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
+                                mJetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures()
                         );
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1406,6 +1406,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given dynamic cards enabled + new site, when check & start QS triggered, then new site QS starts`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, false, isNewSite = true)
 
@@ -1422,6 +1423,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given dynamic cards enabled + existing site, when check & start QS triggered, then existing site QS starts`() {
         whenever(quickStartRepository.quickStartType).thenReturn(ExistingSiteQuickStartType)
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, false, isNewSite = false)
 
@@ -1438,6 +1440,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given no selected site, when check and start QS is triggered, then QSP is not shown`() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, isSiteTitleTaskCompleted = false, isNewSite = false)
 
@@ -1449,6 +1452,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, isSiteTitleTaskCompleted = false, isNewSite = true)
 
@@ -1460,6 +1464,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(false)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, isSiteTitleTaskCompleted = false, isNewSite = false)
 
@@ -1471,6 +1476,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, false, isNewSite = true)
 
@@ -1489,6 +1495,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartDynamicCardsFeatureConfig.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(quickStartUtilsWrapper.isQuickStartAvailableForTheSite(site)).thenReturn(true)
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()).thenReturn(true)
 
         viewModel.checkAndStartQuickStart(siteLocalId, false, isNewSite = false)
 


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-Android/issues/18131

## Description
This PR focuses on disabling the following features during the static screens phase.
- Page Creation template picker
- Jetpack powered editor blocks
- Help and Support on the editor
- Quick Start

## To test
- Install and login to the app
- Navigate to Me > App Settings > Privacy Settings  and enable Collect Information
- Enable the `jp_removal_static_posters` and restart the app

**Test - Page Creation Template Picker**
- Navigate to Pages List
- Tap the FAB on the pages list
- ✅ Verify the page creation template flow is not shown
- Navigate back to My Site

**Test - Quick Start**
- Logout of the app
- Login back 
- Select a site when prompted
- ✅ Verify the quick start dialog is not shown

<details>
<summary><b>Test - Jetpack powered editor blocks AND Help and Support</b></summary>
Note: These instructions were copied from PR #17587 - thanks @fluiddot 
### 1 - Editor Jetpack-powered features **ENABLED** in **WordPress app**

#### Preparation
1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Disable `p_removal_static_posters` and restart the app

#### Check Jetpack blocks
1. Create a post.
2. Tap on _➕ Add Blocks_ button.
3. Scroll down the block list.
4. Observe that the Jetpack blocks are present within the _Jetpack powered section_ section and can be added to the post.
5. Add all Jetpack blocks (`Contact Info`, `Story`, `Layout Grid` blocks).
6. Observe that all Jetpack blocks are displayed and can be edited.
7. Save the post with some Jetpack blocks (this post will be used in other test cases).

#### Check @-mentions and X-posts features
1. Add a Paragraph block.
2. Type the `+` character and observe that the `x-post` sheet is displayed.
**NOTE:** `x-post` feature only works in sites with the [O2 plugin](https://github.com/Automattic/o2) enabled like P2-based sites. **In order to test this, please use a P2-based site.**
3. Type the `@` character and observe that the `@-mentions` sheet is displayed.
4. Observe that in the toolbar the `@` format button is displayed.

#### Check the help's support section
1. Open a post.
2. Tap on the three dots button to open the contextual menu.
3. Observe that there's the option _Help & Support_ that references `Support`, tap on it.
4. Observe that the section _Get support_ is present.

#### Check Reusable blocks
1. Create a reusable block in the web version of the editor (instructions [here](https://wordpress.com/support/wordpress-editor/blocks/reusable-block/#create-a-reusable-block)).
2. Create a post in the app.
3. Tap on _➕ Add Blocks_ button.
4. Observe that in the bottom sheet the "Reusable" tab is shown.
5. Tap on the "Reusable" tab and insert a Reusable block.
6. Observe that the block is displayed.
7. Save the post with at least one Reusable block (this post will be used in other test cases).

#### Check Unsupported Block Editor (UBE)
1. Create a post in the web version of the editor.
2. Add a block that is not supported in the native version like the Table block.
3. Save the post (this post will be used in other test cases).
4. Open the same post in the app.
5. Observe that the block is displayed as unsupported.
6. Tap on the block and try to edit it with UBE.
7. Observe that it can be edited with UBE.

### 2 - Editor Jetpack-powered features **DISABLED** in **WordPress app**
1. Navigate to App Settings in the WordPress app and open Debug settings.
2. Enable `p_removal_static_posters` and restart the app

#### Check Jetpack blocks
1. Open the previous post saved with Jetpack blocks.
2. Observe that the Jetpack blocks are displayed as unsupported.
3. Tap on a Jetpack block and observe that a bottom sheet is displayed indicating that the block is not supported.
4. Tap on _➕ Add Blocks_ button.
5. Scroll down the block list.
6. Observe that the Jetpack blocks are NOT present.

#### Check @-mentions and X-posts features
1. Add a Paragraph block.
2. Type the `+` character and observe that the `x-post` sheet is NOT displayed.
**NOTE:** `x-post` feature only works in sites with the [O2 plugin](https://github.com/Automattic/o2) enabled like P2-based sites. **In order to test this, please use a P2-based site.**
4. Type the `@` character and observe that the `@-mentions` sheet is NOT displayed.
5. Observe that in the toolbar the `@` format button is NOT displayed.

#### Check the help's support section
1. Open a post.
2. Tap on the three dots button to open the contextual menu.
3. Observe that there's the option _Help_ but doesn't reference `Support`, tap on it.
4. Observe that the section _Get support_ is NOT present.

#### Check Reusable blocks
1. Open the previous post saved with Reusable blocks.
2. Observe that the Reusable block is displayed as unsupported.
3. Tap on the block and observe that a bottom sheet is displayed indicating that the block is not supported.
4. Tap on _➕ Add Blocks_ button.
6. Observe that in the bottom sheet the "Reusable" tab is NOT shown.

#### Check Unsupported Block Editor (UBE)
1. Open the previous post saved with unsupported blocks.
2. Observe that the block is displayed as unsupported.
3. Tap on the block and observe that it can't be edited with UBE.

### 3- Editor Jetpack-powered features **ENABLED** in **Jetpack app**

1. Navigate to App Settings in the Jetpack app and open Debug settings.
2. Turn `jp_removal_four` flag on. _This flag should be omitted by the Jetpack app._
3. Repeat the same test cases described in "1 - Editor Jetpack-powered features **ENABLED** in **WordPress app**":
    - Check Jetpack blocks
    - Check @-mentions and X-posts features
    - Check the help's support section
    - Check Reusable blocks
    - Check Unsupported Block Editor (UBE)



</details>

## Regression Notes
1. Potential unintended areas of impact
The features are still visible when in static poster phase

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
