### PR TITLE
[Reader] Add support to Prompt block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1625,6 +1625,15 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             return true
         }
 
+        // if this is a tag URL (some link pointing to a tag or the daily prompt block, for instance), then open it in
+        // the reader directly
+        if (ReaderUtils.isTagUrl(url)) {
+            ReaderUtils.getTagFromTagUrl(url)?.let {
+                viewModel.onTagItemClicked(it)
+                return true
+            }
+        }
+
         if (isFile(url)) {
             onFileDownloadClick(url)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1609,38 +1609,33 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     override fun onUrlClick(url: String): Boolean {
         readerTracker.track(AnalyticsTracker.Stat.READER_ARTICLE_LINK_TAPPED)
-        // if this is a "wordpress://blogpreview?" link, show blog preview for the blog - this is
-        // used for Discover posts that highlight a blog
-        if (ReaderUtils.isBlogPreviewUrl(url)) {
-            val siteId = ReaderUtils.getBlogIdFromBlogPreviewUrl(url)
-            if (siteId != 0L) {
-                ReaderActivityLauncher.showReaderBlogPreview(
-                    activity,
-                    siteId,
-                    viewModel.post?.isFollowedByCurrentUser,
-                    ReaderTracker.SOURCE_POST_DETAIL,
-                    readerTracker
-                )
-            }
-            return true
-        }
 
-        // if this is a tag URL (some link pointing to a tag or the daily prompt block, for instance), then open it in
-        // the reader directly
-        if (ReaderUtils.isTagUrl(url)) {
-            ReaderUtils.getTagFromTagUrl(url)?.let {
-                viewModel.onTagItemClicked(it)
-                return true
+        when {
+            ReaderUtils.isBlogPreviewUrl(url) -> onBlogPreviewUrlClick(url)
+            ReaderUtils.isTagUrl(url) -> viewModel.onTagItemClicked(ReaderUtils.getTagFromTagUrl(url))
+            isFile(url) -> onFileDownloadClick(url)
+            else -> {
+                val openUrlType = if (shouldOpenExternal(url)) OpenUrlType.EXTERNAL else OpenUrlType.INTERNAL
+                ReaderActivityLauncher.openUrl(activity, url, openUrlType)
             }
         }
 
-        if (isFile(url)) {
-            onFileDownloadClick(url)
-        } else {
-            val openUrlType = if (shouldOpenExternal(url)) OpenUrlType.EXTERNAL else OpenUrlType.INTERNAL
-            ReaderActivityLauncher.openUrl(activity, url, openUrlType)
-        }
         return true
+    }
+
+    // if this is a "wordpress://blogpreview?" link, show blog preview for the blog - this is
+    // used for Discover posts that highlight a blog
+    private fun onBlogPreviewUrlClick(url: String) {
+        val siteId = ReaderUtils.getBlogIdFromBlogPreviewUrl(url)
+        if (siteId != 0L) {
+            ReaderActivityLauncher.showReaderBlogPreview(
+                activity,
+                siteId,
+                viewModel.post?.isFollowedByCurrentUser,
+                ReaderTracker.SOURCE_POST_DETAIL,
+                readerTracker
+            )
+        }
     }
 
     override fun onPageJumpClick(pageJump: String?): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -540,12 +540,13 @@ public class ReaderPostRenderer {
     private void appendMappedColors(StringBuilder sb) {
         sb.append(" :root { ")
           .append("--color-text: ").append(mResourceVars.mTextColor).append("; ")
-          .append("--color-neutral-70: ").append(mResourceVars.mTextColor).append("; ")
           .append("--color-neutral-0: ").append(mResourceVars.mGreyMediumDarkStr).append("; ")
-          .append("--color-neutral-50: ").append(mResourceVars.mGreyLightStr).append("; ")
-          .append("--color-neutral-20: ").append(mResourceVars.mGreyExtraLightStr).append("; ")
-          .append("--main-link-color: ").append(mResourceVars.mLinkColorStr).append("; ")
+          .append("--color-neutral-5: ").append(mResourceVars.mGreyExtraLightStr).append("; ")
           .append("--color-neutral-10: ").append(mResourceVars.mGreyDisabledStr).append("; ")
+          .append("--color-neutral-20: ").append(mResourceVars.mGreyExtraLightStr).append("; ")
+          .append("--color-neutral-50: ").append(mResourceVars.mGreyLightStr).append("; ")
+          .append("--color-neutral-70: ").append(mResourceVars.mTextColor).append("; ")
+          .append("--main-link-color: ").append(mResourceVars.mLinkColorStr).append("; ")
           .append("} ");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -367,9 +367,9 @@ public class ReaderPostRenderer {
         sbHtml.append("<meta name='viewport' content='width=device-width, initial-scale=1'>")
               .append("<style type='text/css'>");
         appendMappedColors(sbHtml);
-              // force font style
+              // force font style and 1px margin from the right to avoid elements being cut off
         sbHtml.append(" body.reader-full-post__story-content { font-family: 'Noto Serif', serif; font-weight: 400; ")
-              .append("font-size: 16px; margin: 0px; padding: 0px; }")
+              .append("font-size: 16px; margin: 0px; padding: 0px; margin-right: 1px; }")
               .append(" p, div, li { line-height: 1.6em; font-size: 100%; }")
               .append(" body, p, div { max-width: 100% !important; word-wrap: break-word; }")
               // set line-height, font-size but not for .tiled-gallery divs when rendering as tiled

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
@@ -244,6 +245,19 @@ public class ReaderUtils {
             return StringUtils.stringToLong(strBlogId);
         } else {
             return 0;
+        }
+    }
+
+    public static boolean isTagUrl(String url) {
+        return (url != null && url.matches("^https?://wordpress\\.com/tag/[^/]+$"));
+    }
+
+    @Nullable
+    public static String getTagFromTagUrl(String url) {
+        if (isTagUrl(url)) {
+            return url.substring(url.lastIndexOf("/") + 1);
+        } else {
+            return null;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -252,12 +252,11 @@ public class ReaderUtils {
         return (url != null && url.matches("^https?://wordpress\\.com/tag/[^/]+$"));
     }
 
-    @Nullable
     public static String getTagFromTagUrl(String url) {
         if (isTagUrl(url)) {
             return url.substring(url.lastIndexOf("/") + 1);
         } else {
-            return null;
+            return "";
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -505,7 +505,7 @@ class ReaderPostDetailViewModel @Inject constructor(
         _uiState.value = convertPostToUiState(post)
     }
 
-    private fun onTagItemClicked(tagSlug: String) {
+    fun onTagItemClicked(tagSlug: String) {
         launch(ioDispatcher) {
             val readerTag = readerUtilsWrapper.getTagFromTagName(tagSlug, FOLLOWED)
             _navigationEvents.postValue(Event(ShowPostsByTag(readerTag)))

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderUtilsTest.kt
@@ -136,4 +136,32 @@ class ReaderUtilsTest {
         val result = ReaderUtils.sanitizeWithDashes(nonUrlEncodedString)
         assertThat(result).isEqualTo("nonurlencodedstring")
     }
+
+    @Test
+    fun `given valid reader tag link, when isTagUrl is invoked, then returns true`() {
+        val tagLink = "https://wordpress.com/tag/dailyprompt-123"
+        val result = ReaderUtils.isTagUrl(tagLink)
+        assertThat(result).isEqualTo(true)
+    }
+
+    @Test
+    fun `given invalid reader tag link, when isTagUrl is invoked, then returns false`() {
+        val tagLink = "https://wordpress.com/tag/dailyprompt-123/abc"
+        val result = ReaderUtils.isTagUrl(tagLink)
+        assertThat(result).isEqualTo(false)
+    }
+
+    @Test
+    fun `given valid reader tag link, when getTagFromTagUrl is invoked, then returns only tag slug`() {
+        val tagLink = "https://wordpress.com/tag/dailyprompt-123"
+        val result = ReaderUtils.getTagFromTagUrl(tagLink)
+        assertThat(result).isEqualTo("dailyprompt-123")
+    }
+
+    @Test
+    fun `given invalid reader tag link, when isTagUrl is invoked, then returns empty string`() {
+        val tagLink = "https://wordpress.com/tag/dailyprompt-123/abc"
+        val result = ReaderUtils.getTagFromTagUrl(tagLink)
+        assertThat(result).isEqualTo("")
+    }
 }


### PR DESCRIPTION
The "Prompt Block" is shown in posts made on the web as an answer to the Daily Prompts. The Loop team [just implemented the CSS](https://github.com/Automattic/wp-calypso/pull/76092) for it to work properly both on the web and on the mobile apps but a few minor issues still needed to be resolved on the app side:
- Add `--color-neutral-5` CSS variable to the Reader Renderer (even though we are not currently using it)
- Add a 1-pixel `margin-right` to the body of the content because Android's Webview has a bug that cuts off 1 pixel from the right
- Intercept `tag` URLs inside the post to show them inside the app reader

The WebView 1-pixel issue
<img src="https://user-images.githubusercontent.com/5091503/234587527-442f6704-87ed-4889-b707-568d3d49d690.png" height="640">

## To test

### Prompt Block UI
It seems the calypso CSS changes have been deployed, so it's possible to test the block UI.

1. Install Jetpack
2. Login with a WP.com account
3. Select a blog site (has a few posts)
4. Go to `My Site > Home`
5. Tap "View all responses" in the Prompts card
6. Find a post that has a preview starting with "Daily writing prompt" (those are posts answered from the web)
7. **Verify** the Prompt block is formatted as expected

### Tag URL interception
1. Install Jetpack
2. Login with a WP.com account
3. Select a blog site (has a few posts)
4. Go to `My Site > Home`
5. Tap "View all responses" in the Prompts card
6. Find a post that has a preview starting with "Daily writing prompt" (those are posts answered from the web)
8. Tap the "View all responses" link inside the post
9. **Verify** the Reader `topic` page is opened

## Demo
Demo of the CSS fix by using the proxy to also change the provided CSS to use `--color-neutral-5` in the block border, just to test that change as well (using _Map Local_ in Charles Proxy).

https://user-images.githubusercontent.com/5091503/234424088-ed1d915c-2079-4558-b611-73f841413ec6.mp4

## Regression Notes
1. Potential unintended areas of impact
Content being shifted because of the border. Wrong links being intercepted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests for the ViewModel.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)

**Note: most changes here only affect the content inside a Webview so some of the items above do not apply.**