### PR TITLE
 Implement final screen UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -23,10 +23,8 @@ import org.wordpress.android.databinding.SiteCreationPreviewScreenDefaultBinding
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity.Companion.ARG_STATE
 import org.wordpress.android.ui.sitecreation.SiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.SiteCreationState
-import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewData
-import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewLoadingShimmerState
-import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewWebErrorUiState
+import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.UrlData
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ErrorManagedWebViewClient.ErrorManagedWebViewClientListener
 import org.wordpress.android.util.URLFilteredWebViewClient
@@ -85,11 +83,9 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     private fun SiteCreationPreviewScreenDefaultBinding.observeState() {
         viewModel.uiState.observe(this@SiteCreationPreviewFragment) {
             it?.let { ui ->
-                when (ui) {
-                    is SitePreviewContentUiState -> updateContentLayout(ui.data)
-                    is SitePreviewWebErrorUiState -> updateContentLayout(ui.data)
-                    is SitePreviewLoadingShimmerState -> updateContentLayout(ui.data, isFirstContent = true)
-                }
+                uiHelpers.setTextOrHide(siteCreationPreviewHeaderItem.sitePreviewSubtitle, ui.subtitle)
+                uiHelpers.setTextOrHide(sitePreviewCaption, ui.caption)
+                updateContentLayout(ui.urlData, isFirstContent = ui is SitePreviewLoadingShimmerState)
                 siteCreationPreviewWebViewContainer.apply {
                     uiHelpers.updateVisibility(sitePreviewWebView, ui.webViewVisibility)
                     uiHelpers.updateVisibility(sitePreviewWebError, ui.webViewErrorVisibility)
@@ -110,10 +106,10 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     }
 
     private fun SiteCreationPreviewScreenDefaultBinding.updateContentLayout(
-        sitePreviewData: SitePreviewData,
+        urlData: UrlData,
         isFirstContent: Boolean = false,
     ) {
-        sitePreviewData.apply {
+        urlData.apply {
             siteCreationPreviewWebViewContainer.sitePreviewWebUrlTitle.text = createSpannableUrl(
                 requireNotNull(activity),
                 shortUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -64,10 +64,10 @@ class SitePreviewViewModel @Inject constructor(
     private var webviewFullyLoadedTracked = false
 
     private var siteDesign: String? = null
-    private var urlWithoutScheme: String? = null
     private var isFree: Boolean = true
 
     private lateinit var result: Created
+    private lateinit var domainName: String
 
     private val _uiState: MutableLiveData<SitePreviewUiState> = MutableLiveData()
     val uiState: LiveData<SitePreviewUiState> = _uiState
@@ -83,8 +83,8 @@ class SitePreviewViewModel @Inject constructor(
         require(siteCreationState.result is Created)
         siteDesign = siteCreationState.siteDesign
         result = siteCreationState.result
-        urlWithoutScheme = result.site.url
         isFree = requireNotNull(siteCreationState.domain).isFree
+        domainName = requireNotNull(siteCreationState.domain).domainName
         startPreLoadingWebView()
         if (result is CreatedButNotFetched) {
             launch {
@@ -115,7 +115,7 @@ class SitePreviewViewModel @Inject constructor(
             }
         }
         // Load the newly created site in the webview
-        urlWithoutScheme?.let { url ->
+        result.site.url?.let { url ->
             val urlToLoad = urlUtils.addUrlSchemeIfNeeded(
                 url = url,
                 addHttps = isWordPressComSubDomain(url)
@@ -160,7 +160,7 @@ class SitePreviewViewModel @Inject constructor(
     }
 
     private fun createSitePreviewData(): UrlData {
-        val url = urlWithoutScheme ?: ""
+        val url = domainName
         val subDomain = urlUtils.extractSubDomain(url)
         val fullUrl = urlUtils.addUrlSchemeIfNeeded(url, true)
         val subDomainIndices = 0 to subDomain.length

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiHelpers.kt
@@ -58,9 +58,11 @@ class UiHelpers @Inject constructor() {
         view.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
-    fun setTextOrHide(view: TextView, uiString: UiString?) {
-        val text = uiString?.let { getTextOfUiString(view.context, uiString) }
-        setTextOrHide(view, text)
+    fun setTextOrHide(view: TextView?, uiString: UiString?) {
+        view?.let {
+            val text = uiString?.let { getTextOfUiString(view.context, uiString) }
+            setTextOrHide(view, text)
+        }
     }
 
     fun setTextOrHide(view: TextView, @StringRes resId: Int?) {

--- a/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
@@ -23,6 +23,13 @@
             android:id="@+id/site_creation_preview_header_item"
             layout="@layout/site_creation_preview_header_item" />
 
+        <TextView
+            android:id="@+id/sitePreviewCaption"
+            style="@style/SiteCreationHeaderV2Subtitle"
+            android:lineSpacingExtra="@null"
+            android:paddingBottom="@null"
+            android:text="@string/new_site_creation_preview_caption_paid" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/okButton"
             style="@style/WordPress.Button.Primary"
@@ -38,7 +45,10 @@
         layout="@layout/site_creation_preview_web_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_margin="@dimen/margin_large"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
         android:layout_toStartOf="@+id/sitePreviewTitleAndButtonContainer" />
 </RelativeLayout>
 

--- a/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
@@ -38,9 +38,7 @@
         layout="@layout/site_creation_preview_web_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_extra_medium_large"
-        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_margin="@dimen/margin_large"
         android:layout_toStartOf="@+id/sitePreviewTitleAndButtonContainer" />
 </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/site_creation_header_v2.xml
+++ b/WordPress/src/main/res/layout/site_creation_header_v2.xml
@@ -9,8 +9,6 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/title"
         style="@style/SiteCreationHeaderV2Title"
-        android:lineSpacingExtra="-4sp"
-        android:letterSpacing="0.01"
         android:paddingBottom="@dimen/margin_large"
         app:fixWidowWords="true"
         app:autoSizeTextType="uniform"
@@ -20,8 +18,6 @@
         android:id="@+id/subtitle"
         style="@style/SiteCreationHeaderV2Subtitle"
         android:paddingBottom="@dimen/margin_extra_medium_large"
-        android:lineSpacingExtra="5sp"
-        android:letterSpacing="0.01"
         app:fixWidowWords="true"
         tools:text="@string/new_site_creation_intents_header_subtitle" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
@@ -6,11 +6,20 @@
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/sitePreviewTitle"
-        style="@style/SiteCreationPreviewHeaderTitle"
-        app:fixWidowWords="true" />
+        style="@style/SiteCreationHeaderV2Title"
+        android:lineSpacingExtra="-4sp"
+        android:letterSpacing="0.01"
+        android:paddingBottom="@dimen/margin_large"
+        android:text="@string/new_site_creation_preview_title"
+        app:fixWidowWords="true"
+        app:autoSizeTextType="uniform" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/sitePreviewSubtitle"
-        style="@style/SiteCreationPreviewHeaderSubtitle"
+        style="@style/SiteCreationHeaderV2Subtitle"
+        android:paddingBottom="@dimen/margin_large"
+        android:lineSpacingExtra="5sp"
+        android:letterSpacing="0.01"
+        android:text="@string/new_site_creation_preview_subtitle"
         app:fixWidowWords="true" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
@@ -16,7 +16,7 @@
         android:id="@+id/sitePreviewSubtitle"
         style="@style/SiteCreationHeaderV2Subtitle"
         android:lineSpacingExtra="@null"
-        android:paddingBottom="@dimen/margin_large"
+        android:paddingBottom="@null"
         android:text="@string/new_site_creation_preview_subtitle"
         app:fixWidowWords="true" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_header_item.xml
@@ -7,8 +7,6 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/sitePreviewTitle"
         style="@style/SiteCreationHeaderV2Title"
-        android:lineSpacingExtra="-4sp"
-        android:letterSpacing="0.01"
         android:paddingBottom="@dimen/margin_large"
         android:text="@string/new_site_creation_preview_title"
         app:fixWidowWords="true"
@@ -17,9 +15,8 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/sitePreviewSubtitle"
         style="@style/SiteCreationHeaderV2Subtitle"
+        android:lineSpacingExtra="@null"
         android:paddingBottom="@dimen/margin_large"
-        android:lineSpacingExtra="5sp"
-        android:letterSpacing="0.01"
         android:text="@string/new_site_creation_preview_subtitle"
         app:fixWidowWords="true" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
@@ -13,10 +13,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_marginBottom="@dimen/margin_extra_medium_large"
-        android:layout_marginEnd="@dimen/margin_large"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_extra_medium_large" />
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginVertical="@dimen/margin_large" />
 
     <include
         android:id="@+id/site_creation_preview_web_view_container"

--- a/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
@@ -24,8 +24,7 @@
         android:layout_above="@+id/sitePreviewOkButtonContainer"
         android:layout_below="@id/site_creation_preview_header_item"
         android:layout_marginBottom="@dimen/negative_margin_medium"
-        android:layout_marginLeft="@dimen/site_creation_preview_web_view_side_margin"
-        android:layout_marginRight="@dimen/site_creation_preview_web_view_side_margin" />
+        android:layout_marginHorizontal="@dimen/margin_extra_large" />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/sitePreviewOkButtonContainer"

--- a/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
@@ -21,10 +21,19 @@
         layout="@layout/site_creation_preview_web_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/sitePreviewOkButtonContainer"
+        android:layout_above="@+id/sitePreviewCaption"
         android:layout_below="@id/site_creation_preview_header_item"
-        android:layout_marginBottom="@dimen/negative_margin_medium"
         android:layout_marginHorizontal="@dimen/margin_extra_large" />
+
+    <TextView
+        android:id="@+id/sitePreviewCaption"
+        style="@style/SiteCreationHeaderV2Subtitle"
+        android:layout_above="@+id/sitePreviewOkButtonContainer"
+        android:lineSpacingExtra="@null"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:paddingBottom="@null"
+        android:text="@string/new_site_creation_preview_caption_paid" />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/sitePreviewOkButtonContainer"
@@ -32,7 +41,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/site_creation_preview_ok_button_container_height"
         android:layout_alignParentBottom="true"
-        android:layout_marginTop="@dimen/margin_medium"
+        android:layout_marginTop="@dimen/margin_large"
         app:cardElevation="@dimen/site_creation_container_elevation"
         tools:ignore="InconsistentLayout">
 

--- a/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
@@ -6,8 +6,11 @@
     style="@style/Widget.MaterialComponents.CardView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:cardCornerRadius="0dp"
-    app:cardElevation="@dimen/card_elevation">
+    android:layout_marginBottom="@dimen/margin_small"
+    app:cardCornerRadius="@dimen/margin_large"
+    app:cardElevation="@dimen/card_elevation"
+    app:strokeColor="@color/site_creation_preview_card_border"
+    app:strokeWidth="@dimen/margin_extra_extra_small">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_web_view_container.xml
@@ -6,7 +6,6 @@
     style="@style/Widget.MaterialComponents.CardView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="@dimen/margin_small"
     app:cardCornerRadius="@dimen/margin_large"
     app:cardElevation="@dimen/card_elevation"
     app:strokeColor="@color/site_creation_preview_card_border"

--- a/WordPress/src/main/res/values-land/styles.xml
+++ b/WordPress/src/main/res/values-land/styles.xml
@@ -2,5 +2,6 @@
 <resources>
     <style name="SiteCreationHeaderV2Title" parent="SiteCreationHeaderV2Title.Base">
         <item name="android:textSize">@dimen/text_sz_double_extra_large</item>
+        <item name="android:lineSpacingExtra">@null</item>
     </style>
 </resources>

--- a/WordPress/src/main/res/values-land/styles.xml
+++ b/WordPress/src/main/res/values-land/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SiteCreationHeaderV2Title" parent="SiteCreationHeaderV2Title.Base">
+        <item name="android:textSize">@dimen/text_sz_double_extra_large</item>
+    </style>
+</resources>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -99,6 +99,7 @@
 
     <!-- Site creation  -->
     <color name="site_creation_intent_item_emoji_bg">#3d3d3d</color>
+    <color name="site_creation_preview_card_border">@color/white_translucent_20</color>
 
     <!-- Jetpack Migration -->
     <color name="bg_jp_migration_buttons_panel">#E6121212</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -130,6 +130,7 @@
     <!-- Site creation  -->
     <color name="site_creation_skip_button_text">@color/blue_50</color>
     <color name="site_creation_intent_item_emoji_bg">@color/grey_lighten_30</color>
+    <color name="site_creation_preview_card_border">@color/black_translucent_20</color>
 
     <!-- Jetpack Migration -->
     <color name="bg_jp_migration_buttons_panel">@color/white_translucent_80</color>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -528,7 +528,6 @@
     <dimen name="site_creation_verticals_clear_search_icon_size">24dp</dimen>
     <dimen name="site_creation_verticals_clear_search_clickable_area_width">48dp</dimen>
 
-    <dimen name="site_creation_preview_web_view_side_margin">40dp</dimen>
     <dimen name="site_creation_preview_ok_button_container_height">68dp</dimen>
     <dimen name="site_creation_container_elevation">6dp</dimen>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3331,6 +3331,8 @@
     <string name="new_site_creation_screen_title_step_count">%1$d of %2$d</string>
     <string name="new_site_creation_preview_title">Your site has been created!</string>
     <string name="new_site_creation_preview_subtitle">You\'ll be able to customize the look and feel of your site later</string>
+    <string name="new_site_creation_preview_subtitle_paid">We’ve emailed your receipt. %s</string>
+    <string name="new_site_creation_preview_caption_paid">It may take up to 30 minutes for your custom domain to start working.</string>
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1191,29 +1191,6 @@
         <item name="android:focusable">true</item>
     </style>
 
-    <style name="SiteCreationHeaderBaseTextStyle">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:gravity">center</item>
-        <item name="android:textAlignment">center</item>
-        <item name="android:textAppearance">?attr/textAppearanceSubtitle1</item>
-    </style>
-
-    <style name="SiteCreationHeaderSubtitle" parent="SiteCreationHeaderBaseTextStyle">
-        <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
-    </style>
-
-    <style name="SiteCreationPreviewHeaderTitle" parent="SiteCreationHeaderBaseTextStyle">
-        <item name="android:layout_marginBottom">@dimen/margin_small</item>
-        <item name="android:fontFamily">sans-serif-medium</item>
-        <item name="android:textAppearance">?attr/textAppearanceHeadline6</item>
-        <item name="android:text">@string/new_site_creation_preview_title</item>
-    </style>
-
-    <style name="SiteCreationPreviewHeaderSubtitle" parent="SiteCreationHeaderSubtitle">
-        <item name="android:text">@string/new_site_creation_preview_subtitle</item>
-    </style>
-
     <style name="SitePreviewSkeletonView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_marginTop">@dimen/margin_large</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1553,7 +1553,7 @@
         <item name="android:ellipsize">end</item>
     </style>
 
-    <style name="SiteCreationHeaderV2Title" parent="SiteCreationHeaderV2Text">
+    <style name="SiteCreationHeaderV2Title.Base" parent="SiteCreationHeaderV2Text">
         <item name="android:paddingTop">@dimen/mlp_titles_top_margin</item>
         <item name="android:paddingBottom">@dimen/margin_small_medium</item>
         <item name="android:textAppearance">?attr/textAppearanceHeadline4</item>
@@ -1561,6 +1561,8 @@
         <item name="android:maxLines">3</item>
         <item name="fontFamily">serif</item>
     </style>
+
+    <style name="SiteCreationHeaderV2Title" parent="SiteCreationHeaderV2Title.Base" />
 
     <style name="SiteCreationHeaderV2Subtitle" parent="SiteCreationHeaderV2Text">
         <item name="android:paddingTop">@dimen/margin_small</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1559,6 +1559,8 @@
         <item name="android:textAppearance">?attr/textAppearanceHeadline4</item>
         <item name="android:textStyle">bold</item>
         <item name="android:maxLines">3</item>
+        <item name="android:letterSpacing">0.01</item>
+        <item name="android:lineSpacingExtra">-4sp</item>
         <item name="fontFamily">serif</item>
     </style>
 
@@ -1570,6 +1572,8 @@
         <item name="android:textAppearance">?attr/textAppearanceBody1</item>
         <item name="android:maxLines">5</item>
         <item name="android:alpha">0.6</item>
+        <item name="android:letterSpacing">0.01</item>
+        <item name="android:lineSpacingExtra">5sp</item>
         <item name="fontFamily">sans-serif</item>
     </style>
 


### PR DESCRIPTION
Resolves #17906

This PR:
- ★ Updates the final screen UI
- ⊕ Adds require additional info for paid domains
- ⊜ Fixes the url that is displayed to match the iOS implementation, showing the custom domain when following a purchase

## To Test

#### Prerequisite
<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
</details>

### ● Treatment Variation

- **Verify** All updates from the task are implemented. Expect:
  - Title typeface updated
  - Landscape view adapted accordingly
  - Preview card has rounded corners and proper paddings
  - Paid domains have additional info on the receipt and delay until the custom domain is guaranteed to work
  - Preview card shows custom domain at the top


### ○ Control Variation

- **Verify** No regression. The UI tweaks are fine, they don't have to be hidden behind the feature flag.

### Previews

#### Portrait - Light
| ● | ○ |
| - | - |
| <img width="315" src="https://user-images.githubusercontent.com/4588074/233894046-02a04943-1b77-4294-843e-90bc370b5334.png"> | <img width="315" src="https://user-images.githubusercontent.com/4588074/233893916-3483dced-5aae-4d18-a09a-4765cd6183eb.png"> |

| Landscape - Light |
| - |
| <img width="720" src="https://user-images.githubusercontent.com/4588074/233896651-e53c4aea-1f66-4f54-9416-7b7310f0a7e8.png"> |
| <img width="720" src="https://user-images.githubusercontent.com/4588074/233894311-1f1aa877-4ab0-4332-b119-3bd48736546d.png"> |

#### Portrait - Dark
| ● | ○ |
| - | - |
| <img width="315" src="https://user-images.githubusercontent.com/4588074/233894494-dbc409b1-a47f-44b8-84df-09426629799b.png"> | <img width="315" src="https://user-images.githubusercontent.com/4588074/233894406-ebdd7c8a-db93-481a-b590-e207b45fb35b.png"> |

| Landscape - Dark |
| - |
| <img width="720" src="https://user-images.githubusercontent.com/4588074/233897005-ada96d4f-5d80-4ef5-a9e9-0b007215e1be.png"> |
| <img width="720" src="https://user-images.githubusercontent.com/4588074/233894759-81995e0b-4223-4f2e-a2d8-f61d29fc7eac.png"> |

## Regression Notes

1. Potential unintended areas of impact
   - `Site Creation` → `Large Titles` because of small refactoring
   - Landscape view - had to decrease title font size

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

8. What automated tests I added (or what prevented me from doing so)
   We don't have automated tests for small UI changes and they're inefficient. We could have snapshot testing though but that's a big step not in scope of this task.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
