### PR TITLE
[WP Individual JP Plugin] Create overlay feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,6 +132,7 @@ android {
         buildConfigField "boolean", "ENABLE_WORDPRESS_SUPPORT_FORUM", "false"
         buildConfigField "boolean", "JETPACK_INSTALL_FULL_PLUGIN", "false"
         buildConfigField "boolean", "ENABLE_BLAZE_FEATURE", "false"
+        buildConfigField "boolean", "WP_INDIVIDUAL_PLUGIN_OVERLAY", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -58,6 +58,7 @@ import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig;
 import org.wordpress.android.util.helpers.Debouncer;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.viewmodel.main.SitePickerViewModel;
@@ -133,6 +134,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Inject StatsStore mStatsStore;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
+    @Inject WPIndividualPluginOverlayFeatureConfig mWPIndividualPluginOverlayFeatureConfig;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -213,6 +215,12 @@ public class SitePickerActivity extends LocaleAwareActivity
     public void onResume() {
         super.onResume();
         ActivityId.trackLastActivity(ActivityId.SITE_PICKER);
+
+        // TODO thomashortadev temporary during development of #18114
+        if (mWPIndividualPluginOverlayFeatureConfig.isEnabled()) {
+            // show toast saying the feature is enabled
+            ToastUtils.showToast(this, "WP - Individual plugin overlay is enabled");
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayFeatureConfig.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.FeatureInDevelopment
+import javax.inject.Inject
+
+@FeatureInDevelopment
+class WPIndividualPluginOverlayFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+        appConfig,
+        BuildConfig.WP_INDIVIDUAL_PLUGIN_OVERLAY,
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && !BuildConfig.IS_JETPACK_APP
+    }
+}


### PR DESCRIPTION
Part of #18114

Creates the `WPIndividualPluginOverlayFeatureConfig` flag to enable / disable the overlay feature (in development) for WordPress.

Demo

https://user-images.githubusercontent.com/5091503/226999670-d6bcc11b-535b-46a2-bd41-a9be0d33edce.mp4

To test:
1. Install WordPress
2. Login with a WP.com account
3. Select any site
4. Open the site picker
5. **Verify** no toast regarding the new FF is shown
6. Go to Debug settings and enable the `WPIndividualPluginOverlayFeatureConfig` Feature In Development
7. Go back to the home screen
8. Open the site picker
9. **Verify** a toast saying "WP - Individual plugin overlay is enabled" is shown

To confirm this is only being shown in WordPress, you can do the same steps above in the Jetpack app and confirm the toast is never shown, even with the feature config ON.

## Regression Notes
1. Potential unintended areas of impact
N/A

11. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

12. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
