### PR TITLE
Add ripgrep ignore file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ WordPress/src/main/res/values/com_crashlytics_export_strings.xml
 # Silver Searcher ignore file
 .agignore
 
+# ripgrep ignore file
+.rgignore
+
 # Monkey runner settings
 *.pyc
 


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2369, this PR adds [ripgrep's .rgignore file](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#automatic-filtering) to .gitignore so that developers can add custom ignore rules for `ripgrep`.

I'd like to add this so I can search for `.buildkite` files with `ripgrep`.

**To test:**
N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
