### PR TITLE
[WP Individual JP Plugin] Create Overlay UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
+
+@Composable
+fun MultipleSitesContent(
+    sites: List<SiteWithIndividualJetpackPlugins>
+) {
+    Text(
+        text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_multiple_sites_content_1),
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(
+        text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_content_2)
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        sites.forEach { site ->
+            MultipleSitesContentItem(site = site)
+        }
+    }
+}
+
+@Composable
+private fun MultipleSitesContentItem(
+    site: SiteWithIndividualJetpackPlugins
+) {
+    val text = if (site.individualPluginNames.size > 1) {
+        stringResource(
+            R.string.wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_multiple_plugins,
+            site.url,
+            site.individualPluginNames.size,
+        )
+    } else {
+        stringResource(
+            R.string.wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_single_plugin,
+            site.url,
+            site.individualPluginNames.firstOrNull().orEmpty(),
+        )
+    }
+
+    Text(
+        text = text,
+        modifier = Modifier.padding(vertical = 12.dp)
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(LocalContentColor.current.copy(alpha = 0.1f))
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
 
 @Composable
@@ -57,7 +58,7 @@ private fun MultipleSitesContentItem(
     }
 
     Text(
-        text = text,
+        text = htmlToAnnotatedString(text),
         modifier = Modifier.padding(vertical = 12.dp)
     )
     Box(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
+
+@Composable
+fun SingleSiteContent(
+    site: SiteWithIndividualJetpackPlugins
+) {
+    val firstParagraphContent = if (site.individualPluginNames.size > 1) {
+        stringResource(
+            R.string.wp_jetpack_individual_plugin_overlay_single_site_multiple_plugins_content_1,
+            site.url,
+        )
+    } else {
+        stringResource(
+            R.string.wp_jetpack_individual_plugin_overlay_single_site_single_plugin_content_1,
+            site.url,
+            site.individualPluginNames.firstOrNull().orEmpty(),
+        )
+    }
+
+    Text(firstParagraphContent)
+    Spacer(modifier = Modifier.height(16.dp))
+    Text(stringResource(R.string.wp_jetpack_individual_plugin_overlay_content_2))
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
 
 @Composable
@@ -27,7 +28,7 @@ fun SingleSiteContent(
         )
     }
 
-    Text(firstParagraphContent)
+    Text(htmlToAnnotatedString(firstParagraphContent))
     Spacer(modifier = Modifier.height(16.dp))
     Text(stringResource(R.string.wp_jetpack_individual_plugin_overlay_content_2))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,8 +36,6 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.theme.JpColorPalette
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.JPInstallFullPluginAnimation
-
-// TODO hthomas move strings to resources
 
 private val TitleTextStyle
     @ReadOnlyComposable
@@ -95,14 +95,12 @@ fun WPJetpackIndividualPluginOverlayScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Content
-            // TODO hthomas add content for each variation:
-            //  1. multiple problem sites
-            //  2. single problem site with 1 individual plugin
-            //  3. single problem site with multiple individual plugins
-            Text(
-                text = "You have ${sites.size} sites with individual Jetpack plugins. Switch to Jetpack!",
-                style = ContentTextStyle,
-            )
+            CompositionLocalProvider(LocalTextStyle provides ContentTextStyle) {
+                when {
+                    sites.size > 1 -> MultipleSitesContent(sites)
+                    sites.size == 1 -> SingleSiteContent(sites.first())
+                }
+            }
 
             Spacer(modifier = Modifier.weight(1f)) // Spacer to push the content to the center of the screen
 
@@ -135,10 +133,10 @@ fun WPJetpackIndividualPluginOverlayScreen(
 
 @ReadOnlyComposable
 @Composable
-fun getTitle(siteCount: Int): String = if (siteCount > 1) {
-    "Unable to access some of your sites"
+private fun getTitle(siteCount: Int): String = if (siteCount > 1) {
+    stringResource(R.string.wp_jetpack_individual_plugin_overlay_multiple_sites_title)
 } else {
-    "Unable to access one of your sites"
+    stringResource(R.string.wp_jetpack_individual_plugin_overlay_single_site_title)
 }
 
 @Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -115,7 +114,7 @@ fun WPJetpackIndividualPluginOverlayScreen(
                     .fillMaxWidth()
                     .padding(vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
-            ){
+            ) {
                 PrimaryButton(
                     text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_primary_button),
                     onClick = onPrimaryButtonClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
 
+import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,9 +19,11 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -75,21 +78,38 @@ fun WPJetpackIndividualPluginOverlayScreen(
             )
         }
     ) {
+        val orientation = LocalConfiguration.current.orientation
+        val isLandscape = remember(orientation) { orientation == Configuration.ORIENTATION_LANDSCAPE }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .let {
+                    if (isLandscape) it.verticalScroll(rememberScrollState()) else it
+                }
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
+                    .let {
+                        if (!isLandscape) {
+                            it
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState())
+                        } else {
+                            it
+                        }
+                    }
                     .padding(ContentMargin),
                 verticalArrangement = Arrangement.Center,
             ) {
                 // Icon
                 JPInstallFullPluginAnimation(
-                    modifier = Modifier.align(Alignment.Start)
+                    modifier = Modifier
+                        .align(Alignment.Start)
+                        .let {
+                            if (isLandscape) it.height(48.dp) else it
+                        }
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -154,6 +174,7 @@ private fun getTitle(siteCount: Int): String = if (siteCount > 1) {
 
 @Preview
 @Preview(uiMode = UI_MODE_NIGHT_YES)
+@Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
     AppTheme {
@@ -174,6 +195,7 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
 
 @Preview
 @Preview(uiMode = UI_MODE_NIGHT_YES)
+@Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
     AppTheme {
@@ -194,6 +216,8 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
 
 @Preview
 @Preview(uiMode = UI_MODE_NIGHT_YES)
+@Preview(widthDp = 360, heightDp = 600)
+@Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenMultipleSitesPreview() {
     AppTheme {
@@ -208,6 +232,11 @@ fun WPJetpackIndividualPluginOverlayScreenMultipleSitesPreview() {
                     name = "Site 2",
                     url = "site2.wordpress.com",
                     individualPluginNames = listOf("Jetpack Boost")
+                ),
+                SiteWithIndividualJetpackPlugins(
+                    name = "Site 3",
+                    url = "site3.wordpress.com",
+                    individualPluginNames = listOf("Jetpack Social")
                 ),
             ),
             onCloseClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -1,10 +1,13 @@
 package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -77,7 +80,8 @@ fun WPJetpackIndividualPluginOverlayScreen(
                 .verticalScroll(rememberScrollState())
                 .padding(20.dp)
         ) {
-            Spacer(modifier = Modifier.weight(1f)) // Spacer to push the content to the center of the screen
+            // Spacer to push the content to the center of the screen
+            Spacer(modifier = Modifier.weight(1f))
 
             // Icon
             JPInstallFullPluginAnimation(
@@ -102,31 +106,37 @@ fun WPJetpackIndividualPluginOverlayScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f)) // Spacer to push the content to the center of the screen
+            // Spacer to push the content to the center of the screen
+            Spacer(modifier = Modifier.weight(1f))
 
             // Buttons
-            PrimaryButton(
-                text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_primary_button),
-                onClick = onPrimaryButtonClick,
-                buttonSize = ButtonSize.LARGE,
-                padding = PaddingValues(0.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = JpColorPalette().primary,
-                    contentColor = AppColor.White,
-                ),
-            )
-            Spacer(modifier = Modifier.height(5.dp))
-            SecondaryButton(
-                text = stringResource(R.string.wp_jetpack_continue_without_jetpack),
-                onClick = onSecondaryButtonClick,
-                buttonSize = ButtonSize.LARGE,
-                padding = PaddingValues(0.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color.Transparent,
-                    contentColor = JpColorPalette().primary,
-                ),
-            )
-            Spacer(modifier = Modifier.height(12.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ){
+                PrimaryButton(
+                    text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_primary_button),
+                    onClick = onPrimaryButtonClick,
+                    buttonSize = ButtonSize.LARGE,
+                    padding = PaddingValues(0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = JpColorPalette().primary,
+                        contentColor = AppColor.White,
+                    ),
+                )
+                SecondaryButton(
+                    text = stringResource(R.string.wp_jetpack_continue_without_jetpack),
+                    onClick = onSecondaryButtonClick,
+                    buttonSize = ButtonSize.LARGE,
+                    padding = PaddingValues(0.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = Color.Transparent,
+                        contentColor = JpColorPalette().primary,
+                    ),
+                )
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -57,6 +57,8 @@ private val ContentTextStyle
         letterSpacing = 0.25.sp,
     )
 
+private val ContentMargin = 20.dp
+
 @Composable
 fun WPJetpackIndividualPluginOverlayScreen(
     sites: List<SiteWithIndividualJetpackPlugins>,
@@ -76,43 +78,45 @@ fun WPJetpackIndividualPluginOverlayScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(20.dp)
         ) {
-            // Spacer to push the content to the center of the screen
-            Spacer(modifier = Modifier.weight(1f))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(ContentMargin),
+                verticalArrangement = Arrangement.Center,
+            ) {
+                // Icon
+                JPInstallFullPluginAnimation(
+                    modifier = Modifier.align(Alignment.Start)
+                )
 
-            // Icon
-            JPInstallFullPluginAnimation(
-                modifier = Modifier.align(Alignment.Start)
-            )
+                Spacer(modifier = Modifier.height(24.dp))
 
-            Spacer(modifier = Modifier.height(24.dp))
+                // Title
+                Text(
+                    text = getTitle(siteCount = sites.size),
+                    style = TitleTextStyle,
+                )
 
-            // Title
-            Text(
-                text = getTitle(siteCount = sites.size),
-                style = TitleTextStyle,
-            )
+                Spacer(modifier = Modifier.height(16.dp))
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Content
-            CompositionLocalProvider(LocalTextStyle provides ContentTextStyle) {
-                when {
-                    sites.size > 1 -> MultipleSitesContent(sites)
-                    sites.size == 1 -> SingleSiteContent(sites.first())
+                // Content
+                CompositionLocalProvider(LocalTextStyle provides ContentTextStyle) {
+                    when {
+                        sites.size > 1 -> MultipleSitesContent(sites)
+                        sites.size == 1 -> SingleSiteContent(sites.first())
+                    }
                 }
             }
-
-            // Spacer to push the content to the center of the screen
-            Spacer(modifier = Modifier.weight(1f))
 
             // Buttons
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 12.dp),
+                    .padding(top = 10.dp, bottom = ContentMargin)
+                    .padding(horizontal = ContentMargin),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 PrimaryButton(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -106,7 +106,7 @@ fun WPJetpackIndividualPluginOverlayScreen(
 
             // Buttons
             PrimaryButton(
-                text = "Switch to Jetpack",
+                text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_primary_button),
                 onClick = onPrimaryButtonClick,
                 buttonSize = ButtonSize.LARGE,
                 padding = PaddingValues(0.dp),

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -1,0 +1,208 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.components.buttons.ButtonSize
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.JpColorPalette
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
+import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.JPInstallFullPluginAnimation
+
+// TODO hthomas move strings to resources
+
+private val TitleTextStyle
+    @ReadOnlyComposable
+    @Composable
+    get() = TextStyle(
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        fontWeight = FontWeight.Bold,
+    )
+
+private val ContentTextStyle
+    @ReadOnlyComposable
+    @Composable
+    get() = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp,
+    )
+
+@Composable
+fun WPJetpackIndividualPluginOverlayScreen(
+    sites: List<SiteWithIndividualJetpackPlugins>,
+    onCloseClick: () -> Unit,
+    onPrimaryButtonClick: () -> Unit,
+    onSecondaryButtonClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            MainTopAppBar(
+                title = null,
+                navigationIcon = NavigationIcons.CloseIcon,
+                onNavigationIconClick = onCloseClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp)
+        ) {
+            Spacer(modifier = Modifier.weight(1f)) // Spacer to push the content to the center of the screen
+
+            // Icon
+            JPInstallFullPluginAnimation(
+                modifier = Modifier.align(Alignment.Start)
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Title
+            Text(
+                text = getTitle(siteCount = sites.size),
+                style = TitleTextStyle,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Content
+            // TODO hthomas add content for each variation:
+            //  1. multiple problem sites
+            //  2. single problem site with 1 individual plugin
+            //  3. single problem site with multiple individual plugins
+            Text(
+                text = "You have ${sites.size} sites with individual Jetpack plugins. Switch to Jetpack!",
+                style = ContentTextStyle,
+            )
+
+            Spacer(modifier = Modifier.weight(1f)) // Spacer to push the content to the center of the screen
+
+            // Buttons
+            PrimaryButton(
+                text = "Switch to Jetpack",
+                onClick = onPrimaryButtonClick,
+                buttonSize = ButtonSize.LARGE,
+                padding = PaddingValues(0.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = JpColorPalette().primary,
+                    contentColor = AppColor.White,
+                ),
+            )
+            Spacer(modifier = Modifier.height(5.dp))
+            SecondaryButton(
+                text = stringResource(R.string.wp_jetpack_continue_without_jetpack),
+                onClick = onSecondaryButtonClick,
+                buttonSize = ButtonSize.LARGE,
+                padding = PaddingValues(0.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color.Transparent,
+                    contentColor = JpColorPalette().primary,
+                ),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+@ReadOnlyComposable
+@Composable
+fun getTitle(siteCount: Int): String = if (siteCount > 1) {
+    "Unable to access some of your sites"
+} else {
+    "Unable to access one of your sites"
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
+    AppTheme {
+        WPJetpackIndividualPluginOverlayScreen(
+            sites = listOf(
+                SiteWithIndividualJetpackPlugins(
+                    name = "Site 1",
+                    url = "site1.wordpress.com",
+                    individualPluginNames = listOf("Jetpack Social")
+                ),
+            ),
+            onCloseClick = {},
+            onPrimaryButtonClick = {},
+            onSecondaryButtonClick = {},
+        )
+    }
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
+    AppTheme {
+        WPJetpackIndividualPluginOverlayScreen(
+            sites = listOf(
+                SiteWithIndividualJetpackPlugins(
+                    name = "Site 1",
+                    url = "site1.wordpress.com",
+                    individualPluginNames = listOf("Jetpack Social", "Jetpack Search")
+                ),
+            ),
+            onCloseClick = {},
+            onPrimaryButtonClick = {},
+            onSecondaryButtonClick = {},
+        )
+    }
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun WPJetpackIndividualPluginOverlayScreenMultipleSitesPreview() {
+    AppTheme {
+        WPJetpackIndividualPluginOverlayScreen(
+            sites = listOf(
+                SiteWithIndividualJetpackPlugins(
+                    name = "Site 1",
+                    url = "site1.wordpress.com",
+                    individualPluginNames = listOf("Jetpack Social", "Jetpack Search")
+                ),
+                SiteWithIndividualJetpackPlugins(
+                    name = "Site 2",
+                    url = "site2.wordpress.com",
+                    individualPluginNames = listOf("Jetpack Boost")
+                ),
+            ),
+            onCloseClick = {},
+            onPrimaryButtonClick = {},
+            onSecondaryButtonClick = {},
+        )
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/JPInstallFullPluginAnimation.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/JPInstallFullPluginAnimation.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.comp
 import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Devices
@@ -27,7 +28,8 @@ fun JPInstallFullPluginAnimation(
     val lottieComposition by rememberLottieComposition(LottieCompositionSpec.RawRes(animationRawRes))
     LottieAnimation(
         modifier = modifier,
-        composition = lottieComposition
+        composition = lottieComposition,
+        alignment = Alignment.CenterStart
     )
 }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4453,4 +4453,27 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Blaze -->
     <string name="blaze_header_done_label" translatable="false">@string/label_done_button</string>
     <string name="blaze_menu_item_label" translatable="false">@string/blaze_activity_title</string>
+
+    <!-- WordPress - Jetpack Individual Plugin sites not supported Overlay -->
+    <string name="wp_jetpack_individual_plugin_overlay_content_2">Please switch to the Jetpack app where we’ll guide you through connecting the full Jetpack plugin to use this site with the app.</string>
+
+    <string name="wp_jetpack_individual_plugin_overlay_single_site_title">Unable to access one of your sites</string>
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_title">Unable to access some of your sites</string>
+
+    <!-- translators:
+        %1$s = the current site address (e.g. "wordpress.com"),
+        %2$s = the non-translatable "<plugin name>" (e.g. "Jetpack Backup") -->
+    <string name="wp_jetpack_individual_plugin_overlay_single_site_single_plugin_content_1">%1$s is using the %2$s plugin, which isn’t supported by the WordPress app.</string>
+    <!-- translators:
+        %1$s = the current site address (e.g. "wordpress.com") -->
+    <string name="wp_jetpack_individual_plugin_overlay_single_site_multiple_plugins_content_1">%1$s is using individual Jetpack plugins, which aren’t supported by the WordPress app.</string>
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_1">Sites with individual Jetpack plugins aren’t supported by the WordPress app.</string>
+    <!-- translators:
+        %1$s = the current site address (e.g. "wordpress.com"),
+        %2$s = the non-translatable "<plugin name>" (e.g. "Jetpack Backup") -->
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_single_plugin">%1$s is using the %2$s plugin</string>
+    <!-- translators:
+       %1$s = the current site address (e.g. "wordpress.com"),
+       %2$s = the quantity of plugins the site has (e.g. "3") -->
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_multiple_plugins">%1$s is using %2$s individual Jetpack plugins</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4455,6 +4455,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blaze_menu_item_label" translatable="false">@string/blaze_activity_title</string>
 
     <!-- WordPress - Jetpack Individual Plugin sites not supported Overlay -->
+    <string name="wp_jetpack_individual_plugin_overlay_primary_button">Switch to the Jetpack app</string>
     <string name="wp_jetpack_individual_plugin_overlay_content_2">Please switch to the Jetpack app where we’ll guide you through connecting the full Jetpack plugin to use this site with the app.</string>
 
     <string name="wp_jetpack_individual_plugin_overlay_single_site_title">Unable to access one of your sites</string>
@@ -4463,17 +4464,17 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- translators:
         %1$s = the current site address (e.g. "wordpress.com"),
         %2$s = the non-translatable "<plugin name>" (e.g. "Jetpack Backup") -->
-    <string name="wp_jetpack_individual_plugin_overlay_single_site_single_plugin_content_1">%1$s is using the %2$s plugin, which isn’t supported by the WordPress app.</string>
+    <string name="wp_jetpack_individual_plugin_overlay_single_site_single_plugin_content_1">&lt;b&gt;%1$s&lt;/b&gt; is using the &lt;b&gt;%2$s&lt;/b&gt; plugin, which isn’t supported by the WordPress app.</string>
     <!-- translators:
         %1$s = the current site address (e.g. "wordpress.com") -->
-    <string name="wp_jetpack_individual_plugin_overlay_single_site_multiple_plugins_content_1">%1$s is using individual Jetpack plugins, which aren’t supported by the WordPress app.</string>
+    <string name="wp_jetpack_individual_plugin_overlay_single_site_multiple_plugins_content_1">&lt;b&gt;%1$s&lt;/b&gt; is using individual Jetpack plugins, which aren’t supported by the WordPress app.</string>
     <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_1">Sites with individual Jetpack plugins aren’t supported by the WordPress app.</string>
     <!-- translators:
         %1$s = the current site address (e.g. "wordpress.com"),
         %2$s = the non-translatable "<plugin name>" (e.g. "Jetpack Backup") -->
-    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_single_plugin">%1$s is using the %2$s plugin</string>
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_single_plugin">&lt;b&gt;%1$s&lt;/b&gt; is using the &lt;b&gt;%2$s&lt;/b&gt; plugin</string>
     <!-- translators:
        %1$s = the current site address (e.g. "wordpress.com"),
        %2$s = the quantity of plugins the site has (e.g. "3") -->
-    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_multiple_plugins">%1$s is using %2$s individual Jetpack plugins</string>
+    <string name="wp_jetpack_individual_plugin_overlay_multiple_sites_content_item_multiple_plugins">&lt;b&gt;%1$s&lt;/b&gt; is using %2$s individual Jetpack plugins</string>
 </resources>


### PR DESCRIPTION
Part of #18114 

Creates the Compose screen that will be used in the Overlay, as well as needed components for it.

## Previews
Note: the icon animation does not appear in the Previews, only in Interactive mode.

### Single Site - Single Plugin
![issue-18114-ui-single-site-single-plugin](https://user-images.githubusercontent.com/5091503/227369440-e941866c-4b36-4d7b-909e-c32382be41c2.png)

### Single Site - Multiple Plugins
![issue-18114-ui-single-site-multiple-plugins](https://user-images.githubusercontent.com/5091503/227369478-02d6e27c-57ab-4739-aa7a-a7b4db80ca1d.png)

### Multiple Sites
![issue-18114-ui-multiple-sites](https://user-images.githubusercontent.com/5091503/227369551-50ea25c2-16f2-4ced-927f-276ed1ae2496.png) 

## To test
Dev-only testing:
Pull this branch, in AndroidStudio, make sure you have the `wordpress` variant selected, go to `WPJetpackIndividualPluginOverlayScreen.kt` file, and build the code to see the Previews.

## Regression Notes
1. Potential unintended areas of impact
N/A (new file created but not used yet)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A (UI only)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
