### PR TITLE
Dashboard Cards: Activity Card tweak UI

### DIFF
--- a/WordPress/src/main/res/layout/my_site_activity_card_item.xml
+++ b/WordPress/src/main/res/layout/my_site_activity_card_item.xml
@@ -8,7 +8,8 @@
     android:clipChildren="false"
     android:clipToPadding="false"
     android:foreground="?attr/selectableItemBackground"
-    android:padding="@dimen/my_site_card_row_padding">
+    android:paddingHorizontal="@dimen/activity_card_row_start_end_padding"
+    android:paddingVertical="@dimen/activity_card_row_top_bottom_padding">
 
     <ImageView
         android:id="@+id/icon"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -745,6 +745,8 @@
     <dimen name="menu_item_icon_size">24dp</dimen>
 
     <!-- Activity Log Card -->
-    <dimen name="activity_card_icon_size">48dp</dimen>
+    <dimen name="activity_card_icon_size">40dp</dimen>
+    <dimen name="activity_card_row_start_end_padding">16dp</dimen>
+    <dimen name="activity_card_row_top_bottom_padding">12dp</dimen>
 
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1887,7 +1887,7 @@
     <style name="MySiteCardItemActivityCardLabel">
         <item name="android:textAlignment">viewStart</item>
         <item name="android:textAppearance">?attr/textAppearanceBody2</item>
-        <item name="android:layout_marginTop">@dimen/margin_medium</item>
+        <item name="android:layout_marginTop">@dimen/margin_small</item>
         <item name="android:textColor">?attr/wpColorOnSurfaceMedium</item>
     </style>
 </resources>


### PR DESCRIPTION
Closes #18307 

This PR tweaks the Activity Card UI
- Tightens spacing
- Decreases icon size from 48dp to 40dp to match the Activity Log list view

Before Light | After Light
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/233706932-6df118ce-3014-4be6-a163-caa7649551c0.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/233706934-f85f81d1-bb8c-4588-9dc0-ce46f548610c.png">

Before Dark | After Dark
-- | --
<img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/233706931-cff5b1f0-788c-45af-8f1b-e9a97f440776.png"> | <img width="250" height="500" alt="Alt desc" src="https://user-images.githubusercontent.com/506707/233706933-de9e1963-d206-4705-961c-c346f8a75ba6.png">

**To test:**
1. Install the Jetpack app
2. Login with a wp account
3. Select a site in which you can access the activity log (manage content/admin)
4. Navigate to App Setting > Debug Settings 
5. Enable `dashboard_card_activity_log` and restart the app
6. Navigate to Home
7. ✅ Verify that the activity card is matches the requested changes


## Regression Notes
1. Potential unintended areas of impact
Activity card does not have enough spacing

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

