### PR TITLE
Dashboard Cards: Activity Card implement onclick behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -165,6 +165,7 @@ import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_LAUNCHE
 import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_POST_LOCAL_ID;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_ID_KEY;
+import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModelKt.ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY;
 import static org.wordpress.android.viewmodel.activitylog.ActivityLogViewModelKt.ACTIVITY_LOG_REWINDABLE_ONLY_KEY;
 
@@ -819,6 +820,26 @@ public class ActivityLauncher {
         intent.putExtra(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, isRestoreHidden);
         intent.putExtra(SOURCE_TRACK_EVENT_PROPERTY_KEY, source);
         activity.startActivityForResult(intent, RequestCodes.ACTIVITY_LOG_DETAIL);
+    }
+
+    public static void viewActivityLogDetailFromDashboardCard(
+            Activity activity,
+            SiteModel site,
+            String activityId,
+            Boolean isRewindable
+    ) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ACTIVITY_LOG_ACTIVITY_ID_KEY, activityId);
+        properties.put(SOURCE_TRACK_EVENT_PROPERTY_KEY, ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE);
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.ACTIVITY_LOG_DETAIL_OPENED, site, properties);
+
+        Intent intent = new Intent(activity, ActivityLogDetailActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(ACTIVITY_LOG_ID_KEY, activityId);
+        intent.putExtra(ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY, true);
+        intent.putExtra(ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY, isRewindable);
+        intent.putExtra(SOURCE_TRACK_EVENT_PROPERTY_KEY, ACTIVITY_LOG_TRACK_EVENT_PROPERTY_VALUE);
+        activity.startActivity(intent);
     }
 
     public static void viewScan(Activity activity, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -113,21 +113,21 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
     }
 
     private fun ActivityLogItemDetailBinding.setupObservers() {
-        viewModel.activityLogItem.observe(viewLifecycleOwner, { activityLogModel ->
+        viewModel.activityLogItem.observe(viewLifecycleOwner) { activityLogModel ->
             loadLogItem(activityLogModel, requireActivity())
-        })
+        }
 
-        viewModel.restoreVisible.observe(viewLifecycleOwner, { available ->
+        viewModel.restoreVisible.observe(viewLifecycleOwner) { available ->
             activityRestoreButton.visibility = if (available == true) View.VISIBLE else View.GONE
-        })
-        viewModel.downloadBackupVisible.observe(viewLifecycleOwner, { available ->
+        }
+        viewModel.downloadBackupVisible.observe(viewLifecycleOwner) { available ->
             activityDownloadBackupButton.visibility = if (available == true) View.VISIBLE else View.GONE
-        })
-        viewModel.multisiteVisible.observe(viewLifecycleOwner, { available ->
+        }
+        viewModel.multisiteVisible.observe(viewLifecycleOwner) { available ->
             checkAndShowMultisiteMessage(available)
-        })
+        }
 
-        viewModel.navigationEvents.observeEvent(viewLifecycleOwner, {
+        viewModel.navigationEvents.observeEvent(viewLifecycleOwner) {
             when (it) {
                 is ShowBackupDownload -> ActivityLauncher.showBackupDownloadForResult(
                     requireActivity(),
@@ -145,9 +145,9 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                 )
                 is ShowDocumentationPage -> ActivityLauncher.openUrlExternal(requireContext(), it.url)
             }
-        })
+        }
 
-        viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner, { range ->
+        viewModel.handleFormattableRangeClick.observe(viewLifecycleOwner) { range ->
             if (range != null) {
                 formattableContentClickHandler.onClick(
                     requireActivity(),
@@ -155,7 +155,7 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
                     ReaderTracker.SOURCE_ACTIVITY_LOG_DETAIL
                 )
             }
-        })
+        }
 
         viewModel.showJetpackPoweredBottomSheet.observeEvent(viewLifecycleOwner) {
             JetpackPoweredBottomSheetFragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/activitylog/detail/ActivityLogDetailFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.AVATAR_WITH_BACKGROUND
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_ID_KEY
+import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY
 import org.wordpress.android.viewmodel.activitylog.ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY
 import org.wordpress.android.viewmodel.activitylog.ActivityLogDetailViewModel
 import org.wordpress.android.viewmodel.observeEvent
@@ -85,8 +86,9 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
             val (site, activityLogId) = sideAndActivityId(savedInstanceState, activity.intent)
             val areButtonsVisible = areButtonsVisible(savedInstanceState, activity.intent)
             val isRestoreHidden = isRestoreHidden(savedInstanceState, activity.intent)
+            val isDashboardCardEntry = isDashboardCardEntry(savedInstanceState, activity.intent)
 
-            viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden)
+            viewModel.start(site, activityLogId, areButtonsVisible, isRestoreHidden, isDashboardCardEntry)
         }
 
         if (jetpackBrandingUtils.shouldShowJetpackBranding()) {
@@ -259,12 +261,21 @@ class ActivityLogDetailFragment : Fragment(R.layout.activity_log_item_detail) {
         else -> throw Throwable("Couldn't initialize Activity Log view model")
     }
 
+    private fun isDashboardCardEntry(savedInstanceState: Bundle?, intent: Intent?) = when {
+        savedInstanceState != null ->
+            requireNotNull(savedInstanceState.getBoolean(ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY, false))
+        intent != null ->
+            intent.getBooleanExtra(ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY, false)
+        else -> throw Throwable("Couldn't initialize Activity Log view model")
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putSerializable(WordPress.SITE, viewModel.site)
         outState.putString(ACTIVITY_LOG_ID_KEY, viewModel.activityLogId)
         outState.putBoolean(ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY, viewModel.areButtonsVisible)
         outState.putBoolean(ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY, viewModel.isRestoreHidden)
+        outState.putBoolean(ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY, viewModel.isDashboardCardEntry)
     }
 
     private fun ActivityLogItemDetailBinding.setActorIcon(actorIcon: String?, showJetpackIcon: Boolean?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -103,9 +103,14 @@ sealed class MySiteCardAndItemBuilderParams {
     data class ActivityCardBuilderParams(
         val site: SiteModel,
         val activityCardModel: CardModel.ActivityCardModel?,
-        val onActivityItemClick: (activityId: String) -> Unit,
+        val onActivityItemClick: (activityCardItemClickParams: ActivityCardItemClickParams) -> Unit,
         val onFooterLinkClick: () -> Unit
-    ) : MySiteCardAndItemBuilderParams()
+    ) : MySiteCardAndItemBuilderParams() {
+        data class ActivityCardItemClickParams(
+            val activityId: String,
+            val isRewindable: Boolean
+        )
+    }
 
     data class SiteItemsBuilderParams(
         val site: SiteModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -721,9 +721,10 @@ class MySiteViewModel @Inject constructor(
         // implement navigation logic for activity item
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun onActivityCardFooterLinkClick() {
-        // implement navigation logic for activity card footer link
+        // implement track event for activity card footer link
+        _onNavigation.value =
+            Event(SiteNavigationAction.OpenActivityLog(requireNotNull(selectedSiteRepository.getSelectedSite())))
     }
 
     private fun buildJetpackBadgeIfEnabled(): JetpackBadge? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.JetpackBadge
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams.ActivityCardItemClickParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloggingPromptCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardDomainBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
@@ -620,7 +621,7 @@ class MySiteViewModel @Inject constructor(
                     activityCardModel = cardsUpdate?.cards?.firstOrNull {
                         it is ActivityCardModel
                     } as? ActivityCardModel,
-                    onActivityItemClick = this::onActivityItemClick,
+                    onActivityItemClick = this::onActivityCardItemClick,
                     onFooterLinkClick = this::onActivityCardFooterLinkClick
                 ),
             ),
@@ -716,9 +717,16 @@ class MySiteViewModel @Inject constructor(
         // implement navigation logic for create page
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    private fun onActivityItemClick(activityId: String) {
-        // implement navigation logic for activity item
+    private fun onActivityCardItemClick(activityCardItemClickParams: ActivityCardItemClickParams) {
+        // implement track event for activity item click
+        _onNavigation.value =
+            Event(
+                SiteNavigationAction.OpenActivityLogDetail(
+                    requireNotNull(selectedSiteRepository.getSelectedSite()),
+                    activityCardItemClickParams.activityId,
+                    activityCardItemClickParams.isRewindable
+                )
+            )
     }
 
     private fun onActivityCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -85,4 +85,6 @@ sealed class SiteNavigationAction {
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
     data class OpenPromoteWithBlazeOverlay(val source: BlazeFlowSource) : SiteNavigationAction()
     object ShowJetpackRemovalStaticPostersView : SiteNavigationAction()
+    data class OpenActivityLogDetail(val site: SiteModel, val activityId: String, val isRewindable: Boolean) :
+        SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard.ActivityCardWithItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard.ActivityCardWithItems.ActivityItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams.ActivityCardItemClickParams
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -40,17 +41,21 @@ class ActivityCardBuilder @Inject constructor(
         )
     }
 
-    private fun List<ActivityLogModel>.mapToActivityItems(onClick: (activityId: String) -> Unit) =
-        map {
-            ActivityItem(
-                label = UiString.UiStringText(it.content?.text?:""),
-                subLabel = it.summary,
-                displayDate = buildDateLine(it.published),
-                icon = ActivityLogListItem.Icon.fromValue(it.gridicon).drawable,
-                iconBackgroundColor = ActivityLogListItem.Status.fromValue(it.status).color,
-                onClick = ListItemInteraction.create(it.activityID, onClick),
+    private fun List<ActivityLogModel>.mapToActivityItems(
+        onClick: (activityCardItemClickParams: ActivityCardItemClickParams) -> Unit
+    ) = map {
+        ActivityItem(
+            label = UiString.UiStringText(it.content?.text ?: ""),
+            subLabel = it.summary,
+            displayDate = buildDateLine(it.published),
+            icon = ActivityLogListItem.Icon.fromValue(it.gridicon).drawable,
+            iconBackgroundColor = ActivityLogListItem.Status.fromValue(it.status).color,
+            onClick = ListItemInteraction.create(
+                ActivityCardItemClickParams(it.activityID, it.rewindable ?: false),
+                onClick
             )
-        }
+        )
+    }
 
     private fun buildDateLine(published: Date) = dateTimeUtilsWrapper.javaDateToTimeSpan(published)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -441,7 +441,12 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         is SiteNavigationAction.ShowJetpackRemovalStaticPostersView -> {
             ActivityLauncher.showJetpackStaticPoster(requireActivity())
         }
-        is SiteNavigationAction.OpenActivityLogDetail -> {}
+        is SiteNavigationAction.OpenActivityLogDetail -> ActivityLauncher.viewActivityLogDetailFromDashboardCard(
+            activity,
+            action.site,
+            action.activityId,
+            action.isRewindable
+        )
     }
 
     private fun showJetpackPoweredBottomSheet() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -441,6 +441,7 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         is SiteNavigationAction.ShowJetpackRemovalStaticPostersView -> {
             ActivityLauncher.showJetpackStaticPoster(requireActivity())
         }
+        is SiteNavigationAction.OpenActivityLogDetail -> {}
     }
 
     private fun showJetpackPoweredBottomSheet() {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -30,6 +30,7 @@ import javax.inject.Inject
 const val ACTIVITY_LOG_ID_KEY: String = "activity_log_id_key"
 const val ACTIVITY_LOG_ARE_BUTTONS_VISIBLE_KEY: String = "activity_log_are_buttons_visible_key"
 const val ACTIVITY_LOG_IS_RESTORE_HIDDEN_KEY: String = "activity_log_is_restore_hidden_key"
+const val ACTIVITY_LOG_IS_DASHBOARD_CARD_ENTRY_KEY: String = "activity_log_is_dashboard_card_entry_key"
 
 @HiltViewModel
 class ActivityLogDetailViewModel @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -43,6 +43,7 @@ class ActivityLogDetailViewModel @Inject constructor(
     lateinit var activityLogId: String
     var areButtonsVisible = false
     var isRestoreHidden = false
+    var isDashboardCardEntry = false
 
     private val _navigationEvents = MutableLiveData<Event<ActivityLogDetailNavigationEvents>>()
     val navigationEvents: LiveData<Event<ActivityLogDetailNavigationEvents>>
@@ -75,12 +76,14 @@ class ActivityLogDetailViewModel @Inject constructor(
         site: SiteModel,
         activityLogId: String,
         areButtonsVisible: Boolean,
-        isRestoreHidden: Boolean
+        isRestoreHidden: Boolean,
+        isDashboardCardEntry: Boolean
     ) {
         this.site = site
         this.activityLogId = activityLogId
         this.areButtonsVisible = areButtonsVisible
         this.isRestoreHidden = isRestoreHidden
+        this.isDashboardCardEntry = isDashboardCardEntry
 
         _restoreVisible.value = areButtonsVisible && !isRestoreHidden
         _downloadBackupVisible.value = areButtonsVisible

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -91,10 +91,16 @@ class ActivityLogDetailViewModel @Inject constructor(
         _multisiteVisible.value = if (isRestoreHidden) Pair(true, getMultisiteMessage()) else Pair(false, null)
 
         if (activityLogId != _item.value?.activityID) {
-            _item.value = activityLogStore
-                .getActivityLogForSite(site)
-                .find { it.activityID == activityLogId }?.toActivityLogDetailModel()
+            findAndPostActivityLogItemDetail()
         }
+    }
+
+    private fun findAndPostActivityLogItemDetail() {
+        activityLogStore
+            .getActivityLogForSite(site)
+            .find { it.activityID == activityLogId }?.toActivityLogDetailModel()?.let {
+                _item.postValue(it)
+            }
     }
 
     private fun ActivityLogModel.toActivityLogDetailModel() =

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -126,12 +126,14 @@ class ActivityLogDetailViewModel @Inject constructor(
             cardsStore.getCards(site, listOf(CardModel.Type.ACTIVITY))
                 .map { it.model }
                 .collect { result ->
-                    (result?.get(0) as? CardModel.ActivityCardModel)
-                        ?.activities
-                        ?.firstOrNull { it.activityID == activityLogId }
-                        ?.toActivityLogDetailModel()?.let {
-                            _item.postValue(it)
-                        }?.let { _item.postValue(null) }
+                    _item.postValue(
+                        result.takeIf { !it.isNullOrEmpty() }
+                            ?.let { activityCardModelList ->
+                                (activityCardModelList[0] as CardModel.ActivityCardModel)
+                                    .activities
+                                    .find { it.activityID == activityLogId }
+                                    ?.toActivityLogDetailModel()
+                            })
                 }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel.ActivityActor
 import org.wordpress.android.fluxc.store.ActivityLogStore
 import org.wordpress.android.fluxc.tools.FormattableRange
@@ -92,24 +93,24 @@ class ActivityLogDetailViewModel @Inject constructor(
         if (activityLogId != _item.value?.activityID) {
             _item.value = activityLogStore
                 .getActivityLogForSite(site)
-                .find { it.activityID == activityLogId }
-                ?.let {
-                    ActivityLogDetailModel(
-                        activityID = it.activityID,
-                        rewindId = it.rewindID,
-                        actorIconUrl = it.actor?.avatarURL,
-                        showJetpackIcon = it.actor?.showJetpackIcon(),
-                        isRewindButtonVisible = it.rewindable ?: false,
-                        actorName = it.actor?.displayName,
-                        actorRole = it.actor?.role,
-                        content = it.content,
-                        summary = it.summary,
-                        createdDate = it.published.toFormattedDateString(),
-                        createdTime = it.published.toFormattedTimeString()
-                    )
-                }
+                .find { it.activityID == activityLogId }?.toActivityLogDetailModel()
         }
     }
+
+    private fun ActivityLogModel.toActivityLogDetailModel() =
+        ActivityLogDetailModel(
+            activityID = activityID,
+            rewindId = rewindID,
+            actorIconUrl = actor?.avatarURL,
+            showJetpackIcon = actor?.showJetpackIcon(),
+            isRewindButtonVisible = rewindable ?: false,
+            actorName = actor?.displayName,
+            actorRole = actor?.role,
+            content = content,
+            summary = summary,
+            createdDate = published.toFormattedDateString(),
+            createdTime = published.toFormattedTimeString()
+        )
 
     private fun getMultisiteMessage(): SpannableString {
         val clickableText = resourceProvider.getString(R.string.activity_log_visit_our_documentation_page)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
@@ -62,7 +62,7 @@ class ActivityCardBuilderTest : BaseUnitTest() {
     private val activityCardModel = ActivityCardModel(activities = listOf(activityLogModel))
 
     private val onActivityCardFooterLinkClick: () -> Unit = {}
-    private val onActivityItemClick: (String) -> Unit = {}
+    private val onActivityItemClick: (ActivityCardBuilderParams.ActivityCardItemClickParams) -> Unit = {}
 
     @Before
     fun setUp() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.store.ActivityLogStore
+import org.wordpress.android.fluxc.store.dashboard.CardsStore
 import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.fluxc.tools.FormattableRange
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailModel
@@ -48,6 +49,11 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
 
     @Mock
     private lateinit var site: SiteModel
+
+    @Mock
+    private lateinit var cardsStore: CardsStore
+
+
     private lateinit var viewModel: ActivityLogDetailViewModel
 
     private val areButtonsVisible = true
@@ -92,7 +98,10 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
             dispatcher,
             activityLogStore,
             resourceProvider,
-            htmlMessageUtils
+            htmlMessageUtils,
+            cardsStore,
+            testDispatcher(),
+            testDispatcher()
         )
         viewModel.activityLogItem.observeForever { lastEmittedItem = it }
         viewModel.restoreVisible.observeForever { restoreVisible = it }
@@ -117,7 +126,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(false, restoreVisible)
     }
@@ -127,7 +136,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(false, restoreVisible)
     }
@@ -137,7 +146,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(true, restoreVisible)
     }
@@ -147,7 +156,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(false, restoreVisible)
     }
@@ -157,7 +166,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(false, downloadBackupVisible)
     }
@@ -167,7 +176,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertEquals(true, downloadBackupVisible)
     }
@@ -177,7 +186,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertFalse(multisiteVisible.first)
         assertNull(multisiteVisible.second)
@@ -188,7 +197,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertTrue(multisiteVisible.first)
         assertNotNull(multisiteVisible.second)
@@ -198,7 +207,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
     fun emitsUIModelOnStart() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -217,7 +226,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -237,7 +246,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -250,11 +259,11 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
     fun doesNotReemitUIModelOnStartWithTheSameActivityID() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertNull(lastEmittedItem)
     }
@@ -267,11 +276,11 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val secondActivity = activityLogModel.copy(activityID = activityID2, content = updatedContent)
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel, secondActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID2, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID2, areButtonsVisible, isRestoreHidden, false)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -286,7 +295,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
 
         lastEmittedItem = mock()
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden)
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
 
         assertNull(lastEmittedItem)
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -449,7 +449,6 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val updatedContent = FormattableContent(text = changedText)
         val secondActivity = activityLogModel.copy(activityID = ACTIVITY_ID, content = updatedContent)
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel, secondActivity))
-        whenever(cardsStore.getCards(any(), any())).thenReturn(flowOf(data))
 
         lastEmittedItem = null
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
+
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class ActivityLogDetailViewModelTest : BaseUnitTest() {
@@ -126,7 +127,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(false, restoreVisible)
     }
@@ -136,7 +137,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(false, restoreVisible)
     }
@@ -146,7 +147,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(true, restoreVisible)
     }
@@ -156,7 +157,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(false, restoreVisible)
     }
@@ -166,7 +167,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = false
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(false, downloadBackupVisible)
     }
@@ -176,7 +177,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertEquals(true, downloadBackupVisible)
     }
@@ -186,7 +187,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = false
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertFalse(multisiteVisible.first)
         assertNull(multisiteVisible.second)
@@ -197,7 +198,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val areButtonsVisible = true
         val isRestoreHidden = true
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(areButtonsVisible = areButtonsVisible, isRestoreHidden = isRestoreHidden)
 
         assertTrue(multisiteVisible.first)
         assertNotNull(multisiteVisible.second)
@@ -207,7 +208,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
     fun emitsUIModelOnStart() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -226,7 +227,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -246,7 +247,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         )
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(updatedActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -259,11 +260,11 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
     fun doesNotReemitUIModelOnStartWithTheSameActivityID() {
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         assertNull(lastEmittedItem)
     }
@@ -276,11 +277,11 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         val secondActivity = activityLogModel.copy(activityID = activityID2, content = updatedContent)
         whenever(activityLogStore.getActivityLogForSite(site)).thenReturn(listOf(activityLogModel, secondActivity))
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         lastEmittedItem = null
 
-        viewModel.start(site, activityID2, areButtonsVisible, isRestoreHidden, false)
+        startViewModel(activityID = activityID2)
 
         assertNotNull(lastEmittedItem)
         lastEmittedItem?.let {
@@ -295,7 +296,7 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
 
         lastEmittedItem = mock()
 
-        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, false)
+        startViewModel()
 
         assertNull(lastEmittedItem)
     }
@@ -351,5 +352,15 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         navigationEvents.last().peekContent()?.let {
             assertEquals(model, (it as ActivityLogDetailNavigationEvents.ShowBackupDownload).model)
         }
+    }
+
+    private fun startViewModel(
+        site: SiteModel = this.site,
+        activityID: String = this.activityID,
+        areButtonsVisible: Boolean = this.areButtonsVisible,
+        isRestoreHidden: Boolean = this.isRestoreHidden,
+        isDashboardCardEntry: Boolean = false
+    ) {
+        viewModel.start(site, activityID, areButtonsVisible, isRestoreHidden, isDashboardCardEntry)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -441,7 +441,6 @@ class ActivityLogDetailViewModelTest : BaseUnitTest() {
         startViewModel(activityID = ACTIVITY_ID, isDashboardCardEntry = true)
 
         assertNotNull(lastEmittedItem)
-        //verify(mySiteSourceManager).refresh()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogDetailViewModelTest.kt
@@ -35,7 +35,6 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Date
 
-
 /* ACTIVITY */
 const val ACTIVITY_ID = "activity123"
 const val ACTIVITY_SUMMARY = "activity"


### PR DESCRIPTION
Closes #18217 

This PR implements the click actions for the ActivityLog dashboard card
- On footer row click (View All Activity), navigate to Activity Log view
- On activity card item click, navigate to Activity detail view
- Modifications were made to the activity item onClick handler to allow for a multiple parameters in the form of `ActivityCardItemClickParams` instead of a single string. 
- `ActivityLogDetailViewModel` was refactored to check for the presence of activityId in activity log table first and then check the dashboard cards table (if entry was from the activity card)
- Multiple refactors to `ActivityLogDetailViewModelTest` to support the changes in `ActivityLogDetailViewModel

Notes:
- A decision was made that when accessing the detail view via the activity card, the rewind/backup-download buttons will be managed by the isRewinable attribute on the ActivityLog item itself. If there's a restore / backup running already, the user will still be able to see and tap the restore / backup buttons, but they'll get an error message when they attempt to kick it off. This is preexisting behavior.
- Event tracking will follow in a separate PR


**To test:**
**Activity Detail View is shown when tapping on activity card item BEFORE visiting activity log list**
1. Install the Jetpack app (do a fresh install - want to make sure the DB is clear)
2. Login with a wp account
3. Select a site in which you can access the activity log (manage content/admin)
4. Navigate to App Setting > Debug Settings 
5. Enable `dashboard_card_activity_log` and restart the app
6. Navigate to Home tab
7. Scroll to the activity card 
8. Tap on an activity item 
9. ✅ Verify you are taken to the Activity Detail view
----------------
**Activity Log list is shown when tapping on Footer link**
1. Continue from test above
2. Navigate back to the home tab
4. Scroll to the activity card 
5. Tap on an footer link "View all activity"
6. ✅ Verify you are taken to the Activity Log list view
---------------
**Activity Detail View is shown when tapping on activity card item AFTER visiting activity log list**
1. Continue from test above
2. Navigate back to the home tab
3. Scroll to the activity card 
4. Tap on an activity item 
5. ✅ Verify you are taken to the Activity Detail view

## Regression Notes
1. Potential unintended areas of impact
Activity Log detail view doesn't function correctly when accessed via the activity dashboard card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and new unit test

4. What automated tests I added (or what prevented me from doing so)
Add tests to `ActivityLogDetailViewModelTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
