### PR TITLE
[Blogging Prompts] Add remote field to Social FF and enable it

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 22.2
 -----
-
+* [**] [Jetpack-only] Blogging Prompts: adds the ability to view other users' responses to a prompt. [https://github.com/wordpress-mobile/WordPress-Android/pull/18265]
 
 22.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsSocialFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsSocialFeatureConfig.kt
@@ -1,14 +1,17 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val BLOGGING_PROMPTS_SOCIAL_REMOTE_FIELD = "blogging_prompts_social_enabled"
+
+@Feature(BLOGGING_PROMPTS_SOCIAL_REMOTE_FIELD, true)
 class BloggingPromptsSocialFeatureConfig
 @Inject constructor(appConfig: AppConfig) : FeatureConfig(
     appConfig,
     BuildConfig.BLOGGING_PROMPTS_SOCIAL,
+    BLOGGING_PROMPTS_SOCIAL_REMOTE_FIELD,
 ) {
     override fun isEnabled(): Boolean {
         return super.isEnabled() && BuildConfig.IS_JETPACK_APP


### PR DESCRIPTION
Fixes #18264 

Sets a remote feature flag called `blogging_prompts_social_enabled` and sets the local default value of the `BloggingPromptsSocialFeatureConfig` flag to `true`.

_I am using the "Not Ready for Merge" tag while I confirm if we need to add a message to the release notes._

To test:
1. Install and open an older Jetpack app version (such as [this one](https://github.com/wordpress-mobile/WordPress-Android/pull/18253#issuecomment-1502653621))
2. Login with a WP.com account
3. Select a blogging site (has at least a few posts)
4. **Verify** the Prompts card is shown in the dashboard
5. **Verify** it shows the number of answers and that is **not** clickable
6. Install and open the Jetpack app from this PR
7. Do steps 2-3 if needed
8. **Verify** the Prompts card is shown in the dashboard
9. **Verify** it shows a "View all responses" action
10. Tap the "View all responses" button
11. **Verify** it takes you to the `topic` screen for that prompt

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A just FF update.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
