### PR TITLE
Fix the infinite loading indicator issue on my site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -101,7 +101,6 @@ class MySiteSourceManager @Inject constructor(
         domainRegistrationSource.clear()
         scanAndBackupSource.clear()
         selectedSiteSource.clear()
-        dashboardCardDomainSource.clear()
     }
 
     private fun refreshSubsetOfAllSources() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -31,14 +31,14 @@ data class MySiteUiState(
     val cardsUpdate: CardsUpdate? = null,
     val bloggingPromptsUpdate: BloggingPromptUpdate? = null,
     val promoteWithBlazeUpdate: PartialState.PromoteWithBlazeUpdate? = null,
-    val hasSiteDomains: Boolean = false
+    val hasSiteCustomDomains: Boolean = false
 ) {
     sealed class PartialState {
         data class CurrentAvatarUrl(val url: String) : PartialState()
         data class SelectedSite(val site: SiteModel?) : PartialState()
         data class ShowSiteIconProgressBar(val showSiteIconProgressBar: Boolean) : PartialState()
         data class DomainCreditAvailable(val isDomainCreditAvailable: Boolean) : PartialState()
-        data class DomainsAvailable(val hasSiteDomains: Boolean) : PartialState()
+        data class CustomDomainsAvailable(val hasSiteCustomDomains: Boolean) : PartialState()
 
         data class JetpackCapabilities(val scanAvailable: Boolean, val backupAvailable: Boolean) : PartialState()
         data class QuickStartUpdate(
@@ -75,7 +75,7 @@ data class MySiteUiState(
             is SelectedSite -> uiState.copy(site = partialState.site)
             is ShowSiteIconProgressBar -> uiState.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
             is DomainCreditAvailable -> uiState.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)
-            is PartialState.DomainsAvailable -> uiState.copy(hasSiteDomains = partialState.hasSiteDomains)
+            is PartialState.CustomDomainsAvailable -> uiState.copy(hasSiteCustomDomains = partialState.hasSiteCustomDomains)
             is JetpackCapabilities -> uiState.copy(
                 scanAvailable = partialState.scanAvailable,
                 backupAvailable = partialState.backupAvailable

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -75,7 +75,9 @@ data class MySiteUiState(
             is SelectedSite -> uiState.copy(site = partialState.site)
             is ShowSiteIconProgressBar -> uiState.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
             is DomainCreditAvailable -> uiState.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)
-            is PartialState.CustomDomainsAvailable -> uiState.copy(hasSiteCustomDomains = partialState.hasSiteCustomDomains)
+            is PartialState.CustomDomainsAvailable -> uiState.copy(
+                hasSiteCustomDomains = partialState.hasSiteCustomDomains
+            )
             is JetpackCapabilities -> uiState.copy(
                 scanAvailable = partialState.scanAvailable,
                 backupAvailable = partialState.backupAvailable

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -24,9 +24,9 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.DynamicCardType
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
-import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.fluxc.store.QuickStartStore.Companion.QUICK_START_CHECK_STATS_LABEL
@@ -45,7 +45,6 @@ import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsPostTagProvider
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
-import org.wordpress.android.ui.mysite.cards.dashboard.domain.DashboardCardDomainUtils
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource.FEATURE_CARD
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
@@ -62,13 +61,13 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.JetpackBadge
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloggingPromptCardBuilderParams
-import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardDomainBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainRegistrationCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.JetpackInstallFullPluginCardBuilderParams
-import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PromoteWithBlazeCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickActionsCardBuilderParams
@@ -91,6 +90,7 @@ import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
+import org.wordpress.android.ui.mysite.cards.dashboard.domain.DashboardCardDomainUtils
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardHelper
@@ -345,7 +345,7 @@ class MySiteViewModel @Inject constructor(
                     cardsUpdate,
                     bloggingPromptsUpdate,
                     promoteWithBlazeUpdate,
-                    hasSiteDomains
+                    hasSiteCustomDomains
                 )
                 selectDefaultTabIfNeeded()
                 trackCardsAndItemsShownIfNeeded(state)
@@ -354,7 +354,7 @@ class MySiteViewModel @Inject constructor(
                     viewModelScope,
                     state.dashboardCardsAndItems.filterIsInstance<DashboardCards>().firstOrNull()
                 )
-                
+
                 state
             } else {
                 buildNoSiteState()
@@ -394,7 +394,7 @@ class MySiteViewModel @Inject constructor(
         cardsUpdate: CardsUpdate?,
         bloggingPromptUpdate: BloggingPromptUpdate?,
         promoteWithBlazeUpdate: PromoteWithBlazeUpdate?,
-        hasSiteDomains: Boolean
+        hasSiteCustomDomains: Boolean
     ): SiteSelected {
         val siteItems = buildSiteSelectedState(
             site,
@@ -408,7 +408,7 @@ class MySiteViewModel @Inject constructor(
             cardsUpdate,
             bloggingPromptUpdate,
             promoteWithBlazeUpdate,
-            hasSiteDomains
+            hasSiteCustomDomains
         )
 
         val siteInfoCardBuilderParams = SiteInfoCardBuilderParams(
@@ -498,7 +498,7 @@ class MySiteViewModel @Inject constructor(
         cardsUpdate: CardsUpdate?,
         bloggingPromptUpdate: BloggingPromptUpdate?,
         promoteWithBlazeUpdate: PromoteWithBlazeUpdate?,
-        hasSiteDomains: Boolean
+        hasSiteCustomDomains: Boolean
     ): Map<MySiteTabType, List<MySiteCardAndItem>> {
         val infoItem = siteItemsBuilder.build(
             InfoItemBuilderParams(
@@ -602,7 +602,7 @@ class MySiteViewModel @Inject constructor(
                 ),
                 dashboardCardDomainBuilderParams = DashboardCardDomainBuilderParams(
                     isEligible = dashboardCardDomainUtils.shouldShowCard(
-                        site, isDomainCreditAvailable, hasSiteDomains
+                        site, isDomainCreditAvailable, hasSiteCustomDomains
                     ),
                     onClick = this::onDashboardCardDomainClick,
                     onHideMenuItemClick = this::onDashboardCardDomainHideMenuItemClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
@@ -38,10 +38,10 @@ class DashboardCardDomainSource @Inject constructor(
     }
 
     private fun shouldFetchDomains(selectedSite: SiteModel): Boolean {
-        // By assuming that "isDomainCreditAvailable" and "hasSiteDomain" are true, we are checking other cases for
+        // By assuming that "isDomainCreditAvailable" and "hasSiteDomain" are false, we are checking other cases for
         // "shouldShowCard". If "shouldShowCard" still returns false, then we do not need to fetch domains.
-        val isDomainCreditAvailable = true
-        val hasSiteDomain = true
+        val isDomainCreditAvailable = false
+        val hasSiteDomain = false
 
         return domainUtils.shouldShowCard(selectedSite, isDomainCreditAvailable, hasSiteDomain)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
@@ -3,18 +3,11 @@ package org.wordpress.android.ui.mysite.cards.dashboard.domain
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteSource
@@ -24,25 +17,15 @@ import org.wordpress.android.ui.plans.hasSiteDomains
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.coroutines.resume
 
 class DashboardCardDomainSource @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val dispatcher: Dispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
+    private val siteStore: SiteStore,
+    private val domainUtils: DashboardCardDomainUtils,
     private val appLogWrapper: AppLogWrapper
 ) : MySiteSource.MySiteRefreshSource<MySiteUiState.PartialState.DomainsAvailable> {
     override val refresh = MutableLiveData(false)
-
-    private val continuations = mutableMapOf<Int, CancellableContinuation<FetchedDomainsPayload>?>()
-
-    init {
-        dispatcher.register(this)
-    }
-
-    fun clear() {
-        dispatcher.unregister(this)
-    }
 
     override fun build(
         coroutineScope: CoroutineScope,
@@ -52,6 +35,15 @@ class DashboardCardDomainSource @Inject constructor(
         data.addSource(refresh) { data.refreshData(coroutineScope, siteLocalId, refresh.value) }
         refresh()
         return data
+    }
+
+    private fun shouldFetchDomains(selectedSite: SiteModel): Boolean {
+        // By assuming that "isDomainCreditAvailable" and "hasSiteDomain" are true, we are checking other cases for
+        // "shouldShowCard". If "shouldShowCard" still returns false, then we do not need to fetch domains.
+        val isDomainCreditAvailable = true
+        val hasSiteDomain = true
+
+        return domainUtils.shouldShowCard(selectedSite, isDomainCreditAvailable, hasSiteDomain)
     }
 
     private fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.refreshData(
@@ -71,58 +63,30 @@ class DashboardCardDomainSource @Inject constructor(
         siteLocalId: Int,
         selectedSite: SiteModel?
     ) {
-        if (selectedSite == null || selectedSite.id != siteLocalId) {
+        if (selectedSite == null || selectedSite.id != siteLocalId || !shouldFetchDomains(selectedSite)) {
             postState(MySiteUiState.PartialState.DomainsAvailable(false))
         } else {
-            fetchDomainsAndRefreshData(coroutineScope, siteLocalId, selectedSite)
+            fetchDomainsAndRefreshData(coroutineScope, selectedSite)
         }
     }
 
     private fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.fetchDomainsAndRefreshData(
         coroutineScope: CoroutineScope,
-        siteLocalId: Int,
         selectedSite: SiteModel
     ) {
-        if (continuations[siteLocalId] == null) {
-            coroutineScope.launch(bgDispatcher) { fetchDomains(siteLocalId, selectedSite) }
-        } else {
-            appLogWrapper.d(AppLog.T.DOMAIN_REGISTRATION, "A request is already running for $siteLocalId")
-        }
-    }
+        coroutineScope.launch(bgDispatcher) {
+            val result = siteStore.fetchSiteDomains(selectedSite)
+            val domains = result.domains
+            val error = result.error
 
-    @Suppress("SwallowedException")
-    private suspend fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.fetchDomains(
-        siteLocalId: Int,
-        selectedSite: SiteModel
-    ) {
-        try {
-            val event = suspendCancellableCoroutine<FetchedDomainsPayload> { cancellableContinuation ->
-                continuations[siteLocalId] = cancellableContinuation
-                dispatchFetchDomains(selectedSite)
+            if (result.isError) {
+                appLogWrapper.e(
+                    AppLog.T.DOMAIN_REGISTRATION,
+                    "An error occurred while fetching domains: ${error.message}"
+                )
             }
-            when {
-                event.isError -> {
-                    val message = "An error occurred while fetching plans :${event.error.message}"
-                    appLogWrapper.e(AppLog.T.DOMAIN_REGISTRATION, message)
-                    postState(MySiteUiState.PartialState.DomainsAvailable(false))
-                }
-                siteLocalId == event.site.id -> {
-                    postState(MySiteUiState.PartialState.DomainsAvailable(hasSiteDomains(event.domains)))
-                }
-                else -> {
-                    postState(MySiteUiState.PartialState.DomainsAvailable(false))
-                }
-            }
-        } catch (e: CancellationException) {
-            postState(MySiteUiState.PartialState.DomainsAvailable(false))
+
+            postState(MySiteUiState.PartialState.DomainsAvailable(hasSiteDomains(domains)))
         }
-    }
-
-    private fun dispatchFetchDomains(site: SiteModel) = dispatcher.dispatch(SiteActionBuilder.newFetchPlansAction(site))
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDomainsFetched(event: FetchedDomainsPayload) {
-        continuations[event.site.id]?.resume(event)
-        continuations[event.site.id] = null
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
@@ -23,14 +23,14 @@ class DashboardCardDomainSource @Inject constructor(
     private val siteStore: SiteStore,
     private val domainUtils: DashboardCardDomainUtils,
     private val appLogWrapper: AppLogWrapper
-) : MySiteSource.MySiteRefreshSource<MySiteUiState.PartialState.DomainsAvailable> {
+) : MySiteSource.MySiteRefreshSource<MySiteUiState.PartialState.CustomDomainsAvailable> {
     override val refresh = MutableLiveData(false)
 
     override fun build(
         coroutineScope: CoroutineScope,
         siteLocalId: Int
-    ): LiveData<MySiteUiState.PartialState.DomainsAvailable> {
-        val data = MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>()
+    ): LiveData<MySiteUiState.PartialState.CustomDomainsAvailable> {
+        val data = MediatorLiveData<MySiteUiState.PartialState.CustomDomainsAvailable>()
         data.addSource(refresh) { data.refreshData(coroutineScope, siteLocalId, refresh.value) }
         refresh()
         return data
@@ -45,7 +45,7 @@ class DashboardCardDomainSource @Inject constructor(
         return domainUtils.shouldShowCard(selectedSite, isDomainCreditAvailable, hasSiteDomain)
     }
 
-    private fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.refreshData(
+    private fun MediatorLiveData<MySiteUiState.PartialState.CustomDomainsAvailable>.refreshData(
         coroutineScope: CoroutineScope,
         siteLocalId: Int,
         isRefresh: Boolean? = null
@@ -57,19 +57,19 @@ class DashboardCardDomainSource @Inject constructor(
         }
     }
 
-    private fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.refreshData(
+    private fun MediatorLiveData<MySiteUiState.PartialState.CustomDomainsAvailable>.refreshData(
         coroutineScope: CoroutineScope,
         siteLocalId: Int,
         selectedSite: SiteModel?
     ) {
         if (selectedSite == null || selectedSite.id != siteLocalId || !shouldFetchDomains(selectedSite)) {
-            postState(MySiteUiState.PartialState.DomainsAvailable(false))
+            postState(MySiteUiState.PartialState.CustomDomainsAvailable(false))
         } else {
             fetchDomainsAndRefreshData(coroutineScope, selectedSite)
         }
     }
 
-    private fun MediatorLiveData<MySiteUiState.PartialState.DomainsAvailable>.fetchDomainsAndRefreshData(
+    private fun MediatorLiveData<MySiteUiState.PartialState.CustomDomainsAvailable>.fetchDomainsAndRefreshData(
         coroutineScope: CoroutineScope,
         selectedSite: SiteModel
     ) {
@@ -85,7 +85,7 @@ class DashboardCardDomainSource @Inject constructor(
                 )
             }
 
-            postState(MySiteUiState.PartialState.DomainsAvailable(domainUtils.hasCustomDomain(domains)))
+            postState(MySiteUiState.PartialState.CustomDomainsAvailable(domainUtils.hasCustomDomain(domains)))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteSource
 import org.wordpress.android.ui.mysite.MySiteUiState
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.plans.hasSiteDomains
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import javax.inject.Named
@@ -86,7 +85,7 @@ class DashboardCardDomainSource @Inject constructor(
                 )
             }
 
-            postState(MySiteUiState.PartialState.DomainsAvailable(hasSiteDomains(domains)))
+            postState(MySiteUiState.PartialState.DomainsAvailable(domainUtils.hasCustomDomain(domains)))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
@@ -35,12 +35,12 @@ class DashboardCardDomainUtils @Inject constructor(
     private val waitingToTrack = AtomicBoolean(false)
     private val currentSite = AtomicReference<Int?>(null)
 
-    fun shouldShowCard(siteModel: SiteModel, isDomainCreditAvailable: Boolean, hasSiteDomains: Boolean): Boolean {
+    fun shouldShowCard(siteModel: SiteModel, isDomainCreditAvailable: Boolean, hasSiteCustomDomains: Boolean): Boolean {
         return isDashboardCardDomainEnabled() &&
                 !isDashboardCardDomainHiddenByUser(siteModel.siteId) &&
                 (siteModel.isWPCom || siteModel.isWPComAtomic) &&
                 siteModel.isAdmin &&
-                !hasSiteDomains &&
+                !hasSiteCustomDomains &&
                 !isDomainCreditAvailable
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.DashboardDomainCard
@@ -147,6 +148,8 @@ class DashboardCardDomainUtils @Inject constructor(
             waitingToTrack.set(true)
         }
     }
+
+    fun hasCustomDomain(domains: List<Domain>?) = domains?.any { !it.wpcomDomain } == true
 
     companion object {
         const val POSITION_INDEX = "position_index"

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanUtils.kt
@@ -1,10 +1,7 @@
 package org.wordpress.android.ui.plans
 
 import org.wordpress.android.fluxc.model.PlanModel
-import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 
 fun getCurrentPlan(plans: List<PlanModel>?): PlanModel? = plans?.find { it.isCurrentPlan }
 
 fun isDomainCreditAvailable(plans: List<PlanModel>?): Boolean = getCurrentPlan(plans)?.hasDomainCredit ?: false
-
-fun hasSiteDomains(domains: List<Domain>?): Boolean = domains?.isNotEmpty() ?: false


### PR DESCRIPTION
This fixes the incorrect endpoint for the domains dashboard card and resolves the issue of the infinite loading indicator on HOME screen.

The root of the issue is that `DashboardCardDomainSource` was fetching plans instead of domains:
https://github.com/wordpress-mobile/WordPress-Android/blob/4b8eada4a8d62573b3956a490d69304d0aec789f/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainSource.kt#L121

Additionally, the `shouldFetchDomains()` function is added to avoid unnecessarily fetchings when the card isn't shown.

> **Warning**
> A possible improvement is storing the result of `siteStore.fetchSiteDomains()` in db. Without it, we're showing wrong state until we fetch domains.

To test:
**When the feature flag is off**
1. Launch the JP app and log in, if the `dashboard_card_domain` feature flag is already disabled, go to step 5.
2. Go to App Settings. (Tap on Avatar at the top right hand corner on "My Site -> Find App Settings".)
3. Tap Debug Settings.
4. Find dashboard_card_domain under Remote features, disable it, and restart the app.
5. Navigate to "My Site →HOME".
6. Ensure there is no infinite loading indicator on the HOME screen.
7. Ensure there is no `Dispatching action: SiteAction-FETCHED_PLANS`,  `Dispatching action: SiteAction-FETCH_PLANS` or `SiteStore: Fetch site domains` messages in logs.

**When the feature flag is on**
1. Launch the JP app and log in, if the `dashboard_card_domain` feature flag is already enabled, go to step 5.
2. Go to App Settings. (Tap on Avatar at the top right hand corner on "My Site -> Find App Settings".)
3. Tap Debug Settings.
4. Find dashboard_card_domain under Remote features, enable it, and restart the app.
5. Navigate to "My Site →HOME".
6. Ensure there is no infinite loading indicator on the HOME screen.

> **Note**
> Verify logs in Android Studio Logcat or Application Log (Me -> Help -> Logs)

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
Nothing. This doesn't introduce a new feature to test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
