### PR TITLE
Runtime permission to notification settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -7,14 +7,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.PorterDuff.Mode;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
-import android.provider.Settings;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -590,13 +588,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
                         NOTIFICATIONS_PERMISSION_REQUEST_CODE);
             } else {
                 // Navigate to app settings.
-                Intent intent = new Intent();
-                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                Uri uri =
-                        Uri.fromParts("package", getActivity().getApplicationContext().getPackageName(), null);
-                intent.setData(uri);
-
-                startActivity(intent);
+                WPPermissionUtils.showNotificationsSettings(getContext());
             }
             return true;
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -24,6 +24,7 @@ import android.widget.ListView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.view.ViewCompat;
@@ -571,18 +572,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     }
 
     private void updateDisabledMessagePreference(Preference disabledMessagePreference) {
-        boolean isAlwaysDenied =
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && WPPermissionUtils.isPermissionAlwaysDenied(
-                        getActivity(), Manifest.permission.POST_NOTIFICATIONS);
-        int summaryResId;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isAlwaysDenied) {
-            summaryResId = R.string.notifications_disabled_permission_dialog;
-        } else {
-            summaryResId = R.string.notifications_disabled;
-        }
-        disabledMessagePreference.setSummary(summaryResId);
+        disabledMessagePreference.setSummary(getDisabledMessageResId());
         disabledMessagePreference.setOnPreferenceClickListener(preference -> {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isAlwaysDenied) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && shouldRequestRuntimePermission()) {
                 // Request runtime permission.
                 requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS},
                         NOTIFICATIONS_PERMISSION_REQUEST_CODE);
@@ -592,6 +584,20 @@ public class NotificationsSettingsFragment extends PreferenceFragment
             }
             return true;
         });
+    }
+
+    private boolean shouldRequestRuntimePermission() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+               && !WPPermissionUtils.isPermissionAlwaysDenied(getActivity(), Manifest.permission.POST_NOTIFICATIONS);
+    }
+
+    @StringRes
+    private int getDisabledMessageResId() {
+        if (shouldRequestRuntimePermission()) {
+            return R.string.notifications_disabled_permission_dialog;
+        } else {
+            return R.string.notifications_disabled;
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -58,6 +58,7 @@ import org.wordpress.android.fluxc.store.AccountStore.SubscriptionType;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateSubscriptionPayload.SubscriptionFrequency;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.models.JetpackPoweredScreen;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
@@ -76,7 +77,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.JetpackBrandingUtils;
-import org.wordpress.android.models.JetpackPoweredScreen;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
@@ -545,7 +545,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
     // Updates the UI for preference screens based on if notifications are enabled or not
     private void updateUIForNotificationsEnabledState() {
-        if (mTypePreferenceCategories == null || mTypePreferenceCategories.size() == 0) {
+        if (mTypePreferenceCategories.size() == 0) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -573,11 +573,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     }
 
     private void updateDisabledMessagePreference(Preference disabledMessagePreference) {
-        boolean isAlwaysDenied = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                                 WPPermissionUtils.isPermissionAlwaysDenied(
-                                         getActivity(),
-                                         Manifest.permission.POST_NOTIFICATIONS
-                                 );
+        boolean isAlwaysDenied =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && WPPermissionUtils.isPermissionAlwaysDenied(
+                        getActivity(), Manifest.permission.POST_NOTIFICATIONS);
         int summaryResId;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isAlwaysDenied) {
             summaryResId = R.string.notifications_disabled_permission_dialog;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1536,6 +1536,7 @@
     <string name="error_loading_notifications">Couldn\'t load notification settings</string>
     <string name="notification_types">Notification Types</string>
     <string name="notifications_disabled">App notifications have been disabled. Tap here to enable them in Settings.</string>
+    <string name="notifications_disabled_permission_dialog">App notifications have been disabled. Tap here to enable them.</string>
     <string name="notifications_tab_summary">Settings for notifications that appear in the Notifications tab.</string>
     <string name="notifications_email_summary">Settings for notifications that are sent to the email tied to your account.</string>
     <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>


### PR DESCRIPTION
This introduces support for runtime permissions in the notification settings screen.
**Before**, the "disabled message" on the notification settings screen always opened device settings, even though it could request runtime permissions on Android 13 devices.
**After**, if runtime permissions are available on Android 13 devices, it will request them, and if not, it will open the device settings.

**When we can request runtime permission:**
<img src="https://user-images.githubusercontent.com/2471769/234960179-4802feba-eff5-4334-8365-87dbb9d14198.png" width=600 />


**When we can't request runtime permission, this can be a device lower than Android 13, or maybe the permission dialog was denied, and we can't request runtime permission anymore:**
<img src="https://user-images.githubusercontent.com/2471769/234960130-3cdde894-6ed2-48e7-b2a4-ee0733f817a7.png" width=600 />


> **Note**
> The `NotificationsSettingsFragment` is a deprecated fragment class that doesn't have a view model. I tried to make minimum changes to introduce the feature.

To test:
**Case 1:**
1. On an Android 13 device, perform a clean installation of JP and log in.
2. Navigate to the "Notifications" tab.
3. Tap the settings icon on top of the screen.
4. Tap one of your sites.
5. Ensure there is a message `App notifications have been disabled. Tap here to enable them.` at the end of the list.
6. Tap the button.
7. Ensure it opens the permission dialog.
8. Allow permission.
9. Ensure permission is allowed on the app.

**Case 2:**
1. Repeat 1-7 on case 1.
2. Don't allow permission once or twice.
3. Ensure there is a message `App notifications have been disabled. Tap here to enable them in Settings.` at the end of the list.
4. Tap the button.
5. Ensure it opens the permission settings screen of the device.

**Case 3:**
1. Repeat 1-5 on Case 1.
2. Take the app to the background and open the device settings.
3. Allow the JP notification permission from the device settings.
4. Reopen JP.
5. Ensure there is no disabled notification message.
6. Repeat step 2 and disable JP notification permission from the device settings.
7. Reopen JP.
8. Ensure disable message comes back.

## Regression Notes
1. Potential unintended areas of impact
Same feature on Android 12 devices.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on Android 12 device.

3. What automated tests I added (or what prevented me from doing so)
Nothing because `NotificationsSettingsFragment` needs refactoring. See my note above.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
