### PR TITLE
Fix the font crash on Android 7.1

### DIFF
--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/compose/theme/Fonts.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/compose/theme/Fonts.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.R.font
  * see: [GitHub: Problem with fonts on the Android platform](https://github.com/JetBrains/compose-jb/issues/333)
  */
 val FontFamily.Companion.EBGaramond
-    get() = when (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+    get() = when (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
         true -> FontFamily(Font(font.eb_garamond))
         false -> Serif
     }


### PR DESCRIPTION
The `eb_garamond` font crashes on API 24 and API 25. However, the app currently avoids using it only on API 24.
This PR updates the logic to also avoid using the font on Android 7.1 (API 25).

To test:
1. Launch the app on Android 7.1 devices.
2. Ensure it doesn't crash on the launch screen.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
