### PR TITLE
[Blogging Prompts] Fix answer label in prompt sample card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapper.kt
@@ -10,11 +10,11 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboar
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingUiState.Ready
 import org.wordpress.android.ui.utils.UiString.UiStringPluralRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 import javax.inject.Inject
 
 class BloggingPromptsOnboardingUiStateMapper @Inject constructor(
-    private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig
+    private val bloggingPromptsSocialFeatureConfig: BloggingPromptsSocialFeatureConfig
 ) {
     @Suppress("MagicNumber")
     fun mapReady(
@@ -30,7 +30,7 @@ class BloggingPromptsOnboardingUiStateMapper @Inject constructor(
             dummyRespondent
         )
 
-        val trailingLabel = if (bloggingPromptsEnhancementsFeatureConfig.isEnabled()) {
+        val trailingLabel = if (bloggingPromptsSocialFeatureConfig.isEnabled()) {
             UiStringRes(
                 R.string.my_site_blogging_prompt_card_view_answers
             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingUiStateMapperTest.kt
@@ -16,12 +16,12 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboar
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingUiState.Ready
 import org.wordpress.android.ui.utils.UiString.UiStringPluralRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 
 @ExperimentalCoroutinesApi
 class BloggingPromptsOnboardingUiStateMapperTest : BaseUnitTest() {
     @Mock
-    lateinit var bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig
+    lateinit var bloggingPromptsSocialFeatureConfig: BloggingPromptsSocialFeatureConfig
 
     private lateinit var classToTest: BloggingPromptsOnboardingUiStateMapper
 
@@ -87,46 +87,46 @@ class BloggingPromptsOnboardingUiStateMapperTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        classToTest = BloggingPromptsOnboardingUiStateMapper(bloggingPromptsEnhancementsFeatureConfig)
+        classToTest = BloggingPromptsOnboardingUiStateMapper(bloggingPromptsSocialFeatureConfig)
     }
 
     @Test
     fun `Should return correct Ready state for ONBOARDING type dialog when enhancements are turned off`() {
-        val enhancementsEnabled = false
-        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(enhancementsEnabled)
+        val socialEnabled = false
+        whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(socialEnabled)
 
         val actual = classToTest.mapReady(ONBOARDING, primaryButtonListener, secondaryButtonListener)
-        val expected = expectedOnboardingDialogReadyState(enhancementsEnabled)
+        val expected = expectedOnboardingDialogReadyState(socialEnabled)
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `Should return correct Ready state for INFORMATION type dialog when enhancements are turned off`() {
-        val enhancementsEnabled = false
-        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(enhancementsEnabled)
+        val socialEnabled = false
+        whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(socialEnabled)
 
         val actual = classToTest.mapReady(INFORMATION, primaryButtonListener, secondaryButtonListener)
-        val expected = expectedInformationDialogReadyState(enhancementsEnabled)
+        val expected = expectedInformationDialogReadyState(socialEnabled)
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `Should return correct Ready state for ONBOARDING type dialog when enhancements are turned on`() {
-        val enhancementsEnabled = true
-        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(enhancementsEnabled)
+        val socialEnabled = true
+        whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(socialEnabled)
 
         val actual = classToTest.mapReady(ONBOARDING, primaryButtonListener, secondaryButtonListener)
-        val expected = expectedOnboardingDialogReadyState(enhancementsEnabled)
+        val expected = expectedOnboardingDialogReadyState(socialEnabled)
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `Should return correct Ready state for INFORMATION type dialog when enhancements are turned on`() {
-        val enhancementsEnabled = true
-        whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(enhancementsEnabled)
+        val socialEnabled = true
+        whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(socialEnabled)
 
         val actual = classToTest.mapReady(INFORMATION, primaryButtonListener, secondaryButtonListener)
-        val expected = expectedInformationDialogReadyState(enhancementsEnabled)
+        val expected = expectedInformationDialogReadyState(socialEnabled)
         assertThat(actual).isEqualTo(expected)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -35,14 +35,14 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.usecase.SaveFirstBlog
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.config.BloggingPromptsEnhancementsFeatureConfig
+import org.wordpress.android.util.config.BloggingPromptsSocialFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import java.util.Date
 
 @ExperimentalCoroutinesApi
 class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
-    private val bloggingPromptsEnhancementsFeatureConfig: BloggingPromptsEnhancementsFeatureConfig = mock()
-    private val uiStateMapper = BloggingPromptsOnboardingUiStateMapper(bloggingPromptsEnhancementsFeatureConfig)
+    private val bloggingPromptsSocialFeatureConfig: BloggingPromptsSocialFeatureConfig = mock()
+    private val uiStateMapper = BloggingPromptsOnboardingUiStateMapper(bloggingPromptsSocialFeatureConfig)
     private val siteStore: SiteStore = mock()
     private val selectedSiteRepository: SelectedSiteRepository = mock()
     private val bloggingPromptsStore: BloggingPromptsStore = mock()


### PR DESCRIPTION
Fixes #18137 

The Prompts sample card (inside `Learn more`) displays the appropriate answer label depending on the `BloggingPromptsSocialFeatureConfig` current value:
- `3 answers` with `BloggingPromptsSocialFeatureConfig` OFF
- `View all responses` with`BloggingPromptsSocialFeatureConfig` ON


https://user-images.githubusercontent.com/5091503/225992888-66e1bf57-8c8b-4ca1-b7d2-97a6a7c395ab.mp4

## To test
Please test with both the `BloggingPromptsSocialFeatureConfig` feature OFF and ON in the `Debug Settings` (`Profile` -> `App Settings` -> `Debug Settings`).

1. Open the Jetpack app
2. Login with a WP.com account
3. Select a blog site (has a few posts)
4. **Verify** the Prompts card answer label says:
   1. something like `123 answers` with `BloggingPromptsSocialFeatureConfig` OFF
   2. `View all responses` with`BloggingPromptsSocialFeatureConfig` ON
6. Tap the `overflow` menu in the `Prompts` card
7. Tap `Learn more`
8. **Verify** the sample Prompts card answer label says:
   1. `3 answers` with `BloggingPromptsSocialFeatureConfig` OFF
   2. `View all responses` with`BloggingPromptsSocialFeatureConfig` ON

## Regression Notes
1. Potential unintended areas of impact
Show the incorrect label in the actual card.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests in place for this.

10. What automated tests I added (or what prevented me from doing so)
Updated to use the correct feature flag.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
