### PR TITLE
[Static Posters Phase] Remove static poster menu badge

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseF
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseThree
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseTwo
-import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseStaticPosters
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringPluralRes
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -40,7 +39,6 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
             PhaseOne,
             PhaseTwo,
             PhaseThree,
-            PhaseStaticPosters,
             PhaseFour -> true
             else -> false
         }
@@ -50,7 +48,6 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
             PhaseTwo,
             PhaseThree,
-            PhaseStaticPosters,
             PhaseFour -> true
             else -> false
         }
@@ -58,7 +55,6 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
 
     fun getBrandingTextByPhase(screen: JetpackPoweredScreen): UiString {
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
-            PhaseStaticPosters -> UiStringRes(R.string.wp_jetpack_feature_removal_static_posters_phase)
             PhaseThree -> (screen as? JetpackPoweredScreen.WithDynamicText)?.let { screenWithDynamicText ->
                 getDynamicBrandingForScreen(screenWithDynamicText)
             } ?: UiStringRes(JetpackBrandingUiState.RES_JP_POWERED)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4378,8 +4378,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="wp_jetpack_feature_removal_phase_new_users_notifications_description">Get notifications for new comments, likes, views, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_description">The Jetpack mobile app is designed to work in companion with the Jetpack plugin. Switch now to get access to stats, notifications, reader, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_title">Your site has the Jetpack plugin</string>
-    <string name="wp_jetpack_feature_removal_static_posters_phase">Moving to the Jetpack app in a few days.</string>
-
 
     <!-- Deep Linking Activity Aliases -->
     <string name="deep_linking_urilinks_alias_label">urilinks</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -296,6 +296,17 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyNoInteractions(dateTimeUtilsWrapper)
     }
 
+    @Test
+    fun `given static posters phase started, all banners and badges should be Jetpack powered`() {
+            givenPhase(JetpackFeatureRemovalPhase.PhaseStaticPosters)
+
+            val actual = allJpScreens.map(classToTest::getBrandingTextByPhase)
+
+            actual.assertAllMatch(R.string.wp_jetpack_powered)
+            verifyNoInteractions(dateTimeUtilsWrapper)
+        }
+
+
     // endregion
 
     // region Helpers

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -296,16 +296,6 @@ class JetpackFeatureRemovalBrandingUtilTest {
         verifyNoInteractions(dateTimeUtilsWrapper)
     }
 
-    @Test
-    fun `given static posters phase started, all banners and badges should be Jetpack powered`() {
-        givenPhase(JetpackFeatureRemovalPhase.PhaseStaticPosters)
-
-        val actual = allJpScreens.map(classToTest::getBrandingTextByPhase)
-
-        actual.assertAllMatch(R.string.wp_jetpack_feature_removal_static_posters_phase)
-        verifyNoInteractions(dateTimeUtilsWrapper)
-    }
-
     // endregion
 
     // region Helpers


### PR DESCRIPTION
## The issue
This was added but according to this internal ref () it was not supposed to be merged.

![image](https://user-images.githubusercontent.com/5091503/226495867-8091569f-155c-4aca-92a2-9e79ae13043d.png)

## The fix
I just reverted the PR that added it and added a unit test to confirm the correct text is shown in the badge.

![image](https://user-images.githubusercontent.com/5091503/226495955-7429aefe-f71f-40b3-b073-fcd5f53d4b65.png)

## To test
1. Install WordPress
2. Login with a WP.com account
3. Turn on the static poster feature flag in Debug Settings
4. **Verify** the badge at the bottom of the Menu says "Jetpack powered"

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
Kept the unit test asserting the correct branding text.

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
