### PR TITLE
[Sharing] Fix Tumblr form being pushed down

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -35,7 +35,6 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     private int mConnectionId;
     private WebView mWebView;
     private ProgressBar mProgress;
-    private View mNestedScrollView;
 
     @Inject AccountStore mAccountStore;
 
@@ -98,7 +97,6 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
 
         mProgress = rootView.findViewById(R.id.progress);
         mWebView = rootView.findViewById(R.id.webView);
-        mNestedScrollView = rootView.findViewById(R.id.publicize_webview_nested_scroll_view);
 
         mWebView.setWebViewClient(new PublicizeWebViewClient());
         mWebView.setWebChromeClient(new PublicizeWebChromeClient());
@@ -127,7 +125,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         super.onResume();
         setNavigationIcon(R.drawable.ic_close_white_24dp);
         if (getActivity() instanceof ScrollableViewInitializedListener) {
-            ((ScrollableViewInitializedListener) getActivity()).onScrollableViewInitialized(mNestedScrollView.getId());
+            ((ScrollableViewInitializedListener) getActivity()).onScrollableViewInitialized(mWebView.getId());
         }
     }
 

--- a/WordPress/src/main/res/layout/publicize_webview_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_webview_fragment.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/publicize_webview_nested_scroll_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <org.wordpress.android.ui.WPWebView
+        <org.wordpress.android.widgets.NestedWebView
             android:id="@+id/webView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
@@ -23,5 +19,4 @@
             android:visibility="gone"
             tools:visibility="visible" />
 
-    </RelativeLayout>
-</androidx.core.widget.NestedScrollView>
+</RelativeLayout>


### PR DESCRIPTION
Fixes #17401 

This fixes the bug reported in [this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/17401#issuecomment-1434061112) in the original issue.

The NestedScrollView behavior paired with the WebView was causing the `WebView` height to increase indefinitely while the Tumblr login was trying to center its content vertically, causing the login form to be pushed down.

This likely didn't happen with other services because they do not center their content vertically or at least don't do it the same way Tumblr was doing.

The correct solution though was to use the `NestedWebView`, which was created to avoid this kind of scroll issue that can affect WebViews inside scrolling layouts.

https://user-images.githubusercontent.com/5091503/233196569-d9cd10c8-78e6-4324-9442-c34606e4703d.mp4

To test:
1. Open Jetpack
2. Login with a WP.com account
3. Go to My Site > Menu > Sharing
4. Select `Tumblr`
5. Tap `Connect`
6. 🔎  **Verify the page loads correctly and scrolls normally, if needed**

Extra verification: check that the login page for the other services works as expected as well.

## Regression Notes
1. Potential unintended areas of impact
Connection pages for other services are affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A, UI only fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)

---

Note: tested with RTL and Talkback, but since this issue refers to a WebView, I am not assessing the content behavior for this.