### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.14.0
+    - automattic/a8c-ci-toolkit#2.15.0
 
 steps:
   #################

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#2.14.0
 
 steps:
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#2.14.0
 
 steps:
   #################

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.11.0
+    - automattic/a8c-ci-toolkit#2.14.0
 
 steps:
   #################


### PR DESCRIPTION
## What

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.15.0` 

## Testing

Ensure that CI is green and that all checks passed.

To test:

## Regression Notes
1. Potential unintended areas of impact - N/A


2. What I did to test those areas of impact (or what existing automated tests I relied on) - N/A


3. What automated tests I added (or what prevented me from doing so) - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes. - N/A
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. - N/A
