### PR TITLE
[Dependency Updates] Update `daggerVersion` to 2.45

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -103,30 +103,30 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     }
 
     enum class FieldType(@StringRes val errorStringRes: Int, val isValid: (String) -> Boolean) {
-        USER_NAME(R.string.comment_edit_user_name_error, { isValidUserName(it) }),
-        USER_EMAIL(R.string.comment_edit_user_email_error, { isValidUserEmail(it) }),
-        WEB_ADDRESS(R.string.comment_edit_web_address_error, { isValidWebAddress(it) }),
-        COMMENT(R.string.comment_edit_comment_error, { isValidComment(it) });
+        USER_NAME(R.string.comment_edit_user_name_error, { Utilities.isValidUserName(it) }),
+        USER_EMAIL(R.string.comment_edit_user_email_error, { Utilities.isValidUserEmail(it) }),
+        WEB_ADDRESS(R.string.comment_edit_web_address_error, { Utilities.isValidWebAddress(it) }),
+        COMMENT(R.string.comment_edit_comment_error, { Utilities.isValidComment(it) });
 
         // This is here for testing purposes
         fun matches(expectedField: FieldType): Boolean {
             return this == expectedField
         }
 
-        companion object {
-            private fun isValidUserName(userName: String): Boolean {
+        private object Utilities {
+            fun isValidUserName(userName: String): Boolean {
                 return userName.isNotBlank()
             }
 
-            private fun isValidUserEmail(email: String): Boolean {
+            fun isValidUserEmail(email: String): Boolean {
                 return email.isBlank() || validateEmail(email)
             }
 
-            private fun isValidWebAddress(url: String): Boolean {
+            fun isValidWebAddress(url: String): Boolean {
                 return url.isBlank() || validateUrl(url)
             }
 
-            private fun isValidComment(comment: String): Boolean {
+            fun isValidComment(comment: String): Boolean {
                 return comment.isNotBlank()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -34,12 +34,12 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Error
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Loading
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.DeleteStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.DoneStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.ErrorStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.deleteStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.doneStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.errorStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.NotificationsStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.WelcomeStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.notificationsStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.welcomeStep
 import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.LocaleManager
@@ -157,11 +157,11 @@ private fun JetpackMigrationScreen(viewModel: JetpackMigrationViewModel = viewMo
 
         Crossfade(targetState = uiState) { state ->
             when (state) {
-                is Content.Welcome -> WelcomeStep(state)
-                is Content.Notifications -> NotificationsStep(state)
-                is Content.Done -> DoneStep(state)
-                is Content.Delete -> DeleteStep(state)
-                is Error -> ErrorStep(state)
+                is Content.Welcome -> welcomeStep(state)
+                is Content.Notifications -> notificationsStep(state)
+                is Content.Done -> doneStep(state)
+                is Content.Delete -> deleteStep(state)
+                is Error -> errorStep(state)
                 is Loading -> LoadingState()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -60,13 +60,13 @@ fun SiteList(
             .then(blurModifier),
     ) {
         item {
-            SiteListHeader(uiState)
+            siteListHeader(uiState)
         }
         items(
             items = uiState.sites,
             key = { it.id },
         ) { site ->
-            SiteListItem(
+            siteListItem(
                 uiState = site,
                 isDimmed = uiState.isProcessing,
             )
@@ -86,7 +86,7 @@ fun SiteList(
 }
 
 @Composable
-private fun SiteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with(uiState) {
+private fun siteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with(uiState) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -102,7 +102,7 @@ private fun SiteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with
 }
 
 @Composable
-private fun SiteListHeader(uiState: UiState.Content.Welcome) = with(uiState) {
+private fun siteListHeader(uiState: UiState.Content.Welcome) = with(uiState) {
     Column(
         modifier = Modifier
             .dimmed(uiState.isProcessing)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun DeleteStep(uiState: UiState.Content.Delete) = with(uiState) {
+fun deleteStep(uiState: UiState.Content.Delete) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -94,6 +94,6 @@ fun DeleteStep(uiState: UiState.Content.Delete) = with(uiState) {
 private fun PreviewDeleteStep() {
     AppTheme {
         val uiState = UiState.Content.Delete(DeletePrimaryButton {}, DeleteSecondaryButton {})
-        DeleteStep(uiState)
+        deleteStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun DoneStep(uiState: UiState.Content.Done) = with(uiState) {
+fun doneStep(uiState: UiState.Content.Done) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -87,6 +87,6 @@ fun DoneStep(uiState: UiState.Content.Done) = with(uiState) {
 private fun PreviewDoneStep() {
     AppTheme {
         val uiState = UiState.Content.Done(DonePrimaryButton {})
-        DoneStep(uiState)
+        doneStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.components.Screen
 import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 
 @Composable
-fun ErrorStep(uiState: UiState.Error) = with(uiState) {
+fun errorStep(uiState: UiState.Error) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -77,6 +77,6 @@ private fun PreviewErrorStep() {
             secondaryActionButton = ErrorSecondaryButton {},
             type = UiState.Error.Generic,
         )
-        ErrorStep(uiState)
+        errorStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun NotificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
+fun notificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -52,6 +52,6 @@ fun NotificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
 private fun PreviewNotificationsStep() {
     AppTheme {
         val uiState = UiState.Content.Notifications(NotificationsPrimaryButton {})
-        NotificationsStep(uiState)
+        notificationsStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 
 @Composable
 @SuppressLint("FrequentlyChangedStateReadInComposition")
-fun WelcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
+fun welcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
     Box {
         val listState = rememberLazyListState()
         val blurredListState = rememberLazyListState()
@@ -216,7 +216,7 @@ private val previewUiState = UiState.Content.Welcome(
 private fun PreviewWelcomeStep() {
     AppTheme {
         Box {
-            WelcomeStep(previewUiState)
+            welcomeStep(previewUiState)
         }
     }
 }
@@ -228,7 +228,7 @@ private fun PreviewWelcomeStepInProgress() {
     val uiState = previewUiState.copy(isProcessing = true)
     AppTheme {
         Box {
-            WelcomeStep(uiState)
+            welcomeStep(uiState)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.ui.main.jetpack.staticposter.compose.JetpackStaticPoster
+import org.wordpress.android.ui.main.jetpack.staticposter.compose.jetpackStaticPoster
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
@@ -36,7 +36,7 @@ class JetpackStaticPosterFragment : Fragment() {
             AppTheme {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
-                    is UiState.Content -> JetpackStaticPoster(
+                    is UiState.Content -> jetpackStaticPoster(
                         uiState = state,
                         onPrimaryClick = viewModel::onPrimaryClick,
                         onSecondaryClick = viewModel::onSecondaryClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -53,7 +53,7 @@ import org.wordpress.android.util.extensions.isRtl
 
 @Composable
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
-fun JetpackStaticPoster(
+fun jetpackStaticPoster(
     uiState: UiState.Content,
     onPrimaryClick: () -> Unit = {},
     onSecondaryClick: () -> Unit = {},
@@ -147,7 +147,7 @@ private fun PreviewJetpackStaticPoster() {
     AppTheme {
         Box {
             val uiState = UiData.STATS.toContentUiState()
-            JetpackStaticPoster(uiState)
+            jetpackStaticPoster(uiState)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -35,8 +35,8 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
-import org.wordpress.android.ui.qrcodeauth.compose.state.ContentState
-import org.wordpress.android.ui.qrcodeauth.compose.state.ErrorState
+import org.wordpress.android.ui.qrcodeauth.compose.state.contentState
+import org.wordpress.android.ui.qrcodeauth.compose.state.errorState
 import org.wordpress.android.ui.qrcodeauth.compose.state.LoadingState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.viewmodel.observeEvent
@@ -136,8 +136,8 @@ private fun QRCodeAuthScreen(viewModel: QRCodeAuthViewModel = viewModel()) {
 
         @Suppress("UnnecessaryVariable") // See: https://stackoverflow.com/a/69558316/4129245
         when (val state = uiState) {
-            is Content -> ContentState(state)
-            is Error -> ErrorState(state)
+            is Content -> contentState(state)
+            is Error -> errorState(state)
             is Loading -> LoadingState()
             is Scanning -> Unit
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.ui.qrcodeauth.compose.components.Subtitle
 import org.wordpress.android.ui.qrcodeauth.compose.components.Title
 
 @Composable
-fun ContentState(uiState: QRCodeAuthUiState.Content) = with(uiState) {
+fun contentState(uiState: QRCodeAuthUiState.Content) = with(uiState) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -98,6 +98,6 @@ private fun ContentStatePreview() {
             primaryActionButton = ValidatedPrimaryActionButton {},
             secondaryActionButton = ValidatedSecondaryActionButton {},
         )
-        ContentState(state)
+        contentState(state)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.qrcodeauth.compose.components.Subtitle
 import org.wordpress.android.ui.qrcodeauth.compose.components.Title
 
 @Composable
-fun ErrorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
+fun errorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -74,6 +74,6 @@ private fun ErrorStatePreview() {
             primaryActionButton = ErrorPrimaryActionButton {},
             secondaryActionButton = ErrorSecondaryActionButton {},
         )
-        ErrorState(state)
+        errorState(state)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -6,6 +6,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
@@ -81,6 +82,7 @@ class ReaderFollowButton @JvmOverloads constructor(
         setIsFollowed(isFollowed, true)
     }
 
+    @SuppressLint("Recycle")
     private fun setIsFollowed(isFollowed: Boolean, animateChanges: Boolean) {
         if (isFollowed == this.isFollowed && isSelected == isFollowed) {
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old.DomainUiState.AvailableDomain
-import org.wordpress.android.ui.sitecreation.domains.compose.DomainItem
+import org.wordpress.android.ui.sitecreation.domains.compose.domainItem
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.viewBinding
 
@@ -66,7 +66,7 @@ sealed class SiteCreationDomainViewHolder<T : ViewBinding>(protected val binding
         fun onBind(uiState: New.DomainUiState) = with(binding) {
             composeView.setContent {
                 AppThemeWithoutBackground {
-                    DomainItem(uiState)
+                    domainItem(uiState)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -49,7 +49,7 @@ private val PrimaryFontSize = 17.sp
 private val StartPadding = 40.dp
 
 @Composable
-fun DomainItem(uiState: DomainUiState) = with(uiState) {
+fun domainItem(uiState: DomainUiState) = with(uiState) {
     Column(Modifier.background(if (isSelected) HighlightBgColor else Unspecified)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -188,7 +188,7 @@ private fun DomainItemPreview() {
     }
     AppThemeWithoutBackground {
         Column {
-            uiStates.forEach { DomainItem(it) }
+            uiStates.forEach { domainItem(it) }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.previews
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.os.Bundle
@@ -164,6 +165,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     private fun SiteCreationPreviewScreenDefaultBinding.animateContentTransition() {
         contentLayout.addOnLayoutChangeListener(
             object : OnLayoutChangeListener {
+                @SuppressLint("Recycle")
                 override fun onLayoutChange(
                     v: View?,
                     left: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.progress
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.view.View
@@ -131,6 +132,7 @@ class SiteCreationProgressFragment : Fragment(R.layout.site_creation_progress_sc
         }
     }
 
+    @SuppressLint("Recycle")
     private fun SiteCreationProgressCreatingSiteBinding.updateLoadingTextWithFadeAnimation(newText: CharSequence) {
         val animationDuration = AniUtils.Duration.SHORT
         val fadeOut = AniUtils.getFadeOutAnim(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -43,7 +43,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
         initDagger()
         with(StatsJetpackConnectionActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-            setActionBar()
+            initActionBar()
             setTitle(string.stats)
             checkAndContinueJetpackConnectionFlow(savedInstanceState)
             initViews()
@@ -54,7 +54,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
         (application as WordPress).component().inject(this)
     }
 
-    private fun StatsJetpackConnectionActivityBinding.setActionBar() {
+    private fun StatsJetpackConnectionActivityBinding.initActionBar() {
         setSupportActionBar(toolbarLayout.toolbarMain)
         val actionBar = supportActionBar
         if (actionBar != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
     androidxAppcompatVersion = '1.4.2'
     androidxArchCoreVersion = '2.1.0'
     androidxComposeBomVersion = '2023.01.00'
-    androidxComposeCompilerVersion = '1.3.2'
+    androidxComposeCompilerVersion = '1.4.6'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.7.20'
     gradle.ext.agpVersion = '7.2.1'
-    gradle.ext.daggerVersion = "2.42"
+    gradle.ext.daggerVersion = "2.45"
     gradle.ext.detektVersion = '1.21.0'
     gradle.ext.navComponentVersion = '2.4.2'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.7.20'
+    gradle.ext.kotlinVersion = '1.8.20'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = "2.45"
     gradle.ext.detektVersion = '1.21.0'


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR updates `daggerVersion` to [2.45](https://github.com/google/dagger/releases/tag/dagger-2.45).

FYI: See this [related comment](https://github.com/wordpress-mobile/WordPress-Android/issues/17563#issuecomment-1527280787) for the reasoning behind this update.

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test both, the WordPress and Jetpack apps, and see if everything is working as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within, which is mainly related to this [2.43](https://github.com/google/dagger/releases/tag/dagger-2.43) update and a `Hilt` related potentially breaking changes with `androidx.navigation` and the necessity for the [2.5.0](https://developer.android.com/jetpack/androidx/releases/navigation#2.5.0) update to interoperate:

<details>
    <summary>Image Editing Screen [EditImageActivity.kt + PreviewImageFragment.kt + CropFragment.kt]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` apps.
ℹ️ Testing this flow and see it working, which is the only flow that is using `androidx.navigation`, make me think that updating the [Navigation Component](https://developer.android.com/jetpack/androidx/releases/navigation) library is not necessary at this point of time.

- Add a new `blog` post.
- Add a new `image` block.
- Choose an image and wait for it to be uploaded within the `image` block.
- Click on the `media options` of this image (top right) and then click `edit`.
- Verify that the `Edit Image` screen is shown and functioning as expected.
- Crop the image and click the `done` menu option (top right).
- Make sure the image is updated accordingly.

</details>

-----

## Merge instructions

- [x] Wait for [this other](https://github.com/wordpress-mobile/WordPress-Android/pull/18330) PR to be reviewed, tested and approved.
- [x] Update PR's base [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) branch with latest `trunk`.
- [x] Update this PR with latest [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) and make sure everything is still working as expected.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Merge PR to [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all app screens, especially the `Image Editing` screen, which is related to `androidx.navigation`, and it not being (yet) update to [2.5.0](https://developer.android.com/jetpack/androidx/releases/navigation#2.5.0) and above.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
