### PR TITLE
Disable email contact on Start Over for WP users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -558,8 +558,8 @@ public class SiteSettingsFragment extends PreferenceFragment
 
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_START_OVER_ACCESSED, mSite);
 
-            if (mSite.getHasFreePlan()) {
-                // Don't show the start over detail screen for free users, instead show the support page
+            if (!BuildConfig.IS_JETPACK_APP || mSite.getHasFreePlan()) {
+                // Don't show the start over detail screen for free users or WP app users, instead show the support page
                 dialog.dismiss();
                 WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(getActivity(), WORDPRESS_EMPTY_SITE_SUPPORT_URL);
             } else {


### PR DESCRIPTION
This PR changes the function of "Start Over" button. ON WP app, the button will always open `https://en.support.wordpress.com/empty-site/`.

Fixes #18129 

To test:
1. Navigate to a WordPress.com paid site (Personal or Premium plan)
2. Tap Site Settings
3. Tap Start Over
4. Ensure the button opens `https://en.support.wordpress.com/empty-site/` in the web view.
5. Repeat 1-4 with a free site.

## Regression Notes
1. Potential unintended areas of impact
JP app should still open `https://en.support.wordpress.com/empty-site/` for free sites and the CONTACT SUPPORT screen for paid sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
I haven't. I updated a simple logic. I don't think it's worth adding a test for the logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
