### PR TITLE
Merge 22.0 editorialized release notes to trunk

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -10,17 +10,17 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
+msgctxt "release_note_220"
+msgid ""
+"22.0:\n"
+"You can now transform most types of blocks into other block types, like quotes, columns, and groups.\n"
+msgstr ""
+
 msgctxt "release_note_219"
 msgid ""
 "21.9:\n"
 "Hot news—Jetpack now supports Blaze, so you can reach new readers by promoting a post or page from within the app.\n"
 "We also added a post-migration FAQ card to the Help screen, which you’ll see after switching from the WordPress app over to Jetpack.\n"
-msgstr ""
-
-msgctxt "release_note_218"
-msgid ""
-"21.8:\n"
-"We’ve added a little extra support for sites with individual plugins. These plugins don’t support all app features yet, but you can always install the full Jetpack plugin instead. Ready to launch?\n"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,2 +1,1 @@
-* [*] Block editor: Allow new block transforms for most blocks. [https://github.com/WordPress/gutenberg/pull/48792]
-
+You can now transform most types of blocks into other block types, like quotes, columns, and groups.

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -10,6 +10,12 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
+msgctxt "release_note_220"
+msgid ""
+"22.0:\n"
+"You can now transform most types of blocks into other block types, like quotes, columns, and groups.\n"
+msgstr ""
+
 msgctxt "release_note_219"
 msgid ""
 "21.9:\n"
@@ -17,12 +23,6 @@ msgid ""
 "The WordPress logo is blue\n"
 "There are no new updates\n"
 "Sorry to disappoint you\n"
-msgstr ""
-
-msgctxt "release_note_218"
-msgid ""
-"21.8:\n"
-"Say hello to our shiny new in-app landing screen! It almost makes you want to look at it all day and not publish anything new. Almost.\n"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,2 +1,1 @@
-* [*] Block editor: Allow new block transforms for most blocks. [https://github.com/WordPress/gutenberg/pull/48792]
-
+You can now transform most types of blocks into other block types, like quotes, columns, and groups.

--- a/WordPress/src/main/java/org/wordpress/android/models/NotificationsSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/NotificationsSettings.java
@@ -22,7 +22,7 @@ public class NotificationsSettings {
     private JSONObject mWPComSettings;
     private LongSparseArray<JSONObject> mBlogSettings;
 
-    // The main notification settings channels (displayed at root of NoticationsSettingsFragment)
+    // The main notification settings channels (displayed at root of NotificationsSettingsFragment)
     public enum Channel {
         OTHER,
         BLOGS,

--- a/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout/jetpack_feature_removal_overlay.xml
@@ -12,6 +12,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_medium"
         android:orientation="vertical">
 
         <ImageButton

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -41,7 +41,7 @@ Language: en_GB
     <string name="only_one_primary_site_message">Only one site is available, so you can\'t change your primary site.</string>
     <string name="jetpack_individual_plugin_support_onboarding_title">Please install the full Jetpack plugin</string>
     <string name="button_promote_with_blaze">Promote with Blaze</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="wp_jetpack_feature_removal_phase_self_hosted_users_title">Your site has the Jetpack plugin</string>
     <string name="wp_jetpack_feature_removal_phase_new_users_notifications_description">Get notifications for new comments, likes, views, and more.</string>
     <string name="wp_jetpack_feature_removal_phase_new_users_reader_description">Find and follow your favourite sites and communities, and share you content.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4393,7 +4393,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Jetpack Feature Card -->
     <string name="jetpack_feature_card_content_phase_three">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="jetpack_feature_card_learn_more" translatable="false">@string/learn_more</string>
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -4393,7 +4393,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Jetpack Feature Card -->
     <string name="jetpack_feature_card_content_phase_three">Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.</string>
-    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notications and more with Jetpack.</string>
+    <string name="jetpack_feature_card_content_phase_self_hosted_and_new_users">Unlock your site’s full potential. Get stats, notifications and more with Jetpack.</string>
     <string name="jetpack_feature_card_learn_more" translatable="false">@string/learn_more</string>
     <string name="jetpack_feature_card_menu_item_remind_me_later">Remind me later</string>
     <string name="gutenberg_native_featured" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Featured</string>


### PR DESCRIPTION
Also includes changes from https://github.com/wordpress-mobile/WordPress-Android/pull/18160 & https://github.com/wordpress-mobile/WordPress-Android/pull/18163.