### PR TITLE
Handle edge cases on the new Site Creation progress screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -316,7 +316,7 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onFreeSiteCreated(site: SiteModel) {
         siteCreationState = siteCreationState.copy(result = CreatedButNotFetched.NotInLocalDb(site))
-        if (requireNotNull(siteCreationState.domain).isFree) {
+        if (checkNotNull(siteCreationState.domain).isFree) {
             wizardManager.showNextStep()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -316,7 +316,9 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onFreeSiteCreated(site: SiteModel) {
         siteCreationState = siteCreationState.copy(result = CreatedButNotFetched.NotInLocalDb(site))
-        wizardManager.showNextStep()
+        if (requireNotNull(siteCreationState.domain).isFree) {
+            wizardManager.showNextStep()
+        }
     }
 
     fun onWizardCancelled() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -128,7 +128,9 @@ class SiteCreationProgressViewModel @Inject constructor(
 
     fun retry() {
         when (uiState.value) {
-            is GenericError -> startCreateSiteService(serviceStateForRetry)
+            is GenericError,
+            is ConnectionError -> startCreateSiteService(serviceStateForRetry)
+
             is CartError -> createCart()
             else -> error("Unexpected state for retry: ${uiState.value}")
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -91,7 +91,7 @@ class SiteCreationProgressViewModel @Inject constructor(
     fun start(siteCreationState: SiteCreationState) {
         if (siteCreationState.result is CreatedButNotFetched.InCart) {
             // reuse the previously blog when returning with the same domain
-            if (siteCreationState.domain == this.siteCreationState.domain) {
+            if (siteCreationState.domain == domain) {
                 createCart(siteCreationState.result.site)
                 return
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.sitecreation.services.SiteCreationServiceState.S
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -40,7 +41,6 @@ import javax.inject.Named
 private const val CONNECTION_ERROR_DELAY_TO_SHOW_LOADING_STATE = 1000L
 const val LOADING_STATE_TEXT_ANIMATION_DELAY = 2000L
 private const val ERROR_CONTEXT = "site_preview"
-private val LOG_TAG = AppLog.T.SITE_CREATION
 
 private val loadingTexts = listOf(
     UiStringRes(R.string.new_site_creation_creating_site_loading_1),
@@ -186,7 +186,7 @@ class SiteCreationProgressViewModel @Inject constructor(
     }
 
     private fun createCart(site: SiteModel) = launch {
-        AppLog.d(LOG_TAG, "Creating cart: $domain")
+        AppLog.d(T.SITE_CREATION, "Creating cart: $domain")
 
         val event = createCartUseCase.execute(
             site,
@@ -197,10 +197,10 @@ class SiteCreationProgressViewModel @Inject constructor(
         )
 
         if (event.isError) {
-            AppLog.e(LOG_TAG, "Failed cart creation: ${event.error.message}")
-            updateUiStateAsync(GenericError)
+            AppLog.e(T.SITE_CREATION, "Failed cart creation: ${event.error.message}")
+            updateUiStateAsync(CartError)
         } else {
-            AppLog.d(LOG_TAG, "Successful cart creation: ${event.cartDetails}")
+            AppLog.d(T.SITE_CREATION, "Successful cart creation: ${event.cartDetails}")
             _onCartCreated.postValue(CheckoutDetails(site, domain.domainName))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.sitecreation.progress
+﻿package org.wordpress.android.ui.sitecreation.progress
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -180,7 +180,7 @@ class SiteCreationProgressViewModel @Inject constructor(
         require(payload is Pair<*, *>) { "Expected Pair in Payload, got: $payload" }
         val (blogId, blogUrl) = payload
         require(blogId is Long) { "Expected the 1st element in the Payload Pair to be a Long, got: $blogId" }
-        require(blogUrl is String)  { "Expected the 2nd element in the Payload Pair to be a Long, got: $blogUrl" }
+        require(blogUrl is String) { "Expected the 2nd element in the Payload Pair to be a Long, got: $blogUrl" }
         return SiteModel().apply { siteId = blogId; url = blogUrl }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -13,7 +13,9 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
-import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Completed
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.Created
+import org.wordpress.android.ui.sitecreation.SiteCreationResult.CreatedButNotFetched.InCart
 import org.wordpress.android.ui.sitecreation.SiteCreationState
 import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
@@ -91,11 +93,14 @@ class SiteCreationProgressViewModel @Inject constructor(
     }
 
     fun start(siteCreationState: SiteCreationState) {
-        if (siteCreationState.result is CreatedButNotFetched.InCart) {
+        if (siteCreationState.result is Created) {
+            check(siteCreationState.result !is Completed) { "Unexpected state on progress screen." }
             // reuse the previously blog when returning with the same domain
             if (siteCreationState.domain == domain) {
                 site = siteCreationState.result.site
-                createCart()
+                if (siteCreationState.result is InCart) {
+                    createCart()
+                }
                 return
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -158,12 +158,13 @@ class SiteCreationProgressViewModel @Inject constructor(
             IDLE, CREATE_SITE -> Unit
             SUCCESS -> {
                 val site = mapPayloadToSiteModel(event.payload)
-                if (domain.isFree) {
-                    _onFreeSiteCreated.postValue(site)
-                } else {
+                // MainVM will navigate forward if the domain is free
+                _onFreeSiteCreated.postValue(site)
+                if (!domain.isFree) {
                     createCart(site)
                 }
             }
+
             FAILURE -> {
                 serviceStateForRetry = event.payload as SiteCreationServiceState
                 tracker.trackErrorShown(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3336,6 +3336,7 @@
     <string name="site_creation_fetch_suggestions_error_unknown">There was a problem</string>
     <string name="site_creation_error_generic_title">There was a problem</string>
     <string name="site_creation_error_generic_subtitle">Error communicating with the server, please try again</string>
+    <string name="site_creation_error_cart_subtitle">Your website has been created successfully, but we encountered an issue while preparing your custom domain for checkout. Please try again or contact support for assistance.</string>
     <string name="new_site_creation_intents_title">Site topic</string>
     <string name="new_site_creation_intents_header_title">What’s your website about?</string>
     <string name="new_site_creation_intents_header_subtitle">Choose a topic from the list below or type your own.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -203,15 +203,24 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on progress screen finished updates result`() {
+    fun `on site created updates result`() = test {
+        viewModel.onDomainsScreenFinished(FREE_DOMAIN)
         viewModel.onFreeSiteCreated(SITE_MODEL)
         assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }
 
     @Test
-    fun `on progress screen finished shows next step`() {
+    fun `on site created for free domain shows next step`() {
+        viewModel.onDomainsScreenFinished(FREE_DOMAIN).run { clearInvocations(wizardManager) }
         viewModel.onFreeSiteCreated(SITE_MODEL)
         verify(wizardManager).showNextStep()
+    }
+
+    @Test
+    fun `on site created for paid domain does not show next step`() {
+        viewModel.onDomainsScreenFinished(PAID_DOMAIN).run { clearInvocations(wizardManager) }
+        viewModel.onFreeSiteCreated(SITE_MODEL)
+        verifyNoMoreInteractions(wizardManager)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.ui.sitecreation.CART_ERROR
 import org.wordpress.android.ui.sitecreation.CART_SUCCESS
 import org.wordpress.android.ui.sitecreation.PAID_DOMAIN
+import org.wordpress.android.ui.sitecreation.RESULT_CREATED
 import org.wordpress.android.ui.sitecreation.RESULT_IN_CART
 import org.wordpress.android.ui.sitecreation.SERVICE_ERROR
 import org.wordpress.android.ui.sitecreation.SERVICE_SUCCESS
@@ -236,7 +237,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     fun `on restart with same paid domain reuses previous blog to create new cart`() = testWith(CART_SUCCESS) {
         val state = SITE_CREATION_STATE.copy(domain = PAID_DOMAIN)
         startViewModel(state)
-        val previous = SiteModel().apply { siteId = 9L;url = "blog.wordpress.com" }
+        val previous = SiteModel().apply { siteId = 9L; url = "blog.wordpress.com" }
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS.copy(payload = previous.siteId to previous.url))
 
         startViewModel(state.copy(result = RESULT_IN_CART))
@@ -249,6 +250,18 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
             eq(PAID_DOMAIN.supportsPrivacy),
             any()
         )
+    }
+
+    @Test
+    fun `on restart with same free domain reuses it`() = testWith(CART_SUCCESS) {
+        val state = SITE_CREATION_STATE
+        startViewModel(state)
+        val previous = SiteModel().apply { siteId = 9L; url = "blog.wordpress.com" }
+        viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS.copy(payload = previous.siteId to previous.url))
+
+        startViewModel(state.copy(result = RESULT_CREATED))
+
+        verify(startServiceObserver, atMost(1)).onChanged(any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -154,6 +154,15 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `on retry click after network error restarts site creation service`() = test {
+        whenever(networkUtils.isNetworkAvailable()).thenReturn(false, true)
+        startViewModel()
+        advanceUntilIdle()
+        viewModel.retry()
+        verify(startServiceObserver).onChanged(any())
+    }
+
+    @Test
     fun `on retry click after cart error retries to create cart`() = testWith(CART_ERROR) {
         startViewModel(SITE_CREATION_STATE.copy(domain = PAID_DOMAIN))
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)


### PR DESCRIPTION
Fixes #18324

This PR solves various issues related to edge cases on the progress screen:
- ⊕ Adds specific error message for cart errors
- ⊕ Fixes retry after cart errors
- ⊕ Fixes restoring the screen after errors on configuration changes by deliberately retrying the previous operation

## To Test
#### Prerequisite
<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
<img width="315" src="https://user-images.githubusercontent.com/4588074/233447831-b3ec505c-8fcd-4776-9f43-0c070cdc17da.png">

</details>

### ● Treatment Variation
- **Verify** Cart errors are handled with custom text expecting to be able to retry
  - Apply 
[`cart_error.patch`](https://github.com/wordpress-mobile/WordPress-Android/files/11335970/cart_error.patch) then build and run the project. On first try it force-shows the error, after retry it allows the code to run normally.
- **Verify** restoring the screen after errors on config changes retries the previously failed operation
  - To do this, while the error screen is displayed go to your device's `Settings` then `Accessibility` → `Display size and text` and increase font size to max or min. Afterwards return to the app and the view should _restart_.

### ○ Control Variation
- **Verify** Network errors are handled and retrying works afterwards
  - The quickest way to test this is to disable internet connection with a domain selected, then continuing the flow.

### ● Previews
| New error | Recording |
| - |  -|
| <img width="315" src="https://user-images.githubusercontent.com/4588074/234660030-9cdac001-dc1b-4d6b-b69d-4864b1d062e5.png"> | <video src="https://user-images.githubusercontent.com/4588074/234662503-3c73b662-692e-45ab-b6c6-a3791865e375.mov" style="max-width: 315px;"></video> |

## Regression Notes
1. Potential unintended areas of impact
   `Site Creation` → `Progress` errors & error handling.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

8. What automated tests I added (or what prevented me from doing so)
   Unit tests in `SiteCreationMainVMTest` and `SiteCreationProgressViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

> **Note** some points are irrelevant, as the UI changes are behind a flag.

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- ~~Talkback.~~
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- ~~Large and small screen sizes. (Tablet and smaller phones)~~
- ~~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~~
