### PR TITLE
Integrate gutenberg-mobile release 1.92.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5613-637fbe266e3acb23b389aaca5de6caadd6ea3cc1'
+    gutenbergMobileVersion = 'v1.92.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-fcede535112327abf59416b7b544cf526c44fd00'
     wordPressLoginVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.92.0-alpha1'
+    gutenbergMobileVersion = '5613-637fbe266e3acb23b389aaca5de6caadd6ea3cc1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-fcede535112327abf59416b7b544cf526c44fd00'
     wordPressLoginVersion = '1.0.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.92.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5613

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.