### PR TITLE
Fix PhaseSelfHostedUsers returned incorrectly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -604,6 +604,8 @@ class AppInitializer @Inject constructor(
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onAuthenticationChanged(event: OnAuthenticationChanged) {
+        appConfig.refresh(appScope)
+
         if (accountStore.hasAccessToken()) {
             // Make sure the Push Notification token is sent to our servers after a successful login
             GCMRegistrationIntentService.enqueueWork(


### PR DESCRIPTION
## The issue
After logging into the app with a WP.com account, some of the Jetpack Focus features targeted at **self-hosted** users were shown. After some investigation, I discovered the `JetpackFeatureRemovalPhase.PhaseSelfHostedUsers` was being returned in that scenario, which consists of opening the app in a logged-out state, then logging in. After restarting the app a few times everything was back to normal.

In that case, the major bugs seen were:
- Dashboard not showing up (top tabs)
- Bottom navigation bar not showing up
- Jetpack plugin overlay showing up

The wrong phase was being returned because it seems like a change was recently deployed to remotely turn the **self-hosted** phase `FeatureConfig` (`jp_removal_self_hosted`) ON for non-authenticated users, and we were only fetching the `FeatureConfig`s remotely on app start (logged-out), and not refreshing them after authentication, which means that even logging in we were using the stale config.

https://user-images.githubusercontent.com/5091503/226481011-b09af9c2-412f-413a-926f-cb92446c62fc.mp4

internal ref for backend changes: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Ssrngher%2Qsyntf%2Spbasvt%2Szbovyr%2Qnccf.cuc%3Sn%3Qgehr%26e%3Q69orr356%2343%2Q48-og

## The fix
Adding a `refresh` call to get the most up-to-date values for `FeatureConfig`s right after receiving `OnAuthenticationChanged` event fixes the issue by making sure we will use the correct values.

https://user-images.githubusercontent.com/5091503/226481740-003434cd-a1c1-4ac4-b04e-247e6cddbb78.mp4

To test:
1. Install WordPress
2. Login with a WP.com account
3. **Verify** the top tabs with dashboard ("Home") is showing
4. **Verify** the bottom navigation with "Reader" and "Notifications" is showing
5. **Verify** the Jetpack **plugin** overlay did not show up

## Regression Notes
1. Potential unintended areas of impact
Usage of other `FeatureConfig`s.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Quick manual testing, but hard to know what could be affected.

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.