### PR TITLE
Adds feature flags for Pages and Activity logs dashboard card

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -133,6 +133,7 @@ android {
         buildConfigField "boolean", "JETPACK_INSTALL_FULL_PLUGIN", "false"
         buildConfigField "boolean", "ENABLE_BLAZE_FEATURE", "false"
         buildConfigField "boolean", "WP_INDIVIDUAL_PLUGIN_OVERLAY", "false"
+        buildConfigField "boolean", "DASHBOARD_CARD_PAGES", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,6 +134,7 @@ android {
         buildConfigField "boolean", "ENABLE_BLAZE_FEATURE", "false"
         buildConfigField "boolean", "WP_INDIVIDUAL_PLUGIN_OVERLAY", "false"
         buildConfigField "boolean", "DASHBOARD_CARD_PAGES", "false"
+        buildConfigField "boolean", "DASHBOARD_CARD_ACTIVITY_LOG", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardActvitiyLogConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardActvitiyLogConfig.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-const val DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD = "dashboard_card_pages"
+const val DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD = "dashboard_card_activity_log"
 
 @Feature(DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD, false)
 class DashboardCardActivityLogConfig @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardActvitiyLogConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardActvitiyLogConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+const val DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD = "dashboard_card_pages"
+
+@Feature(DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD, false)
+class DashboardCardActivityLogConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.DASHBOARD_CARD_ACTIVITY_LOG,
+    DASHBOARD_CARD_ACTIVITY_LOG_REMOTE_FIELD
+)

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardPagesConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardPagesConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+const val DASHBOARD_CARD_PAGES_REMOTE_FIELD = "dashboard_card_pages"
+
+@Feature(DASHBOARD_CARD_PAGES_REMOTE_FIELD, false)
+class DashboardCardPagesConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.DASHBOARD_CARD_PAGES,
+    DASHBOARD_CARD_PAGES_REMOTE_FIELD
+)


### PR DESCRIPTION
Closes #18206 and #18208

## PR Description
This PR adds the feature flags for handling the Pages and Activity logs in Dashboard


![screenshot__](https://user-images.githubusercontent.com/17463767/229124311-575b7451-5cce-4dd1-8dfc-60bb22776804.png)


## Test - Page feature flag is shown
1. Go to the **Jetpack** app
2. 🚪 Login
3. ⛳ Go to **app settings** → **Debug settings** 
4. ✅ Verify that the feature flag `dashboard_card_pages ****`is shown 

## Test - Activity log feature flag is shown

1. Go to the **Jetpack** app
2. 🚪 Login 
3. ⛳ Go to **app settings** → **Debug settings** 
4. ✅ Verify that the feature flag `dashboard_card_activity_log`is shown


## Regression Notes
1. Potential unintended areas of impact
Nothing,as this is a new feature flag 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
