### PR TITLE
Fix button color for Static Poster and Primary Button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/PrimaryButton.kt
@@ -9,8 +9,9 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,6 +21,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
@@ -29,6 +31,8 @@ fun PrimaryButton(
     modifier: Modifier = Modifier,
     isInProgress: Boolean = false,
     colors: ButtonColors = ButtonDefaults.buttonColors(
+        contentColor = AppColor.White,
+        disabledContentColor = AppColor.White.copy(alpha = ContentAlpha.disabled),
         disabledBackgroundColor = colorResource(R.color.jetpack_green_70),
     ),
     padding: PaddingValues = PaddingValues(
@@ -53,7 +57,7 @@ fun PrimaryButton(
     ) {
         if (isInProgress) {
             CircularProgressIndicator(
-                color = MaterialTheme.colors.onPrimary,
+                color = LocalContentColor.current,
                 strokeWidth = 2.dp,
                 modifier = Modifier.size(20.dp),
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.PrimaryButton
 import org.wordpress.android.ui.compose.components.SecondaryButton
+import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.theme.JpColorPalette
 import org.wordpress.android.ui.compose.utils.uiStringText
@@ -101,7 +102,7 @@ fun JetpackStaticPoster(
                 onPrimaryClick,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = JpColorPalette().primary,
-                    contentColor = JpColorPalette().onPrimary,
+                    contentColor = AppColor.White,
                 ),
                 padding = PaddingValues(bottom = 15.dp),
                 textStyle = MaterialTheme.typography.body1.copy(fontSize = 17.sp, fontWeight = FontWeight.SemiBold),


### PR DESCRIPTION
## Issue
The color of the Primary Button in the Static Poster overlay was Black for Dark mode. A similar issue was fixed in `trunk` and the same solution was applied here.

![image](https://user-images.githubusercontent.com/5091503/226457195-f0969342-bb10-4db1-9a8e-57a73b29fe85.png)


## This PR
Picked some of the changes from `trunk` regarding the compose `PrimaryButton` common component content colors (which should be White for both Light mode and Dark mode) as well as made the appropriate changes to the Static Poster screen, which was using the `onPrimary` color but that is `Black` in Dark mode.

Fixing the `onPrimary` color in the [`JetpackColors` file](https://github.com/wordpress-mobile/WordPress-Android/blob/7166ac77b2f19b8ddc851b42ea8ad94c75f16a1b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/JetpackColors.kt#L34) was taken into account for this fix, though it would touch a color that might be used by different Material components under the hood so it is a bit risky to do as `hotfix` though we will explore it on `trunk` afterwards.

https://user-images.githubusercontent.com/5091503/226457370-8d3c108d-6751-4fd3-a35c-e48f77118a9c.mp4

## To test
Test it on any flow that displays the Static Poster overlay, such as enabling the `jp_removal_static_posters` feature flag then tapping `Stats`.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A. UI changes only.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
