### PR TITLE
Default static poster to portrait in standalone activity

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1068,6 +1068,7 @@
         <activity android:name=".ui.jetpackoverlay.JetpackStaticPosterActivity"
             android:exported="false"
             android:label="@string/stats"
+            android:screenOrientation="portrait"
             android:theme="@style/WordPress.NoActionBar"/>
 
     </application>

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui.main.jetpack.staticposter
 
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -33,6 +36,7 @@ class JetpackStaticPosterFragment : Fragment() {
     ) = ComposeView(requireContext()).apply {
         setContent {
             AppTheme {
+                LockScreenOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Content -> JetpackStaticPoster(
@@ -43,6 +47,21 @@ class JetpackStaticPosterFragment : Fragment() {
                     )
                     is UiState.Loading -> CircularProgressIndicator()
                 }
+            }
+        }
+    }
+
+    @Composable
+    fun LockScreenOrientation(orientation: Int) {
+        DisposableEffect(orientation) {
+            requireActivity().requestedOrientation = orientation
+            onDispose {
+                // Although restore original orientation seems like the logical solution, it does not
+                // work in this case because dispose runs after the new fragment is created, which
+                // then just resets to the orientation that is started with. If we weren't using the
+                // same activity (like we are for tabs), this would work very nicely by setting orientation
+                // to user.
+                // no op
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite
 
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -63,6 +64,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
             super.onPageSelected(position)
+            requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
             viewModel.onTabChanged(position)
         }
     }
@@ -83,6 +85,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
+    }
     private fun initSoftKeyboard() {
         // The following prevents the soft keyboard from leaving a white space when dismissed.
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)


### PR DESCRIPTION
This PR forces the Jetpack Static Posters view to show in Portrait mode.
See pcdRpT-21n-p2#comment-3726 for additional information

**Implementation details:**
- `JetpackStaticPosterActivity` is defaulted to portrait in the manifest. This is used for the standalone stats activity
- The bottom nav tabs all belong to the same class `WPMainActivity`, which makes this a bit more difficult to manage, especially given the fact that the fragments are contained in a ViewPager. To manage this situation I had to make changes in a few places:
-- Added a new Composable `LockScreenOrientation` to `JetpackStaticPosterFragment` that uses a DisposableEffect to change the orientation of the view. I
-- Added an `onResume` to `MySiteFragment` to ensure the screen orientation is correct when this fragment resumes. This should handle the cases of return from background.
-- Updated onPageSelected callback to reset the screen orientation. This will handle the tab to tab changes

**To test:**
- Do a fresh install of the app
- Login using the static poster test account OR use a wp.com site and enable the `jp_removal_static_posters` flag (app settings > debug settings > restart the app)
- Navigate to the dashboard
- Navigate between the bottom tabs and rotate the device
- ✅ Verify the My Site tab will rotate between landscape and portrait
- Navigate to Reader or Notifications
- ✅ Verify the screen is in portrait mode and can not be switched to landscape
- Background the app while you are in the Reader or Notifications tab
- Return to the app
- ✅ Verify the Reader or Notifications tab is still shown in Portrait orientation

## Regression Notes
1. Potential unintended areas of impact
The wrong orientation will show for MySite

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testin

3. What automated tests I added (or what prevented me from doing so)
N/A


PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.