### PR TITLE
Fix dashboard card domain navigation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1605,7 +1605,7 @@ class MySiteViewModel @Inject constructor(
     private fun onDashboardCardDomainClick() {
         val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
         dashboardCardDomainUtils.trackDashboardCardDomainTapped(uiModel.value?.state as? SiteSelected)
-        _onNavigation.value = Event(SiteNavigationAction.OpenDomainRegistration(selectedSite))
+        _onNavigation.value = Event(SiteNavigationAction.OpenPaidDomainSearch(selectedSite))
     }
 
     private fun onDashboardCardDomainHideMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -60,6 +60,7 @@ sealed class SiteNavigationAction {
     ) : SiteNavigationAction()
 
     data class OpenDomainRegistration(val site: SiteModel) : SiteNavigationAction()
+    data class OpenPaidDomainSearch(val site: SiteModel) : SiteNavigationAction()
     data class AddNewSite(val hasAccessToken: Boolean, val source: SiteCreationSource) : SiteNavigationAction()
     data class ShowQuickStartDialog(
         @StringRes val title: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.TextInputDialogFragment
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.Companion.RESULT_REGISTERED_DOMAIN_EMAIL
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.CTA_DOMAIN_CREDIT_REDEMPTION
+import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.DOMAIN_PURCHASE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingDialogFragment
@@ -399,6 +400,12 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             action.site,
             CTA_DOMAIN_CREDIT_REDEMPTION
         )
+        is SiteNavigationAction.OpenPaidDomainSearch -> ActivityLauncher.viewDomainRegistrationActivityForResult(
+            this,
+            action.site,
+            DOMAIN_PURCHASE
+        )
+
         is SiteNavigationAction.AddNewSite -> SitePickerActivity.addSite(activity, action.hasAccessToken, action.source)
         is SiteNavigationAction.ShowQuickStartDialog -> showQuickStartDialog(
             action.title,


### PR DESCRIPTION
Pass domain_purchase parameter to list prices, and not as free

| Before | After |
|--------|--------|
| ![Screenshot_20230421_141050](https://user-images.githubusercontent.com/990349/233539063-89f62752-5ab8-47db-8c16-815a1c9cd374.png) | ![Screenshot_20230421_140158](https://user-images.githubusercontent.com/990349/233538542-0429e346-23a5-4363-9251-7c348ca3bf17.png) | 

Fixes #

To test:

- Launch Jetpack/WordPress app
- Verify **domain card** appears on the dashboard
- **Tap** on **domain card**
- **Verify** that it launches domains search
- **Verify** it shows prices listed for domains, and not free as before


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
