### PR TITLE
Fix crash when opening app after upgrade to 22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.92.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2701-4d67a3e7dff3ba53e110629516bcbcaa81b5f7af' // TODO use 2.23.1
+    wordPressFluxCVersion = '2.23.1'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.92.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2.23.0'
+    wordPressFluxCVersion = '2701-4d67a3e7dff3ba53e110629516bcbcaa81b5f7af' // TODO use 2.23.1
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'


### PR DESCRIPTION
Fixes #18232

The fix consists of pointing to the fixed FluxC version
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2701

Important: we need to update the FluxC version to 2.23.1 (which will be released after PR above is merged) before merging this PR, so we don't point to a commit SHA.

## To test:
This is a bit tricky since it requires installing older versions but the steps below should work.

### Testing the crash condition
1. Install WP/JP app version 22.0 for the `jalapenoDebug` variant, you can find them in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18222)'s comments.
2. Open the WP/JP app
3. Install WP/JP app version 22.1 for the `jalapenoDebug` variant, you can find them in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18228)'s comments.
4. Open the WP/JP app
5. **Verify** the app crashes (does not open)
6. Uninstall the app

### Testing the fix
1. Install WP/JP app version 22.0 for the `jalapenoDebug` variant, you can find them in [this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18222)'s comments.
2. Open the WP/JP app
3. Install WP/JP app from the comments of this PR
4. **Verify** app opens and works as expected

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A, just FluxC version update.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
