### PR TITLE
Adds bottom margin in feature removal overlay

### DIFF
--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -12,6 +12,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_medium"
         android:orientation="vertical">
 
         <ImageButton


### PR DESCRIPTION
## Description
Adds bottom margin in feature removal overlay (internal ref pcdRpT-21n-p2#comment-3792)

This PR increases the bottom margin for all screen using the `jetpack_feature_removal_overlay.xml`. Given the current feature removal phase and the complexity of the making a custom implementation for the Site Creation overlay I increased the bottom margin for all. My understanding is that this has no side implications at this point but I'll be glad to customise the solution if needed.

|Before|After|
|---|---|
|![Screenshot_20230322_124525](https://user-images.githubusercontent.com/304044/226880593-5ce5376b-b715-4f0f-ab7b-cd4b62cf49c0.png)|![Screenshot_20230322_124447](https://user-images.githubusercontent.com/304044/226880578-1e38faa4-a58e-43b6-8381-02f206ea5983.png)|

To test:
1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on `jp_removal_static_posters`
4. Start the site creation flow
5. **Verify** that the bottom margin is increased

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.