### PR TITLE
Fix typo in notifications word

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/NotificationsSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/NotificationsSettings.java
@@ -22,7 +22,7 @@ public class NotificationsSettings {
     private JSONObject mWPComSettings;
     private LongSparseArray<JSONObject> mBlogSettings;
 
-    // The main notification settings channels (displayed at root of NoticationsSettingsFragment)
+    // The main notification settings channels (displayed at root of NotificationsSettingsFragment)
     public enum Channel {
         OTHER,
         BLOGS,

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -41,7 +41,7 @@ Language: en_GB
     <string name="only_one_primary_site_message">Only one site is available, so you can\'t change your primary site.</string>
     <string name="jetpack_individual_plugin_support_onboarding_title">Please install the full Jetpack plugin</string>
     <string name="button_promote_with_blaze">Promote with Blaze</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_title">Your site has the Jetpack plugin</string>
     <string name="wp_jetpack_feature_removal_phase_new_users_notifications_description">Get notifications for new comments, likes, views, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_new_users_reader_description">Find and follow your favourite sites and communities, and share you content.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4393,7 +4393,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Jetpack Feature Card -->
     <string name="jetpack_feature_card_content_phase_three">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="jetpack_feature_card_learn_more" translatable="false">@string/learn_more</string>
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4393,7 +4393,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Jetpack Feature Card -->
     <string name="jetpack_feature_card_content_phase_three">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="jetpack_feature_card_learn_more" translatable="false">@string/learn_more</string>
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>


### PR DESCRIPTION
To test:
- **Verify** correct `notifications` word on `WP app → My Site` in: `jp_removal_self_hosted` or `jp_removal_new_users`

### Previews

![preview](https://user-images.githubusercontent.com/4588074/226911102-398cf82b-c676-4a11-88ed-df61e29023da.png)


## Regression Notes

1. Potential unintended areas of impact
  N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/a

3. What automated tests I added (or what prevented me from doing so)
  N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
