### PR TITLE
[Dependency Updates] Update `androidxRecyclerviewVersion` to 1.3.0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.sitecreation.domains
 
 import android.view.ViewGroup
-import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.core.content.ContextCompat
 import androidx.core.view.isInvisible
 import androidx.recyclerview.widget.RecyclerView
@@ -58,17 +57,11 @@ sealed class SiteCreationDomainViewHolder<T : ViewBinding>(protected val binding
         }
     }
 
-    @Suppress("ForbiddenComment")
     class NewDomainViewHolder(parentView: ViewGroup) :
         SiteCreationDomainViewHolder<SiteCreationDomainsItemV2Binding>(
             parentView.viewBinding(SiteCreationDomainsItemV2Binding::inflate)
         ) {
         val composeView = binding.composeView
-
-        init {
-            // TODO: Remove this for Compose 1.2.0-beta02+ and RecyclerView 1.3.0-alpha02+
-            binding.composeView.setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
-        }
 
         fun onBind(uiState: New.DomainUiState) = with(binding) {
             composeView.setContent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsAdapter.kt
@@ -53,15 +53,6 @@ class SiteCreationDomainsAdapter(
         diffResult.dispatchUpdatesTo(this)
     }
 
-    @Suppress("ForbiddenComment")
-    override fun onViewRecycled(holder: SiteCreationDomainViewHolder<*>) {
-        if (holder is NewDomainViewHolder) {
-            // TODO: Remove this for Compose 1.2.0-beta02+ and RecyclerView 1.3.0-alpha02+
-            holder.composeView.disposeComposition()
-        }
-        super.onViewRecycled(holder)
-    }
-
     private class DomainsDiffUtils(
         val oldItems: List<ListItemUiState>,
         val newItems: List<ListItemUiState>

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     androidxLifecycleVersion = '2.5.1'
     androidxPercentlayoutVersion = '1.0.0'
     androidxPreferenceVersion = '1.2.0'
-    androidxRecyclerviewVersion = '1.2.1'
+    androidxRecyclerviewVersion = '1.3.0'
     androidxSwipeToRefreshVersion = '1.1.0'
     androidxViewpager2Version = '1.0.0'
     androidxWorkManagerVersion = "2.7.1"


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR updates `androidxRecyclerviewVersion` to [1.3.0](https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.3.0).

-----

Fix List: [Remove manual jetpack compose interop config for recyclerview](https://github.com/wordpress-mobile/WordPress-Android/commit/52b264e98b7889c50bffc3c2e76942a0b280b277)

FYI: @ovitrif please take a close look at this commit as it reverts the manual `Jetpack Compose` interop configuration for `RecyclerView` (52b264e98b7889c50bffc3c2e76942a0b280b277). You can read the commit's description for more details.

For more info see: https://github.com/wordpress-mobile/WordPress-Android/issues/17563#issuecomment-1439830915

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any `RecyclerView` related screens (aka lists), on both, the WordPress and Jetpack apps, and see if everything is working as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within, which is mainly related to this [fix](https://github.com/wordpress-mobile/WordPress-Android/commit/52b264e98b7889c50bffc3c2e76942a0b280b277) commit:

<details>
    <summary>Site Creation Domain View [SiteCreationDomainViewHolder.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `Debug Settings` and enable the `SiteCreationDomainPurchasingFeatureConfig` feature flag.
- Go to `Site Picker` -> Click the `+` button -> Chose `Create WordPress.com site` -> Click the `SKIP` button -> And again, click the `SKIP` button.
- Enter any search query in the input (eg. 'awesome').
- Verify the list of domain suggestions is presented (the item UI is compose)
- Verify that the `Site Creation Domain` view and its list is shown and functioning as expected.

</details>

-----

## Merge instructions

- [x] Wait for [this other](https://github.com/wordpress-mobile/WordPress-Android/pull/18326) PR to be reviewed, tested and approved.
- [x] Update PR's base [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) branch with latest `trunk`.
- [x] Update this PR with latest [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) and make sure everything is still working as expected.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Merge PR to [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or `RecyclerView` list related app functionalities (aka lists), like list of posts/pages, reader and reader details, media, site picker and creation, list of plugins, etc.
    - Some of the transitive dependencies added might be causing some kind of misbehaviour.
    - The `Site Creation Domain` view and its list might not be performing as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
