### PR TITLE
Fixes: the last seen tab before the Phase 4 gets enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -107,7 +107,12 @@ class WPMainNavigationView @JvmOverloads constructor(
             itemView.addView(customView)
         }
 
-        currentPosition = AppPrefs.getMainPageIndex(numPages() - 1)
+        currentPosition = getMainPageIndex()
+    }
+
+    private fun getMainPageIndex(): Int {
+        return if (jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()) 0
+        else AppPrefs.getMainPageIndex(numPages() - 1)
     }
 
     private fun hideReaderTab() {
@@ -169,7 +174,9 @@ class WPMainNavigationView @JvmOverloads constructor(
 
         setImageViewSelected(position, true)
 
-        AppPrefs.setMainPageIndex(position)
+        if(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures())
+            AppPrefs.setMainPageIndex(0)
+        else AppPrefs.setMainPageIndex(position)
 
         // temporarily disable the nav listeners so they don't fire when we change the selected page
         assignNavigationListeners(false)
@@ -327,7 +334,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             }
         }
 
-        private fun checkAndCreateForStaticPage(fragment: Fragment, pageType: PageType) : Fragment {
+        private fun checkAndCreateForStaticPage(fragment: Fragment, pageType: PageType): Fragment {
             return if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
                 fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
                 createFragment(pageType, jetpackFeatureRemovalPhaseHelper)
@@ -336,7 +343,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             }
         }
 
-        private fun checkAndCreateForNonStaticPage(fragment: Fragment, pageType: PageType) : Fragment {
+        private fun checkAndCreateForNonStaticPage(fragment: Fragment, pageType: PageType): Fragment {
             return if (!jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
                 fragmentManager?.beginTransaction()?.remove(fragment)?.commitNow()
                 createFragment(pageType, jetpackFeatureRemovalPhaseHelper)


### PR DESCRIPTION
Fixes #

## Description 
This PR fixes last seen tab issue when the user goes from phase_3/phase_static_posters → phase 4 gets turned on in the background 

### Issue 
- When the last used tab of a user is Notifications/Reader 
- When the app is in the background and Phase 4 gets turned on 
- The Reader/notifications tab will be shown without any bottom bar and the user wont be able to navigate to any parts of the app 

## To test:

### Reproduce the issue 

1. - Go to Notifications/Reader 
2. - Put app in the background 
3. - Add the following line to the `JetpackFeatureRemovalPhaseFourConfig`
` override fun isEnabled(): Boolean {
return true   }
`
4. - Launch the app 
5. - Notice that the ReaderFragment/ NotificationsFragment without bottom bar 

### Test 
1. Repeat steps 1-4 
2. Notice that the correct UI is shown 

## Regression Notes
1. Potential unintended areas of impact


3. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
