### PR TITLE
Integrate gutenberg-mobile release 1.93.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5665-3bfcb833fd968dfdfe3e82213dbf895cf7a1bb74'
+    gutenbergMobileVersion = 'v1.93.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-700df45f317e7aecfd2cb73a6cfa39b2f9b7de81'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5665-81d30450e6e6e38e0ef0da9d717d05d624e55d36'
+    gutenbergMobileVersion = '5665-3bfcb833fd968dfdfe3e82213dbf895cf7a1bb74'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-700df45f317e7aecfd2cb73a6cfa39b2f9b7de81'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.0.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.93.0-alpha2'
+    gutenbergMobileVersion = '5665-81d30450e6e6e38e0ef0da9d717d05d624e55d36'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-700df45f317e7aecfd2cb73a6cfa39b2f9b7de81'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.93.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5665

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

**Note**: There are no release note updates for Android, since the only user-facing change is for iOS.