### PR TITLE
Dashboard Cards: Activity Card implement tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -718,7 +718,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun onActivityCardItemClick(activityCardItemClickParams: ActivityCardItemClickParams) {
-        // implement track event for activity item click
+        cardsTracker.trackActivityCardItemClicked()
         _onNavigation.value =
             Event(
                 SiteNavigationAction.OpenActivityLogDetail(
@@ -730,7 +730,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     private fun onActivityCardFooterLinkClick() {
-        // implement track event for activity card footer link
+        cardsTracker.trackActivityCardFooterClicked()
         _onNavigation.value =
             Event(SiteNavigationAction.OpenActivityLog(requireNotNull(selectedSiteRepository.getSelectedSite())))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
@@ -97,7 +97,7 @@ class CardsShownTracker @Inject constructor(
                 Type.PAGES.label
             )
         )
-        is DashboardCard.ActivityCard -> trackCardShown(
+        is DashboardCard.ActivityCard.ActivityCardWithItems -> trackCardShown(
             Pair(
                 card.dashboardCardType.toTypeValue().label,
                 Type.ACTIVITY.label

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -26,7 +26,7 @@ class CardsTracker @Inject constructor(
         BLOGGING_PROMPT("blogging_prompt"),
         PROMOTE_WITH_BLAZE("promote_with_blaze"),
         PAGES("pages"),
-        ACTIVITY("activity"),
+        ACTIVITY("activity_log"),
         DASHBOARD_CARD_DOMAIN("dashboard_card_domain"),
     }
 
@@ -47,6 +47,10 @@ class CardsTracker @Inject constructor(
         CREATE_NEXT("create_next"),
         DRAFT("draft"),
         SCHEDULED("scheduled")
+    }
+
+    enum class ActivityLogSubtype(val label: String) {
+        ACTIVITY_LOG("activity_log"),
     }
 
     fun trackQuickStartCardItemClicked(quickStartTaskType: QuickStartTaskType) {
@@ -71,6 +75,14 @@ class CardsTracker @Inject constructor(
 
     fun trackPostItemClicked(postCardType: PostCardType) {
         trackCardItemClicked(Type.POST.label, postCardType.toSubtypeValue().label)
+    }
+
+    fun trackActivityCardItemClicked() {
+        trackCardItemClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
+    }
+
+    fun trackActivityCardFooterClicked() {
+        trackCardFooterLinkClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
     }
 
     private fun trackCardFooterLinkClicked(type: String, subtype: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -9,11 +9,14 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard.ActivityCardWithItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
@@ -77,6 +80,13 @@ class CardsShownTrackerTest {
         )
     }
 
+    @Test
+    fun `when activity card is shown, then activity log shown event is tracked`() {
+        cardsShownTracker.track(buildActivityDashboardCards())
+
+        verifyCardShownTracked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
+    }
+
     private fun verifyCardShownTracked(type: String, subtype: String) {
         verify(analyticsTracker).track(
             Stat.MY_SITE_DASHBOARD_CARD_SHOWN,
@@ -124,6 +134,21 @@ class CardsShownTrackerTest {
             footerLink = FooterLink(UiStringText(""), onClick = mock())
         )
     )
+
+    private fun buildActivityDashboardCards() = DashboardCards(
+        cards = mutableListOf<DashboardCard>().apply {
+            addAll(buildActivityCard())
+        }
+    )
+
+    private fun buildActivityCard() =
+        listOf(
+            ActivityCardWithItems(
+                title = UiStringText("title"),
+                footerLink = ActivityCard.FooterLink(UiStringText("footer"), onClick = mock()),
+                activityItems = emptyList()
+            )
+        )
 
     private fun buildErrorCard(): DashboardCards {
         val cards = listOf(ErrorCard(onRetryClick = mock()))

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.verify
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.StatsSubtype
@@ -117,6 +118,20 @@ class CardsTrackerTest {
         cardsTracker.trackPostItemClicked(PostCardType.SCHEDULED)
 
         verifyCardItemClickedTracked(Type.POST, PostSubtype.SCHEDULED.label)
+    }
+
+    @Test
+    fun `when activity log item is clicked, then activity card item event is tracked`() {
+        cardsTracker.trackActivityCardItemClicked()
+
+        verifyCardItemClickedTracked(Type.ACTIVITY, ActivityLogSubtype.ACTIVITY_LOG.label)
+    }
+
+    @Test
+    fun `when activity card footer link is clicked, then footer link clicked is tracked`() {
+        cardsTracker.trackActivityCardFooterClicked()
+
+        verifyFooterLinkClickedTracked(Type.ACTIVITY, ActivityLogSubtype.ACTIVITY_LOG.label)
     }
 
     private fun verifyFooterLinkClickedTracked(


### PR DESCRIPTION
Closes #18219 

This PR adds tracks events for Activity Card:
- `my_site_dashboard_card_shown` - when the Activity card is shown
- `my_site_dashboard_card_item_tapped` - when an Activity log item is tapped within the card
- `my_site_dashboard_card_footer_action_tapped` - when the activity card footer link is tapped

**Merge Instructions**
- Ensure that #18306 has been merged
- Remove Not Ready for Merge Label
- Merge as normal

cc: @startuptester - testing milestone

**To test:**
1. Install the Jetpack app
2. Login with a wp account
3. Select a site in which you can access the activity log (manage content/admin)
4. Navigate to App Settings > Privacy Settings 
5. Enable Collect Information
6. Navigate to back App Settings > Debug Settings 
7. Enable `dashboard_card_activity_log` and restart the app
9. Navigate to Home
10. ✅ Verify logs contain:  🔵 Tracked: my_site_dashboard_card_shown, Properties: {"type":"activity_log","subtype":"activity_log"}
11. Locate the Activity Card and tap on the "View all activity" footer link
12. ✅ Verify logs contain:  🔵 Tracked: my_site_dashboard_card_footer_action_tapped, Properties: {"type":"activity_log","subtype":"activity_log"}
13. Navigate back to Home
14. Locate the Activity Card and tap on an activity log item row
15.  ✅ Verify logs contain: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"activity_log","subtype":"activity_log"}

## Regression Notes
1. Potential unintended areas of impact
Events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
Added tests to `CardsTrackerTest` and `CardsShownTrackerTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

