### PR TITLE
Move media permissions from debug to main AndroidManifest

### DIFF
--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -12,17 +12,6 @@
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <!-- Allows for storing and retrieving screenshots, photos, videos and audios -->
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29" />
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-
     <!-- Allows changing locales for screenshot automation -->
     <uses-permission
         android:name="android.permission.CHANGE_CONFIGURATION"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -17,11 +17,18 @@
     <!-- Dangerous permissions, access must be requested at runtime -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Required for storing and retrieving screenshots, taking photos, accessing media files -->
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />


### PR DESCRIPTION
This PR moves the following permissions from `/debug/AndroidManifest.xml` to `main/AndroidManifest.xml`.
- `WRITE_EXTERNAL_STORAGE` (was also already in `main/AndroidManifest.xml`)
- `READ_EXTERNAL_STORAGE`
- `READ_MEDIA_IMAGES`
- `READ_MEDIA_VIDEO`
- `READ_MEDIA_AUDIO`

These permissions were required for `WPScreenshotTest` and `JPScreenshotTest`, but they are also required for the main project. So, they are needed in the main AndroidManifest file.

To test:
**`WPScreenshotTest`, `JPScreenshotTest`**
- WPScreenshotTest` and `JPScreenshotTest` should pass.

**Media permissions in the app**
1. Launch the JP app on a device with API 33.
2. Ensure you have all types of files on your media browser. (image, video, audio, and a file such as pdf)
3. Navigate to "My Site → Media".
4. Ensure all files on your device are listed.
5. Tap an image.
6. On the media detail screen, tap the save button at the top of the screen.
7. Ensure the file is downloaded to your device.
8. Repeat 1-7 with a device with API lower than 29.

## Regression Notes
1. Potential unintended areas of impact
`WPScreenshotTest`, `JPScreenshotTest` and media permissions in the app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
None because this PR doesn't introduce any change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
