### PR TITLE
[WP Individual JP Plugin] Hardcoded overlay shown max count

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.jetpackoverlay.individualplugin
 
 import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSiteModel
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig
 import org.wordpress.android.util.extensions.activeIndividualJetpackPluginNames
 import org.wordpress.android.util.extensions.isJetpackIndividualPluginConnectedWithoutFullPlugin
@@ -10,9 +11,12 @@ import javax.inject.Inject
 class WPJetpackIndividualPluginHelper @Inject constructor(
     private val siteStore: SiteStore,
     private val wpIndividualPluginOverlayFeatureConfig: WPIndividualPluginOverlayFeatureConfig,
+    private val appPrefs: AppPrefsWrapper,
 ) {
     suspend fun shouldShowJetpackIndividualPluginOverlay(): Boolean {
-        return wpIndividualPluginOverlayFeatureConfig.isEnabled() && hasIndividualPluginJetpackConnectedSites()
+        return wpIndividualPluginOverlayFeatureConfig.isEnabled() &&
+                hasIndividualPluginJetpackConnectedSites() &&
+                !wasOverlayShownOverMaxTimes()
     }
 
     suspend fun getJetpackConnectedSitesWithIndividualPlugins(): List<SiteWithIndividualJetpackPlugins> {
@@ -36,8 +40,12 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
             .filter { it.isJetpackIndividualPluginConnectedWithoutFullPlugin() }
     }
 
+    private fun wasOverlayShownOverMaxTimes(): Boolean {
+        return appPrefs.wpJetpackIndividualPluginOverlayShownCount >= OVERLAY_MAX_SHOWN_COUNT
+    }
+
     companion object {
-        private const val OVERLAY_MAX_SHOWN = 3
+        private const val OVERLAY_MAX_SHOWN_COUNT = 3
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -35,6 +35,10 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
         return siteStore.getJetpackCPConnectedSites()
             .filter { it.isJetpackIndividualPluginConnectedWithoutFullPlugin() }
     }
+
+    companion object {
+        private const val OVERLAY_MAX_SHOWN = 3
+    }
 }
 
 data class SiteWithIndividualJetpackPlugins(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -30,6 +30,10 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
         }
     }
 
+    fun incrementJetpackIndividualPluginOverlayShownCount() {
+        appPrefs.incrementWPJetpackIndividualPluginOverlayShownCount()
+    }
+
     private suspend fun hasIndividualPluginJetpackConnectedSites(): Boolean {
         val individualPluginConnectedSites = getIndividualPluginJetpackConnectedSites()
         return individualPluginConnectedSites.isNotEmpty()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -29,7 +28,6 @@ class WPJetpackIndividualPluginViewModel @Inject constructor(
             val sites = wpJetpackIndividualPluginHelper.getJetpackConnectedSitesWithIndividualPlugins()
             _uiState.update { UiState.Loaded(sites) }
             wpJetpackIndividualPluginHelper.incrementJetpackIndividualPluginOverlayShownCount()
-            AppLog.d(AppLog.T.JETPACK_MIGRATION, "WPJetpackIndividualPluginViewModel onScreenShown")
             // TODO thomashortadev add tracking
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -23,21 +24,24 @@ class WPJetpackIndividualPluginViewModel @Inject constructor(
     val actionEvents = _actionEvents
 
     fun onScreenShown() {
-        // TODO thomashortadev add tracking
+        if (_uiState.value != UiState.None) return
         launch {
             val sites = wpJetpackIndividualPluginHelper.getJetpackConnectedSitesWithIndividualPlugins()
             _uiState.update { UiState.Loaded(sites) }
+            wpJetpackIndividualPluginHelper.incrementJetpackIndividualPluginOverlayShownCount()
+            AppLog.d(AppLog.T.JETPACK_MIGRATION, "WPJetpackIndividualPluginViewModel onScreenShown")
+            // TODO thomashortadev add tracking
         }
     }
 
     fun onDismissScreenClick() {
-        // TODO thomashortadev add tracking
         postActionEvent(ActionEvent.Dismiss)
+        // TODO thomashortadev add tracking
     }
 
     fun onPrimaryButtonClick() {
-        // TODO thomashortadev add tracking
         postActionEvent(ActionEvent.PrimaryButtonClick)
+        // TODO thomashortadev add tracking
     }
 
     private fun postActionEvent(actionEvent: ActionEvent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -185,6 +185,9 @@ public class AppPrefs {
         SHOULD_HIDE_JETPACK_INSTALL_FULL_PLUGIN_CARD,
         SHOULD_SHOW_JETPACK_FULL_PLUGIN_INSTALL_ONBOARDING,
         SHOULD_HIDE_PROMOTE_WITH_BLAZE_CARD,
+
+        // Jetpack Individual Plugin overlay for WordPress app
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT,
     }
 
     /**
@@ -1611,5 +1614,14 @@ public class AppPrefs {
 
     @NonNull private static String getSiteIdHideBlazeKey(long siteId) {
         return DeletablePrefKey.SHOULD_HIDE_PROMOTE_WITH_BLAZE_CARD.name() + siteId;
+    }
+
+    public static int getWPJetpackIndividualPluginOverlayShownCount() {
+        return getInt(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT, 0);
+    }
+
+    public static void incrementWPJetpackIndividualPluginOverlayShownCount() {
+        int count = getWPJetpackIndividualPluginOverlayShownCount();
+        setInt(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT, count + 1);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -86,6 +86,9 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.shouldScheduleCreateSiteNotification()
         set(shouldSchedule) = AppPrefs.setShouldScheduleCreateSiteNotification(shouldSchedule)
 
+    val wpJetpackIndividualPluginOverlayShownCount: Int
+        get() = AppPrefs.getWPJetpackIndividualPluginOverlayShownCount()
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)
@@ -326,6 +329,9 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun setShouldHidePromoteWithBlazeCard(siteId: Long, isHidden: Boolean) =
         AppPrefs.setShouldHidePromoteWithBlazeCard(siteId, isHidden)
+
+    fun incrementWPJetpackIndividualPluginOverlayShownCount() =
+        AppPrefs.incrementWPJetpackIndividualPluginOverlayShownCount()
 
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
@@ -1,0 +1,83 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.testCollect
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.ActionEvent
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.UiState
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
+    @Mock
+    lateinit var helper: WPJetpackIndividualPluginHelper
+
+    private lateinit var viewModel: WPJetpackIndividualPluginViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = WPJetpackIndividualPluginViewModel(helper, testDispatcher())
+    }
+
+    @Test
+    fun `WHEN onScreenShown THEN UI state is updated only once`() = test {
+        whenever(helper.getJetpackConnectedSitesWithIndividualPlugins()).thenReturn(connectedSites)
+        val uiStates = viewModel.uiState.testCollect(this) {
+            viewModel.onScreenShown()
+            viewModel.onScreenShown()
+            viewModel.onScreenShown()
+        }
+
+        assertThat(uiStates).hasSize(2)
+        assertThat(uiStates[0]).isEqualTo(UiState.None)
+        assertThat(uiStates[1]).isEqualTo(UiState.Loaded(connectedSites))
+    }
+
+    @Test
+    fun `WHEN onScreenShown THEN overlay shown count is incremented only once`() = test {
+        whenever(helper.getJetpackConnectedSitesWithIndividualPlugins()).thenReturn(connectedSites)
+        viewModel.onScreenShown()
+        viewModel.onScreenShown()
+        viewModel.onScreenShown()
+
+        verify(helper).incrementJetpackIndividualPluginOverlayShownCount()
+    }
+
+    @Test
+    fun `WHEN onDismissScreenClick THEN emit appropriate event`() = test {
+        val result = viewModel.actionEvents.testCollect(this) {
+            viewModel.onDismissScreenClick()
+        }
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first()).isEqualTo(ActionEvent.Dismiss)
+    }
+
+    @Test
+    fun `WHEN onPrimaryButtonClick THEN emit appropriate event`() = test {
+        val result = viewModel.actionEvents.testCollect(this) {
+            viewModel.onPrimaryButtonClick()
+        }
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first()).isEqualTo(ActionEvent.PrimaryButtonClick)
+    }
+
+    companion object {
+        private val connectedSites = listOf(
+            SiteWithIndividualJetpackPlugins(
+                name = "Site 1",
+                url = "site1.wordpress.com",
+                individualPluginNames = listOf("Jetpack Social")
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Part of #18175 

The first implementation of a max number of Overlay appearances. This is hardcoded to 3 for now and will be provided by a remote config in future PRs.

To test:
Run any logged in scenario from https://github.com/wordpress-mobile/WordPress-Android/pull/18169, such as opening the site picker having at least a problem site connected to your WordPress.com account, multiple times and **verify** the Individual Jetpack Plugin overlay modal is shown at most 3 times while logged in.

Also **verify** that logging out and logging in again should clear the count so logging in and testing again will make the dialog be shown again 3 times.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the new functions and to the whole overlay ViewModel code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
