### PR TITLE
[WIP] [UI Tests] Minor refactoring around "e2eAllDayStatsLoad" UI test.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
@@ -154,7 +154,11 @@ class MySitesPage {
 
     fun goToStats(): StatsPage {
         goToMenuTab()
-        clickQuickActionOrSiteMenuItem(R.id.quick_action_stats_button, R.string.stats)
+        val statsButton = Espresso.onView(Matchers.allOf(
+            ViewMatchers.withText(R.string.stats),
+            ViewMatchers.withId(R.id.my_site_item_primary_text)
+        ))
+        WPSupportUtils.clickOn(statsButton)
         WPSupportUtils.idleFor(4000)
         WPSupportUtils.dismissJetpackAdIfPresent()
         WPSupportUtils.waitForElementToBeDisplayedWithoutFailure(R.id.tabLayout)

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/WPSupportUtils.java
@@ -37,6 +37,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.util.image.ImageType;
 
@@ -818,6 +819,10 @@ public class WPSupportUtils {
     }
 
     public static void dismissJetpackAdIfPresent() {
+        if (BuildConfig.IS_JETPACK_APP) {
+            return;
+        }
+
         String jetpackAdText = "Stats, Reader, Notifications, and other features are powered by Jetpack.";
         ViewInteraction jetpackBanner = onView(withText(jetpackAdText));
 


### PR DESCRIPTION
### What
There was an influx of fails of `e2eAllDayStatsLoad` for JP recently, and before realizing that they are coming from [release/21.9.1](https://github.com/wordpress-mobile/WordPress-Android/tree/release/21.9.1) branch, which did not contain the fix (#18074) yet, I tried to replicate the fail locally. For some reason, it started failing in a different place, while trying to tap `Stats` button. So, I've adjusted a locator a bit, which solved the local issue, and at the same time seems not to break the CI execution.

### To test
- See that the CI is green for both WP and JP
- I also have a different sort-of "test" PR #18152, where there are more executions, none of them failed.