### PR TITLE
[Jetpack] Fix pagination not working when opening a tag from "View all responses" blogging prompt card button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
@@ -14,6 +14,6 @@ object BloggingPromptsPostTagProvider {
         promptIdTag(promptId),
         promptIdTag(promptId),
         "",
-        ReaderTagType.SEARCH,
+        ReaderTagType.FOLLOWED,
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.bloggingprompts
 
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.ui.reader.services.post.ReaderPostLogic
 
 object BloggingPromptsPostTagProvider {
     const val BLOGGING_PROMPT_TAG = "dailyprompt"
@@ -13,7 +14,7 @@ object BloggingPromptsPostTagProvider {
         promptIdTag(promptId),
         promptIdTag(promptId),
         promptIdTag(promptId),
-        "",
+        ReaderPostLogic.formatFullEndpointForTag(promptIdTag(promptId)),
         ReaderTagType.FOLLOWED,
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.reader.services.post;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
@@ -309,8 +311,16 @@ public class ReaderPostLogic {
         if (tag.tagType == ReaderTagType.DEFAULT) {
             return null;
         }
+        return formatRelativeEndpointForTag(tag.getTagSlug());
+    }
 
-        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagSlug()));
+    private static String formatRelativeEndpointForTag(@NonNull final String tagSlug) {
+        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tagSlug));
+    }
+
+    public static String formatFullEndpointForTag(@NonNull final String tagSlug) {
+        return WordPress.getRestClientUtilsV1_2().getRestClient().getEndpointURL()
+               + formatRelativeEndpointForTag(tagSlug);
     }
 
     /*

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.ui.reader.services.post.ReaderPostLogic
 import kotlin.test.assertEquals
 
 class BloggingPromptsPostTagProviderTest {
-
     @Test
     fun `Should return the expected ReaderTag when promptIdSearchReaderTag is called`() {
         val promptId = 1234

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import org.junit.Test
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.ui.reader.services.post.ReaderPostLogic
+import kotlin.test.assertEquals
+
+class BloggingPromptsPostTagProviderTest {
+
+    @Test
+    fun `Should return the expected ReaderTag when promptIdSearchReaderTag is called`() {
+        val promptId = 1234
+        val expected = ReaderTag(
+            BloggingPromptsPostTagProvider.promptIdTag(promptId),
+            BloggingPromptsPostTagProvider.promptIdTag(promptId),
+            BloggingPromptsPostTagProvider.promptIdTag(promptId),
+            ReaderPostLogic.formatFullEndpointForTag(BloggingPromptsPostTagProvider.promptIdTag(promptId)),
+            ReaderTagType.FOLLOWED,
+        )
+        val actual = BloggingPromptsPostTagProvider.promptIdSearchReaderTag(promptId)
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
Fixes #

To test:
1 - Run Jetpack;
2 - Log in and select a blog so that the prompt card is shown on "My Site";
3 - Tap on `"View all responses"`
4 - Check the posts list: they should be the same as web.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
Implemented ` BloggingPromptsPostTagProviderTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
