### PR TITLE
[Jetpack Plugin Full Install] Track error reason when installation fails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallAnalyticsTracker.kt
@@ -5,14 +5,18 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 private const val KEY_STATUS_PARAMETER = "status"
+private const val KEY_DESCRIPTION_PARAMETER = "description"
 
 class JetpackFullPluginInstallAnalyticsTracker @Inject constructor(
     private val analyticsTracker: AnalyticsTrackerWrapper
 ) {
-    fun trackScreenShown(status: Status) {
+    fun trackScreenShown(status: Status, description: String? = null) {
         analyticsTracker.track(
             AnalyticsTracker.Stat.JETPACK_INSTALL_FULL_PLUGIN_FLOW_VIEWED,
-            mapOf(KEY_STATUS_PARAMETER to status.trackingValue)
+            mapOf(
+                KEY_STATUS_PARAMETER to status.trackingValue,
+                KEY_DESCRIPTION_PARAMETER to description,
+            ).filterValues { it != null }
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallAnalyticsTrackerTest.kt
@@ -14,10 +14,20 @@ class JetpackFullPluginInstallAnalyticsTrackerTest {
     )
 
     @Test
-    fun `Should track screen status when trackScreenShown is called`() {
+    fun `Should track screen status when trackScreenShown is called without description`() {
         classToTest.trackScreenShown(Status.Initial)
         verify(analyticsTrackerWrapper)
             .track(Stat.JETPACK_INSTALL_FULL_PLUGIN_FLOW_VIEWED, mapOf("status" to "initial"))
+    }
+
+    @Test
+    fun `Should track screen status when trackScreenShown is called with description`() {
+        classToTest.trackScreenShown(Status.Error, "description")
+        verify(analyticsTrackerWrapper)
+            .track(
+                Stat.JETPACK_INSTALL_FULL_PLUGIN_FLOW_VIEWED,
+                mapOf("status" to "error", "description" to "description")
+            )
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallViewModelTest.kt
@@ -142,9 +142,20 @@ class JetpackFullPluginInstallViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should track error screen shown when onErrorShown is called`() {
+    fun `Should track error screen shown when onErrorShown is called without description`() {
         classToTest.onErrorShown()
-        verify(analyticsTracker).trackScreenShown(Status.Error)
+        verify(analyticsTracker).trackScreenShown(Status.Error, null)
+    }
+
+    @Test
+    fun `Should track error screen shown when onErrorShown is called with description`() {
+        val event = PluginStore.OnSitePluginInstalled(null, null).apply {
+            error = PluginStore.InstallSitePluginError("GENERIC_ERROR", "description")
+        }
+
+        classToTest.onSitePluginInstalled(event)
+        classToTest.onErrorShown()
+        verify(analyticsTracker).trackScreenShown(Status.Error, "GENERIC_ERROR: description")
     }
 
     @Test


### PR DESCRIPTION
Fixes #18230 

To test:
I wasn't able to figure out a way to force an error other than turning off connection (which tracks a "GENERIC_ERROR"). The steps for that scenario are:
1. Setup a self-hosted site with individual Jetpack plugins and connect it to you WP.com account
2. Open the Jetpack app
3. Login with your WP.com account
4. Select the problem site
5. Go to the full plugin installation flow
6. Turn off connection
7. Continue the installation flow
8. **Verify** the error screen is shown
9. **Verify** the log for:
``` 
🔵 Tracked: jp_install_full_plugin_flow_viewed, Properties: {"status":"error","description":"GENERIC_ERROR: "}
```

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Updated and create a couple of unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
