### PR TITLE
Fix crash on comment detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboar
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderBottomSheetFragment;
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderTimePicker;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
-import org.wordpress.android.ui.comments.CommentsDetailActivity;
 import org.wordpress.android.ui.comments.EditCommentActivity;
 import org.wordpress.android.ui.comments.unified.EditCancelDialogFragment;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentDetailsFragment;
@@ -216,8 +215,6 @@ public interface AppComponent {
     void inject(CommentDetailFragment object);
 
     void inject(EditCommentActivity object);
-
-    void inject(CommentsDetailActivity object);
 
     void inject(MeFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -32,8 +32,8 @@ import org.wordpress.android.ui.CollapseFullScreenDialogFragment;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.comments.unified.CommentConstants;
-import org.wordpress.android.ui.comments.unified.OnLoadMoreListener;
 import org.wordpress.android.ui.comments.unified.CommentsStoreAdapter;
+import org.wordpress.android.ui.comments.unified.OnLoadMoreListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -47,12 +47,15 @@ import javax.inject.Inject;
 
 import static org.wordpress.android.ui.comments.unified.CommentConstants.COMMENTS_PER_PAGE;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 /**
  * @deprecated
  * Comments are being refactored as part of Comments Unification project. If you are adding any
  * features or modifying this class, please ping develric or klymyam
  */
 @Deprecated
+@AndroidEntryPoint
 public class CommentsDetailActivity extends LocaleAwareActivity
         implements OnLoadMoreListener,
         CommentActions.OnCommentActionListener, ScrollableViewInitializedListener {
@@ -78,7 +81,6 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        ((WordPress) getApplication()).component().inject(this);
         mCommentsStoreAdapter.register(this);
         AppLog.i(AppLog.T.COMMENTS, "Creating CommentsDetailActivity");
 


### PR DESCRIPTION
This fixes the crash on the comment detail screen.
`CollapseFullScreenDialogFragment` was migrated to Hilt in https://github.com/wordpress-mobile/WordPress-Android/pull/18158. This fragment can be used with several activities, the other activities were Hilt activity, instead of `CommentsDetailActivity`. This PR migrates `CommentsDetailActivity` to fix the crash.

Crash video:

https://user-images.githubusercontent.com/2471769/231896270-15e57c2b-86c7-4207-89a4-076ddf3f329d.mp4

To test:
1. Navigate to MENU → Comments.
2. Tap on a comment to open the comment detail screen.
3. Tap the "Reply to comment" box to open the full-screen edit comment screen.
4. Ensure it doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
