### PR TITLE
Fix dark mode colors on notification permission warning

### DIFF
--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -54,7 +54,7 @@
                 android:gravity="start|center_vertical"
                 android:text="@string/notifications_permission_off_desc"
                 android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="?attr/colorOnSurface" />
+                android:textColor="@android:color/black" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:layout_width="wrap_content"
@@ -73,7 +73,7 @@
                 android:contentDescription="@string/notifications_permission_dismiss_content_description"
                 android:padding="@dimen/margin_large"
                 android:src="@drawable/ic_cross_small_white_24dp"
-                app:tint="?attr/colorOnSurface" />
+                app:tint="@android:color/black" />
         </LinearLayout>
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
This fixes the wrong colors of notification permission warning in dark mode.

|before|after|
|-|-|
|<img src="https://user-images.githubusercontent.com/2471769/234882400-13492fd3-b9f0-4e41-aaef-ae02b8eece09.png" width=300>|<img src="https://user-images.githubusercontent.com/2471769/234882455-c2e05afb-c4b4-4870-bf88-9919ae44250f.png" width=300>|

To test:
1. Launch the JP app on an Android 13 device.
2. Ensure your app is in dark mode. If not, go to "My Site → Me (your profile pic on top of the screen) → App Settings → Appearance" and select "Dark" mode.
3. Navigate to the "Notifications" tab.
4. Ensure that the warning message "Push notifications are turned off" is well visible in dark mode, as shown in the screenshots.

> **Note**
> The content of the permission bottom sheet doesn't fit the screen. It'll be fixed in a separate PR.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
Nothing, because this PR just updates the wrong colors.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
