### PR TITLE
Open Domain Checkout web-view in Site Creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainProductDetails.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainProductDetails.kt
@@ -1,11 +1,9 @@
 package org.wordpress.android.ui.domains
 
-import android.annotation.SuppressLint
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@SuppressLint("ParcelCreator")
 data class DomainProductDetails(
     val productId: Int,
     val domainName: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -136,7 +136,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, isSiteTitleTaskComplete)
                     }
-                    is DomainRegistered -> {
+                    is DomainRegistrationPurchased -> {
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, isSiteTitleTaskComplete)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -82,8 +82,10 @@ class SiteCreationActivity : LocaleAwareActivity(),
     private val jetpackFullScreenViewModel: JetpackFeatureFullScreenOverlayViewModel by viewModels()
     private val progressViewModel: SiteCreationProgressViewModel by viewModels()
     private val previewViewModel: SitePreviewViewModel by viewModels()
+
     @Inject
     internal lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
+
     @Inject
     internal lateinit var activityLauncherWrapper: ActivityLauncherWrapper
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -29,9 +29,9 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistered
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotInLocalDb
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.PROGRESS
@@ -98,7 +98,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
     }
 
     private val domainCheckoutActivityLauncher = registerForActivityResult(OpenCheckout()) {
-        it?.let(mainViewModel::onCheckoutSuccess)
+        mainViewModel.onCheckoutResult(it)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -130,7 +130,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
                     is NotCreated -> {
                         Triple(false, null, false)
                     }
-                    is NotInLocalDb -> {
+                    is Created -> {
                         // Site was created, but we haven't been able to fetch it, let `SitePickerActivity` handle
                         // this with a Snackbar message.
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayViewModel
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.DismissDialog
@@ -28,6 +29,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistered
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotInLocalDb
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
@@ -95,6 +97,10 @@ class SiteCreationActivity : LocaleAwareActivity(),
         }
     }
 
+    private val domainCheckoutActivityLauncher = registerForActivityResult(OpenCheckout()) {
+        it?.let(mainViewModel::onCheckoutSuccess)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.site_creation_activity)
@@ -130,6 +136,10 @@ class SiteCreationActivity : LocaleAwareActivity(),
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, isSiteTitleTaskComplete)
                     }
+                    is DomainRegistered -> {
+                        intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
+                        Triple(true, null, isSiteTitleTaskComplete)
+                    }
                     is Completed -> {
                         Triple(true, localId, isSiteTitleTaskComplete)
                     }
@@ -151,6 +161,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
             ActivityUtils.hideKeyboard(this)
             onBackPressedDispatcher.onBackPressedCompat(backPressedCallback)
         }
+        mainViewModel.launchDomainCheckout.observe(this, domainCheckoutActivityLauncher::launch)
         siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
@@ -130,9 +130,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
                     is NotCreated -> {
                         Triple(false, null, false)
                     }
-                    is Created -> {
-                        // Site was created, but we haven't been able to fetch it, let `SitePickerActivity` handle
-                        // this with a Snackbar message.
+                    is CreatedButNotFetched -> {
+                        // Let `SitePickerActivity` handle this with a Snackbar message
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, isSiteTitleTaskComplete)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -177,6 +177,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         progressViewModel.onRemoteSiteCreated.observe(this) { remoteSiteId ->
             mainViewModel.onProgressScreenFinished(remoteSiteId)
         }
+        progressViewModel.onCartCreated.observe(this) { mainViewModel.onCartCreated(it) }
         previewViewModel.onOkButtonClicked.observe(this) { result ->
             mainViewModel.onWizardFinished(result)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
@@ -132,10 +131,6 @@ class SiteCreationActivity : LocaleAwareActivity(),
                     }
                     is CreatedButNotFetched -> {
                         // Let `SitePickerActivity` handle this with a Snackbar message
-                        intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
-                        Triple(true, null, isSiteTitleTaskComplete)
-                    }
-                    is DomainRegistrationPurchased -> {
                         intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
                         Triple(true, null, isSiteTitleTaskComplete)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -161,7 +161,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
             ActivityUtils.hideKeyboard(this)
             onBackPressedDispatcher.onBackPressedCompat(backPressedCallback)
         }
-        mainViewModel.launchDomainCheckout.observe(this, domainCheckoutActivityLauncher::launch)
+        mainViewModel.showDomainCheckout.observe(this, domainCheckoutActivityLauncher::launch)
         siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -56,7 +56,6 @@ data class SiteCreationState(
     val segmentId: Long? = null,
     val siteDesign: String? = null,
     val domain: DomainModel? = null,
-    val remoteSiteId: Long? = null,
     val result: SiteCreationResult = NotCreated,
 ) : WizardState, Parcelable {
     fun isSiteTitleStepCompleted() = !siteName.isNullOrBlank()
@@ -265,7 +264,6 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onProgressScreenFinished(remoteSiteId: Long) {
         siteCreationState = siteCreationState.copy(
-            remoteSiteId = remoteSiteId,
             result = NotInLocalDb(remoteSiteId, siteCreationState.isSiteTitleStepCompleted())
         )
         wizardManager.showNextStep()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.networking.MShot
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
+import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
@@ -108,6 +109,7 @@ class SiteCreationMainVM @Inject constructor(
     private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil,
     private val domainPurchasingExperiment: SiteCreationDomainPurchasingExperiment,
     private val domainPurchasingFeatureConfig: SiteCreationDomainPurchasingFeatureConfig,
+    private val domainsRegistrationTracker: DomainsRegistrationTracker,
 ) : ViewModel() {
     init {
         dispatcher.register(fetchHomePageLayoutsUseCase)
@@ -296,6 +298,7 @@ class SiteCreationMainVM @Inject constructor(
                 isSiteTitleTaskCompleted()
             )
         )
+        domainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(checkoutDetails.site, isSiteCreation = true)
         _showDomainCheckout.value = checkoutDetails
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -341,21 +341,13 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onPositiveDialogButtonClicked(instanceTag: String) {
-        when (instanceTag) {
-            TAG_WARNING_DIALOG -> {
-                exitFlow(true)
-            }
-            else -> NotImplementedError("Unknown dialog tag: $instanceTag")
-        }
+        check(instanceTag == TAG_WARNING_DIALOG) { "Unknown dialog tag: $instanceTag" }
+        exitFlow(true)
     }
 
     fun onNegativeDialogButtonClicked(instanceTag: String) {
-        when (instanceTag) {
-            TAG_WARNING_DIALOG -> {
-                // do nothing
-            }
-            else -> NotImplementedError("Unknown dialog tag: $instanceTag")
-        }
+        check(instanceTag == TAG_WARNING_DIALOG) { "Unknown dialog tag: $instanceTag" }
+        // do nothing
     }
 
     sealed class SiteCreationScreenTitle {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -72,7 +72,7 @@ sealed interface SiteCreationResult : Parcelable {
     data class NotInLocalDb(val remoteId: Long, val isSiteTitleTaskComplete: Boolean) : SiteCreationResult
 
     @Parcelize
-    data class DomainRegistered(
+    data class DomainRegistrationPurchased(
         val domainName: String,
         val email: String,
         val remoteId: Long,
@@ -284,7 +284,7 @@ class SiteCreationMainVM @Inject constructor(
     fun onCheckoutSuccess(event: DomainRegistrationCompletedEvent) {
         val (remoteId, isSiteTitleTaskComplete) = siteCreationState.result as NotInLocalDb
         siteCreationState = siteCreationState.copy(
-            result = DomainRegistered(
+            result = DomainRegistrationPurchased(
                 event.domainName,
                 event.email,
                 remoteId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -151,7 +151,7 @@ class SiteCreationMainVM @Inject constructor(
     val showJetpackOverlay: LiveData<Event<Boolean>> = _showJetpackOverlay
 
     private val _showDomainCheckout = SingleLiveEvent<CheckoutDetails>()
-    val launchDomainCheckout: LiveData<CheckoutDetails> = _showDomainCheckout
+    val showDomainCheckout: LiveData<CheckoutDetails> = _showDomainCheckout
 
     fun start(savedInstanceState: Bundle?, siteCreationSource: SiteCreationSource) {
         if (isStarted) return

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -57,9 +57,7 @@ data class SiteCreationState(
     val siteDesign: String? = null,
     val domain: DomainModel? = null,
     val result: SiteCreationResult = NotCreated,
-) : WizardState, Parcelable {
-    fun isSiteTitleStepCompleted() = !siteName.isNullOrBlank()
-}
+) : WizardState, Parcelable
 
 typealias NavigationTarget = WizardNavigationTarget<SiteCreationStep, SiteCreationState>
 
@@ -264,10 +262,12 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onProgressScreenFinished(remoteSiteId: Long) {
         siteCreationState = siteCreationState.copy(
-            result = NotInLocalDb(remoteSiteId, siteCreationState.isSiteTitleStepCompleted())
+            result = NotInLocalDb(remoteSiteId, isSiteTitleTaskCompleted())
         )
         wizardManager.showNextStep()
     }
+
+    private fun isSiteTitleTaskCompleted() = !siteCreationState.siteName.isNullOrBlank()
 
     fun onWizardCancelled() {
         _wizardFinishedObservable.value = NotCreated

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
@@ -84,15 +83,15 @@ sealed interface SiteCreationResult : Parcelable {
             override val remoteId: Long,
             override val isSiteTitleTaskComplete: Boolean,
         ) : CreatedButNotFetched
-    }
 
-    @Parcelize
-    data class DomainRegistrationPurchased(
-        val domainName: String,
-        val email: String,
-        val remoteId: Long,
-        val isSiteTitleTaskComplete: Boolean,
-    ) : SiteCreationResult
+        @Parcelize
+        data class DomainRegistrationPurchased(
+            val domainName: String,
+            val email: String,
+            override val remoteId: Long,
+            override val isSiteTitleTaskComplete: Boolean,
+        ) : CreatedButNotFetched
+    }
 
     @Parcelize
     data class Completed(val localId: Int, val isSiteTitleTaskComplete: Boolean, val url: String) : SiteCreationResult
@@ -305,7 +304,7 @@ class SiteCreationMainVM @Inject constructor(
         siteCreationState = siteCreationState.run {
             check(result is CreatedButNotFetched.InCart)
             copy(
-                result = DomainRegistrationPurchased(
+                result = CreatedButNotFetched.DomainRegistrationPurchased(
                     event.domainName,
                     event.email,
                     result.remoteId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -291,7 +291,11 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onCartCreated(checkoutDetails: CheckoutDetails) {
         siteCreationState = siteCreationState.copy(
-            result = CreatedButNotFetched.InCart(checkoutDetails.site.url, checkoutDetails.site.siteId, isSiteTitleTaskCompleted())
+            result = CreatedButNotFetched.InCart(
+                checkoutDetails.site.url,
+                checkoutDetails.site.siteId,
+                isSiteTitleTaskCompleted()
+            )
         )
         _showDomainCheckout.value = checkoutDetails
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
@@ -68,7 +68,7 @@ sealed interface SiteCreationResult : Parcelable {
     @Parcelize
     object NotCreated : SiteCreationResult
 
-    sealed interface Created : SiteCreationResult {
+    sealed interface CreatedButNotFetched : SiteCreationResult {
         val remoteId: Long
         val isSiteTitleTaskComplete: Boolean
 
@@ -76,14 +76,14 @@ sealed interface SiteCreationResult : Parcelable {
         data class NotInLocalDb(
             override val remoteId: Long,
             override val isSiteTitleTaskComplete: Boolean,
-        ) : Created
+        ) : CreatedButNotFetched
 
         @Parcelize
         data class InCart(
             val siteSlug: String,
             override val remoteId: Long,
             override val isSiteTitleTaskComplete: Boolean,
-        ) : Created
+        ) : CreatedButNotFetched
     }
 
     @Parcelize
@@ -291,7 +291,7 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onCartCreated(checkoutDetails: CheckoutDetails) {
         siteCreationState = siteCreationState.copy(
-            result = Created.InCart(checkoutDetails.site.url, checkoutDetails.site.siteId, isSiteTitleTaskCompleted())
+            result = CreatedButNotFetched.InCart(checkoutDetails.site.url, checkoutDetails.site.siteId, isSiteTitleTaskCompleted())
         )
         _showDomainCheckout.value = checkoutDetails
     }
@@ -299,7 +299,7 @@ class SiteCreationMainVM @Inject constructor(
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
         if (event == null) return onBackPressed()
         siteCreationState = siteCreationState.run {
-            check(result is Created.InCart)
+            check(result is CreatedButNotFetched.InCart)
             copy(
                 result = DomainRegistrationPurchased(
                     event.domainName,
@@ -314,7 +314,7 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onProgressScreenFinished(remoteSiteId: Long) {
         siteCreationState = siteCreationState.copy(
-            result = Created.NotInLocalDb(remoteSiteId, isSiteTitleTaskCompleted())
+            result = CreatedButNotFetched.NotInLocalDb(remoteSiteId, isSiteTitleTaskCompleted())
         )
         wizardManager.showNextStep()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -299,7 +299,7 @@ class SiteCreationMainVM @Inject constructor(
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
         if (event == null) return onBackPressed()
         siteCreationState = siteCreationState.run {
-            check(result is Created)
+            check(result is Created.InCart)
             copy(
                 result = DomainRegistrationPurchased(
                     event.domainName,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/DomainsScreenListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/DomainsScreenListener.kt
@@ -13,4 +13,5 @@ data class DomainModel(
     val isFree: Boolean,
     val cost: String,
     val productId: Int,
+    val supportsPrivacy: Boolean,
 ) : Parcelable

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -226,6 +226,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
             isFree = is_free,
             cost = cost.orEmpty(),
             productId = product_id,
+            supportsPrivacy = supports_privacy,
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.sitecreation.SiteCreationResult
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
@@ -80,7 +80,7 @@ class SitePreviewViewModel @Inject constructor(
         urlWithoutScheme = requireNotNull(siteCreationState.domain) { "url required for preview" }.domainName
         startPreLoadingWebView()
         result = siteCreationState.result.also {
-            if (it is Created) {
+            if (it is CreatedButNotFetched) {
                 launch {
                     fetchNewlyCreatedSiteModel(it.remoteId)?.run {
                         result = Completed(id, it.isSiteTitleTaskComplete, url)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -83,7 +83,7 @@ class SitePreviewViewModel @Inject constructor(
             if (it is NotInLocalDb) {
                 launch {
                     fetchNewlyCreatedSiteModel(it.remoteId)?.run {
-                        result = Completed(id, siteCreationState.isSiteTitleStepCompleted(), url)
+                        result = Completed(id, it.isSiteTitleTaskComplete, url)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -16,7 +16,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.sitecreation.SiteCreationResult
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotInLocalDb
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
@@ -80,7 +80,7 @@ class SitePreviewViewModel @Inject constructor(
         urlWithoutScheme = requireNotNull(siteCreationState.domain) { "url required for preview" }.domainName
         startPreLoadingWebView()
         result = siteCreationState.result.also {
-            if (it is NotInLocalDb) {
+            if (it is Created) {
                 launch {
                     fetchNewlyCreatedSiteModel(it.remoteId)?.run {
                         result = Completed(id, it.isSiteTitleTaskComplete, url)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
@@ -57,7 +58,6 @@ class SiteCreationProgressViewModel @Inject constructor(
     private val createCartUseCase: CreateCartUseCase,
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(mainDispatcher) {
-    private var isStarted = false
     private var loadingAnimationJob: Job? = null
 
     private lateinit var siteCreationState: SiteCreationState
@@ -91,8 +91,13 @@ class SiteCreationProgressViewModel @Inject constructor(
     }
 
     fun start(siteCreationState: SiteCreationState) {
-        if (isStarted) return
-        isStarted = true
+        if (siteCreationState.result is Created.InCart) {
+            // reuse the previously blog when returning with the same domain
+            if (siteCreationState.domain == this.siteCreationState.domain) {
+                createCart(siteCreationState.result.remoteId, siteCreationState.result.siteSlug)
+                return
+            }
+        }
         this.siteCreationState = siteCreationState
         domain = requireNotNull(siteCreationState.domain) { "domain required to create a site" }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
-import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationState
@@ -54,7 +53,6 @@ private val loadingTexts = listOf(
 class SiteCreationProgressViewModel @Inject constructor(
     private val networkUtils: NetworkUtilsWrapper,
     private val tracker: SiteCreationTracker,
-    private val domainsRegistrationTracker: DomainsRegistrationTracker,
     private val createCartUseCase: CreateCartUseCase,
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(mainDispatcher) {
@@ -198,7 +196,6 @@ class SiteCreationProgressViewModel @Inject constructor(
         } else {
             AppLog.d(LOG_TAG, "Successful cart creation: ${event.cartDetails}")
             _onCartCreated.postValue(CheckoutDetails(site, domain.domainName))
-            domainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(site, isSiteCreation = true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
@@ -91,7 +91,7 @@ class SiteCreationProgressViewModel @Inject constructor(
     }
 
     fun start(siteCreationState: SiteCreationState) {
-        if (siteCreationState.result is Created.InCart) {
+        if (siteCreationState.result is CreatedButNotFetched.InCart) {
             // reuse the previously blog when returning with the same domain
             if (siteCreationState.domain == this.siteCreationState.domain) {
                 createCart(siteCreationState.result.remoteId, siteCreationState.result.siteSlug)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -11,7 +11,7 @@ import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.domains.DomainProductDetails
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.SiteCreationState
@@ -81,8 +81,8 @@ class SiteCreationProgressViewModel @Inject constructor(
     private val _onRemoteSiteCreated = SingleLiveEvent<Long>()
     val onRemoteSiteCreated: LiveData<Long> = _onRemoteSiteCreated
 
-    private val _onCartCreated = SingleLiveEvent<DomainProductDetails>()
-    // val onCartCreated: LiveData<DomainProductDetails> = _onCartCreated
+    private val _onCartCreated = SingleLiveEvent<CheckoutDetails>()
+    val onCartCreated: LiveData<CheckoutDetails> = _onCartCreated
 
     override fun onCleared() {
         super.onCleared()
@@ -192,7 +192,7 @@ class SiteCreationProgressViewModel @Inject constructor(
             updateUiStateAsync(GenericError)
         } else {
             AppLog.d(LOG_TAG, "Successful cart creation: ${event.cartDetails}")
-            _onCartCreated.postValue(DomainProductDetails(domain.productId, domain.domainName))
+            _onCartCreated.postValue(CheckoutDetails(site, domain.domainName))
             domainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(site, isSiteCreation = true)
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
+import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
@@ -50,6 +51,8 @@ val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 val RESULT_CREATED = Created.NotInLocalDb(SITE_REMOTE_ID, false)
 val RESULT_IN_CART = Created.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
 val RESULT_COMPLETED = Completed(SITE_LOCAL_ID, false, URL)
+
+val CHECKOUT_EVENT = DomainRegistrationCompletedEvent(URL_CUSTOM, "email@host.com")
 
 val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, URL))
 val SERVICE_ERROR = SiteCreationServiceState(FAILURE, SiteCreationServiceState(CREATE_SITE))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -1,14 +1,16 @@
 package org.wordpress.android.ui.sitecreation
 
 import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartError
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
+import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotInLocalDb
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.SiteCreationStep.CREATE_SITE
@@ -19,6 +21,7 @@ import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 const val SUB_DOMAIN = "test"
 const val URL = "$SUB_DOMAIN.wordpress.com"
 const val URL_CUSTOM = "$SUB_DOMAIN.host.com"
+const val SITE_SLUG = "${SUB_DOMAIN}host0.wordpress.com"
 val FREE_DOMAIN = DomainModel(URL, true, "", 1, false)
 val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2, true)
 
@@ -31,13 +34,21 @@ val SITE_CREATION_STATE = SiteCreationState(
     domain = FREE_DOMAIN,
 )
 
+val SITE_MODEL = SiteModel().apply {
+    siteId = SITE_REMOTE_ID
+    url = SITE_SLUG
+}
+
+val CHECKOUT_DETAILS = DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails(SITE_MODEL, SITE_SLUG)
+
 val FETCH_SUCCESS = OnSiteChanged(1)
 val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
 
 val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
 val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
-val RESULT_CREATED = NotInLocalDb(SITE_REMOTE_ID, false)
+val RESULT_CREATED = Created.NotInLocalDb(SITE_REMOTE_ID, false)
+val RESULT_IN_CART = Created.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
 val RESULT_COMPLETED = Completed(SITE_LOCAL_ID, false, URL)
 
 val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, URL))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -27,7 +27,6 @@ val FREE_DOMAIN = DomainModel(URL, true, "", 1, false)
 val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2, true)
 
 const val SITE_REMOTE_ID = 1L
-private const val SITE_LOCAL_ID = 1
 
 val SITE_CREATION_STATE = SiteCreationState(
     segmentId = 1,
@@ -35,12 +34,10 @@ val SITE_CREATION_STATE = SiteCreationState(
     domain = FREE_DOMAIN,
 )
 
-val SITE_MODEL = SiteModel().apply {
-    siteId = SITE_REMOTE_ID
-    url = SITE_SLUG
-}
+val SITE_MODEL = SiteModel().apply { siteId = SITE_REMOTE_ID; url = SITE_SLUG }
 
 val CHECKOUT_DETAILS = DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails(SITE_MODEL, SITE_SLUG)
+val CHECKOUT_EVENT = DomainRegistrationCompletedEvent(URL_CUSTOM, "email@host.com")
 
 val FETCH_SUCCESS = OnSiteChanged(1)
 val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
@@ -50,9 +47,7 @@ val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
 val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_REMOTE_ID, false)
 val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
-val RESULT_COMPLETED = Completed(SITE_LOCAL_ID, false, URL)
-
-val CHECKOUT_EVENT = DomainRegistrationCompletedEvent(URL_CUSTOM, "email@host.com")
+val RESULT_COMPLETED = Completed(1, false, URL)
 
 val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, URL))
 val SERVICE_ERROR = SiteCreationServiceState(FAILURE, SiteCreationServiceState(CREATE_SITE))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -1,8 +1,12 @@
 package org.wordpress.android.ui.sitecreation
 
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.network.rest.wpcom.transactions.TransactionsRestClient.CreateShoppingCartResponse
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.store.SiteStore.SiteError
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType.GENERIC_ERROR
+import org.wordpress.android.fluxc.store.TransactionsStore.CreateShoppingCartError
+import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotInLocalDb
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
@@ -30,6 +34,9 @@ val SITE_CREATION_STATE = SiteCreationState(
 
 val FETCH_SUCCESS = OnSiteChanged(1)
 val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
+
+val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
+val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
 val RESULT_CREATED = NotInLocalDb(SITE_REMOTE_ID, false)
 val RESULT_COMPLETED = Completed(SITE_LOCAL_ID, false, URL)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -11,7 +11,7 @@ import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.SiteCreationStep.CREATE_SITE
@@ -48,8 +48,8 @@ val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
 val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
 val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
-val RESULT_CREATED = Created.NotInLocalDb(SITE_REMOTE_ID, false)
-val RESULT_IN_CART = Created.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
+val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_REMOTE_ID, false)
+val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
 val RESULT_COMPLETED = Completed(SITE_LOCAL_ID, false, URL)
 
 val CHECKOUT_EVENT = DomainRegistrationCompletedEvent(URL_CUSTOM, "email@host.com")

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -29,7 +29,6 @@ val SITE_CREATION_STATE = SiteCreationState(
     segmentId = 1,
     siteDesign = defaultTemplateSlug,
     domain = FREE_DOMAIN,
-    remoteSiteId = SITE_REMOTE_ID,
 )
 
 val FETCH_SUCCESS = OnSiteChanged(1)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -15,8 +15,8 @@ import org.wordpress.android.ui.sitecreation.theme.defaultTemplateSlug
 const val SUB_DOMAIN = "test"
 const val URL = "$SUB_DOMAIN.wordpress.com"
 const val URL_CUSTOM = "$SUB_DOMAIN.host.com"
-val FREE_DOMAIN = DomainModel(URL, true, "", 1)
-val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2)
+val FREE_DOMAIN = DomainModel(URL, true, "", 1, false)
+val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2, true)
 
 const val SITE_REMOTE_ID = 1L
 private const val SITE_LOCAL_ID = 1

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -141,9 +141,9 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on progress screen finished updates state with remote id`() {
+    fun `on progress screen finished updates state with result`() {
         viewModel.onProgressScreenFinished(SITE_REMOTE_ID)
-        assertThat(currentWizardState(viewModel).remoteSiteId).isEqualTo(SITE_REMOTE_ID)
+        assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_CREATED)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -1,4 +1,3 @@
-
 package org.wordpress.android.ui.sitecreation
 
 import android.os.Bundle

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -196,7 +196,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Test
     fun `on progress screen finished updates state with result`() {
         viewModel.onProgressScreenFinished(SITE_REMOTE_ID)
-        assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_CREATED)
+        assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.DomainRegistrationPurchased
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched.DomainRegistrationPurchased
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.usecases.FetchHomePageLayoutsUseCase

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.experiments.Variation.Control
 import org.wordpress.android.fluxc.model.experiments.Variation.Treatment
+import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleEmpty
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
@@ -104,6 +105,9 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Mock
     lateinit var domainPurchasingFeatureConfig: SiteCreationDomainPurchasingFeatureConfig
 
+    @Mock
+    lateinit var domainsRegistrationTracker: DomainsRegistrationTracker
+
     private val wizardManagerNavigatorLiveData = SingleLiveEvent<SiteCreationStep>()
 
     private lateinit var viewModel: SiteCreationMainVM
@@ -145,9 +149,15 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on cart created is propagated`() {
+    fun `on cart created propagates details to show checkout`() {
         viewModel.onCartCreated(CHECKOUT_DETAILS)
         assertEquals(CHECKOUT_DETAILS, viewModel.showDomainCheckout.value)
+    }
+
+    @Test
+    fun `on cart created tracks checkout webview viewed`() {
+        viewModel.onCartCreated(CHECKOUT_DETAILS)
+        verify(domainsRegistrationTracker).trackDomainsPurchaseWebviewViewed(eq(CHECKOUT_DETAILS.site), eq(true))
     }
 
     @Test
@@ -398,5 +408,6 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         jetpackFeatureRemovalOverlayUtil,
         domainPurchasingExperiment,
         domainPurchasingFeatureConfig,
+        domainsRegistrationTracker,
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -1,3 +1,4 @@
+
 package org.wordpress.android.ui.sitecreation
 
 import android.os.Bundle
@@ -12,6 +13,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
@@ -42,6 +44,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.wizard.WizardManager
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import org.wordpress.android.viewmodel.helpers.DialogHolder
+import kotlin.test.assertEquals
 
 private const val SEGMENT_ID = 1L
 private const val VERTICAL = "Test Vertical"
@@ -138,6 +141,24 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     fun `on wizard finished is propagated`() {
         viewModel.onWizardFinished(RESULT_COMPLETED)
         verify(wizardFinishedObserver).onChanged(eq(RESULT_COMPLETED))
+    }
+
+    @Test
+    fun `on cart created is propagated`() {
+        viewModel.onCartCreated(CHECKOUT_DETAILS)
+        assertEquals(CHECKOUT_DETAILS, viewModel.showDomainCheckout.value)
+    }
+
+    @Test
+    fun `on cart created updates state with result`() {
+        viewModel.onCartCreated(CHECKOUT_DETAILS)
+
+        // Assert on the private state via bundle
+        viewModel.writeToBundle(savedInstanceState)
+        verify(savedInstanceState).putParcelable(
+            eq(KEY_SITE_CREATION_STATE),
+            argWhere<SiteCreationState> { it.result == RESULT_IN_CART }
+        )
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -151,7 +151,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on cart created updates state with result`() {
+    fun `on cart created updates result`() {
         viewModel.onCartCreated(CHECKOUT_DETAILS)
 
         // Assert on the private state via bundle
@@ -180,7 +180,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on checkout result when not null updates state with result`() {
+    fun `on checkout result when not null updates result`() {
         viewModel.onCartCreated(CHECKOUT_DETAILS)
 
         viewModel.onCheckoutResult(CHECKOUT_EVENT)
@@ -193,7 +193,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on progress screen finished updates state with result`() {
+    fun `on progress screen finished updates result`() {
         viewModel.onProgressScreenFinished(SITE_REMOTE_ID)
         assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -577,7 +577,6 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     private fun mockDomain(name: String = "", free: Boolean = true) = mock<DomainModel> {
         on { domainName } doReturn name
         on { isFree } doReturn free
-        on { supportsPrivacy } doReturn true
     }
     // endregion
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -346,6 +346,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
                 is_free = it % 2 == 0
                 cost = if (is_free) "Free" else "$$it.00"
                 product_id = it
+                supports_privacy = !is_free
             }
         }
 
@@ -576,6 +577,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     private fun mockDomain(name: String = "", free: Boolean = true) = mock<DomainModel> {
         on { domainName } doReturn name
         on { isFree } doReturn free
+        on { supportsPrivacy } doReturn true
     }
     // endregion
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.ui.sitecreation.FETCH_ERROR
 import org.wordpress.android.ui.sitecreation.FETCH_SUCCESS
-import org.wordpress.android.ui.sitecreation.RESULT_CREATED
+import org.wordpress.android.ui.sitecreation.RESULT_NOT_IN_LOCAL_DB
 import org.wordpress.android.ui.sitecreation.SITE_CREATION_STATE
 import org.wordpress.android.ui.sitecreation.SITE_REMOTE_ID
 import org.wordpress.android.ui.sitecreation.SUB_DOMAIN
@@ -84,7 +84,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
 
     @Test
     fun `on start fetches site by remote id when result is created`() = testWith(FETCH_SUCCESS) {
-        startViewModel(SITE_CREATION_STATE.copy(result = RESULT_CREATED))
+        startViewModel(SITE_CREATION_STATE.copy(result = RESULT_NOT_IN_LOCAL_DB))
         verify(fetchWpComSiteUseCase).fetchSiteWithRetry(SITE_REMOTE_ID)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -195,13 +195,6 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     fun `on service failure shows generic error`() {
         startViewModel()
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_ERROR)
-        verify(uiStateObserver).onChanged(eq(GenericError))
-    }
-
-    @Test
-    fun `on service failure shows error`() {
-        startViewModel()
-        viewModel.onSiteCreationServiceStateUpdated(SERVICE_ERROR)
         assertIs<GenericError>(viewModel.uiState.value)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
-import org.wordpress.android.ui.domains.DomainsRegistrationTracker
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.CART_ERROR
 import org.wordpress.android.ui.sitecreation.CART_SUCCESS
@@ -58,7 +57,6 @@ import kotlin.test.assertTrue
 class SiteCreationProgressViewModelTest : BaseUnitTest() {
     private var networkUtils = mock<NetworkUtilsWrapper>()
     private var tracker = mock<SiteCreationTracker>()
-    private val domainsRegistrationTracker = mock<DomainsRegistrationTracker>()
     private val createCartUseCase = mock<CreateCartUseCase>()
 
     private val uiStateObserver = mock<Observer<SiteProgressUiState>>()
@@ -75,7 +73,6 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
         viewModel = SiteCreationProgressViewModel(
             networkUtils,
             tracker,
-            domainsRegistrationTracker,
             createCartUseCase,
             testDispatcher(),
         )
@@ -186,13 +183,6 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
             eq(PAID_DOMAIN.supportsPrivacy),
             any(),
         )
-    }
-
-    @Test
-    fun `on cart success tracks domain purchase webview viewed`() = testWith(CART_SUCCESS) {
-        startViewModel(SITE_CREATION_STATE.copy(domain = PAID_DOMAIN))
-        viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)
-        verify(domainsRegistrationTracker).trackDomainsPurchaseWebviewViewed(any(), eq(true))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -188,7 +188,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     fun `on cart failure shows generic error`() = testWith(CART_ERROR) {
         startViewModel(SITE_CREATION_STATE.copy(domain = PAID_DOMAIN))
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)
-        verify(uiStateObserver).onChanged(eq(GenericError))
+        assertIs<GenericError>(viewModel.uiState.value)
     }
 
     @Test


### PR DESCRIPTION
Resolves partially #17905

This PR:

- ★ Implements the logic to reuse the existing domain registration checkout and open it in a web-view
- ⊕ Adds API call to create shopping cart for the paid domain product before checkout
- ⊜ Refactors the vm for the progress screen to support returning to it after back navigation from checkout

## To Test

#### Prerequisite

<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
</details>

### ● Treatment Variation

- **Verify** Checkout is opened and filled in with correctly for domain purchases in site creation
  - **Expect** discounts to be applied on Checkout screen
- **Verify** Back navigation from Checkout is supported
  - **Expect** to be able to create a site when resuming with a free domain
  - **Expect** the previously created wpcom blog to be reused when resuming with same domain
  - **Expect** Checkout is opened and filled in correctly when resuming with a different paid domain

### ○ Control Variation

- **Verify** no regression in the site creation flow: expect no issues when creating a new site with a free domain

### Preview

| ● |
| - |
| <video src="https://user-images.githubusercontent.com/4588074/228221635-f6b76ecc-67e3-4827-9203-0b32227c569a.mp4" style="max-width: 315px;"></video> |

> **Note**
> The recording shows a preview of all tests passing for the **● Treatment Variation**.

## Regression Notes
1. Potential unintended areas of impact
  `SITE CREATION` → `PROGRESS`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
  Unit tests in `SiteCreationMainVMTest` and `SiteCreationProgressViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
