### PR TITLE
Add scrolling to Jetpack Static Posters view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -1,13 +1,10 @@
 package org.wordpress.android.ui.main.jetpack.staticposter
 
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
@@ -36,7 +33,6 @@ class JetpackStaticPosterFragment : Fragment() {
     ) = ComposeView(requireContext()).apply {
         setContent {
             AppTheme {
-                LockScreenOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Content -> JetpackStaticPoster(
@@ -47,21 +43,6 @@ class JetpackStaticPosterFragment : Fragment() {
                     )
                     is UiState.Loading -> CircularProgressIndicator()
                 }
-            }
-        }
-    }
-
-    @Composable
-    fun LockScreenOrientation(orientation: Int) {
-        DisposableEffect(orientation) {
-            requireActivity().requestedOrientation = orientation
-            onDispose {
-                // Although restore original orientation seems like the logical solution, it does not
-                // work in this case because dispose runs after the new fragment is created, which
-                // then just resets to the orientation that is started with. If we weren't using the
-                // same activity (like we are for tabs), this would work very nicely by setting orientation
-                // to user.
-                // no op
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -41,6 +41,7 @@ import org.wordpress.android.ui.compose.components.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.theme.JpColorPalette
+import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.staticposter.UiData
 import org.wordpress.android.ui.main.jetpack.staticposter.UiState
@@ -69,7 +70,7 @@ fun JetpackStaticPoster(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .padding(horizontal = 30.dp)
+                .padding(Margin.ExtraLarge.value)
                 .verticalScroll(rememberScrollState())
                 .fillMaxSize()
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main.jetpack.staticposter.compose
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,9 +19,11 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -41,7 +44,6 @@ import org.wordpress.android.ui.compose.components.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.theme.JpColorPalette
-import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.staticposter.UiData
 import org.wordpress.android.ui.main.jetpack.staticposter.UiState
@@ -66,13 +68,18 @@ fun JetpackStaticPoster(
             }
         },
     ) {
+        val orientation = LocalConfiguration.current.orientation
+        val verticalPadding = remember(orientation) {
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE) 60.dp else 30.dp
+        }
+
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .padding(Margin.ExtraLarge.value)
-                .verticalScroll(rememberScrollState())
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 30.dp, vertical = verticalPadding)
         ) {
             Column(
                 horizontalAlignment = Alignment.Start,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -68,6 +70,7 @@ fun JetpackStaticPoster(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .padding(horizontal = 30.dp)
+                .verticalScroll(rememberScrollState())
                 .fillMaxSize()
         ) {
             Column(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite
 
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -64,7 +63,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private val viewPagerCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
             super.onPageSelected(position)
-            requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
             viewModel.onTabChanged(position)
         }
     }
@@ -85,10 +83,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
-    }
     private fun initSoftKeyboard() {
         // The following prevents the soft keyboard from leaving a white space when dismissed.
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)


### PR DESCRIPTION
This PR reverts the changes made in #18148 for changing the screen orientation for the tabs during the Static Poster phase. Instead scrolling was added to the JetpackStaticPoster view.

To test:
- Install the app
- Login using a wp.com account
- Navigate to Me > App Settings > Debug Settings
- Disable `jp_removal_self_hosted` if it's enabled
- Enable `jp_removal_static_posters`
- Restart the app
- Navigate to Reader and Notifications tabs and turn the device
- ✅ Verify the content is shown in both landscape and portrait mode
- ✅ Verify the content shown landscape mode is scrollable
-
## Regression Notes
1. Potential unintended areas of impact
The static posters views is not scrollable

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
