### PR TITLE
[WP Individual JP Plugin] Delay between overlay appearances

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -18,7 +18,8 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
     suspend fun shouldShowJetpackIndividualPluginOverlay(): Boolean {
         return wpIndividualPluginOverlayFeatureConfig.isEnabled() &&
                 hasIndividualPluginJetpackConnectedSites() &&
-                !wasOverlayShownOverMaxTimes()
+                !wasOverlayShownOverMaxTimes() &&
+                !wasOverlayShownRecently()
     }
 
     suspend fun getJetpackConnectedSitesWithIndividualPlugins(): List<SiteWithIndividualJetpackPlugins> {
@@ -32,8 +33,9 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
         }
     }
 
-    fun incrementJetpackIndividualPluginOverlayShownCount() {
+    fun onJetpackIndividualPluginOverlayShown() {
         appPrefs.incrementWPJetpackIndividualPluginOverlayShownCount()
+        appPrefs.wpJetpackIndividualPluginOverlayLastShownTimestamp = System.currentTimeMillis()
     }
 
     private suspend fun hasIndividualPluginJetpackConnectedSites(): Boolean {
@@ -49,6 +51,29 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
     private fun wasOverlayShownOverMaxTimes(): Boolean {
         val overlayMaxShownCount = wpIndividualPluginOverlayMaxShownConfig.getValue<Int>()
         return appPrefs.wpJetpackIndividualPluginOverlayShownCount >= overlayMaxShownCount
+    }
+
+    private fun wasOverlayShownRecently(): Boolean {
+        val lastShownTimestamp = appPrefs.wpJetpackIndividualPluginOverlayLastShownTimestamp
+        val shownCount = appPrefs.wpJetpackIndividualPluginOverlayShownCount
+        val delayBetweenOverlays = getDelayBetweenOverlays(shownCount)
+        return System.currentTimeMillis() - lastShownTimestamp < delayBetweenOverlays
+    }
+
+    companion object {
+        private const val DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+        private const val DELAY_BETWEEN_OVERLAYS_FIRST_TIME = 1 * DAY_IN_MILLIS
+        private const val DELAY_BETWEEN_OVERLAYS_SECOND_TIME = 3 * DAY_IN_MILLIS
+        private const val DELAY_BETWEEN_OVERLAYS_OTHER_TIMES = 7 * DAY_IN_MILLIS
+
+        private fun getDelayBetweenOverlays(shownCount: Int): Long {
+            if (shownCount < 1) return 0L
+            return when (shownCount) {
+                1 -> DELAY_BETWEEN_OVERLAYS_FIRST_TIME
+                2 -> DELAY_BETWEEN_OVERLAYS_SECOND_TIME
+                else -> DELAY_BETWEEN_OVERLAYS_OTHER_TIMES
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
@@ -27,7 +27,7 @@ class WPJetpackIndividualPluginViewModel @Inject constructor(
         launch {
             val sites = wpJetpackIndividualPluginHelper.getJetpackConnectedSitesWithIndividualPlugins()
             _uiState.update { UiState.Loaded(sites) }
-            wpJetpackIndividualPluginHelper.incrementJetpackIndividualPluginOverlayShownCount()
+            wpJetpackIndividualPluginHelper.onJetpackIndividualPluginOverlayShown()
             // TODO thomashortadev add tracking
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -188,6 +188,7 @@ public class AppPrefs {
 
         // Jetpack Individual Plugin overlay for WordPress app
         WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT,
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP,
     }
 
     /**
@@ -1623,5 +1624,13 @@ public class AppPrefs {
     public static void incrementWPJetpackIndividualPluginOverlayShownCount() {
         int count = getWPJetpackIndividualPluginOverlayShownCount();
         setInt(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN_COUNT, count + 1);
+    }
+
+    public static long getWPJetpackIndividualPluginOverlayLastShownTimestamp() {
+        return getLong(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP, 0);
+    }
+
+    public static void setWPJetpackIndividualPluginOverlayLastShownTimestamp(long timestamp) {
+        setLong(DeletablePrefKey.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP, timestamp);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -89,6 +89,10 @@ class AppPrefsWrapper @Inject constructor() {
     val wpJetpackIndividualPluginOverlayShownCount: Int
         get() = AppPrefs.getWPJetpackIndividualPluginOverlayShownCount()
 
+    var wpJetpackIndividualPluginOverlayLastShownTimestamp: Long
+        get() = AppPrefs.getWPJetpackIndividualPluginOverlayLastShownTimestamp()
+        set(timestamp) = AppPrefs.setWPJetpackIndividualPluginOverlayLastShownTimestamp(timestamp)
+
     fun getAppWidgetSiteId(appWidgetId: Int) = AppPrefs.getStatsWidgetSelectedSiteId(appWidgetId)
     fun setAppWidgetSiteId(siteId: Long, appWidgetId: Int) = AppPrefs.setStatsWidgetSelectedSiteId(siteId, appWidgetId)
     fun removeAppWidgetSiteId(appWidgetId: Int) = AppPrefs.removeStatsWidgetSelectedSiteId(appWidgetId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
@@ -145,10 +145,17 @@ class WPJetpackIndividualPluginHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN incrementJetpackIndividualPluginOverlayShownCount THEN app prefs method is called`() {
-        helper.incrementJetpackIndividualPluginOverlayShownCount()
+    fun `WHEN onJetpackIndividualPluginOverlayShown THEN app prefs is called to increment count`() {
+        helper.onJetpackIndividualPluginOverlayShown()
 
         verify(appPrefs).incrementWPJetpackIndividualPluginOverlayShownCount()
+    }
+
+    @Test
+    fun `WHEN onJetpackIndividualPluginOverlayShown THEN app prefs is called to update timestamp`() {
+        helper.onJetpackIndividualPluginOverlayShown()
+
+        verify(appPrefs).wpJetpackIndividualPluginOverlayLastShownTimestamp = any()
     }
 
     private fun jetpackCPConnectedSiteModel(name: String, url: String, activeJpPlugins: String?) =

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
@@ -42,13 +42,13 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN onScreenShown THEN overlay shown count is incremented only once`() = test {
+    fun `WHEN onScreenShown THEN overlay shown helper method is called only once`() = test {
         whenever(helper.getJetpackConnectedSitesWithIndividualPlugins()).thenReturn(connectedSites)
         viewModel.onScreenShown()
         viewModel.onScreenShown()
         viewModel.onScreenShown()
 
-        verify(helper).incrementJetpackIndividualPluginOverlayShownCount()
+        verify(helper).onJetpackIndividualPluginOverlayShown()
     }
 
     @Test


### PR DESCRIPTION
Part of #18175 

Add a delay between overlay appearances so the overlay is not shown every single time the base conditions are met. The delay between the first and second appearances is 1 day, between the second and third is 3 days, and over that (if we increase the max number of appearances over 3) is 7 days. 

## To test

### Before testing - suggestions
For testing this without having to wait a long time, I recommend pulling the code and changing line 64 of `WPJetpackIndividualPluginHelper.kt` to:
```kotlin
private const val MINUTE_IN_MILLIS = 60 * 1000L
```

So the delay between appearances will be 1 minute, 3 minutes, and 7 minutes. After testing once, I also recommend updating the default `WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT` to `5` to also test the 7 minutes interval.

### Testing
Logout, then run any logged-in scenario from https://github.com/wordpress-mobile/WordPress-Android/pull/18169, such as:
> Open the site picker having at least a problem site connected to your WordPress.com account, multiple times and **verify** the Individual Jetpack Plugin overlay modal is shown the maximum number of times with the appropriate delay between appearances.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added tests for each interval scenario.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
