### PR TITLE
[WP Individual JP Plugin] Enable FF and add release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 22.1
 -----
-
+* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app.
 
 22.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 22.1
 -----
-* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app.
+* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [https://github.com/wordpress-mobile/WordPress-Android/pull/18199]
 
 22.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WPIndividualPluginOverlayFeatureConfig.kt
@@ -1,15 +1,18 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val WP_INDIVIDUAL_PLUGIN_OVERLAY_REMOTE_FIELD = "wp_individual_plugin_overlay"
+
+@Feature(WP_INDIVIDUAL_PLUGIN_OVERLAY_REMOTE_FIELD, true)
 class WPIndividualPluginOverlayFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
-        appConfig,
-        BuildConfig.WP_INDIVIDUAL_PLUGIN_OVERLAY,
+    appConfig,
+    BuildConfig.WP_INDIVIDUAL_PLUGIN_OVERLAY,
+    WP_INDIVIDUAL_PLUGIN_OVERLAY_REMOTE_FIELD
 ) {
     override fun isEnabled(): Boolean {
         return super.isEnabled() && !BuildConfig.IS_JETPACK_APP


### PR DESCRIPTION
Fixes #18198 

To test:
1. Install the app and clear the app storage
2. Login with an account that has problem sites
3. **Verify** the overlay is shown on top of the Login Epilogue (site picker right after login)

Another way to confirm is by going to `App Settings` > `Debug Settings` and confirming the `wp_individual_plugin_overlay` is ON by default.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
