### PR TITLE
[Dependency Updates] Update `androidxComposeCompilerVersion` and `kotlinVersion` to 1.3.2 and 1.7.20

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/list/ActivityLogListFragment.kt
@@ -114,7 +114,7 @@ class ActivityLogListFragment : Fragment(R.layout.activity_log_list_fragment) {
         }
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         with(requireActivity()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/scan/details/ThreatDetailsFragment.kt
@@ -124,7 +124,7 @@ class ThreatDetailsFragment : Fragment(R.layout.threat_details_fragment) {
         threatActionDialog?.show()
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (requireActivity().intent.extras?.containsKey(WordPress.SITE) != true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
@@ -42,6 +42,7 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
         observeActionEvents()
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onBackPressed() {
         if (!viewModel.uiState.value.showCloseButton) return
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -106,7 +106,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         return view
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(bundle: Bundle?) {
         super.onActivityCreated(bundle)
         val listView = listView
@@ -455,6 +455,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             return pingbackUrl
         }
 
+        @Suppress("OVERRIDE_DEPRECATION")
         override fun doInBackground(vararg params: Void): List<NoteBlock>? {
             if (notification == null) {
                 return null
@@ -519,6 +520,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             )
         }
 
+        @Suppress("OVERRIDE_DEPRECATION")
         override fun onPostExecute(noteList: List<NoteBlock>?) {
             if (!isAdded || noteList == null) {
                 return

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -84,7 +84,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     private var lastTabPosition = 0
     private var binding: NotificationsListFragmentBinding? = null
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
@@ -278,17 +278,20 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         }
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onPrepareOptionsMenu(menu: Menu) {
         val notificationSettings = menu.findItem(R.id.notifications_settings)
         notificationSettings.isVisible = accountStore.hasAccessToken()
         super.onPrepareOptionsMenu(menu)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.notifications_list_menu, menu)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.notifications_settings) {
             ActivityLauncher.viewNotificationsSettings(activity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -84,7 +84,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         fun onClickNote(noteId: String?)
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         val adapter = createOrGetNotesAdapter()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -558,6 +558,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         )
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.menu_search, menu)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -30,27 +30,32 @@ open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwn
     val lifecycleScope: LifecycleCoroutineScope
         get() = lifecycle.coroutineScope
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.handleLifecycleEvent(ON_CREATE)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onStart() {
         super.onStart()
         lifecycleRegistry.handleLifecycleEvent(ON_START)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onPause() {
         super.onPause()
         lifecycleRegistry.handleLifecycleEvent(ON_PAUSE)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onStop() {
         super.onStop()
         lifecycleRegistry.handleLifecycleEvent(ON_STOP)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onDestroy() {
         super.onDestroy()
         lifecycleRegistry.handleLifecycleEvent(ON_DESTROY)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/categories/detail/CategoryDetailFragment.kt
@@ -173,17 +173,20 @@ class CategoryDetailFragment : Fragment(R.layout.category_detail_fragment) {
         categoryAdapter.replaceItems(categoryLevels)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.clear()
         inflater.inflate(R.menu.tag_detail, menu)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onPrepareOptionsMenu(menu: Menu) {
         super.onPrepareOptionsMenu(menu)
         menu.findItem(R.id.menu_trash).isVisible = isInEditMode
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.menu_trash) {
             confirmDeleteCategory()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -35,6 +35,7 @@ import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
@@ -864,7 +865,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
                 replaceRelatedPostDetailWithHistory(postId = this.postId, blogId = this.blogId)
 
-            is ReaderNavigationEvents.ShowPostInWebView -> showPostInWebView(post)
+            is ReaderNavigationEvents.ShowPostInWebView -> showPostInWebView(post, this@ReaderPostDetailFragment)
             is ReaderNavigationEvents.ShowEngagedPeopleList -> {
                 ActivityLauncher.viewPostLikesListActivity(
                     activity,
@@ -1505,14 +1506,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     }
 
     @Suppress("DEPRECATION")
-    private fun ReaderPostDetailFragment.showPostInWebView(post: ReaderPost) {
+    private fun showPostInWebView(post: ReaderPost, fragment: Fragment) {
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))
         renderer = ReaderPostRenderer(readerWebView, viewModel.post, readerCssProvider)
 
         // if the post is from private atomic site postpone render until we have a special access cookie
         if (post.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {
-            PrivateAtCookieRefreshProgressDialog.showIfNecessary(fragmentManager, this@ReaderPostDetailFragment)
+            PrivateAtCookieRefreshProgressDialog.showIfNecessary(fragmentManager, fragment)
             requestPrivateAtomicCookie()
         } else if (post.isPrivateAtomic && privateAtomicCookie.exists()) {
             // make sure we add cookie to the cookie manager if it exists before starting render

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1756,6 +1756,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         trackRelatedPostsIfShowing()
     }
 
+    @Suppress("SameParameterValue")
     private fun setRefreshing(refreshing: Boolean) {
         swipeToRefreshHelper.isRefreshing = refreshing
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -147,7 +147,7 @@ class StatsViewAllFragment : Fragment(R.layout.stats_view_all_fragment) {
         binding = null
     }
 
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LargeValueFormatter.kt
@@ -17,6 +17,7 @@ class LargeValueFormatter : ValueFormatter() {
     private var mMaxLength = 5
     private val mFormat: DecimalFormat = DecimalFormat("###E00", DecimalFormatSymbols(Locale.US))
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun getFormattedValue(
         value: Float,
         entry: Entry,

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
@@ -125,7 +125,7 @@ object AppRatingDialog {
             internal const val TAG_APP_RATING_PROMPT_DIALOG = "TAG_APP_RATING_PROMPT_DIALOG"
         }
 
-        @Suppress("SwallowedException")
+        @Suppress("SwallowedException", "OVERRIDE_DEPRECATION")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             val builder = MaterialAlertDialogBuilder(activity)
             val appName = getString(R.string.app_name)
@@ -166,6 +166,7 @@ object AppRatingDialog {
             return builder.create()
         }
 
+        @Suppress("OVERRIDE_DEPRECATION")
         override fun onCancel(dialog: DialogInterface?) {
             super.onCancel(dialog)
             clearSharedPreferences()

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
     androidxAppcompatVersion = '1.4.2'
     androidxArchCoreVersion = '2.1.0'
     androidxComposeVersion = '1.1.1'
-    androidxComposeCompilerVersion = '1.1.1'
+    androidxComposeCompilerVersion = '1.3.2'
     androidxComposeLifecycleVersion = '2.5.1'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.6.10'
+    gradle.ext.kotlinVersion = '1.7.20'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = "2.42"
     gradle.ext.detektVersion = '1.21.0'


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR update `androidxComposeCompilerVersion` and `kotlinVersion` to [1.3.2](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.3.2) and [1.7.20](https://github.com/JetBrains/kotlin/releases/tag/v1.7.20) respectively.

-----

Note that the latest [1.4.6](https://developer.android.com/jetpack/androidx/releases/compose-compiler#version_146_3) update of `androidxComposeCompilerVersion` and [1.8.20](https://github.com/JetBrains/kotlin/releases/tag/v1.8.20) of `kotlinVersion` has been decided to be done at a later point in time in order to avoid jumping 3 major versions, all at once (see [comment](https://github.com/wordpress-mobile/WordPress-Android/issues/17563#issuecomment-1415886958)).

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly, since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

FYI: For me to come down with the below testing instructions I first analysed the current state of `AndroidX Compose` in the codebase, identified all moving parts (🤞) and then, based on that graph (see below) I started pin-pointing and testing the relevant screens in order to get as much confident as possible that this update isn't breaking anything obvious.

PS.1: The `[X]` you would see next to some classes correspond to the number presented on the more explicit `Compose Compiler Update` related testing instruction below.

PS.2 I didn't test each specific `compose` related `components` as those, most probably (🤞), will be tested as part of testing the whole `Compose` related screens that are using those, thus you are seeing an asterisk (`*`) next to those, where I omit any files within.

<details>
    <summary>Current State of Compose: Graph [Per Source Set]</summary>

 - `Main`:
    - `Core`
        - WordPress/src/main/java/org/wordpress/android
            - ui/compose/*
            - util/extensions/ActivityExtensions
    - `Features`:
        - WordPress/src/main/java/org/wordpress/android/ui
            - blaze/ui/blazeoverlay
                - `BlazeOverlayFragment` [5]
                - `BlazeWebViewFragment` [5]
            - bloggingprompts
                - `BloggingPromptsListActivity` [6]
                - compose/*
            - jetpackoverlay
                - `JetpackStaticPosterActivity` [3]
                - individualplugin
                    - `WPJetpackIndividualPluginFragment` [7]
                    - compose/*
            - jetpackplugininstall
                - fullplugin
                    - install
                        - `JetpackFullPluginInstallActivity` [8]
                    - onboarding
                        - `JetpackFullPluginInstallOnboardingDialogFragment` [8]
                        - compose/*
                - install
                    - compose/*
                - remoteplugin
                    - `JetpackRemoteInstallActivity` [9]
            - main/jetpack
                - migration
                    - `JetpackMigrationFragment` [4]
                    - compose/*
                - staticposter
                    - `JetpackStaticPosterFragment` [3]
                    - compose/*
            - mysite/cards/jpfullplugininstall
                - `JetpackInstallFullPluginCardViewHolder` [8]
            - qrcodeauth
                - `QRCodeAuthFragment` [2]
                - compose/*
            - sitecreation/domains
                - `SiteCreationDomainViewHolder` [10]
                - compose/*
  - `WordPress`:
      - `Core`:
          - WordPress/src/wordpress/java/org/wordpress/android/ui
              - compose/*
      - `Features`:
          - WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login
              - `LoginPrologueRevampedFragment` [1]
              - components/*
  - `Jetpack`:
      - `Core`
          - N/A
      - `Features`:
          - WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/
              - `LoginPrologueRevampedFragment` [1]
              - components/*

</details>

I wanted to be thorough with the testing instructions here as I want to base all the subsequent such `Compose` updates on this template, which I will then copy-paste on all other such PRs, without redoing this test related documentation step.

Thus, it would be helpful if we get this right now, enhance it with whatever I might have missed, like a testing instruction here-and-there, which I don't know how to (quickly) complete, and then take all that as the source of truth (or at least the basis) for all other such `Compose` update, even future ones. All and every help I'll get from you here are VERY welcome! 🙏 ❤️ 🙇

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Per update:
    - Based on the `Kotlin` update, smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.
    - Based on the `Compose Compiler` update, thoroughly smoke test any Compose related screens, on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within:

#### Kotlin Update:

<details>
    <summary>Reader Post Detail Screen [ReaderPostDetailFragment.kt]</summary>

ℹ️ You would need to find a post that is private atomic and requiring cookie refresh.
❓ Unfortunately, I am not sure how to do that.

- Go to `Reader` tab -> `DISCOVER` sub-tab.
- Tab on a post to get to its post details screen.
- Verify that the `Post Detail` screen is shown and functioning as expected.

</details>

#### Compose Compiler Update:

<details>
    <summary>1. Login Screen [LoginPrologueRevampedFragment.kt]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.

- Log out of the app (if already logged-in).
- Verify that the `Login` screen is shown and functioning as expected.

</details>

<details>
    <summary>2. QR Code Auth Screen [QRCodeAuthFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
ℹ️ You don't have to follow all 3 steps, just logging in with a non `A8C` and non `2FA` enabled
account, followed by tapping the `Scan Login Code` item on the `Me` screen should be enough, which
is effectively just `Step.1` and the beginning of `Step.3`.

Step.1:
- Build and install the `Jetpack` app (note that you don't need a release build, a debug build will
suffice).
- Login to the `Jetpack` app with a `WP.com` account (note that you need to use a non `A8C` account
and a non `2FA` enabled account).
- Navigate to the `Me` screen (click on avatar at top-right).
(STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to `wordpress.com` (note that if you are logged-in, log-out first).
- Tap the `Log In` link (top-right).
- Tap the `Login via the mobile app` link in the list of options below the main Continue button
(bottom-middle).
- Verify you are on the `Login via the mobile app` view and `Use QR Code to login` is shown, along with
a QR code for you to scan.
- (STOP)

Step.3:
- Head back to your mobile.
- Tap the `Scan Login Code` item on the `Me` screen you are currently at.
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to login to WordPress on your web browser (desktop),
verify that you have successfully logged-in and are able to use WordPress as expected.

</details>

<details>
    <summary>3a. Jetpack Static Poster Screen [JetpackStaticPosterActivity.kt + JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Stats` option.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Stats` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>3b. Jetpack Static Poster Screen [JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `Reader` or `Notifications` tab.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Reader` or `Notifications` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>4. Jetpack Migration Screen [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the card on top that prompts the user to uninstall the WordPress app and click on it.
- Verify that the `Jetpack Migration` screen is shown and functioning as expected.

</details>

<details>
    <summary>5. Blaze Screen [BlazeOverlayFragment.kt + BlazeWebViewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Blaze` option.
- Verify that the `Blaze` screen is shown and functioning as expected.

</details>

<details>
    <summary>6. Blogging Prompts Screen [BloggingPromptsListActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the `Prompts` card on top and click on its options (top right).
- From the options menu, select `View more prompts`.
- Verify that the `Blogging Prompts` screen is shown and functioning as expected.

</details>

<details>
    <summary>7. Individual Plugin Screen [WPJetpackIndividualPluginFragment.kt]</summary>

❓️ Not sure how to best and quickly test this, let me know if you have an idea.

- TODO
- TODO
- TODO

</details>

<details>
    <summary>8. Jetpack Full Plugin Install Screen [JetpackFullPluginInstallOnboardingDialogFragment.kt + JetpackFullPluginInstallActivity.kt + JetpackInstallFullPluginCardViewHolder.kt]</summary>

❓️ Not sure how to best and quickly test this, let me know if you have an idea.

- TODO
- TODO
- TODO

</details>

<details>
    <summary>9. Jetpack Remove Install Screen [JetpackRemoteInstallActivity.kt]</summary>

❓️ Not sure how to best and quickly test this, let me know if you have an idea.

- TODO
- TODO
- TODO

</details>

<details>
    <summary>10. Site Creation Domain Screen [SiteCreationDomainViewHolder.kt]</summary>

❗️ Not sure if it is worth testing this, but I am leaving it here just in case as I am seeing this
this Compose related `DisposeOnViewTreeLifecycleDestroyed` import that related to this
`Remove this for Compose 1.2.0-beta02+ and RecyclerView 1.3.0-alpha02+` TODO comment.
❓ Maybe it is worth testing this with the `RecyclerView 1.3.1` update later on and by the end of
updating Compose/Kotlin and all its related libraries (see description).
https://github.com/wordpress-mobile/WordPress-Android/issues/17563

- TODO
- TODO
- TODO

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all Compose related screens, like the `Login` screen, the `Jetpack Migration` screens or the `Blaze` green (to name a few).

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
