### PR TITLE
[Tool] Configure Dependabot to Ignore AGP Plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       # The Android Gradle Plugin is a dependency that needs to be in sync with other
       # in-house libraries due to compatibility with composite build.
       - dependency-name: "com.android.tools.build:gradle"
+      - dependency-name: "com.android.application"
+      - dependency-name: "com.android.library"
       # Bumping 1.2.1 to 1.3.0 causes some issues, fist spotted in Reader. For more details, see
       # https://github.com/wordpress-mobile/WordPress-Android/pull/14431
       # An update related issue has been created to make sure that this gets the needed attention:


### PR DESCRIPTION
This PR disables `Dependabot` alerts for AGP plugins. As cited from the code comments, the Android Gradle Plugin is a dependency that needs to be in sync with other in-house libraries due to compatibility with composite build.

PS: This [configuration update](https://github.com/woocommerce/woocommerce-android/pull/8906) was already done on WCAndroid, and as such, this commit just replicates the same configuration. @wzieba I added you as the reviewer here as it would be super-quick for you to verify that change on WPAndroid too, many thanks in advance. 😊 

-----

## To test:

See testing instructions on WCAndroid PR [here](https://github.com/woocommerce/woocommerce-android/pull/8906). Verifying that this indeed worked on WCAndroid (its [fork](https://github.com/wzieba/woocommerce-android)) should be enough, no need for extra testing instructions on WPAndroid.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
