### PR TITLE
[Common] Fix progress indicator color in PrimaryButton (Compose)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Text
@@ -32,6 +33,7 @@ fun PrimaryButton(
     isInProgress: Boolean = false,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         contentColor = AppColor.White,
+        disabledContentColor = AppColor.White.copy(alpha = ContentAlpha.disabled),
         disabledBackgroundColor = colorResource(R.color.jetpack_green_70),
     ),
     padding: PaddingValues = PaddingValues(


### PR DESCRIPTION
Fixes #18143

Fixes the progress indicator inside the PrimaryButton being black in Light mode.

To test:
Go to any app flow that uses the progress indicator inside the PrimaryButton, such as installing the Jetpack plugin in a self-hosted site without plugins (upon tapping a Jetpack feature like Stats).

## Regression Notes
1. Potential unintended areas of impact
N/A, small UI change in a specific component.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
