### PR TITLE
[Dependency Updates] Add and Update `androidxComposeBomVersion` to 2023.01.00

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -495,20 +495,23 @@ dependencies {
     lintChecks "org.wordpress:lint:$wordPressLintVersion"
 
     // Jetpack Compose
+    def composeBom = platform("androidx.compose:compose-bom:$androidxComposeBomVersion")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
     // - Jetpack Compose - Android Studio
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$androidxComposeVersion"
-    debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
+    debugImplementation "androidx.compose.ui:ui-tooling"
     // - Jetpack Compose - Main
-    implementation "androidx.compose.runtime:runtime:$androidxComposeVersion"
-    implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-    implementation "androidx.compose.foundation:foundation:$androidxComposeVersion"
-    implementation "androidx.compose.foundation:foundation-layout:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-graphics:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-text:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-unit:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
-    implementation "androidx.compose.material:material:$androidxComposeVersion"
+    implementation "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.runtime:runtime-livedata"
+    implementation "androidx.compose.foundation:foundation"
+    implementation "androidx.compose.foundation:foundation-layout"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-graphics"
+    implementation "androidx.compose.ui:ui-text"
+    implementation "androidx.compose.ui:ui-unit"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation "androidx.compose.material:material"
     // - Jetpack Compose - AndroidX
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
     implementation "androidx.constraintlayout:constraintlayout-compose:$androidxConstraintlayoutComposeVersion"
@@ -516,7 +519,7 @@ dependencies {
     implementation "io.coil-kt:coil-compose:$coilComposeVersion"
     implementation "com.airbnb.android:lottie-compose:$lottieVersion"
     // - Jetpack Compose - UI Tests
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 }
 
 configurations.all {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -443,7 +443,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-text:$androidxComposeVersion"
     implementation "androidx.compose.ui:ui-unit:$androidxComposeVersion"
     implementation "androidx.compose.material:material:$androidxComposeVersion"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxComposeLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
     implementation "io.coil-kt:coil-compose:$coilComposeVersion"
     implementation "com.github.indexos.media-for-mobile:domain:$indexosMediaForMobileVersion"
     implementation "com.github.indexos.media-for-mobile:android:$indexosMediaForMobileVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -371,10 +371,6 @@ dependencies {
     }
     implementation "org.wordpress:persistentedittext:$wordPressPersistentEditTextVersion"
 
-    // To enable Android Studio specific features for Jetpack Compose.
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$androidxComposeVersion"
-    debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
     // To enable Stetho, a debug bridge that enables the Chrome Developer Tools for debug purposes.
     debugImplementation "com.facebook.stetho:stetho:$stethoVersion"
     debugImplementation "com.facebook.stetho:stetho-okhttp3:$stethoVersion"
@@ -403,7 +399,6 @@ dependencies {
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
-    implementation "androidx.constraintlayout:constraintlayout-compose:$androidxConstraintlayoutComposeVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-core:$androidxLifecycleVersion"
@@ -424,7 +419,6 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$squareupRetrofitVersion"
     implementation "org.apache.commons:commons-text:$apacheCommonsTextVersion"
     implementation "com.airbnb.android:lottie:$lottieVersion"
-    implementation "com.airbnb.android:lottie-compose:$lottieVersion"
     implementation "com.facebook.shimmer:shimmer:$facebookShimmerVersion"
     implementation ("com.github.yalantis:ucrop:$uCropVersion") {
         exclude group: 'androidx.core', module: 'core'
@@ -434,17 +428,6 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVolleyVersion"
-    implementation "androidx.compose.runtime:runtime:$androidxComposeVersion"
-    implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-    implementation "androidx.compose.foundation:foundation:$androidxComposeVersion"
-    implementation "androidx.compose.foundation:foundation-layout:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-graphics:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-text:$androidxComposeVersion"
-    implementation "androidx.compose.ui:ui-unit:$androidxComposeVersion"
-    implementation "androidx.compose.material:material:$androidxComposeVersion"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
-    implementation "io.coil-kt:coil-compose:$coilComposeVersion"
     implementation "com.github.indexos.media-for-mobile:domain:$indexosMediaForMobileVersion"
     implementation "com.github.indexos.media-for-mobile:android:$indexosMediaForMobileVersion"
     implementation "com.zendesk:support:$zendeskVersion"
@@ -507,10 +490,33 @@ dependencies {
     androidTestImplementation "androidx.work:work-testing:$androidxWorkManagerVersion"
     androidTestImplementation "com.google.dagger:hilt-android-testing:$gradle.ext.daggerVersion"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
     // Enables Java 8+ API desugaring support
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$androidDesugarVersion"
     lintChecks "org.wordpress:lint:$wordPressLintVersion"
+
+    // Jetpack Compose
+    // - Jetpack Compose - Android Studio
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$androidxComposeVersion"
+    debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
+    // - Jetpack Compose - Main
+    implementation "androidx.compose.runtime:runtime:$androidxComposeVersion"
+    implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
+    implementation "androidx.compose.foundation:foundation:$androidxComposeVersion"
+    implementation "androidx.compose.foundation:foundation-layout:$androidxComposeVersion"
+    implementation "androidx.compose.ui:ui:$androidxComposeVersion"
+    implementation "androidx.compose.ui:ui-graphics:$androidxComposeVersion"
+    implementation "androidx.compose.ui:ui-text:$androidxComposeVersion"
+    implementation "androidx.compose.ui:ui-unit:$androidxComposeVersion"
+    implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
+    implementation "androidx.compose.material:material:$androidxComposeVersion"
+    // - Jetpack Compose - AndroidX
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
+    implementation "androidx.constraintlayout:constraintlayout-compose:$androidxConstraintlayoutComposeVersion"
+    // - Jetpack Compose - Other
+    implementation "io.coil-kt:coil-compose:$coilComposeVersion"
+    implementation "com.airbnb.android:lottie-compose:$lottieVersion"
+    // - Jetpack Compose - UI Tests
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
 }
 
 configurations.all {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeOverlayFragment.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.blaze.ui.blazeoverlay
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -99,6 +100,7 @@ class BlazeOverlayFragment : Fragment() {
     }
 
     @Composable
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
     fun BlazeOverlayScreen(
         content: BlazeUiState.PromoteScreen,
         isDarkTheme: Boolean = isSystemInDarkTheme()

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazewebview/BlazeWebViewFragment.kt
@@ -88,6 +88,7 @@ class BlazeWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
     // The next 2 Composable(s) live in the fragment because they need access to the chromeClient outside of the fun
     // Also the clients needs access to activity and we are not holding on to that elsewhere
     @Composable
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
     private fun BlazeWebViewScreen(
         viewModel: BlazeWebViewViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.bloggingprompts.promptslist.compose
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,6 +31,7 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 fun BloggingPromptsListScreen(
     uiState: UiState,
     onNavigateUp: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
@@ -63,6 +64,7 @@ private val ContentTextStyle
 private val ContentMargin = 20.dp
 
 @Composable
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 fun WPJetpackIndividualPluginOverlayScreen(
     sites: List<SiteWithIndividualJetpackPlugins>,
     onCloseClick: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/JetpackPluginInstallScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/JetpackPluginInstallScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.jetpackplugininstall.install.compose
 
+import android.annotation.SuppressLint
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -11,6 +12,7 @@ import org.wordpress.android.ui.jetpackplugininstall.install.compose.state.Error
 import org.wordpress.android.ui.jetpackplugininstall.install.compose.state.InitialState
 import org.wordpress.android.ui.jetpackplugininstall.install.compose.state.InstallingState
 @Composable
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 fun JetpackPluginInstallScreen(
     uiState: UiState,
     onDismissScreenClick: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main.jetpack.migration.compose.state
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
@@ -44,6 +45,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.components.UserAv
 import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 
 @Composable
+@SuppressLint("FrequentlyChangedStateReadInComposition")
 fun WelcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
     Box {
         val listState = rememberLazyListState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main.jetpack.staticposter.compose
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,6 +52,7 @@ import org.wordpress.android.ui.main.jetpack.staticposter.toContentUiState
 import org.wordpress.android.util.extensions.isRtl
 
 @Composable
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 fun JetpackStaticPoster(
     uiState: UiState.Content,
     onPrimaryClick: () -> Unit = {},

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ ext {
     androidxArchCoreVersion = '2.1.0'
     androidxComposeVersion = '1.1.1'
     androidxComposeCompilerVersion = '1.3.2'
-    androidxComposeLifecycleVersion = '2.5.1'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     androidVolleyVersion = '1.2.1'
     androidxAppcompatVersion = '1.4.2'
     androidxArchCoreVersion = '2.1.0'
-    androidxComposeVersion = '1.1.1'
+    androidxComposeBomVersion = '2023.01.00'
     androidxComposeCompilerVersion = '1.3.2'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR migrates to [BOM](https://developer.android.com/jetpack/compose/bom) and uses the `androidxComposeBomVersion` update as of [2023.01.00](https://developer.android.com/jetpack/androidx/releases/compose#2023.01.00).

-----

Note that the latest [2023.04.01](https://developer.android.com/jetpack/androidx/releases/compose#2023.04.01) update of `androidxComposeBomVersion` has been decided to be done at a later point in time in order to avoid jumping many versions, all at once (see [comment](https://github.com/wordpress-mobile/WordPress-Android/issues/17563#issuecomment-1415886958)).

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

Warnings Suppression List:

1. [Suppress unused material scaffold padding parameter lint warns](https://github.com/wordpress-mobile/WordPress-Android/pull/18319/commits/ebd5152d7a2b33e3e76e806ed64548569e314dbd)
2. [Suppress freq. changed state read in composition lint warns](https://github.com/wordpress-mobile/WordPress-Android/pull/18319/commits/aebc6577f67f5bbe56f8df46b4a383060f880cc6)

FYI: @ovitrif after checking on those, thinking about the changes a bit and trying to reason about them, I chose to suppress these Lint warnings instead of resolving them. I feared it might take me longer to conclude with this update and worse, I might introduce breaking changes to any `Scaffold` or `Scroll` related functionalities. However, if you think we could quickly resolve them instead, and with that we wouldn't add any regression while doing so (as long as we test them), plus that it is worth it for us spend the time doing it now, let me know and I'll jump right on it. 🤔

PS: When WCAndroid did a similar update (see [here](https://github.com/woocommerce/woocommerce-android/pull/8091)), it seems that they actually resolved those Lint warnings (see [here](https://github.com/woocommerce/woocommerce-android/pull/8091/commits/a0ee42eb42d7cfd41ece875d4bbbe3e623374661) and [here](https://github.com/woocommerce/woocommerce-android/pull/8091/commits/1302bd5a5e3d289495300a05481026342f659ec8)). Having said that, I am not sure how confident I am to do that on your behalf and for WPAndroid as I having been involved with those screens much, thus, your guidance here would be much appreciated. 🙏

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any `Compose` related screen, on both, the WordPress and Jetpack apps, and see if everything is working as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within:

<details>
    <summary>1. Login Screen [LoginPrologueRevampedFragment.kt]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.

- Log out of the app (if already logged-in).
- Verify that the `Login` screen is shown and functioning as expected.

</details>

<details>
    <summary>2. QR Code Auth Screen [QRCodeAuthFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
ℹ️ You don't have to follow all 3 steps, just logging in with a non `A8C` and non `2FA` enabled
account, followed by tapping the `Scan Login Code` item on the `Me` screen should be enough, which
is effectively just `Step.1` and the beginning of `Step.3`.

Step.1:
- Build and install the `Jetpack` app (note that you don't need a release build, a debug build will
suffice).
- Login to the `Jetpack` app with a `WP.com` account (note that you need to use a non `A8C` account
and a non `2FA` enabled account).
- Navigate to the `Me` screen (click on avatar at top-right).
(STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to `wordpress.com` (note that if you are logged-in, log-out first).
- Tap the `Log In` link (top-right).
- Tap the `Login via the mobile app` link in the list of options below the main Continue button
(bottom-middle).
- Verify you are on the `Login via the mobile app` view and `Use QR Code to login` is shown, along with
a QR code for you to scan.
- (STOP)

Step.3:
- Head back to your mobile.
- Tap the `Scan Login Code` item on the `Me` screen you are currently at.
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to login to WordPress on your web browser (desktop),
verify that you have successfully logged-in and are able to use WordPress as expected.

</details>

<details>
    <summary>3a. Jetpack Static Poster Screen [JetpackStaticPosterActivity.kt + JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Stats` option.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Stats` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>3b. Jetpack Static Poster Screen [JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `Reader` or `Notifications` tab.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Reader` or `Notifications` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>4a. Jetpack Migration Screen [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the card on top that prompts the user to uninstall the WordPress app and click on it.
- Verify that the `Jetpack Migration` screen is shown and functioning as expected.

</details>

<details>
    <summary>4b. Jetpack Migration Flow [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Install both apps.
- Clear cache/data of the `Jetpack` app and restart it.
- The migration flow should appear, verify that it is shown and functioning as expected.

</details>

<details>
    <summary>5. Blaze Screen [BlazeOverlayFragment.kt + BlazeWebViewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Blaze` option.
- Verify that the `Blaze` screen is shown and functioning as expected.

</details>

<details>
    <summary>6. Blogging Prompts Screen [BloggingPromptsListActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the `Prompts` card on top and click on its options (top right).
- From the options menu, select `View more prompts`.
- Verify that the `Blogging Prompts` screen is shown and functioning as expected.

</details>

<details>
    <summary>7. Individual Plugin Screen [WPJetpackIndividualPluginFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [individual.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309662/individual.patch) patch to quickly test this screen.

- Go to `My Site` tab -> `Site Picker` (down-arrow).
- Let `individual.patch` patch do its magic... 🪄
- Verify that the `Individual Plugin` screen is shown and functioning as expected.

</details>

<details>
    <summary>8a. Jetpack Full Plugin Install Screen [JetpackFullPluginInstallOnboardingDialogFragment.kt + JetpackFullPluginInstallActivity.kt + JetpackInstallFullPluginCardViewHolder.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [full.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309714/full.patch) patch to quickly test this screen.

- Go to `My Site` tab.
- Let `full.patch` patch do its magic... 🪄
- Verify that the `Jetpack Full Plugin Install` dialog is shown and functioning as expected.
- Click on `Install the full plugin` button.
- Verify that the `Jetpack Full Plugin Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>8b. Jetpack Install Full Plugin View [JetpackInstallFullPluginCardViewHolder.kt] -> ❓️</summary>

ℹ️ This test applies to the `Jetpack` app.
❓️ Not sure how to best and quickly test this, let me know if you have an idea.

TODO
TODO
TODO

</details>

<details>
    <summary>9. Jetpack Remove Install Screen [JetpackRemoteInstallActivity.kt] -> ❗️</summary>

ℹ️ This test applies to the `WordPress` app.
❓️ Not sure how to best and quickly test this, let me know if you have an idea.
❗️ @ovitrif I know [you said](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#pullrequestreview-1397613208) that in order to test this, one would need to just press the `Install`
button within the `Jetpack Full Plugin Install` dialog, but this actually launches the
`JetpackFullPluginInstallActivity` activity and not the `JetpackRemoteInstallActivity` activity,
is it not? 🧐

- TODO
- TODO
- TODO

</details>

<details>
    <summary>10. Site Creation Domain View [SiteCreationDomainViewHolder.kt] -> ❗️</summary>

ℹ️ This test applies to the `Jetpack` app.
❓️ Not sure how to best and quickly test this, let me know if you have an idea.
❗️ @ovitrif I know [you said](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#pullrequestreview-1397613208) that you tested it previously, you being everyday in that screen,
but if you could provide some testing instructions here too, just for future reference, and
in order to help me test this in between and before opening a PR, that would be great. 🙏

- TODO
- TODO
- TODO

</details>

<details>
    <summary>11. About App Screen [com.automattic:about]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.
❗️ This test makes sure that the `About App` screen, which comes from the [com.automattic:about](https://github.com/Automattic/about-automattic-android) library is also working as expected and that any transitive dependency changes aren't affecting this `Compose` related screen.

- Go to `My Site` tab and navigate to the `Me` screen (click on avatar at top-right).
- Tap the `About App` item on the `Me` screen you are currently at.
- Verify that the `About App` screen is shown and functioning as expected.

</details>

PS: @ovitrif apologies for me keep adding these ❓ + ❗️ on the above list of testing instructions and thus (implicitly) pressuring you to help me with those, but, I hope, if we get this right, that will help our QE folks test the [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) at the very end, when it becomes ready, and before we merge all those changes to `trunk`. 🤞

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all `Compose` related screens, like the `Login` screen, the `Jetpack Migration` screens or the `Blaze` green (to name a few).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
