### PR TITLE
Removes: Stats button from published Posts more menu 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -108,6 +108,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowPublishedPostStatsButton(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return true
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -107,7 +107,8 @@ class PostListItemUiStateHelper @Inject constructor(
             uploadUiState = uploadUiState,
             siteHasCapabilitiesToPublish = capabilitiesToPublish,
             statsSupported = statsSupported,
-            shouldRemoveJetpackFeatures = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures(),
+            shouldShowStatsInJetpackRemovalPhase =
+            jetpackFeatureRemovalPhaseHelper.shouldShowPublishedPostStatsButton(),
             shouldShowPromoteWithBlaze = isSiteBlazeEligible && blazeFeatureUtils.isPostBlazeEligible(
                 postStatus,
                 post
@@ -381,7 +382,7 @@ class PostListItemUiStateHelper @Inject constructor(
         uploadUiState: PostUploadUiState,
         siteHasCapabilitiesToPublish: Boolean,
         statsSupported: Boolean,
-        shouldRemoveJetpackFeatures: Boolean,
+        shouldShowStatsInJetpackRemovalPhase: Boolean,
         shouldShowPromoteWithBlaze: Boolean
     ): List<PostListButtonType> {
         val canRetryUpload = uploadUiState is UploadFailed
@@ -395,7 +396,7 @@ class PostListItemUiStateHelper @Inject constructor(
                 postStatus == PUBLISHED &&
                 !isLocalDraft &&
                 !isLocallyChanged &&
-                !shouldRemoveJetpackFeatures
+                shouldShowStatsInJetpackRemovalPhase
         val canShowCopy = postStatus == PUBLISHED || postStatus == DRAFT
         val canShowCopyUrlButton = !isLocalDraft && postStatus != TRASHED
         val canShowViewButton = !canRetryUpload && postStatus != TRASHED

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -243,6 +243,7 @@ class PostListItemUiStateHelperTest {
 
     @Test
     fun `verify published post actions`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowPublishedPostStatsButton()).thenReturn(true)
         val state = createPostListItemUiState(
             post = createPostModel(status = POST_STATE_PUBLISH)
         )
@@ -282,8 +283,8 @@ class PostListItemUiStateHelperTest {
     }
 
     @Test
-    fun `given published post with stats access when jetpack removal phase then stats is not in menu`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+    fun `given published post with stats access when jetpack removal phase then stats is in menu`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowPublishedPostStatsButton()).thenReturn(true)
         val state = createPostListItemUiState(
             post = createPostModel(status = POST_STATE_PUBLISH)
         )
@@ -294,16 +295,17 @@ class PostListItemUiStateHelperTest {
         assertThat(state.actions).hasSize(3)
 
         val moreActions = (state.actions[2] as MoreItem).actions
-        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
-        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(4)
+        assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(5)
     }
 
     @Test
-    fun `given published post with stats access when not jetpack removal phase then stats is in menu`() {
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()).thenReturn(true)
+    fun `given published post with stats access when not jetpack removal phase then stats is not in menu`() {
+        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowPublishedPostStatsButton()).thenReturn(false)
         val state = createPostListItemUiState(
             post = createPostModel(status = POST_STATE_PUBLISH)
         )


### PR DESCRIPTION
Fixes #

## Description 
This PR removes the stats button from published posts more menu 

## To test:
- Go to Wordpress app 
- Login with a wp account 
- Go to **app settings** → **Debug settings** 
- enable feature flag → `jp_removal_static_posters`
- Go to Posts → Published Posts → Click at more menu 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
