### PR TITLE
Integrate gutenberg-mobile release 1.92.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 22.1
 -----
 * [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [https://github.com/wordpress-mobile/WordPress-Android/pull/18199]
+* [*] Block editor: Avoid empty Gallery block error [https://github.com/WordPress/gutenberg/pull/49557]
 
 22.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.92.0'
+    gutenbergMobileVersion = '5651-6d5c25e75765fbd9c808e1e80ad29affbd5c6627'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.23.1'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5651-6d5c25e75765fbd9c808e1e80ad29affbd5c6627'
+    gutenbergMobileVersion = '5651-d3b44f56bb01b467999073be3c2eed69317e42c1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.23.1'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5651-d3b44f56bb01b467999073be3c2eed69317e42c1'
+    gutenbergMobileVersion = 'v1.92.1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.23.1'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.92.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5651

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.