### PR TITLE
Integrate gutenberg-mobile release 1.94.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5706-b555fc928d1d0a03af07ca6e7132fb607c75cbeb'
+    gutenbergMobileVersion = 'v1.94.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.25.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.94.0-alpha1'
+    gutenbergMobileVersion = '5706-b555fc928d1d0a03af07ca6e7132fb607c75cbeb'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.25.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.94.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5706

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.