### PR TITLE
Fix inconsistent background color of domain list in dark theme on landscape

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.SiteCreationDomainsItemBinding
 import org.wordpress.android.databinding.SiteCreationDomainsItemV2Binding
 import org.wordpress.android.databinding.SiteCreationSuggestionsErrorItemBinding
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old.DomainUiState.AvailableDomain
@@ -72,7 +72,7 @@ sealed class SiteCreationDomainViewHolder<T : ViewBinding>(protected val binding
 
         fun onBind(uiState: New.DomainUiState) = with(binding) {
             composeView.setContent {
-                AppTheme {
+                AppThemeWithoutBackground {
                     DomainItem(uiState)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R.string
 import org.wordpress.android.ui.compose.components.SolidCircle
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.asString
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState
@@ -186,7 +186,7 @@ private fun DomainItemPreview() {
             onClick = {}
         )
     }
-    AppTheme {
+    AppThemeWithoutBackground {
         Column {
             uiStates.forEach { DomainItem(it) }
         }


### PR DESCRIPTION
Fixes #18269

This PR provides a very simple approach to fix the issue, basically adapting the existing implementation to use the **proper** Compose theme wrapper utility that we already had in the code.

## To Test
#### Prerequisite
<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
<img width="315" src="https://user-images.githubusercontent.com/4588074/233447831-b3ec505c-8fcd-4776-9f43-0c070cdc17da.png">

</details>

### ● Treatment Variation
<details><summary><b>Verify</b> the background color of domain list in site creation matches the screen bg in dark theme on landscape</summary>

1. Set the device in dark mode
2. Start the site creation flow
3. Select a design
4. Search for a domain
5. Turn the device in landscape mode
6. **Verify** that the background color **is** consistent

</details>

### Preview
| <img width="720" src="https://user-images.githubusercontent.com/4588074/234270193-f97c8057-4d8e-4a2f-8799-2962e6089267.png"> |
| - |
| <img width="720" src="https://user-images.githubusercontent.com/4588074/234270265-54af6da2-3fc3-4b3b-8521-f5172c612415.png"> |

## Regression Notes
1. Potential unintended areas of impact
   N/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   N/a

3. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
