### PR TITLE
[WP Individual JP Plugin] Remote overlay shown max count 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtil.kt
@@ -29,7 +29,7 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
     private val jpDeadlineConfig: JPDeadlineConfig,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
 ) {
-    private val jpDeadlineDate: String? by lazy {
+    private val jpDeadlineDate: String by lazy {
         jpDeadlineConfig.getValue()
     }
 
@@ -91,7 +91,7 @@ class JetpackFeatureRemovalBrandingUtil @Inject constructor(
         }
     }
 
-    private fun retrieveDeadline(): LocalDate? = jpDeadlineDate?.let {
+    private fun retrieveDeadline(): LocalDate? = jpDeadlineDate.takeIf { it.isNotBlank() }?.let {
         dateTimeUtilsWrapper.parseDateString(it, JETPACK_OVERLAY_ORIGINAL_DATE_FORMAT)?.toLocalDate()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -18,7 +18,8 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
     suspend fun shouldShowJetpackIndividualPluginOverlay(): Boolean {
         return wpIndividualPluginOverlayFeatureConfig.isEnabled() &&
                 hasIndividualPluginJetpackConnectedSites() &&
-                !wasOverlayShownOverMaxTimes()
+                !wasOverlayShownOverMaxTimes() &&
+                !wasOverlayShownRecently()
     }
 
     suspend fun getJetpackConnectedSitesWithIndividualPlugins(): List<SiteWithIndividualJetpackPlugins> {
@@ -32,8 +33,9 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
         }
     }
 
-    fun incrementJetpackIndividualPluginOverlayShownCount() {
+    fun onJetpackIndividualPluginOverlayShown() {
         appPrefs.incrementWPJetpackIndividualPluginOverlayShownCount()
+        appPrefs.wpJetpackIndividualPluginOverlayLastShownTimestamp = System.currentTimeMillis()
     }
 
     private suspend fun hasIndividualPluginJetpackConnectedSites(): Boolean {
@@ -49,6 +51,29 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
     private fun wasOverlayShownOverMaxTimes(): Boolean {
         val overlayMaxShownCount = wpIndividualPluginOverlayMaxShownConfig.getValue<Int>()
         return appPrefs.wpJetpackIndividualPluginOverlayShownCount >= overlayMaxShownCount
+    }
+
+    private fun wasOverlayShownRecently(): Boolean {
+        val lastShownTimestamp = appPrefs.wpJetpackIndividualPluginOverlayLastShownTimestamp
+        val shownCount = appPrefs.wpJetpackIndividualPluginOverlayShownCount
+        val delayBetweenOverlays = getDelayBetweenOverlays(shownCount)
+        return System.currentTimeMillis() - lastShownTimestamp < delayBetweenOverlays
+    }
+
+    companion object {
+        private const val DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+        private const val DELAY_BETWEEN_OVERLAYS_FIRST_TIME = 1 * DAY_IN_MILLIS
+        private const val DELAY_BETWEEN_OVERLAYS_SECOND_TIME = 3 * DAY_IN_MILLIS
+        private const val DELAY_BETWEEN_OVERLAYS_OTHER_TIMES = 7 * DAY_IN_MILLIS
+
+        private fun getDelayBetweenOverlays(shownCount: Int): Long {
+            if (shownCount < 1) return 0L
+            return when (shownCount) {
+                1 -> DELAY_BETWEEN_OVERLAYS_FIRST_TIME
+                2 -> DELAY_BETWEEN_OVERLAYS_SECOND_TIME
+                else -> DELAY_BETWEEN_OVERLAYS_OTHER_TIMES
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -4,14 +4,16 @@ import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig
+import org.wordpress.android.util.config.WPIndividualPluginOverlayMaxShownConfig
 import org.wordpress.android.util.extensions.activeIndividualJetpackPluginNames
 import org.wordpress.android.util.extensions.isJetpackIndividualPluginConnectedWithoutFullPlugin
 import javax.inject.Inject
 
 class WPJetpackIndividualPluginHelper @Inject constructor(
     private val siteStore: SiteStore,
-    private val wpIndividualPluginOverlayFeatureConfig: WPIndividualPluginOverlayFeatureConfig,
     private val appPrefs: AppPrefsWrapper,
+    private val wpIndividualPluginOverlayFeatureConfig: WPIndividualPluginOverlayFeatureConfig,
+    private val wpIndividualPluginOverlayMaxShownConfig: WPIndividualPluginOverlayMaxShownConfig,
 ) {
     suspend fun shouldShowJetpackIndividualPluginOverlay(): Boolean {
         return wpIndividualPluginOverlayFeatureConfig.isEnabled() &&
@@ -45,11 +47,8 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
     }
 
     private fun wasOverlayShownOverMaxTimes(): Boolean {
-        return appPrefs.wpJetpackIndividualPluginOverlayShownCount >= OVERLAY_MAX_SHOWN_COUNT
-    }
-
-    companion object {
-        private const val OVERLAY_MAX_SHOWN_COUNT = 3
+        val overlayMaxShownCount = wpIndividualPluginOverlayMaxShownConfig.getValue<Int>()
+        return appPrefs.wpJetpackIndividualPluginOverlayShownCount >= overlayMaxShownCount
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
@@ -27,7 +27,7 @@ class WPJetpackIndividualPluginViewModel @Inject constructor(
         launch {
             val sites = wpJetpackIndividualPluginHelper.getJetpackConnectedSitesWithIndividualPlugins()
             _uiState.update { UiState.Loaded(sites) }
-            wpJetpackIndividualPluginHelper.incrementJetpackIndividualPluginOverlayShownCount()
+            wpJetpackIndividualPluginHelper.onJetpackIndividualPluginOverlayShown()
             // TODO thomashortadev add tracking
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -188,6 +188,7 @@ public class AppPrefs {
 
         // Jetpack Individual Plugin overlay for WordPress app
         WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT,
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP,
     }
 
     /**
@@ -1623,5 +1624,13 @@ public class AppPrefs {
     public static void incrementWPJetpackIndividualPluginOverlayShownCount() {
         int count = getWPJetpackIndividualPluginOverlayShownCount();
         setInt(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT, count + 1);
+    }
+
+    public static long getWPJetpackIndividualPluginOverlayLastShownTimestamp() {
+        return getLong(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP, 0);
+    }
+
+    public static void setWPJetpackIndividualPluginOverlayLastShownTimestamp(long timestamp) {
+        setLong(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP, timestamp);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -89,6 +89,10 @@ class AppPrefsWrapper @Inject constructor() {
     val wpJetpackIndividualPluginOverlayShownCount: Int
         get() = AppPrefs.getWPJetpackIndividualPluginOverlayShownCount()
 
+    var wpJetpackIndividualPluginOverlayLastShownTimestamp: Long
+        get() = AppPrefs.getWPJetpackIndividualPluginOverlayLastShownTimestamp()
+        set(timestamp) = AppPrefs.setWPJetpackIndividualPluginOverlayLastShownTimestamp(timestamp)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BlazeRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BlazeRemoteFields.kt
@@ -15,8 +15,7 @@ const val BLAZE_NON_DISMISSABLE_HASH_DEFAULT = "step-4"
 class BlazeNonDismissableHashConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        BLAZE_NON_DISMISSABLE_HASH_REMOTE_FIELD,
-        BLAZE_NON_DISMISSABLE_HASH_DEFAULT
+        BLAZE_NON_DISMISSABLE_HASH_REMOTE_FIELD
     )
 
 
@@ -30,6 +29,5 @@ const val BLAZE_COMPLETED_STEP_HASH_DEFAULT = "step-5"
 class BlazeCompletedStepHashConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        BLAZE_COMPLETED_STEP_HASH_REMOTE_FIELD,
-        BLAZE_COMPLETED_STEP_HASH_DEFAULT
+        BLAZE_COMPLETED_STEP_HASH_REMOTE_FIELD
     )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
@@ -10,8 +10,7 @@ const val JP_DEADLINE_DEFAULT = ""
 class JPDeadlineConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        JP_DEADLINE_REMOTE_FIELD,
-        JP_DEADLINE_DEFAULT
+        JP_DEADLINE_REMOTE_FIELD
     )
 
 const val PHASE_TWO_BLOG_POST_REMOTE_FIELD = "phase_two_blog_post"
@@ -21,8 +20,7 @@ const val PHASE_TWO_BLOG_POST_DEFAULT = ""
 class PhaseTwoBlogPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        PHASE_TWO_BLOG_POST_REMOTE_FIELD,
-        PHASE_TWO_BLOG_POST_DEFAULT
+        PHASE_TWO_BLOG_POST_REMOTE_FIELD
     )
 
 const val PHASE_THREE_BLOG_POST_LINK_REMOTE_FIELD = "phase_three_blog_post"
@@ -35,8 +33,7 @@ const val PHASE_THREE_BLOG_POST_LINK_DEFAULT_VALUE = ""
 class PhaseThreeBlogPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        PHASE_THREE_BLOG_POST_LINK_REMOTE_FIELD,
-        PHASE_THREE_BLOG_POST_LINK_DEFAULT_VALUE
+        PHASE_THREE_BLOG_POST_LINK_REMOTE_FIELD
     )
 
 const val PHASE_FOUR_BLOG_POST_LINK_REMOTE_FIELD = "phase_four_blog_post"
@@ -49,8 +46,7 @@ const val PHASE_FOUR_BLOG_POST_LINK_DEFAULT_VALUE = ""
 class PhaseFourBlogPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        PHASE_FOUR_BLOG_POST_LINK_REMOTE_FIELD,
-        PHASE_FOUR_BLOG_POST_LINK_DEFAULT_VALUE
+        PHASE_FOUR_BLOG_POST_LINK_REMOTE_FIELD
     )
 
 const val PHASE_NEW_USERS_BLOG_POST_LINK = "phase_new_users_blog_post"
@@ -63,8 +59,7 @@ const val PHASE_NEW_USERS_BLOG_POST_LINK_DEFAULT_VALUE = ""
 class PhaseNewUsersBlogPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        PHASE_NEW_USERS_BLOG_POST_LINK,
-        PHASE_NEW_USERS_BLOG_POST_LINK_DEFAULT_VALUE
+        PHASE_NEW_USERS_BLOG_POST_LINK
     )
 
 const val PHASE_SELF_HOSTED_BLOG_POST_LINK_REMOTE_FIELD = "phase_self_hosted_blog_post"
@@ -77,6 +72,5 @@ const val PHASE_SELF_HOSTED_BLOG_POST_LINK_DEFAULT_VALUE = ""
 class PhaseSelfHostedPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     RemoteConfigField<String>(
         appConfig,
-        PHASE_SELF_HOSTED_BLOG_POST_LINK_REMOTE_FIELD,
-        PHASE_SELF_HOSTED_BLOG_POST_LINK_DEFAULT_VALUE
+        PHASE_SELF_HOSTED_BLOG_POST_LINK_REMOTE_FIELD
     )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.util.config
 
 open class RemoteConfigField<T>(val appConfig: AppConfig, val remoteField: String) {
     @Suppress("UseCheckOrError")
-    inline fun <reified R : T> getValue(): R {
+    inline fun <reified R> getValue(): R {
         val remoteFieldValue = appConfig.getRemoteFieldConfigValue(remoteField)
         return when (R::class) {
             Int::class -> remoteFieldValue.toInt() as R

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.util.config
 
-open class RemoteConfigField<T>(val appConfig: AppConfig, val remoteField: String) {
+open class RemoteConfigField<T : Any>(val appConfig: AppConfig, val remoteField: String) {
     @Suppress("UseCheckOrError")
-    inline fun <reified R> getValue(): R {
+    inline fun <reified R : T> getValue(): R {
         val remoteFieldValue = appConfig.getRemoteFieldConfigValue(remoteField)
         return when (R::class) {
             Int::class -> remoteFieldValue.toInt() as R

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigField.kt
@@ -1,13 +1,13 @@
 package org.wordpress.android.util.config
 
-open class RemoteConfigField<T>(val appConfig: AppConfig, val remoteField: String, val defaultValue: T) {
+open class RemoteConfigField<T>(val appConfig: AppConfig, val remoteField: String) {
     @Suppress("UseCheckOrError")
-    inline fun <reified T> getValue(): T {
+    inline fun <reified R : T> getValue(): R {
         val remoteFieldValue = appConfig.getRemoteFieldConfigValue(remoteField)
-        return when (T::class) {
-            Int::class -> remoteFieldValue.toInt() as T
-            String::class -> remoteFieldValue as T
-            Long::class -> remoteFieldValue.toLong() as T
+        return when (R::class) {
+            Int::class -> remoteFieldValue.toInt() as R
+            String::class -> remoteFieldValue as R
+            Long::class -> remoteFieldValue.toLong() as R
             // add other types here if need
             else -> throw IllegalStateException("Unknown Generic Type")
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayMaxShownConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayMaxShownConfig.kt
@@ -14,6 +14,5 @@ class WPIndividualPluginOverlayMaxShownConfig @Inject constructor(
     appConfig: AppConfig,
 ) : RemoteConfigField<Int>(
     appConfig = appConfig,
-    remoteField = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_REMOTE_FIELD,
-    defaultValue = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT
+    remoteField = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_REMOTE_FIELD
 )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayMaxShownConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayMaxShownConfig.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.annotation.RemoteFieldDefaultGenerater
+import javax.inject.Inject
+
+private const val WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_REMOTE_FIELD = "wp_plugin_overlay_max_shown"
+private const val WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT = 3
+
+@RemoteFieldDefaultGenerater(
+    remoteField = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_REMOTE_FIELD,
+    defaultValue = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT.toString()
+)
+class WPIndividualPluginOverlayMaxShownConfig @Inject constructor(
+    appConfig: AppConfig,
+) : RemoteConfigField<Int>(
+    appConfig = appConfig,
+    remoteField = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_REMOTE_FIELD,
+    defaultValue = WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT
+)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalBrandingUtilTest.kt
@@ -315,7 +315,7 @@ class JetpackFeatureRemovalBrandingUtilTest {
     }
 
     private fun whenJpDeadlineIs(daysAway: Int?) {
-        whenever(jpDeadlineConfig.appConfig.getRemoteFieldConfigValue(any())).thenReturn(daysAway?.toString())
+        whenever(jpDeadlineConfig.appConfig.getRemoteFieldConfigValue(any())).thenReturn(daysAway?.toString() ?: "")
         daysAway?.toLong()?.let {
             val today = Date(System.currentTimeMillis())
             val deadline = Date.from(today.toInstant().atZone(ZoneId.systemDefault()).plusDays(it).toInstant())

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
@@ -7,13 +7,16 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.AppConfig
 import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig
+import org.wordpress.android.util.config.WPIndividualPluginOverlayMaxShownConfig
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -22,16 +25,29 @@ class WPJetpackIndividualPluginHelperTest : BaseUnitTest() {
     lateinit var siteStore: SiteStore
 
     @Mock
+    lateinit var appPrefs: AppPrefsWrapper
+
+    @Mock
     lateinit var wpIndividualPluginOverlayFeatureConfig: WPIndividualPluginOverlayFeatureConfig
 
     @Mock
-    lateinit var appPrefs: AppPrefsWrapper
+    lateinit var appConfig: AppConfig
 
-    lateinit var helper: WPJetpackIndividualPluginHelper
+    private lateinit var wpIndividualPluginOverlayMaxShownConfig: WPIndividualPluginOverlayMaxShownConfig
+
+    private lateinit var helper: WPJetpackIndividualPluginHelper
 
     @Before
     fun setUp() {
-        helper = WPJetpackIndividualPluginHelper(siteStore, wpIndividualPluginOverlayFeatureConfig, appPrefs)
+        wpIndividualPluginOverlayMaxShownConfig = WPIndividualPluginOverlayMaxShownConfig(appConfig)
+        helper = WPJetpackIndividualPluginHelper(
+            siteStore,
+            appPrefs,
+            wpIndividualPluginOverlayFeatureConfig,
+            wpIndividualPluginOverlayMaxShownConfig,
+        )
+
+        whenever(appConfig.getRemoteFieldConfigValue(any())).thenReturn("3")
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
@@ -145,10 +145,17 @@ class WPJetpackIndividualPluginHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN incrementJetpackIndividualPluginOverlayShownCount THEN app prefs method is called`() {
-        helper.incrementJetpackIndividualPluginOverlayShownCount()
+    fun `WHEN onJetpackIndividualPluginOverlayShown THEN app prefs is called to increment count`() {
+        helper.onJetpackIndividualPluginOverlayShown()
 
         verify(appPrefs).incrementWPJetpackIndividualPluginOverlayShownCount()
+    }
+
+    @Test
+    fun `WHEN onJetpackIndividualPluginOverlayShown THEN app prefs is called to update timestamp`() {
+        helper.onJetpackIndividualPluginOverlayShown()
+
+        verify(appPrefs).wpJetpackIndividualPluginOverlayLastShownTimestamp = any()
     }
 
     private fun jetpackCPConnectedSiteModel(name: String, url: String, activeJpPlugins: String?) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
@@ -42,13 +42,13 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN onScreenShown THEN overlay shown count is incremented only once`() = test {
+    fun `WHEN onScreenShown THEN overlay shown helper method is called only once`() = test {
         whenever(helper.getJetpackConnectedSitesWithIndividualPlugins()).thenReturn(connectedSites)
         viewModel.onScreenShown()
         viewModel.onScreenShown()
         viewModel.onScreenShown()
 
-        verify(helper).incrementJetpackIndividualPluginOverlayShownCount()
+        verify(helper).onJetpackIndividualPluginOverlayShown()
     }
 
     @Test


### PR DESCRIPTION
Part of #18175 

- Fix `RemoteConfigField` defaults loading to local database
- Create a remote field for getting the overlay max shown value

To test:
Logout, then run any logged in scenario from https://github.com/wordpress-mobile/WordPress-Android/pull/18169, such as opening the site picker having at least a problem site connected to your WordPress.com account, multiple times and **verify** the Individual Jetpack Plugin overlay modal is shown at most 3 times while logged in.

Also, verify that logging out and logging in again should clear the count so logging in and testing again will make the dialog be shown again 3 times.

The "3 times" value is currently being returned from the local default, we can also update the endpoint to return this remote config and do an integrated test (e.g.: set the endpoint to return 5 and **verify** the modal is shown 5 times).

## Regression Notes
1. Potential unintended areas of impact
Breakage/overwrite of other remote fields.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Update existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
