### PR TITLE
[Dependency Updates] Update `androidxAppcompatVersion` to 1.6.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1424,6 +1424,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
+    @kotlinx.coroutines.DelicateCoroutinesApi
     public void onCommentChanged(OnCommentChanged event) {
         setProgressVisible(false);
         // requesting local comment cache refresh

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -119,6 +119,7 @@ import javax.inject.Inject;
 
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
+import kotlinx.coroutines.DelicateCoroutinesApi;
 import kotlinx.coroutines.Dispatchers;
 import kotlinx.coroutines.GlobalScope;
 
@@ -1424,6 +1425,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
+    @kotlinx.coroutines.DelicateCoroutinesApi
     public void onCommentChanged(OnCommentChanged event) {
         setProgressVisible(false);
         // requesting local comment cache refresh

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -119,7 +119,6 @@ import javax.inject.Inject;
 
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
-import kotlinx.coroutines.DelicateCoroutinesApi;
 import kotlinx.coroutines.Dispatchers;
 import kotlinx.coroutines.GlobalScope;
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     // main
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.2.1'
-    androidxAppcompatVersion = '1.4.2'
+    androidxAppcompatVersion = '1.6.1'
     androidxArchCoreVersion = '2.1.0'
     androidxComposeVersion = '1.1.1'
     androidxComposeCompilerVersion = '1.1.1'


### PR DESCRIPTION
Updating androidxAppcompatVersion[ from 1.4.2](#17743) to 1.6.1.  Since `compleSdkVersion`, and `targetSdkVersion` are now [migrated to 33](#17947) ([android 13](#18172 )).  It is now time to update AppcompatVersion to the latest stable version.

It is also required for the implementation of Per-app Language Preferences pbArwn-5im-p2.


To test:

- See the dependency tree diff result and verify correctness.
- Thoroughly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

## Regression Notes
1. Potential unintended areas of impact
   Haven't found any in my testing.  However,
   - androidx.appcompat is a library that is being added as a transitive dependency across lots of androidx and com.google and other libraries.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

   - See To test section above.

3. What automated tests I added (or what prevented me from doing so)
   - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
