### PR TITLE
Fix the bold font crash

### DIFF
--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -49,6 +49,7 @@
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textStyle">bold</item>
     </style>
 
 </resources>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -49,7 +49,6 @@
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
 </resources>

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -39,11 +39,13 @@
 
     <!-- TextAppearance -->
     <style name="TextAppearance.App.Toolbar.Title" parent="TextAppearance.MaterialComponents.Headline6">
+        <item name="fontFamily">sans-serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="TextAppearance.App.CollapsingToolbar.Expanded" parent="TextAppearance.MaterialComponents.Headline4">
         <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">sans-serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles_toolbar.xml
+++ b/WordPress/src/main/res/values/styles_toolbar.xml
@@ -49,6 +49,7 @@
 
     <style name="TextAppearance.App.CollapsingToolbar.Collapsed" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="fontFamily">sans-serif</item>
         <item name="android:textStyle">bold</item>
     </style>
 


### PR DESCRIPTION
Collapsing toolbar crashes when the "Bold text" is enabled from the device's "Display size and text" settings. This PR fixes the crash.
This issue was only on the WordPress app since Jetpack uses a different `styles_toolbar.xml` file.

https://user-images.githubusercontent.com/2471769/230979683-3f41bc68-809e-416e-b531-0cde62798070.mp4

Fixes #18250

To test:
1. Go to "Display size and text" from the device's Settings.
2. Enable "Bold text"
3. Launch WP app.
4. Ensure the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
Different font settings can be added to UI tests. It'll be considered later since this is a hotfix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.