### PR TITLE
Fix previews of sites created with paid domains

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.config.SiteDomainsFeatureConfig
 import org.wordpress.android.util.extensions.isOnSale
-import org.wordpress.android.util.extensions.saleCostForDisplay
 import org.wordpress.android.util.helpers.Debouncer
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -186,7 +185,7 @@ class DomainSuggestionsViewModel @Inject constructor(
                     domainName = it.domain_name,
                     cost = it.cost,
                     isOnSale = product.isOnSale(),
-                    saleCost = product.saleCostForDisplay(),
+                    saleCost = product?.combinedSaleCostDisplay.orEmpty(),
                     isFree = it.is_free,
                     supportsPrivacy = it.supports_privacy,
                     productId = it.product_id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -179,10 +179,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
         progressViewModel.onCancelWizardClicked.observe(this) {
             mainViewModel.onWizardCancelled()
         }
-        progressViewModel.onRemoteSiteCreated.observe(this) { remoteSiteId ->
-            mainViewModel.onProgressScreenFinished(remoteSiteId)
-        }
-        progressViewModel.onCartCreated.observe(this) { mainViewModel.onCartCreated(it) }
+        progressViewModel.onRemoteSiteCreated.observe(this, mainViewModel::onProgressScreenFinished)
+        progressViewModel.onCartCreated.observe(this, mainViewModel::onCartCreated)
         previewViewModel.onOkButtonClicked.observe(this) { result ->
             mainViewModel.onWizardFinished(result)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -29,8 +29,8 @@ import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScre
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleGeneral
 import org.wordpress.android.ui.sitecreation.SiteCreationMainVM.SiteCreationScreenTitle.ScreenTitleStepCount
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.NotCreated
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.DOMAINS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.INTENTS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.PROGRESS
@@ -119,30 +119,16 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     @Suppress("LongMethod")
     private fun observeVMState() {
-        mainViewModel.navigationTargetObservable
-            .observe(this) { target -> target?.let { showStep(target) } }
-        mainViewModel.wizardFinishedObservable.observe(this) { result ->
-            result?.run {
-                val intent = Intent()
-                val (siteCreated, localSiteId, titleTaskComplete) = when (this@run) {
-                    // site creation flow was canceled
-                    is NotCreated -> {
-                        Triple(false, null, false)
-                    }
-                    is CreatedButNotFetched -> {
-                        // Let `SitePickerActivity` handle this with a Snackbar message
-                        intent.putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, true)
-                        Triple(true, null, isSiteTitleTaskComplete)
-                    }
-                    is Completed -> {
-                        Triple(true, localId, isSiteTitleTaskComplete)
-                    }
-                }
-                intent.putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, localSiteId)
-                intent.putExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, titleTaskComplete)
-                setResult(if (siteCreated) Activity.RESULT_OK else Activity.RESULT_CANCELED, intent)
-                finish()
+        mainViewModel.navigationTargetObservable.observe(this) { it?.let(::showStep) }
+        mainViewModel.onCompleted.observe(this) { (result, isTitleTaskComplete) ->
+            val intent = Intent().apply {
+                putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, (result as? Created)?.site?.id)
+                putExtra(SitePickerActivity.KEY_SITE_TITLE_TASK_COMPLETED, isTitleTaskComplete)
+                // Let `SitePickerActivity` handle this with a SnackBar message
+                putExtra(SitePickerActivity.KEY_SITE_CREATED_BUT_NOT_FETCHED, result is CreatedButNotFetched)
             }
+            setResult(if (result is Completed) Activity.RESULT_OK else Activity.RESULT_CANCELED, intent)
+            finish()
         }
         mainViewModel.dialogActionObservable.observe(this) {
             it?.show(this, supportFragmentManager, uiHelpers)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -165,7 +165,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         progressViewModel.onCancelWizardClicked.observe(this) {
             mainViewModel.onWizardCancelled()
         }
-        progressViewModel.onRemoteSiteCreated.observe(this, mainViewModel::onProgressScreenFinished)
+        progressViewModel.onFreeSiteCreated.observe(this, mainViewModel::onFreeSiteCreated)
         progressViewModel.onCartCreated.observe(this, mainViewModel::onCartCreated)
         previewViewModel.onOkButtonClicked.observe(this) { result ->
             mainViewModel.onWizardFinished(result)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -314,7 +314,7 @@ class SiteCreationMainVM @Inject constructor(
         wizardManager.showNextStep()
     }
 
-    fun onProgressScreenFinished(site: SiteModel) {
+    fun onFreeSiteCreated(site: SiteModel) {
         siteCreationState = siteCreationState.copy(result = CreatedButNotFetched.NotInLocalDb(site))
         wizardManager.showNextStep()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -50,7 +50,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.SiteCreationDomainPurchasingFeatureConfig
 import org.wordpress.android.util.extensions.isOnSale
-import org.wordpress.android.util.extensions.saleCostForDisplay
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
@@ -321,7 +320,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
                     domain.domainName,
                     cost = when {
                         domain.isFree -> Cost.Free
-                        product.isOnSale() -> Cost.OnSale(product.saleCostForDisplay(), domain.cost)
+                        product.isOnSale() -> Cost.OnSale(product?.combinedSaleCostDisplay.orEmpty(), domain.cost)
                         else -> Cost.Paid(domain.cost)
                     },
                     onClick = { onDomainSelected(domain) },

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -73,18 +73,17 @@ class SitePreviewViewModel @Inject constructor(
     val onOkButtonClicked: LiveData<SiteCreationResult> = _onOkButtonClicked
 
     fun start(siteCreationState: SiteCreationState) {
-        if (isStarted) return
-        isStarted = true
+        if (isStarted) return else isStarted = true
 
         siteDesign = siteCreationState.siteDesign
-        urlWithoutScheme = requireNotNull(siteCreationState.domain) { "url required for preview" }.domainName
-        startPreLoadingWebView()
-        result = siteCreationState.result.also {
-            if (it is CreatedButNotFetched) {
-                launch {
-                    fetchNewlyCreatedSiteModel(it.remoteId)?.run {
-                        result = Completed(id, it.isSiteTitleTaskComplete, url)
-                    }
+        result = siteCreationState.result
+
+        (result as? CreatedButNotFetched)?.let {
+            urlWithoutScheme = it.site.url
+            startPreLoadingWebView()
+            launch {
+                fetchNewlyCreatedSiteModel(it.site.siteId)?.run {
+                    result = Completed(id, it.isSiteTitleTaskComplete, url)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -14,8 +14,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.sitecreation.SiteCreationResult
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
@@ -61,7 +61,7 @@ class SitePreviewViewModel @Inject constructor(
     private var siteDesign: String? = null
     private var urlWithoutScheme: String? = null
 
-    private lateinit var result: SiteCreationResult
+    private lateinit var result: Created
 
     private val _uiState: MutableLiveData<SitePreviewUiState> = MutableLiveData()
     val uiState: LiveData<SitePreviewUiState> = _uiState
@@ -69,21 +69,20 @@ class SitePreviewViewModel @Inject constructor(
     private val _preloadPreview: MutableLiveData<String> = MutableLiveData()
     val preloadPreview: LiveData<String> = _preloadPreview
 
-    private val _onOkButtonClicked = SingleLiveEvent<SiteCreationResult>()
-    val onOkButtonClicked: LiveData<SiteCreationResult> = _onOkButtonClicked
+    private val _onOkButtonClicked = SingleLiveEvent<Created>()
+    val onOkButtonClicked: LiveData<Created> = _onOkButtonClicked
 
     fun start(siteCreationState: SiteCreationState) {
         if (isStarted) return else isStarted = true
-
+        require(siteCreationState.result is Created)
         siteDesign = siteCreationState.siteDesign
         result = siteCreationState.result
-
-        (result as? CreatedButNotFetched)?.let {
-            urlWithoutScheme = it.site.url
-            startPreLoadingWebView()
+        urlWithoutScheme = result.site.url
+        startPreLoadingWebView()
+        if (result is CreatedButNotFetched) {
             launch {
-                fetchNewlyCreatedSiteModel(it.site.siteId)?.run {
-                    result = Completed(id, it.isSiteTitleTaskComplete, url)
+                fetchNewlyCreatedSiteModel(result.site.siteId)?.let {
+                    result = Completed(it)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
@@ -91,7 +91,7 @@ class SiteCreationProgressFragment : Fragment(R.layout.site_creation_progress_sc
                 SiteCreationService.createSite(requireNotNull(activity), it.previousState, it.serviceData)
             }
         }
-        viewModel.onRemoteSiteCreated.observe(viewLifecycleOwner) {
+        viewModel.onFreeSiteCreated.observe(viewLifecycleOwner) {
             view?.announceForAccessibility(getString(R.string.new_site_creation_preview_title))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -76,8 +76,8 @@ class SiteCreationProgressViewModel @Inject constructor(
     private val _onCancelWizardClicked = SingleLiveEvent<Unit>()
     val onCancelWizardClicked: LiveData<Unit> = _onCancelWizardClicked
 
-    private val _onRemoteSiteCreated = SingleLiveEvent<SiteModel>()
-    val onRemoteSiteCreated: LiveData<SiteModel> = _onRemoteSiteCreated
+    private val _onFreeSiteCreated = SingleLiveEvent<SiteModel>()
+    val onFreeSiteCreated: LiveData<SiteModel> = _onFreeSiteCreated
 
     private val _onCartCreated = SingleLiveEvent<CheckoutDetails>()
     val onCartCreated: LiveData<CheckoutDetails> = _onCartCreated
@@ -159,7 +159,7 @@ class SiteCreationProgressViewModel @Inject constructor(
             SUCCESS -> {
                 val site = mapPayloadToSiteModel(event.payload)
                 if (domain.isFree) {
-                    _onRemoteSiteCreated.postValue(site)
+                    _onFreeSiteCreated.postValue(site)
                 } else {
                     createCart(site)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ProductExtensions.kt
@@ -1,8 +1,5 @@
 package org.wordpress.android.util.extensions
 
 import org.wordpress.android.fluxc.model.products.Product
-import java.util.Currency
 
 fun Product?.isOnSale(): Boolean = this?.saleCost?.let { it > 0.0 } == true
-fun Product?.saleCostForDisplay() =
-    this?.run { Currency.getInstance(currencyCode).symbol + "%.2f".format(saleCost) } ?: ""

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -45,9 +45,9 @@ val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
 val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
 val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
-val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_REMOTE_ID, false)
-val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_SLUG, SITE_REMOTE_ID, false)
+val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_MODEL, false)
+val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_MODEL, false)
 val RESULT_COMPLETED = Completed(1, false, URL)
 
-val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, URL))
+val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, SITE_SLUG))
 val SERVICE_ERROR = SiteCreationServiceState(FAILURE, SiteCreationServiceState(CREATE_SITE))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.TransactionsStore.OnShoppingCartCreated
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
 import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
 import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState
@@ -45,9 +46,10 @@ val FETCH_ERROR = OnSiteChanged(0).apply { error = SiteError(GENERIC_ERROR) }
 val CART_SUCCESS = OnShoppingCartCreated(mock<CreateShoppingCartResponse>())
 val CART_ERROR = OnShoppingCartCreated(mock<CreateShoppingCartError>())
 
-val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_MODEL, false)
-val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_MODEL, false)
-val RESULT_COMPLETED = Completed(1, false, URL)
+val RESULT_CREATED = mock<Created>()
+val RESULT_NOT_IN_LOCAL_DB = CreatedButNotFetched.NotInLocalDb(SITE_MODEL)
+val RESULT_IN_CART = CreatedButNotFetched.InCart(SITE_MODEL)
+val RESULT_COMPLETED = Completed(SITE_MODEL)
 
 val SERVICE_SUCCESS = SiteCreationServiceState(SUCCESS, Pair(SITE_REMOTE_ID, SITE_SLUG))
 val SERVICE_ERROR = SiteCreationServiceState(FAILURE, SiteCreationServiceState(CREATE_SITE))

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -196,7 +196,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         viewModel.onCheckoutResult(CHECKOUT_EVENT)
 
         assertIs<DomainRegistrationPurchased>(currentWizardState(viewModel).result).run {
-            assertEquals(CHECKOUT_DETAILS.site.siteId, remoteId)
+            assertEquals(CHECKOUT_DETAILS.site, site)
             assertEquals(CHECKOUT_EVENT.domainName, domainName)
             assertEquals(CHECKOUT_EVENT.email, email)
         }
@@ -204,13 +204,13 @@ class SiteCreationMainVMTest : BaseUnitTest() {
 
     @Test
     fun `on progress screen finished updates result`() {
-        viewModel.onProgressScreenFinished(SITE_REMOTE_ID)
+        viewModel.onProgressScreenFinished(SITE_MODEL)
         assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }
 
     @Test
     fun `on progress screen finished shows next step`() {
-        viewModel.onProgressScreenFinished(SITE_REMOTE_ID)
+        viewModel.onProgressScreenFinished(SITE_MODEL)
         verify(wizardManager).showNextStep()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -64,7 +64,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     lateinit var navigationTargetObserver: Observer<NavigationTarget>
 
     @Mock
-    lateinit var wizardFinishedObserver: Observer<SiteCreationResult>
+    lateinit var onCompletedObserver: Observer<SiteCreationCompletionEvent>
 
     @Mock
     lateinit var wizardExitedObserver: Observer<Unit>
@@ -121,7 +121,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         viewModel = getNewViewModel()
         viewModel.start(null, SiteCreationSource.UNSPECIFIED)
         viewModel.navigationTargetObservable.observeForever(navigationTargetObserver)
-        viewModel.wizardFinishedObservable.observeForever(wizardFinishedObserver)
+        viewModel.onCompleted.observeForever(onCompletedObserver)
         viewModel.dialogActionObservable.observeForever(dialogActionsObserver)
         viewModel.exitFlowObservable.observeForever(wizardExitedObserver)
         viewModel.onBackPressedObservable.observeForever(onBackPressedObserver)
@@ -145,7 +145,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Test
     fun `on wizard finished is propagated`() {
         viewModel.onWizardFinished(RESULT_COMPLETED)
-        verify(wizardFinishedObserver).onChanged(eq(RESULT_COMPLETED))
+        verify(onCompletedObserver).onChanged(eq(RESULT_COMPLETED to false))
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -204,13 +204,13 @@ class SiteCreationMainVMTest : BaseUnitTest() {
 
     @Test
     fun `on progress screen finished updates result`() {
-        viewModel.onProgressScreenFinished(SITE_MODEL)
+        viewModel.onFreeSiteCreated(SITE_MODEL)
         assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }
 
     @Test
     fun `on progress screen finished shows next step`() {
-        viewModel.onProgressScreenFinished(SITE_MODEL)
+        viewModel.onFreeSiteCreated(SITE_MODEL)
         verify(wizardManager).showNextStep()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -125,7 +125,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on start preloads the preview when result is Completed`() = test {
+    fun `on start preloads the preview when result is Completed`() {
         startViewModel(SITE_CREATION_STATE.copy(result = RESULT_COMPLETED))
         assertThat(viewModel.preloadPreview.value).isEqualTo(URL)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -37,8 +37,8 @@ import org.wordpress.android.ui.sitecreation.SERVICE_ERROR
 import org.wordpress.android.ui.sitecreation.SERVICE_SUCCESS
 import org.wordpress.android.ui.sitecreation.SITE_CREATION_STATE
 import org.wordpress.android.ui.sitecreation.SITE_REMOTE_ID
+import org.wordpress.android.ui.sitecreation.SITE_SLUG
 import org.wordpress.android.ui.sitecreation.SiteCreationState
-import org.wordpress.android.ui.sitecreation.URL
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState.Error.ConnectionError
@@ -63,7 +63,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     private val startServiceObserver = mock<Observer<StartServiceData>>()
     private val onHelpClickedObserver = mock<Observer<Unit>>()
     private val onCancelWizardClickedObserver = mock<Observer<Unit>>()
-    private val onRemoteSiteCreatedObserver = mock<Observer<Long>>()
+    private val onRemoteSiteCreatedObserver = mock<Observer<SiteModel>>()
     private val onCartCreatedObserver = mock<Observer<CheckoutDetails>>()
 
     private lateinit var viewModel: SiteCreationProgressViewModel
@@ -97,6 +97,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
         startViewModel()
         assertNotNull(viewModel.startCreateSiteService.value)
     }
+
     @Test
     fun `on start emits service event for free domains with isFree true`() = test {
         startViewModel(SITE_CREATION_STATE)
@@ -166,10 +167,13 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on service success propagates remote id`() {
+    fun `on service success propagates site`() {
         startViewModel()
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)
-        verify(onRemoteSiteCreatedObserver).onChanged(SITE_REMOTE_ID)
+        verify(onRemoteSiteCreatedObserver).onChanged(argThat {
+            assertEquals(SITE_REMOTE_ID, siteId)
+            url == SITE_SLUG
+        })
     }
 
     @Test
@@ -191,7 +195,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)
         verify(onCartCreatedObserver).onChanged(argThat {
             assertEquals(SITE_REMOTE_ID, site.siteId)
-            assertEquals(URL, site.url)
+            assertEquals(SITE_SLUG, site.url)
             domainName == PAID_DOMAIN.domainName
         })
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -80,7 +80,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
         viewModel.startCreateSiteService.observeForever(startServiceObserver)
         viewModel.onHelpClicked.observeForever(onHelpClickedObserver)
         viewModel.onCancelWizardClicked.observeForever(onCancelWizardClickedObserver)
-        viewModel.onRemoteSiteCreated.observeForever(onRemoteSiteCreatedObserver)
+        viewModel.onFreeSiteCreated.observeForever(onRemoteSiteCreatedObserver)
         viewModel.onCartCreated.observeForever(onCartCreatedObserver)
 
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.93.0-alpha2'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = 'trunk-700df45f317e7aecfd2cb73a6cfa39b2f9b7de81'
+    wordPressFluxCVersion = '2708-52ed0e220a163677521b9bc66ba495e0165bd51c'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.93.0-alpha2'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2708-52ed0e220a163677521b9bc66ba495e0165bd51c'
+    wordPressFluxCVersion = 'trunk-a6bbfa04f48fde3be1e30cc99eca5a617b087fd9'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.3.0'


### PR DESCRIPTION
Resolves partially #17905
Related: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2708

This PR:
- ★ Fixes the preview for sites with paid domains f086d89
- ⊕ Integrates with related FluxC PR to display discount prices formatted by the api ddd9c48
- ⊜ Refactors the data models for completion events and results, to simplify the code c0fd8f5

<details><summary><b>Merging Strategy</b></summary>

1. Merge the FluxC PR
2. Update the `wordPressFluxCVersion` of this PR
   1. After the [post-merge BuildKite job for trunk](https://buildkite.com/automattic/wordpress-fluxc-android) completes open its sub-job named:
      `Publish :fluxc`
   2. Search for `is succesfully published` and copy the FluxC version before it:
       `trunk-{commit_sha}`
   3. Paste the FluxC version in `./build.gradle` at:
      `wordPressFluxCVersion`
   5. Commit and push this change
3. Auto-merge this PR
---
</details>

## To Test

#### Prerequisites

- ◐ Toggle the `SiteCreationDomainPurchasingFeatureConfig` flag
  1. Go to `Me` → `App Settings` → `Debug settings`
  2. Scroll to the `Features in development` section
  3. Tap on the item corresponding to the flag
  4. Tap `RESTART THE APP` button
- internal ref: pc8HXX-14D-p2#android for testing purchases

### ● Treatment Variation

- **Verify** the discount prices in `site creation` → `domains` match the checkout ones
- **Verify** the preview works for sites created with paid domains
- **Verify** sites with both free and paid domain can be created

### ○ Control Variation

- **Verify** sites with free subdomain can be created without issues
- **Verify** discount prices in `menu` → `domains` match the checkout ones

## Regression Notes
1. Potential unintended areas of impact
   - `Site creation` → from `Domains` step to `Preview`
   - `Menu` → `Domains` (only discount prices)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
   Unit tests in:
   - `SiteCreationMainVMTest`
   - `SiteCreationProgressViewModelTest`
   - `SitePreviewViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.