### PR TITLE
Fixes: Jetpack powered badge shown on menu in Static posters phase

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -35,6 +35,8 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
 
     fun isInRemovalPhase() = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
 
+    fun shouldShowBrandingInDashboard() = jetpackFeatureRemovalPhaseHelper.shouldShowJetpackBrandingInDashboard()
+
     fun shouldShowPhaseOneBranding(): Boolean {
         return when (jetpackFeatureRemovalPhaseHelper.getCurrentPhase()) {
             PhaseOne,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -124,7 +124,6 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
-    @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false
         return when (currentPhase) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -116,6 +116,14 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    fun shouldShowJetpackBrandingInDashboard(): Boolean {
+        val currentPhase = getCurrentPhase() ?: return false
+        return when (currentPhase) {
+            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+            else -> true
+        }
+    }
+
     @Suppress("Unused")
     fun shouldShowStaticPage(): Boolean {
         val currentPhase = getCurrentPhase() ?: return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -677,8 +677,7 @@ class MySiteViewModel @Inject constructor(
                 null
             }
         ).takeIf {
-            jetpackBrandingUtils.shouldShowJetpackBranding() &&
-                    !jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()
+            jetpackBrandingUtils.shouldShowJetpackBrandingInDashboard()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackBrandingUtils.kt
@@ -29,6 +29,11 @@ class JetpackBrandingUtils @Inject constructor(
                 && !jetpackFeatureRemovalBrandingUtil.isInRemovalPhase()
     }
 
+    fun shouldShowJetpackBrandingInDashboard(): Boolean {
+        return isWpComSite() && jetpackPoweredFeatureConfig.isEnabled() && !buildConfigWrapper.isJetpackApp
+                && jetpackFeatureRemovalBrandingUtil.shouldShowBrandingInDashboard()
+    }
+
     fun shouldShowJetpackBrandingForPhaseOne(): Boolean {
         return shouldShowJetpackBranding() && jetpackFeatureRemovalBrandingUtil.shouldShowPhaseOneBranding()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -3387,7 +3387,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptsEnhancementsFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsEnhancementsEnabled)
         whenever(bloggingPromptsSocialFeatureConfig.isEnabled()).thenReturn(isBloggingPromptsSocialEnabled)
         whenever(mySiteDashboardTabsFeatureConfig.isEnabled()).thenReturn(isMySiteDashboardTabsEnabled)
-        whenever(jetpackBrandingUtils.shouldShowJetpackBranding()).thenReturn(shouldShowJetpackBranding)
+        whenever(jetpackBrandingUtils.shouldShowJetpackBrandingInDashboard()).thenReturn(shouldShowJetpackBranding)
         whenever(blazeFeatureUtils.shouldShowBlazeCardEntryPoint(any(), any())).thenReturn(isBlazeEnabled)
         if (isSiteUsingWpComRestApi) {
             site.setIsWPCom(true)


### PR DESCRIPTION
Fixes Issue Described [here](pcdRpT-21n-p2#comment-3707)
For more details about the change - [Read comment](pcdRpT-21n-p2#comment-3752)

## Description 
This PR fixes the jetpack powered badge shown in menu in Static posters phase. 


## To test

### Static Posters Phase
1. Go to My Site → Me  → App Settings  → Debug Settings
2. Turn the` jp_removal_static_posters` feature flag ON.
3. Relaunch the app.
4. Notice that the Jetpack powered badge is not shown in menu


### Phase 4
1. Go to My Site → Me  → App Settings  → Debug Settings
2. Turn the` jp_removal_four` feature flag ON.
3. Relaunch the app.
4. Notice that the Jetpack powered badge is not shown in menu
5. Verify that the **Switch to Jetpack** menu item is shown at the bottom


### Phase 3 and lower
1. Go to My Site → Me  → App Settings  → Debug Settings
2. Turn the` jp_removal_phase_three` feature flag ON.
3. Relaunch the app.
4. Notice that the Jetpack powered badge is shown in dashboard


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.