### PR TITLE
[Gutenberg] Update VideoPress upload processor (support self-closing block tag)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
@@ -12,6 +12,7 @@ import org.wordpress.android.util.helpers.MediaFile;
 import java.util.regex.Matcher;
 
 import static org.wordpress.android.ui.posts.mediauploadcompletionprocessors.MediaUploadCompletionProcessorPatterns.PATTERN_BLOCK_CAPTURES;
+import static org.wordpress.android.ui.posts.mediauploadcompletionprocessors.MediaUploadCompletionProcessorPatterns.PATTERN_SELF_CLOSING_BLOCK_CAPTURES;
 
 /**
  * Abstract class to be extended for each enumerated {@link MediaBlockType}.
@@ -62,16 +63,18 @@ public abstract class BlockProcessor {
         return document;
     }
 
-    private boolean splitBlock(String block) {
-        Matcher captures = PATTERN_BLOCK_CAPTURES.matcher(block);
+    private boolean splitBlock(String block, Boolean isSelfClosingTag) {
+        Matcher captures = (
+                isSelfClosingTag ? PATTERN_SELF_CLOSING_BLOCK_CAPTURES : PATTERN_BLOCK_CAPTURES
+        ).matcher(block);
 
         boolean capturesFound = captures.find();
 
         if (capturesFound) {
             mBlockName = captures.group(1);
             mJsonAttributes = parseJson(captures.group(2));
-            mBlockContentDocument = parseHTML(captures.group(3));
-            mClosingComment = captures.group(4);
+            mBlockContentDocument = isSelfClosingTag ? null : parseHTML(captures.group(3));
+            mClosingComment = isSelfClosingTag ? null : captures.group(4);
             return true;
         } else {
             mBlockName = null;
@@ -87,12 +90,22 @@ public abstract class BlockProcessor {
      * method should return the original block contents unchanged.
      *
      * @param block The raw block contents
+     * @param isSelfClosingTag True if the block tag is self-closing (e.g. <!-- wp:videopress/video {"id":100} /-->)
      * @return A string containing content with ids and urls replaced
      */
-    String processBlock(String block) {
-        if (splitBlock(block)) {
+    String processBlock(String block, Boolean isSelfClosingTag) {
+        if (splitBlock(block, isSelfClosingTag)) {
             if (processBlockJsonAttributes(mJsonAttributes)) {
-                if (processBlockContentDocument(mBlockContentDocument)) {
+                if (isSelfClosingTag) {
+                    // return injected block
+                    return new StringBuilder()
+                            .append("<!-- wp:")
+                            .append(mBlockName)
+                            .append(" ")
+                            .append(mJsonAttributes) // json parser output
+                            .append(" /-->")
+                            .toString();
+                } else if (processBlockContentDocument(mBlockContentDocument)) {
                     // return injected block
                     return new StringBuilder()
                             .append("<!-- wp:")
@@ -110,6 +123,10 @@ public abstract class BlockProcessor {
         }
         // leave block unchanged
         return block;
+    }
+
+    String processBlock(String block) {
+        return processBlock(block, false);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessorFactory.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessorFactory.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts.mediauploadcompletionprocessors;
 
-import org.wordpress.android.util.UriEncoder;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.util.HashMap;
@@ -18,7 +17,6 @@ import static org.wordpress.android.ui.posts.mediauploadcompletionprocessors.Med
 class BlockProcessorFactory {
     private final MediaUploadCompletionProcessor mMediaUploadCompletionProcessor;
     private final Map<MediaBlockType, BlockProcessor> mMediaBlockTypeBlockProcessorMap;
-    private final UriEncoder mUriEncoder;
 
     /**
      * This factory initializes block processors for all media block types and provides a method to retrieve a block
@@ -27,7 +25,6 @@ class BlockProcessorFactory {
     BlockProcessorFactory(MediaUploadCompletionProcessor mediaUploadCompletionProcessor) {
         mMediaUploadCompletionProcessor = mediaUploadCompletionProcessor;
         mMediaBlockTypeBlockProcessorMap = new HashMap<>();
-        mUriEncoder = new UriEncoder();
     }
 
     /**
@@ -38,7 +35,7 @@ class BlockProcessorFactory {
      */
     BlockProcessorFactory init(String localId, MediaFile mediaFile, String siteUrl) {
         mMediaBlockTypeBlockProcessorMap.put(IMAGE, new ImageBlockProcessor(localId, mediaFile));
-        mMediaBlockTypeBlockProcessorMap.put(VIDEOPRESS, new VideoPressBlockProcessor(localId, mediaFile, mUriEncoder));
+        mMediaBlockTypeBlockProcessorMap.put(VIDEOPRESS, new VideoPressBlockProcessor(localId, mediaFile));
         mMediaBlockTypeBlockProcessorMap.put(VIDEO, new VideoBlockProcessor(localId, mediaFile));
         mMediaBlockTypeBlockProcessorMap.put(MEDIA_TEXT, new MediaTextBlockProcessor(localId, mediaFile));
         mMediaBlockTypeBlockProcessorMap.put(GALLERY, new GalleryBlockProcessor(localId, mediaFile, siteUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorPatterns.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorPatterns.java
@@ -11,7 +11,7 @@ public class MediaUploadCompletionProcessorPatterns {
     public static final Pattern PATTERN_BLOCK_HEADER = Pattern.compile(new StringBuilder()
             .append(PATTERN_BLOCK_PREFIX)
             .append(MediaBlockType.getMatchingGroup())
-            .append(").*? -->\n?")
+            .append(").*? (/?-->)\n?")
             .toString(), Pattern.DOTALL);
 
     /**
@@ -38,5 +38,12 @@ public class MediaUploadCompletionProcessorPatterns {
             .append(" (\\{.*?\\}) -->\n?") // group: block header json
             .append("(.*)") // group: html content
             .append("(<!-- /wp:\\1 -->.*)") // group: closing-comment (name must match group 1: block type)
+            .toString(), Pattern.DOTALL);
+
+    public static final Pattern PATTERN_SELF_CLOSING_BLOCK_CAPTURES = Pattern.compile(new StringBuilder()
+            .append(PATTERN_BLOCK_PREFIX) // start-of-group: block type
+            .append(MediaBlockType.getMatchingGroup())
+            .append(")") // end-of-group: block type
+            .append(" (\\{.*?\\}) /-->\n?") // group: block header json
             .toString(), Pattern.DOTALL);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
@@ -2,170 +2,13 @@ package org.wordpress.android.ui.posts.mediauploadcompletionprocessors
 
 import com.google.gson.JsonObject
 import org.jsoup.nodes.Document
-import org.wordpress.android.util.UriEncoder
 import org.wordpress.android.util.helpers.MediaFile
 
 class VideoPressBlockProcessor(
     localId: String?,
-    mediaFile: MediaFile?,
-    private val uriEncoder: UriEncoder = UriEncoder()
+    mediaFile: MediaFile?
 ) : BlockProcessor(localId, mediaFile) {
-    class VideoPressBlockSettings(
-        var autoplay: Boolean? = null,
-        var controls: Boolean? = null,
-        var loop: Boolean? = null,
-        var muted: Boolean? = null,
-        private var persistVolume: Boolean? = null,
-        var playsinline: Boolean? = null,
-        var poster: String? = null,
-        var preload: String? = null,
-        var seekbarColor: String? = null,
-        var seekbarPlayedColor: String? = null,
-        var seekbarLoadingColor: String? = null,
-        var useAverageColor: Boolean? = null
-    ) {
-        constructor(jsonAttributes: JsonObject) : this() {
-            autoplay = jsonAttributes["autoplay"]?.asBoolean ?: false
-            controls = jsonAttributes["controls"]?.asBoolean ?: true
-            loop = jsonAttributes["loop"]?.asBoolean ?: false
-            jsonAttributes["muted"]?.asBoolean?.let { isMuted ->
-                muted = isMuted
-                persistVolume = !isMuted
-            }
-            playsinline = jsonAttributes["playsinline"]?.asBoolean ?: false
-            poster = jsonAttributes["poster"]?.toString()
-            preload = jsonAttributes["preload"]?.toString() ?: "metadata"
-            seekbarColor = jsonAttributes["seekbarColor"]?.toString()
-            seekbarPlayedColor = jsonAttributes["seekbarPlayedColor"]?.toString()
-            seekbarLoadingColor = jsonAttributes["seekbarLoadingColor"]?.toString()
-            useAverageColor = jsonAttributes["useAverageColor"]?.asBoolean ?: true
-        }
-    }
-
-    private var mBlockSettings = VideoPressBlockSettings()
-
-    /**
-     * Build VideoPress URL based on the values of the block's various settings.
-     * In order to have a cleaner URL, only the options differing from the default settings are added.
-     * Matches logic in Jetpack.
-     * Ref: https://github.com/Automattic/jetpack/blob/b1b826ab38690c5fad18789301ac81297a458878/projects/packages/videopress/src/client/lib/url/index.ts#L19-L67
-     *
-     */
-    private fun getVideoPressURL(guid: String): String {
-        val queryArgs = getDefaultQueryArgs()
-        getBlockSettingsQueryArgs(queryArgs, mBlockSettings)
-
-        val encodedQueryArgs = queryArgs.entries.joinToString("&") {
-            val encodedValue = it.value.removeSurrounding("\"")
-            "${uriEncoder.encode(it.key)}=${uriEncoder.encode(encodedValue)}"
-        }
-
-        return "https://videopress.com/v/$guid?$encodedQueryArgs"
-    }
-
-    private fun getDefaultQueryArgs(): MutableMap<String, String> {
-        return mutableMapOf(
-            "resizeToParent" to "true",
-            "cover" to "true"
-        )
-    }
-
-    private fun getBlockSettingsQueryArgs(
-        queryArgs: MutableMap<String, String>,
-        blockSettings: VideoPressBlockSettings
-    ) {
-        with(blockSettings) {
-            addAutoplayArg(queryArgs, autoplay)
-            addControlsArg(queryArgs, controls)
-            addLoopArg(queryArgs, loop)
-            addMutedAndPersistVolumeArgs(queryArgs, muted)
-            addPlaysinlineArg(queryArgs, playsinline)
-            addPosterArg(queryArgs, poster)
-            addPreloadArg(queryArgs, preload)
-            addSeekbarArgs(queryArgs, seekbarColor, seekbarPlayedColor, seekbarLoadingColor)
-            addUseAverageColorArg(queryArgs, useAverageColor)
-        }
-    }
-
-    // Adds AutoPlay option. Turned OFF by default.
-    private fun addAutoplayArg(queryArgs: MutableMap<String, String>, autoplay: Boolean?) {
-        if (autoplay == true) {
-            queryArgs["autoPlay"] = "true"
-        }
-    }
-
-    // Adds Controls option. Turned ON by default.
-    private fun addControlsArg(queryArgs: MutableMap<String, String>, controls: Boolean?) {
-        if (controls == false) {
-            queryArgs["controls"] = "false"
-        }
-    }
-
-    // Adds Loops option. Turned OFF by default.
-    private fun addLoopArg(queryArgs: MutableMap<String, String>, loop: Boolean?) {
-        if (loop == true) {
-            queryArgs["loop"] = "true"
-        }
-    }
-
-    // Adds Volume-related options. Muted: Turned OFF by default.
-    private fun addMutedAndPersistVolumeArgs(queryArgs: MutableMap<String, String>, muted: Boolean?) {
-        if (muted == true) {
-            queryArgs["muted"] = "true"
-            queryArgs["persistVolume"] = "false"
-        }
-    }
-
-    // Adds PlaysInline option. Turned OFF by default.
-    private fun addPlaysinlineArg(queryArgs: MutableMap<String, String>, playsinline: Boolean?) {
-        if (playsinline == true) {
-            queryArgs["playsinline"] = "true"
-        }
-    }
-
-    // Adds Poster option. No image by default.
-    private fun addPosterArg(queryArgs: MutableMap<String, String>, poster: String?) {
-        poster?.let { queryArgs["posterUrl"] = it }
-    }
-
-    // Adds Preload option. Metadata by default.
-    private fun addPreloadArg(queryArgs: MutableMap<String, String>, preload: String?) {
-        preload?.let { if (it.isNotEmpty()) queryArgs["preloadContent"] = it }
-    }
-
-    /**
-     * Adds Seekbar options.
-     * - SeekbarColor: No color by default.
-     * - SeekbarPlayerColor: No color by default.
-     * - SeekbarLoadingColor: No color by default.
-     */
-    private fun addSeekbarArgs(
-        queryArgs: MutableMap<String, String>,
-        seekbarColor: String?,
-        seekbarPlayedColor: String?,
-        seekbarLoadingColor: String?
-    ) {
-        seekbarColor?.let { if (it.isNotEmpty()) queryArgs["sbc"] = it }
-        seekbarPlayedColor?.let { if (it.isNotEmpty()) queryArgs["sbpc"] = it }
-        seekbarLoadingColor?.let { if (it.isNotEmpty()) queryArgs["sblc"] = it }
-    }
-
-    // Adds UseAverageColor option. Turned ON by default.
-    private fun addUseAverageColorArg(queryArgs: MutableMap<String, String>, useAverageColor: Boolean?) {
-        if (useAverageColor == true) {
-            queryArgs["useAverageColor"] = "true"
-        }
-    }
-
     override fun processBlockContentDocument(document: Document?): Boolean {
-        val videoPressElements = document?.select("figure")
-
-        if (videoPressElements != null) {
-            val url = getVideoPressURL(mRemoteGuid)
-            videoPressElements.append("<div class='jetpack-videopress-player__wrapper'>$url</div>")
-            return true
-        }
-
         return false
     }
 
@@ -177,9 +20,6 @@ class VideoPressBlockProcessor(
                 addProperty(ID_ATTRIBUTE, Integer.parseInt(mRemoteId))
                 addProperty(GUID_ATTRIBUTE, mRemoteGuid)
             }
-
-            mBlockSettings = VideoPressBlockSettings(jsonAttributes)
-
             true
         } else {
             false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
@@ -14,11 +14,15 @@ class VideoPressBlockProcessor(
 
     override fun processBlockJsonAttributes(jsonAttributes: JsonObject?): Boolean {
         val id = jsonAttributes?.get(ID_ATTRIBUTE)
+        val src = jsonAttributes?.get(SRC_ATTRIBUTE)?.asString
 
         return if (id != null && !id.isJsonNull && id.asString == mLocalId) {
             jsonAttributes.apply {
                 addProperty(ID_ATTRIBUTE, Integer.parseInt(mRemoteId))
                 addProperty(GUID_ATTRIBUTE, mRemoteGuid)
+                if (src?.startsWith("file:") == true) {
+                    remove(SRC_ATTRIBUTE)
+                }
             }
             true
         } else {
@@ -29,5 +33,6 @@ class VideoPressBlockProcessor(
     companion object {
         const val ID_ATTRIBUTE = "id"
         const val GUID_ATTRIBUTE = "guid"
+        const val SRC_ATTRIBUTE = "src"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaUploadCompletionProcessorTest.kt
@@ -38,6 +38,14 @@ class MediaUploadCompletionProcessorTest {
     }
 
     @Test
+    fun `processPost splices id and guid for a VideoPress block`() {
+        whenever(mediaFile.videoPressGuid).thenReturn(TestContent.videoPressGuid)
+        processor = MediaUploadCompletionProcessor(TestContent.localMediaId, mediaFile, TestContent.siteUrl)
+        val blocks = processor.processContent(TestContent.oldPostVideoPress)
+        Assertions.assertThat(blocks).isEqualTo(TestContent.newPostVideoPress)
+    }
+
+    @Test
     fun `processPost splices id and url for a media-text block`() {
         val blocks = processor.processContent(TestContent.oldPostMediaText)
         Assertions.assertThat(blocks).isEqualTo(TestContent.newPostMediaText)

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -672,6 +672,8 @@ $newRefactoredGalleryBlockInnerBlocks</figure>
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostVideo = paragraphBlock + newImageBlock + oldVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostVideo = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
+    const val oldPostVideoPress = paragraphBlock + newImageBlock + oldVideoPressBlockWithDefaultAttrs + newMediaTextBlock + newGalleryBlock
+    const val newPostVideoPress = paragraphBlock + newImageBlock + newVideoPressBlockWithDefaultAttrs + newMediaTextBlock + newGalleryBlock
     const val oldPostMediaText = paragraphBlock + newImageBlock + newVideoBlock + oldMediaTextBlock + newGalleryBlock
     const val newPostMediaText = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val oldPostGallery = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + oldGalleryBlock

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -660,7 +660,7 @@ $newRefactoredGalleryBlockInnerBlocks</figure>
 <figure class="wp-block-audio"><audio controls src="$remoteAudioUrl"></audio></figure>
 <!-- /wp:audio -->"""
 
-    const val oldVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${localMediaId}} /-->"""
+    const val oldVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${localMediaId}, "src":"${localVideoUrl}"} /-->"""
 
     const val newVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${remoteMediaId},"guid":"${videoPressGuid}"} /-->"""
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/TestContent.kt
@@ -660,21 +660,13 @@ $newRefactoredGalleryBlockInnerBlocks</figure>
 <figure class="wp-block-audio"><audio controls src="$remoteAudioUrl"></audio></figure>
 <!-- /wp:audio -->"""
 
-    const val oldVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${localMediaId}} -->
-<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
-<!-- /wp:videopress/video -->"""
+    const val oldVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${localMediaId}} /-->"""
 
-    const val newVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${remoteMediaId},"guid":"${videoPressGuid}"} -->
-<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">https://videopress.com/v/${videoPressGuid}?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true</div></figure>
-<!-- /wp:videopress/video -->"""
+    const val newVideoPressBlockWithDefaultAttrs = """<!-- wp:videopress/video {"id":${remoteMediaId},"guid":"${videoPressGuid}"} /-->"""
 
-    const val oldVideoPressBlockWithAttrs = """<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${localMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} -->
-<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
-<!-- /wp:videopress/video -->"""
+    const val oldVideoPressBlockWithAttrs = """<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${localMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} /-->"""
 
-    const val newVideoPressBlockWithAttrs = """<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${remoteMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false,"guid":"${videoPressGuid}"} -->
-<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">https://videopress.com/v/AbCdE?resizeToParent=true&amp;cover=true&amp;autoPlay=true&amp;controls=false&amp;loop=true&amp;muted=true&amp;persistVolume=false&amp;playsinline=true&amp;posterUrl=https%3A%2F%2Ftest.files.wordpress.com%2F2022%2F02%2F265-5000x5000-1.jpeg&amp;preloadContent=none&amp;sbc=%23abb8c3&amp;sbpc=%239b51e0&amp;sblc=%23cf2e2e</div></figure>
-<!-- /wp:videopress/video -->"""
+    const val newVideoPressBlockWithAttrs = """<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${remoteMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false,"guid":"${videoPressGuid}"} /-->"""
 
     const val oldPostImage = paragraphBlock + oldImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock
     const val newPostImage = paragraphBlock + newImageBlock + newVideoBlock + newMediaTextBlock + newGalleryBlock

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessorTest.kt
@@ -34,7 +34,7 @@ class VideoBlockProcessorTest {
     fun `processBlock leaves VideoPress block unchanged`() {
         val nonMatchingId = "123"
         val processor = VideoPressBlockProcessor(nonMatchingId, mediaFile)
-        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithDefaultAttrs)
+        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithDefaultAttrs, true)
         Assertions.assertThat(processedBlock).isEqualTo(TestContent.oldVideoPressBlockWithDefaultAttrs)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessorTest.kt
@@ -4,105 +4,33 @@ import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.wordpress.android.util.UriEncoder
 import org.wordpress.android.util.helpers.MediaFile
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 @RunWith(MockitoJUnitRunner::class)
 class VideoPressBlockProcessorTest {
     private val mediaFile: MediaFile = mock()
-    private val uriEncoder = Mockito.mock(UriEncoder::class.java)
     private lateinit var processor: VideoPressBlockProcessor
-
-    // Keys for each query in VideoPress URL.
-    private val resizeToParentKey = "resizeToParent"
-    private val coverKey = "cover"
-    private val autoPlayKey = "autoPlay"
-    private val controlsKey = "controls"
-    private val loopKey = "loop"
-    private val mutedKey = "muted"
-    private val persistVolumeKey = "persistVolume"
-    private val playsinlineKey = "playsinline"
-    private val posterUrlKey = "posterUrl"
-    private val preloadContentKey = "preloadContent"
-    private val sbcKey = "sbc"
-    private val sbpcKey = "sbpc"
-    private val sblcKey = "sblc"
-    private val useAverageColorKey = "useAverageColor"
-
-    // Un-encoded values for each query in VideoPress URL.
-    private val falseVal = "false"
-    private val trueVal = "true"
-    private val posterUrlVal = "https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg"
-    private val defaultPreloadContentVal = "metadata"
-    private val changedPreloadContentVal = "none"
-    private val sbcVal = "#abb8c3"
-    private val sbpcVal = "#9b51e0"
-    private val sblcVal = "#cf2e2e"
-
-    private val urlKeys = listOf(
-        resizeToParentKey,
-        coverKey,
-        autoPlayKey,
-        controlsKey,
-        loopKey,
-        mutedKey,
-        persistVolumeKey,
-        playsinlineKey,
-        posterUrlKey,
-        preloadContentKey,
-        sbcKey,
-        sbpcKey,
-        sblcKey,
-        useAverageColorKey
-    )
-    private val urlValues = listOf(
-        falseVal,
-        trueVal,
-        posterUrlVal,
-        defaultPreloadContentVal,
-        changedPreloadContentVal,
-        sbcVal,
-        sbpcVal,
-        sblcVal
-    )
 
     @Before
     fun before() {
         whenever(mediaFile.mediaId).thenReturn(TestContent.remoteMediaId)
         whenever(mediaFile.videoPressGuid).thenReturn(TestContent.videoPressGuid)
 
-        /*
-        * As Uri.encode is part of an Android class, it cannot run locally in unit tests by default.
-        * To workaround this, it has been replaced below with URLEncoder.encode, which works in a similar manner.
-        * Note, we cannot currently use URLEncoder.encode in the main app as it only runs with API 33 or later.
-        * We support a minimum of API 24.
-        */
-        for (key in urlKeys) {
-            whenever(uriEncoder.encode(key)).thenReturn(URLEncoder.encode(key, StandardCharsets.UTF_8))
-        }
-
-        for (value in urlValues) {
-            whenever(uriEncoder.encode(value)).thenReturn(URLEncoder.encode(value, StandardCharsets.UTF_8))
-        }
-
-        processor = VideoPressBlockProcessor(TestContent.localMediaId, mediaFile, uriEncoder)
+        processor = VideoPressBlockProcessor(TestContent.localMediaId, mediaFile)
     }
 
     @Test
-    fun `processBlock replaces id and contents in VideoPress block with default attributes`() {
-        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithDefaultAttrs)
+    fun `processBlock replaces id in VideoPress block with default attributes`() {
+        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithDefaultAttrs, true)
         Assertions.assertThat(processedBlock).isEqualTo(TestContent.newVideoPressBlockWithDefaultAttrs)
     }
 
     @Test
-    fun `processBlock replaces id and contents in VideoPress block with different attributes to the default`() {
-        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithAttrs)
+    fun `processBlock replaces id in VideoPress block with different attributes to the default`() {
+        val processedBlock = processor.processBlock(TestContent.oldVideoPressBlockWithAttrs, true)
         Assertions.assertThat(processedBlock).isEqualTo(TestContent.newVideoPressBlockWithAttrs)
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5678.

This PR updates the VideoPress upload processor following [a recent change in the block format](https://github.com/Automattic/jetpack/pull/30134). Additionally, the upload processor logic has been updated to support the self-closing block tag (e.g. `<!-- wp:videopress/video {"id":"1234","guid":"AbCdE" /-->`), as the VideoPress block uses this format. Note that most of the changes are reverting the modifications introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/18187 (https://github.com/wordpress-mobile/WordPress-Android/pull/18287/commits/1419183910c209a1e0b70b2d947409d26ae9c9e6).

## To test
_Testing instructions copied from https://github.com/wordpress-mobile/WordPress-Android/pull/18187._

1. Add a VideoPress block to an existing or new post.
2. Select the **choose from device** option and upload a video.
3. While there’s an ongoing upload, close the post with publishing changes.
4. Verify that you see the upload progress in the post summary.
5. Re-open the post and confirm the upload has completed.
6. Preview the post and observe that the video can be played.

### Default markup examples

**Example default markup before upload:**

```
<!-- wp:videopress/video {"id":"1234" /-->
```

**Example default markup after upload:**

```
<!-- wp:videopress/video {"id":"1234","guid":"AbCdE" /-->
```

### Markup with attributes examples

**Example markup before upload:**

```
<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${localMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} /-->
```

**Example markup after upload:**

```
<!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":${remoteMediaId},"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false,"guid":"${videoPressGuid}"} /-->
```

## Regression Notes
1. Potential unintended areas of impact

This change could impact other upload processors due to the change related to supporting the self-closing tag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested the VideoPress upload processor and checked the unit tests of other upload processors.

3. What automated tests I added (or what prevented me from doing so)

I added a test in https://github.com/wordpress-mobile/WordPress-Android/commit/0d1ce8eed0fde6a010300c6dcd9244348e060ddb and updated other unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
