### PR TITLE
[WP Individual JP Plugin] Remove URL scheme from UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelper.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.jetpackoverlay.individualplugin
 import org.wordpress.android.fluxc.persistence.JetpackCPConnectedSiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.StringUtils
+import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig
 import org.wordpress.android.util.config.WPIndividualPluginOverlayMaxShownConfig
 import org.wordpress.android.util.extensions.activeIndividualJetpackPluginNames
@@ -27,7 +29,7 @@ class WPJetpackIndividualPluginHelper @Inject constructor(
         return individualPluginConnectedSites.map { site ->
             SiteWithIndividualJetpackPlugins(
                 name = site.name,
-                url = site.url,
+                url = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(site.url)),
                 individualPluginNames = site.activeIndividualJetpackPluginNames(),
             )
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginHelperTest.kt
@@ -152,12 +152,12 @@ class WPJetpackIndividualPluginHelperTest : BaseUnitTest() {
             val connectedSites = listOf(
                 jetpackCPConnectedSiteModel(
                     name = "site1",
-                    url = "site1.com",
+                    url = "https://site1.com",
                     activeJpPlugins = "jetpack-social"
                 ),
                 jetpackCPConnectedSiteModel(
                     name = "site2",
-                    url = "site2.com",
+                    url = "https://site2.com",
                     activeJpPlugins = "other-plugin"
                 )
             )
@@ -190,12 +190,12 @@ class WPJetpackIndividualPluginHelperTest : BaseUnitTest() {
         val connectedSites = listOf(
             jetpackCPConnectedSiteModel(
                 name = "site1",
-                url = "site1.com",
+                url = "https://site1.com",
                 activeJpPlugins = "jetpack-social"
             ),
             jetpackCPConnectedSiteModel(
                 name = "site2",
-                url = "site2.com",
+                url = "https://site2.com",
                 activeJpPlugins = "other-plugin"
             )
         )


### PR DESCRIPTION
Fixes #18229 

To test:
Make sure you have a WordPress.com account with "problem sites", that is self-hosted sites that do NOT have the full Jetpack plugin BUT have individual Jetpack plugins installed and connected.

1. Uninstall any WP versions you have
2. Install the WP app
3. Login with your WP.com account
4. **Verify** the Individual JP Plugin overlay is shown after login

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
Updated unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
