### PR TITLE
[WP Individual JP Plugin] Add overlay analytics tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTracker.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin
+
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+
+class WPJetpackIndividualPluginAnalyticsTracker @Inject constructor(
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    ) {
+    fun trackScreenShown() = analyticsTrackerWrapper.track(
+        AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN, emptyMap()
+    )
+
+    fun trackScreenDismissed() = analyticsTrackerWrapper.track(
+        AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_DISMISSED, emptyMap()
+    )
+
+    fun trackPrimaryButtonClick() = analyticsTrackerWrapper.track(
+        AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_PRIMARY_TAPPED, emptyMap()
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTracker.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 
 class WPJetpackIndividualPluginAnalyticsTracker @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    ) {
+) {
     fun trackScreenShown() = analyticsTrackerWrapper.track(
         AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN, emptyMap()
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModel.kt
@@ -14,6 +14,7 @@ import javax.inject.Named
 @HiltViewModel
 class WPJetpackIndividualPluginViewModel @Inject constructor(
     private val wpJetpackIndividualPluginHelper: WPJetpackIndividualPluginHelper,
+    private val analyticsTracker: WPJetpackIndividualPluginAnalyticsTracker,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableStateFlow<UiState>(UiState.None)
@@ -28,18 +29,18 @@ class WPJetpackIndividualPluginViewModel @Inject constructor(
             val sites = wpJetpackIndividualPluginHelper.getJetpackConnectedSitesWithIndividualPlugins()
             _uiState.update { UiState.Loaded(sites) }
             wpJetpackIndividualPluginHelper.onJetpackIndividualPluginOverlayShown()
-            // TODO thomashortadev add tracking
+            analyticsTracker.trackScreenShown()
         }
     }
 
     fun onDismissScreenClick() {
         postActionEvent(ActionEvent.Dismiss)
-        // TODO thomashortadev add tracking
+        analyticsTracker.trackScreenDismissed()
     }
 
     fun onPrimaryButtonClick() {
         postActionEvent(ActionEvent.PrimaryButtonClick)
-        // TODO thomashortadev add tracking
+        analyticsTracker.trackPrimaryButtonClick()
     }
 
     private fun postActionEvent(actionEvent: ActionEvent) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginAnalyticsTrackerTest.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.jetpackoverlay.individualplugin
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+class WPJetpackIndividualPluginAnalyticsTrackerTest {
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val tracker = WPJetpackIndividualPluginAnalyticsTracker(analyticsTrackerWrapper)
+
+    @Test
+    fun `Should track screen shown when trackScreenShown is called`() {
+        tracker.trackScreenShown()
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN, emptyMap()
+        )
+    }
+
+    @Test
+    fun `Should track screen dismissed when trackScreenDismissed is called`() {
+        tracker.trackScreenDismissed()
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_DISMISSED, emptyMap()
+        )
+    }
+
+    @Test
+    fun `Should track install button click when trackInstallButtonClick is called`() {
+        tracker.trackPrimaryButtonClick()
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_PRIMARY_TAPPED, emptyMap()
+        )
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginViewModelTest.kt
@@ -20,11 +20,14 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var helper: WPJetpackIndividualPluginHelper
 
+    @Mock
+    lateinit var tracker: WPJetpackIndividualPluginAnalyticsTracker
+
     private lateinit var viewModel: WPJetpackIndividualPluginViewModel
 
     @Before
     fun setUp() {
-        viewModel = WPJetpackIndividualPluginViewModel(helper, testDispatcher())
+        viewModel = WPJetpackIndividualPluginViewModel(helper, tracker, testDispatcher())
     }
 
     @Test
@@ -52,6 +55,16 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `WHEN onScreenShown THEN analytics event is tracked only once`() = test {
+        whenever(helper.getJetpackConnectedSitesWithIndividualPlugins()).thenReturn(connectedSites)
+        viewModel.onScreenShown()
+        viewModel.onScreenShown()
+        viewModel.onScreenShown()
+
+        verify(tracker).trackScreenShown()
+    }
+
+    @Test
     fun `WHEN onDismissScreenClick THEN emit appropriate event`() = test {
         val result = viewModel.actionEvents.testCollect(this) {
             viewModel.onDismissScreenClick()
@@ -62,6 +75,13 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `WHEN onDismissScreenClick THEN analytics event is tracked`() = test {
+        viewModel.onDismissScreenClick()
+
+        verify(tracker).trackScreenDismissed()
+    }
+
+    @Test
     fun `WHEN onPrimaryButtonClick THEN emit appropriate event`() = test {
         val result = viewModel.actionEvents.testCollect(this) {
             viewModel.onPrimaryButtonClick()
@@ -69,6 +89,13 @@ class WPJetpackIndividualPluginViewModelTest : BaseUnitTest() {
 
         assertThat(result).hasSize(1)
         assertThat(result.first()).isEqualTo(ActionEvent.PrimaryButtonClick)
+    }
+
+    @Test
+    fun `WHEN onPrimaryButtonClick THEN analytics event is tracked`() = test {
+        viewModel.onPrimaryButtonClick()
+
+        verify(tracker).trackPrimaryButtonClick()
     }
 
     companion object {

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1034,7 +1034,10 @@ public final class AnalyticsTracker {
         BLAZE_FLOW_STARTED,
         BLAZE_FLOW_COMPLETED,
         BLAZE_FLOW_CANCELED,
-        BLAZE_FLOW_ERROR
+        BLAZE_FLOW_ERROR,
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN,
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_DISMISSED,
+        WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_PRIMARY_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2563,6 +2563,12 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "blaze_flow_canceled";
             case BLAZE_FLOW_ERROR:
                 return "blaze_flow_error";
+            case WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_SHOWN:
+                return "wp_individual_site_overlay_viewed";
+            case WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_DISMISSED:
+                return "wp_individual_site_overlay_dismissed";
+            case WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_PRIMARY_TAPPED:
+                return "wp_individual_site_overlay_primary_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #18176 

Add analytics tracks to the overlay screen according to specs.

## To test:

### Before testing - suggestions
For testing this without having to wait a long time, I recommend pulling the code and changing line 64 of `WPJetpackIndividualPluginHelper.kt` to:
```kotlin
private const val NONE = 0
```

So the delay between appearances is always 0. I also recommend updating the default `WP_INDIVIDUAL_PLUGIN_OVERLAY_MAX_SHOWN_DEFAULT` to some big number, like `50` so you can test it multiple times.

### Testing
Run any logged-in scenario from https://github.com/wordpress-mobile/WordPress-Android/pull/18169, such as:
> Open the site picker having at least a problem site connected to your WordPress.com account, multiple times and **verify** the Individual Jetpack Plugin overlay modal is shown.

Do it several times, tapping the possible buttons + the device's back button, and **verify** in the logs that the appropriate "Tracked" event logs are registered:
- `wp_individual_site_overlay_viewed` when the overlay is shown
- `wp_individual_site_overlay_dismissed` when the overlay is dismissed (close button, "continue" button,  and back)
- `wp_individual_site_overlay_primary_tapped` when the primary button is tapped ("Switch to the Jetpack app")

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
View Model tests to make sure tacking is working as expected.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
