### PR TITLE
Update deprecated functions of JetpackStaticPosterFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.main.jetpack.staticposter.compose.JetpackStaticPoster
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,7 +40,7 @@ class JetpackStaticPosterFragment : Fragment() {
                         uiState = state,
                         onPrimaryClick = viewModel::onPrimaryClick,
                         onSecondaryClick = viewModel::onSecondaryClick,
-                        onBackClick = requireActivity()::onBackPressed,
+                        onBackClick = requireActivity().onBackPressedDispatcher::onBackPressed,
                     )
                     is UiState.Loading -> CircularProgressIndicator()
                 }
@@ -50,7 +51,7 @@ class JetpackStaticPosterFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeEvents()
-        viewModel.start(requireNotNull(requireArguments().getParcelable(ARG_PARCEL)))
+        viewModel.start(requireNotNull(requireArguments().getParcelableCompat(ARG_PARCEL)))
     }
 
     private fun observeEvents() {


### PR DESCRIPTION
Merging https://github.com/wordpress-mobile/WordPress-Android/pull/17947 caused errors in `JetpackStaticPosterFragment`. This PR resolves errors and makes CI green.

To test:
- **Test the project:** Ensure the project is buildable.
- **Test the app:**
1. Launch WP app and login.
2. Go to Me → App Settings → Debug Settings and enable `jp_removal_static_posters`.
3. Scroll down and tap "RESTART THE APP".
4. Go to "Stats".
5. Ensure there is no crash and the Jetpack Static Poster screen is opened.
6. Tap the back button on the top left of the screen.
7. Ensure it navigates back.

## Regression Notes
1. Potential unintended areas of impact
Behaviors on JetpackStaticPosterFragment.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
None, since this PR doesn't introduce a new feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
