### PR TITLE
Remove Gutenberg VideoPress block for excerpt

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -266,7 +266,10 @@ public class PostUtils {
             return null;
         }
 
-        String s = HtmlUtils.fastStripHtml(removeWPGallery(description));
+        // Remove Gutenberg blocks.
+        String s = removeWPGallery(description);
+        s = removeWPVideoPress(s);
+        s = HtmlUtils.fastStripHtml(s);
         if (s.length() < MAX_EXCERPT_LEN) {
             return trimEx(s);
         }
@@ -301,6 +304,13 @@ public class PostUtils {
      */
     public static String removeWPGallery(String str) {
         return str.replaceAll("(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->", "");
+    }
+
+    /**
+     * Removes the VideoPress block tag from the given string.
+     */
+    public static String removeWPVideoPress(String str) {
+        return str.replaceAll("(?s)\\n?<!--\\swp:videopress/video?(.*?)wp:videopress/video\\s-->", "");
     }
 
     public static String getFormattedDate(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -266,7 +266,10 @@ public class PostUtils {
             return null;
         }
 
-        // Remove certain Gutenberg blocks that would display markup, rather than their associated media, in the excerpt.
+        /**
+         * Remove certain Gutenberg blocks that would display markup, rather than their associated
+         * media, in the excerpt.
+         */
         String s = removeWPGallery(description);
         s = removeWPVideoPress(s);
         s = HtmlUtils.fastStripHtml(s);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -266,7 +266,7 @@ public class PostUtils {
             return null;
         }
 
-        // Remove Gutenberg blocks.
+        // Remove certain Gutenberg blocks that would display markup, rather than their associated media, in the excerpt.
         String s = removeWPGallery(description);
         s = removeWPVideoPress(s);
         s = HtmlUtils.fastStripHtml(s);

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -46,6 +46,51 @@ class PostUtilsUnitTest {
     }
 
     @Test
+    fun `removeWPVideoPress removes VideoPress block tags and its internals without affecting content in between`() {
+        val content = """
+<!-- wp:paragraph -->
+<p>Before</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:videopress/video {"title":"demo","description":"","id":5297,"guid":"AbCDe","videoRatio":56.333333333333336,"privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":1673} -->
+<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
+https://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
+</div></figure>
+<!-- /wp:videopress/video -->
+
+<!-- wp:paragraph -->
+<p>Between</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:videopress/video {"title":"demo","description":"","id":5297,"guid":"AbCDe","videoRatio":56.333333333333336,"privacySetting":2,"allowDownload":false,"rating":"G","isPrivate":true,"duration":1673} -->
+<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
+https://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
+</div></figure>
+<!-- /wp:videopress/video -->
+
+<!-- wp:paragraph -->
+<p>After</p>
+<!-- /wp:paragraph -->
+"""
+        val expectedResult = """
+<!-- wp:paragraph -->
+<p>Before</p>
+<!-- /wp:paragraph -->
+
+
+<!-- wp:paragraph -->
+<p>Between</p>
+<!-- /wp:paragraph -->
+
+
+<!-- wp:paragraph -->
+<p>After</p>
+<!-- /wp:paragraph -->
+"""
+        assertThat(PostUtils.removeWPVideoPress(content)).isEqualTo(expectedResult)
+    }
+
+    @Test
     fun `prepareForPublish updates dateLocallyChanged`() {
         val post = invokePreparePostForPublish()
         assertThat(post.dateLocallyChanged).isNotEmpty()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5601.

This PR removes the VideoPress block tag when generating the excerpt for Gutenberg content.

## To test

### Preparation
1. Go to a site in the browser.
2. Create a post.
3. Add a VideoPress block and add a video.
4. Add a Paragraph block with text after the VideoPress block.
5. Save the post.

### Check excerpt
1. Open the app and go to the post list.
2. Observe that the saved post is displaying the text of the Paragraph block and not the VideoPress URL.

**Example:**
| Content | Before | After |
|--------|--------|--------|
| <img src=https://user-images.githubusercontent.com/14905380/231430952-07fe3a65-eb6b-4360-aeaf-a5c2ab437130.jpg> | <img src=https://user-images.githubusercontent.com/14905380/231430957-ff30d828-8e2f-4968-8e80-9e7eb0aeb27f.jpg> | <img src=https://user-images.githubusercontent.com/14905380/231430959-e57c3e96-20ad-47f3-a43c-43c52f981302.jpg> | 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I added a unit test to cover the change.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
