### PR TITLE
[Dependency Updates] Update `androidxComposeCompilerVersion` and `kotlinVersion` to 1.4.6 and 1.8.20

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsEditViewModel.kt
@@ -103,30 +103,30 @@ class UnifiedCommentsEditViewModel @Inject constructor(
     }
 
     enum class FieldType(@StringRes val errorStringRes: Int, val isValid: (String) -> Boolean) {
-        USER_NAME(R.string.comment_edit_user_name_error, { isValidUserName(it) }),
-        USER_EMAIL(R.string.comment_edit_user_email_error, { isValidUserEmail(it) }),
-        WEB_ADDRESS(R.string.comment_edit_web_address_error, { isValidWebAddress(it) }),
-        COMMENT(R.string.comment_edit_comment_error, { isValidComment(it) });
+        USER_NAME(R.string.comment_edit_user_name_error, { Utilities.isValidUserName(it) }),
+        USER_EMAIL(R.string.comment_edit_user_email_error, { Utilities.isValidUserEmail(it) }),
+        WEB_ADDRESS(R.string.comment_edit_web_address_error, { Utilities.isValidWebAddress(it) }),
+        COMMENT(R.string.comment_edit_comment_error, { Utilities.isValidComment(it) });
 
         // This is here for testing purposes
         fun matches(expectedField: FieldType): Boolean {
             return this == expectedField
         }
 
-        companion object {
-            private fun isValidUserName(userName: String): Boolean {
+        private object Utilities {
+            fun isValidUserName(userName: String): Boolean {
                 return userName.isNotBlank()
             }
 
-            private fun isValidUserEmail(email: String): Boolean {
+            fun isValidUserEmail(email: String): Boolean {
                 return email.isBlank() || validateEmail(email)
             }
 
-            private fun isValidWebAddress(url: String): Boolean {
+            fun isValidWebAddress(url: String): Boolean {
                 return url.isBlank() || validateUrl(url)
             }
 
-            private fun isValidComment(comment: String): Boolean {
+            fun isValidComment(comment: String): Boolean {
                 return comment.isNotBlank()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -34,12 +34,12 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Error
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Loading
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.DeleteStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.DoneStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.ErrorStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.deleteStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.doneStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.errorStep
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.NotificationsStep
-import org.wordpress.android.ui.main.jetpack.migration.compose.state.WelcomeStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.notificationsStep
+import org.wordpress.android.ui.main.jetpack.migration.compose.state.welcomeStep
 import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.LocaleManager
@@ -157,11 +157,11 @@ private fun JetpackMigrationScreen(viewModel: JetpackMigrationViewModel = viewMo
 
         Crossfade(targetState = uiState) { state ->
             when (state) {
-                is Content.Welcome -> WelcomeStep(state)
-                is Content.Notifications -> NotificationsStep(state)
-                is Content.Done -> DoneStep(state)
-                is Content.Delete -> DeleteStep(state)
-                is Error -> ErrorStep(state)
+                is Content.Welcome -> welcomeStep(state)
+                is Content.Notifications -> notificationsStep(state)
+                is Content.Done -> doneStep(state)
+                is Content.Delete -> deleteStep(state)
+                is Error -> errorStep(state)
                 is Loading -> LoadingState()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -60,13 +60,13 @@ fun SiteList(
             .then(blurModifier),
     ) {
         item {
-            SiteListHeader(uiState)
+            siteListHeader(uiState)
         }
         items(
             items = uiState.sites,
             key = { it.id },
         ) { site ->
-            SiteListItem(
+            siteListItem(
                 uiState = site,
                 isDimmed = uiState.isProcessing,
             )
@@ -86,7 +86,7 @@ fun SiteList(
 }
 
 @Composable
-private fun SiteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with(uiState) {
+private fun siteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with(uiState) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -102,7 +102,7 @@ private fun SiteListItem(uiState: SiteListItemUiState, isDimmed: Boolean) = with
 }
 
 @Composable
-private fun SiteListHeader(uiState: UiState.Content.Welcome) = with(uiState) {
+private fun siteListHeader(uiState: UiState.Content.Welcome) = with(uiState) {
     Column(
         modifier = Modifier
             .dimmed(uiState.isProcessing)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun DeleteStep(uiState: UiState.Content.Delete) = with(uiState) {
+fun deleteStep(uiState: UiState.Content.Delete) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -94,6 +94,6 @@ fun DeleteStep(uiState: UiState.Content.Delete) = with(uiState) {
 private fun PreviewDeleteStep() {
     AppTheme {
         val uiState = UiState.Content.Delete(DeletePrimaryButton {}, DeleteSecondaryButton {})
-        DeleteStep(uiState)
+        deleteStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun DoneStep(uiState: UiState.Content.Done) = with(uiState) {
+fun doneStep(uiState: UiState.Content.Done) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -87,6 +87,6 @@ fun DoneStep(uiState: UiState.Content.Done) = with(uiState) {
 private fun PreviewDoneStep() {
     AppTheme {
         val uiState = UiState.Content.Done(DonePrimaryButton {})
-        DoneStep(uiState)
+        doneStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.components.Screen
 import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 
 @Composable
-fun ErrorStep(uiState: UiState.Error) = with(uiState) {
+fun errorStep(uiState: UiState.Error) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -77,6 +77,6 @@ private fun PreviewErrorStep() {
             secondaryActionButton = ErrorSecondaryButton {},
             type = UiState.Error.Generic,
         )
-        ErrorStep(uiState)
+        errorStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
 
 @Composable
-fun NotificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
+fun notificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -52,6 +52,6 @@ fun NotificationsStep(uiState: UiState.Content.Notifications) = with(uiState) {
 private fun PreviewNotificationsStep() {
     AppTheme {
         val uiState = UiState.Content.Notifications(NotificationsPrimaryButton {})
-        NotificationsStep(uiState)
+        notificationsStep(uiState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 
 @Composable
 @SuppressLint("FrequentlyChangedStateReadInComposition")
-fun WelcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
+fun welcomeStep(uiState: UiState.Content.Welcome) = with(uiState) {
     Box {
         val listState = rememberLazyListState()
         val blurredListState = rememberLazyListState()
@@ -216,7 +216,7 @@ private val previewUiState = UiState.Content.Welcome(
 private fun PreviewWelcomeStep() {
     AppTheme {
         Box {
-            WelcomeStep(previewUiState)
+            welcomeStep(previewUiState)
         }
     }
 }
@@ -228,7 +228,7 @@ private fun PreviewWelcomeStepInProgress() {
     val uiState = previewUiState.copy(isProcessing = true)
     AppTheme {
         Box {
-            WelcomeStep(uiState)
+            welcomeStep(uiState)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.ui.main.jetpack.staticposter.compose.JetpackStaticPoster
+import org.wordpress.android.ui.main.jetpack.staticposter.compose.jetpackStaticPoster
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
@@ -36,7 +36,7 @@ class JetpackStaticPosterFragment : Fragment() {
             AppTheme {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
-                    is UiState.Content -> JetpackStaticPoster(
+                    is UiState.Content -> jetpackStaticPoster(
                         uiState = state,
                         onPrimaryClick = viewModel::onPrimaryClick,
                         onSecondaryClick = viewModel::onSecondaryClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -53,7 +53,7 @@ import org.wordpress.android.util.extensions.isRtl
 
 @Composable
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
-fun JetpackStaticPoster(
+fun jetpackStaticPoster(
     uiState: UiState.Content,
     onPrimaryClick: () -> Unit = {},
     onSecondaryClick: () -> Unit = {},
@@ -147,7 +147,7 @@ private fun PreviewJetpackStaticPoster() {
     AppTheme {
         Box {
             val uiState = UiData.STATS.toContentUiState()
-            JetpackStaticPoster(uiState)
+            jetpackStaticPoster(uiState)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -35,8 +35,8 @@ import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Content
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Error
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Loading
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState.Scanning
-import org.wordpress.android.ui.qrcodeauth.compose.state.ContentState
-import org.wordpress.android.ui.qrcodeauth.compose.state.ErrorState
+import org.wordpress.android.ui.qrcodeauth.compose.state.contentState
+import org.wordpress.android.ui.qrcodeauth.compose.state.errorState
 import org.wordpress.android.ui.qrcodeauth.compose.state.LoadingState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.viewmodel.observeEvent
@@ -136,8 +136,8 @@ private fun QRCodeAuthScreen(viewModel: QRCodeAuthViewModel = viewModel()) {
 
         @Suppress("UnnecessaryVariable") // See: https://stackoverflow.com/a/69558316/4129245
         when (val state = uiState) {
-            is Content -> ContentState(state)
-            is Error -> ErrorState(state)
+            is Content -> contentState(state)
+            is Error -> errorState(state)
             is Loading -> LoadingState()
             is Scanning -> Unit
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.ui.qrcodeauth.compose.components.Subtitle
 import org.wordpress.android.ui.qrcodeauth.compose.components.Title
 
 @Composable
-fun ContentState(uiState: QRCodeAuthUiState.Content) = with(uiState) {
+fun contentState(uiState: QRCodeAuthUiState.Content) = with(uiState) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -98,6 +98,6 @@ private fun ContentStatePreview() {
             primaryActionButton = ValidatedPrimaryActionButton {},
             secondaryActionButton = ValidatedSecondaryActionButton {},
         )
-        ContentState(state)
+        contentState(state)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.qrcodeauth.compose.components.Subtitle
 import org.wordpress.android.ui.qrcodeauth.compose.components.Title
 
 @Composable
-fun ErrorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
+fun errorState(uiState: QRCodeAuthUiState.Error) = with(uiState) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
@@ -74,6 +74,6 @@ private fun ErrorStatePreview() {
             primaryActionButton = ErrorPrimaryActionButton {},
             secondaryActionButton = ErrorSecondaryActionButton {},
         )
-        ErrorState(state)
+        errorState(state)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderFollowButton.kt
@@ -6,6 +6,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
@@ -81,6 +82,7 @@ class ReaderFollowButton @JvmOverloads constructor(
         setIsFollowed(isFollowed, true)
     }
 
+    @SuppressLint("Recycle")
     private fun setIsFollowed(isFollowed: Boolean, animateChanges: Boolean) {
         if (isFollowed == this.isFollowed && isSelected == isFollowed) {
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old.DomainUiState.AvailableDomain
-import org.wordpress.android.ui.sitecreation.domains.compose.DomainItem
+import org.wordpress.android.ui.sitecreation.domains.compose.domainItem
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.viewBinding
 
@@ -66,7 +66,7 @@ sealed class SiteCreationDomainViewHolder<T : ViewBinding>(protected val binding
         fun onBind(uiState: New.DomainUiState) = with(binding) {
             composeView.setContent {
                 AppThemeWithoutBackground {
-                    DomainItem(uiState)
+                    domainItem(uiState)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -49,7 +49,7 @@ private val PrimaryFontSize = 17.sp
 private val StartPadding = 40.dp
 
 @Composable
-fun DomainItem(uiState: DomainUiState) = with(uiState) {
+fun domainItem(uiState: DomainUiState) = with(uiState) {
     Column(Modifier.background(if (isSelected) HighlightBgColor else Unspecified)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -188,7 +188,7 @@ private fun DomainItemPreview() {
     }
     AppThemeWithoutBackground {
         Column {
-            uiStates.forEach { DomainItem(it) }
+            uiStates.forEach { domainItem(it) }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitecreation.previews
 
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.os.Bundle
@@ -164,6 +165,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     private fun SiteCreationPreviewScreenDefaultBinding.animateContentTransition() {
         contentLayout.addOnLayoutChangeListener(
             object : OnLayoutChangeListener {
+                @SuppressLint("Recycle")
                 override fun onLayoutChange(
                     v: View?,
                     left: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressFragment.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.progress
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.view.View
@@ -131,6 +132,7 @@ class SiteCreationProgressFragment : Fragment(R.layout.site_creation_progress_sc
         }
     }
 
+    @SuppressLint("Recycle")
     private fun SiteCreationProgressCreatingSiteBinding.updateLoadingTextWithFadeAnimation(newText: CharSequence) {
         val animationDuration = AniUtils.Duration.SHORT
         val fadeOut = AniUtils.getFadeOutAnim(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -43,7 +43,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
         initDagger()
         with(StatsJetpackConnectionActivityBinding.inflate(layoutInflater)) {
             setContentView(root)
-            setActionBar()
+            initActionBar()
             setTitle(string.stats)
             checkAndContinueJetpackConnectionFlow(savedInstanceState)
             initViews()
@@ -54,7 +54,7 @@ class StatsConnectJetpackActivity : LocaleAwareActivity() {
         (application as WordPress).component().inject(this)
     }
 
-    private fun StatsJetpackConnectionActivityBinding.setActionBar() {
+    private fun StatsJetpackConnectionActivityBinding.initActionBar() {
         setSupportActionBar(toolbarLayout.toolbarMain)
         val actionBar = supportActionBar
         if (actionBar != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
     androidxAppcompatVersion = '1.4.2'
     androidxArchCoreVersion = '2.1.0'
     androidxComposeBomVersion = '2023.01.00'
-    androidxComposeCompilerVersion = '1.3.2'
+    androidxComposeCompilerVersion = '1.4.6'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.7.20'
+    gradle.ext.kotlinVersion = '1.8.20'
     gradle.ext.agpVersion = '7.2.1'
     gradle.ext.daggerVersion = "2.45"
     gradle.ext.detektVersion = '1.21.0'


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR update `androidxComposeCompilerVersion` and `kotlinVersion` to [1.4.6](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.4.6) and [1.8.20](https://github.com/JetBrains/kotlin/releases/tag/v1.8.20) respectively.

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

Compile Warnings Resolution List:

1. [Resolve companion object of enum class uninitialized warning](https://github.com/wordpress-mobile/WordPress-Android/commit/5eaf7da3d11f05f7f8ace3068b955fd4f5b54886)

Lint Warnings Resolution List:

1. [Resolve composable naming lint warnings](https://github.com/wordpress-mobile/WordPress-Android/commit/e1a639ff25cc660a09b5774273f8ec430c79b1e3)
2. [Resolve use support action bar lint warning](https://github.com/wordpress-mobile/WordPress-Android/commit/c6d3d424bde47088b9326a149dd736d12f4becf9)

Lint Warnings Suppression List:

1. [Suppress animation set start and recycle related lint warnings](https://github.com/wordpress-mobile/WordPress-Android/commit/59a3db1bd620f7eaad2af0d0e048704f59bee034)

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Per update:
    - Based on the `Kotlin` update, smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.
    - Based on the `Compose Compiler` update, thoroughly smoke test any Compose related screens, on both, the WordPress and Jetpack apps, and see if they both work as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within:

#### Kotlin Update:

<details>
    <summary>Comment Editing Screen [UnifiedCommentsEditFragment.kt + UnifiedCommentsEditViewModel.kt + FieldType]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` apps.

- Go to `Comments` screen.
- Find a a posts from the list of comments and click on it.
- Click on the `More` button (bottom right) and then click `Edit`.
- Verify that the `Edit Comment` screen is shown and functioning as expected. More specifically:
    - Verify that blanking the `Name` entry results into a `User name cannot be empty` error.
    - Verify that deleting part of the `Web address` entry results into a `Web address not valid` error.
    - Verify that deleting part of the `Email address` entry results into a `User email not valid` error.
    - Verify that blanking the `Comment` entry results into a `Comment cannot be empty` error.

</details>

#### Compose Compiler Update:

<details>
    <summary>1. Login Screen [LoginPrologueRevampedFragment.kt]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.

- Log out of the app (if already logged-in).
- Verify that the `Login` screen is shown and functioning as expected.

</details>

<details>
    <summary>2. QR Code Auth Screen [QRCodeAuthFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
ℹ️ You don't have to follow all 3 steps, just logging in with a non `A8C` and non `2FA` enabled
account, followed by tapping the `Scan Login Code` item on the `Me` screen should be enough, which
is effectively just `Step.1` and the beginning of `Step.3`.

Step.1:
- Build and install the `Jetpack` app (note that you don't need a release build, a debug build will
suffice).
- Login to the `Jetpack` app with a `WP.com` account (note that you need to use a non `A8C` account
and a non `2FA` enabled account).
- Navigate to the `Me` screen (click on avatar at top-right).
(STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to `wordpress.com` (note that if you are logged-in, log-out first).
- Tap the `Log In` link (top-right).
- Tap the `Login via the mobile app` link in the list of options below the main Continue button
(bottom-middle).
- Verify you are on the `Login via the mobile app` view and `Use QR Code to login` is shown, along with
a QR code for you to scan.
- (STOP)

Step.3:
- Head back to your mobile.
- Tap the `Scan Login Code` item on the `Me` screen you are currently at.
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to login to WordPress on your web browser (desktop),
verify that you have successfully logged-in and are able to use WordPress as expected.

</details>

<details>
    <summary>3a. Jetpack Static Poster Screen [JetpackStaticPosterActivity.kt + JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Stats` option.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Stats` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>3b. Jetpack Static Poster Screen [JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `Reader` or `Notifications` tab.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Reader` or `Notifications` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>4a. Jetpack Migration Screen [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the card on top that prompts the user to uninstall the WordPress app and click on it.
- Verify that the `Jetpack Migration` screen is shown and functioning as expected.

</details>

<details>
    <summary>4a. Jetpack Migration Flow [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Install both apps.
- Clear cache/data of the `Jetpack` app and restart it.
- The migration flow should appear, verify that it is shown and functioning as expected.

</details>

<details>
    <summary>5. Blaze Screen [BlazeOverlayFragment.kt + BlazeWebViewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Blaze` option.
- Verify that the `Blaze` screen is shown and functioning as expected.

</details>

<details>
    <summary>6. Blogging Prompts Screen [BloggingPromptsListActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the `Prompts` card on top and click on its options (top right).
- From the options menu, select `View more prompts`.
- Verify that the `Blogging Prompts` screen is shown and functioning as expected.

</details>

<details>
    <summary>7. Individual Plugin Screen [WPJetpackIndividualPluginFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [individual.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309662/individual.patch) patch to quickly test this screen.

- Go to `My Site` tab -> `Site Picker` (down-arrow).
- Let `individual.patch` patch do its magic... 🪄
- Verify that the `Individual Plugin` screen is shown and functioning as expected.

</details>

<details>
    <summary>8a. Jetpack Full Plugin Install Screen [JetpackFullPluginInstallOnboardingDialogFragment.kt + JetpackFullPluginInstallActivity.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [full.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309714/full.patch) patch to quickly test this screen.

- Go to `My Site` tab.
- Let `full.patch` patch do its magic... 🪄
- Verify that the `Jetpack Full Plugin Install` dialog is shown and functioning as expected.
- Click on `Install the full plugin` button.
- Verify that the `Jetpack Full Plugin Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>8b. Jetpack Install Full Plugin View [JetpackInstallFullPluginCardViewHolder.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
❗️ Apply the provided [card.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11332106/card.patch) patch to quickly test this screen.

- Go to `Debug Settings` and make sure to enable only `jetpack_removal_one` from all the Jetpack
removal flags.
- Go to `My Site` tab -> `HOME` sub-tab.
- Let `full.patch` patch do its magic... 🪄
- Find the card in the middle that prompts the user to install the full Jetpack plugin and click on
`Learn more`.
- Verify that the `Jetpack Full Plugin Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>9. Jetpack Remove Install Screen [JetpackRemoteInstallActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Spin up a self-hosted site via `Jurassic Ninja` with no `Jetpack` plugins at all.
https://fieldguide.automattic.com/jurassic-ninja/
- Login to the app using the credentials of the new site and then go to `Stats`.
- Tap `Install Jetpack` button.
- Verify that the `Jetpack Remove Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>10. Site Creation Domain View [SiteCreationDomainViewHolder.kt]</summary>

- Go to `Debug Settings` and enable the `SiteCreationDomainPurchasingFeatureConfig` feature flag.
- Go to `Site Picker` -> Click the `+` button -> Chose `Create WordPress.com site` ->
Click the `SKIP` button -> And again, click the `SKIP` button.
- Enter any search query in the input (eg. 'awesome').
- Verify the list of domain suggestions is presented (the item UI is compose)
- Verify that the `Site Creation Domain` view and its list is shown and functioning as expected.

</details>

<details>
    <summary>11. About App Screen [com.automattic:about]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.
❗️ This test makes sure that the `About App` screen, which comes from the [com.automattic:about](https://github.com/Automattic/about-automattic-android)
library is also working as expected and that any transitive dependency changes aren't affecting
this `Compose` related screen.

- Go to `My Site` tab and navigate to the `Me` screen (click on avatar at top-right).
- Tap the `About App` item on the `Me` screen you are currently at.
- Verify that the `About App` screen is shown and functioning as expected.

</details>

-----

## Merge instructions

- [ ] Wait for [this other](https://github.com/wordpress-mobile/WordPress-Android/pull/18336) PR to be reviewed, tested and approved.
- [ ] Update PR's base [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) branch with latest `trunk`.
- [ ] Update this PR with latest [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) and make sure everything is still working as expected.
- [ ] Remove `[PR] Not Ready For Merge]` label.
- [ ] Merge PR to [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all Compose related screens, like the `Login` screen, the `Jetpack Migration` screens or the `Blaze` green (to name a few).

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
