### PR TITLE
[UI Tests] Disabled `e2eAllDayStatsLoad` for JP completely.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -4,8 +4,10 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.matcher.ViewMatchers
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -33,6 +35,10 @@ class StatsTests : BaseTest() {
 
     @Test
     fun e2eAllDayStatsLoad() {
+        // We're not running this test on JP.
+        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
+        assumeTrue(!BuildConfig.IS_JETPACK_APP)
+
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()
         val referrersList: List<StatsKeyValueData> = StatsMocksReader().readDayTopReferrersToList()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -5,7 +5,6 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.Matchers
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.support.WPSupportUtils
 import org.wordpress.android.util.StatsKeyValueData
@@ -67,41 +66,37 @@ class StatsPage {
     }
 
     fun assertVisits(visitsData: StatsVisitsData): StatsPage {
-        // Skip this check for JP because of the bug with Stats card load.
-        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
-        if (!BuildConfig.IS_JETPACK_APP) {
-            val cardStructure = Espresso.onView(
-                Matchers.allOf(
-                    ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),
-                    ViewMatchers.withId(R.id.stats_block_list),
-                    ViewMatchers.hasDescendant(
-                        Matchers.allOf(
-                            ViewMatchers.withText("Views"),
-                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.views))
-                        )
-                    ),
-                    ViewMatchers.hasDescendant(
-                        Matchers.allOf(
-                            ViewMatchers.withText("Visitors"),
-                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.visitors))
-                        )
-                    ),
-                    ViewMatchers.hasDescendant(
-                        Matchers.allOf(
-                            ViewMatchers.withText("Likes"),
-                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.likes))
-                        )
-                    ),
-                    ViewMatchers.hasDescendant(
-                        Matchers.allOf(
-                            ViewMatchers.withText("Comments"),
-                            ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.comments))
-                        )
+        val cardStructure = Espresso.onView(
+            Matchers.allOf(
+                ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),
+                ViewMatchers.withId(R.id.stats_block_list),
+                ViewMatchers.hasDescendant(
+                    Matchers.allOf(
+                        ViewMatchers.withText("Views"),
+                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.views))
+                    )
+                ),
+                ViewMatchers.hasDescendant(
+                    Matchers.allOf(
+                        ViewMatchers.withText("Visitors"),
+                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.visitors))
+                    )
+                ),
+                ViewMatchers.hasDescendant(
+                    Matchers.allOf(
+                        ViewMatchers.withText("Likes"),
+                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.likes))
+                    )
+                ),
+                ViewMatchers.hasDescendant(
+                    Matchers.allOf(
+                        ViewMatchers.withText("Comments"),
+                        ViewMatchers.hasSibling(ViewMatchers.withText(visitsData.comments))
                     )
                 )
             )
-            cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
-        }
+        )
+        cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
         return this
     }
 


### PR DESCRIPTION
### Why?

After several attempts (#18074, #18155) to work around a bug #18065 with JP not loading / partly loading `Stats` screen on Emulator, the issue still persists. [Latest example](https://buildkite.com/automattic/wordpress-android/builds/10502#01876bb0-cb7e-4fa4-bd0d-d9d8fbbea206). 

I decided to disable the test completely for JP.

### To test
- Test [is executed](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.b3d1e88d8b09c8be/matrices/4993164451972180901/details?stepId=bs.c8d80638fa2d1336&testCaseId=14) on FTL for WP
- Test [is not executed](https://console.firebase.google.com/u/1/project/api-project-108380595987/testlab/histories/bh.3ce77db975c1f0c9/matrices/4653059146074818601/details?stepId=bs.16f3a56e82760cc9&testCaseId=28) on FTL for JP