### PR TITLE
Dashboard Card Domain: Do not show card on P2s

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domain/DashboardCardDomainUtils.kt
@@ -40,6 +40,7 @@ class DashboardCardDomainUtils @Inject constructor(
                 !isDashboardCardDomainHiddenByUser(siteModel.siteId) &&
                 (siteModel.isWPCom || siteModel.isWPComAtomic) &&
                 siteModel.isAdmin &&
+                !siteModel.isWpForTeamsSite &&
                 !hasSiteCustomDomains &&
                 !isDomainCreditAvailable
     }


### PR DESCRIPTION
This PR adds a condition to not show card on P2s

Fixes #18293 

To test:
| Before | After |
|--------|--------|
| ![Screenshot_20230424_080026](https://user-images.githubusercontent.com/990349/233869593-646b1e07-1083-4f60-9948-85290417b1f9.png) | ![Screenshot_20230424_080741](https://user-images.githubusercontent.com/990349/233869606-ea930e4c-79c3-47d7-9864-cc99d0fb9ae1.png)  |

To test:

- Launch Jetpack/WordPress app
- Verify **domain card** appears as shown above on dashboard for P2s as in Before
- Launch this version of JP/WP app
- Verify **domain card** doesn't show now on P2s as in after above


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested for conditions

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
