### PR TITLE
Integrate gutenberg-mobile release 1.93.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.93.0'
+    gutenbergMobileVersion = '5690-e88716337ef8b50b1c71188428209258be8b48b6'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.25.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5690-0840f356a63edf3ded8a1df897ffedf997ff9ada'
+    gutenbergMobileVersion = 'v1.93.1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.25.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5690-e88716337ef8b50b1c71188428209258be8b48b6'
+    gutenbergMobileVersion = '5690-0840f356a63edf3ded8a1df897ffedf997ff9ada'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.25.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.93.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5690

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

**Note**: There are no release note updates for Android, since the only user-facing change is for iOS.