### PR TITLE
Dashboard Cards: Pages handle click actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -130,6 +130,7 @@ import org.wordpress.android.util.UriWrapper;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -688,6 +689,21 @@ public class ActivityLauncher {
         context.startActivity(intent);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);
     }
+
+    public static void viewCurrentBlogPagesOfType(Context context, SiteModel site, PageListType pageListType) {
+        if (pageListType == null) {
+            Intent intent = new Intent(context, PagesActivity.class);
+            intent.putExtra(WordPress.SITE, site);
+            context.startActivity(intent);
+        } else {
+            // todo: - PagesActivity must be updated to support PageListType and opening tabs
+            Intent intent = new Intent(context, PagesActivity.class);
+            intent.putExtra(WordPress.SITE, site);
+            context.startActivity(intent);
+        }
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);
+    }
+
 
     public static void viewPageParentForResult(@NonNull Fragment fragment, @NonNull SiteModel site,
                                                @NonNull Long pageRemoteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -160,6 +160,7 @@ import static org.wordpress.android.ui.jetpack.scan.ScanFragment.ARG_THREAT_ID;
 import static org.wordpress.android.ui.main.WPMainActivity.ARG_BYPASS_MIGRATION;
 import static org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationActivity.KEY_DEEP_LINK_DATA;
 import static org.wordpress.android.ui.media.MediaBrowserActivity.ARG_BROWSER_TYPE;
+import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_LIST_TYPE_KEY;
 import static org.wordpress.android.ui.pages.PagesActivityKt.EXTRA_PAGE_REMOTE_ID_KEY;
 import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_ALL_UNFLATTENED_LOADED_SLIDES;
 import static org.wordpress.android.ui.stories.StoryComposerActivity.KEY_LAUNCHED_FROM_GUTENBERG;
@@ -696,9 +697,9 @@ public class ActivityLauncher {
             intent.putExtra(WordPress.SITE, site);
             context.startActivity(intent);
         } else {
-            // todo: - PagesActivity must be updated to support PageListType and opening tabs
             Intent intent = new Intent(context, PagesActivity.class);
             intent.putExtra(WordPress.SITE, site);
+            intent.putExtra(EXTRA_PAGE_LIST_TYPE_KEY, pageListType);
             context.startActivity(intent);
         }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PAGES, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -220,7 +220,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                             @DrawableRes val statusIcon: Int?,
                             val status: UiString?,
                             val lastEditedOrScheduledTime: UiString,
-                            val onCardClick: () -> Unit
+                            val onClick: ListItemInteraction
                         )
 
                         data class CreateNewPageItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -213,7 +213,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                     data class PagesCardWithData(
                         val title: UiString,
                         val pages: List<PageContentItem>,
-                        val footerLink: CreatNewPageItem
+                        val footerLink: CreateNewPageItem
                     ) : PagesCard(dashboardCardType = DashboardCardType.PAGES_CARD) {
                         data class PageContentItem(
                             val title: UiString,
@@ -223,7 +223,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                             val onCardClick: () -> Unit
                         )
 
-                        data class CreatNewPageItem(
+                        data class CreateNewPageItem(
                             val label: UiString,
                             val description: UiString? = null,
                             @DrawableRes val imageRes: Int? = null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -710,28 +710,25 @@ class MySiteViewModel @Inject constructor(
 
     private fun onPagesItemClick(params: PagesCardBuilderParams.PagesItemClickParams) {
         cardsTracker.trackPagesItemClicked(params.pagesCardType)
-        when (params.pagesCardType) {
+        _onNavigation.value = Event(getNavigationActionForPagesItem(params.pagesCardType, params.pageId))
+    }
+
+    private fun getNavigationActionForPagesItem(pagesCardType: PagesCardContentType, pageId: Int): SiteNavigationAction {
+        return when (pagesCardType) {
             PagesCardContentType.SCHEDULED -> {
-                _onNavigation.value =
-                    Event(
-                        SiteNavigationAction.OpenPagesScheduledTab(
-                            requireNotNull(selectedSiteRepository.getSelectedSite()),
-                            params.pageId
-                        )
-                    )
+                SiteNavigationAction.OpenPagesScheduledTab(
+                    requireNotNull(selectedSiteRepository.getSelectedSite()),
+                    pageId
+                )
             }
             PagesCardContentType.DRAFT -> {
-                _onNavigation.value =
-                    Event(
-                        SiteNavigationAction.OpenPagesDraftsTab(
-                            requireNotNull(selectedSiteRepository.getSelectedSite()),
-                            params.pageId
-                        )
-                    )
+                SiteNavigationAction.OpenPagesDraftsTab(
+                    requireNotNull(selectedSiteRepository.getSelectedSite()),
+                    pageId
+                )
             }
             PagesCardContentType.PUBLISH -> {
-                _onNavigation.value =
-                    Event(SiteNavigationAction.OpenPages(requireNotNull(selectedSiteRepository.getSelectedSite())))
+                SiteNavigationAction.OpenPages(requireNotNull(selectedSiteRepository.getSelectedSite()))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -713,7 +713,10 @@ class MySiteViewModel @Inject constructor(
         _onNavigation.value = Event(getNavigationActionForPagesItem(params.pagesCardType, params.pageId))
     }
 
-    private fun getNavigationActionForPagesItem(pagesCardType: PagesCardContentType, pageId: Int): SiteNavigationAction {
+    private fun getNavigationActionForPagesItem(
+        pagesCardType: PagesCardContentType,
+        pageId: Int
+    ): SiteNavigationAction {
         return when (pagesCardType) {
             PagesCardContentType.SCHEDULED -> {
                 SiteNavigationAction.OpenPagesScheduledTab(
@@ -721,12 +724,14 @@ class MySiteViewModel @Inject constructor(
                     pageId
                 )
             }
+
             PagesCardContentType.DRAFT -> {
                 SiteNavigationAction.OpenPagesDraftsTab(
                     requireNotNull(selectedSiteRepository.getSelectedSite()),
                     pageId
                 )
             }
+
             PagesCardContentType.PUBLISH -> {
                 SiteNavigationAction.OpenPages(requireNotNull(selectedSiteRepository.getSelectedSite()))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -94,6 +94,7 @@ import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.domain.DashboardCardDomainUtils
+import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardHelper
@@ -707,9 +708,32 @@ class MySiteViewModel @Inject constructor(
         )
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun onPagesItemClick(params: PagesCardBuilderParams.PagesItemClickParams) {
-        // implement navigation logic for pages
+        cardsTracker.trackPagesItemClicked(params.pagesCardType)
+        when (params.pagesCardType) {
+            PagesCardContentType.SCHEDULED -> {
+                _onNavigation.value =
+                    Event(
+                        SiteNavigationAction.OpenPagesScheduledTab(
+                            requireNotNull(selectedSiteRepository.getSelectedSite()),
+                            params.pageId
+                        )
+                    )
+            }
+            PagesCardContentType.DRAFT -> {
+                _onNavigation.value =
+                    Event(
+                        SiteNavigationAction.OpenPagesDraftsTab(
+                            requireNotNull(selectedSiteRepository.getSelectedSite()),
+                            params.pageId
+                        )
+                    )
+            }
+            PagesCardContentType.PUBLISH -> {
+                _onNavigation.value =
+                    Event(SiteNavigationAction.OpenPages(requireNotNull(selectedSiteRepository.getSelectedSite())))
+            }
+        }
     }
 
     private fun onPagesCardFooterLinkClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -89,4 +89,6 @@ sealed class SiteNavigationAction {
     data class OpenActivityLogDetail(val site: SiteModel, val activityId: String, val isRewindable: Boolean) :
         SiteNavigationAction()
     data class TriggerCreatePageFlow(val site: SiteModel):SiteNavigationAction()
+    data class OpenPagesDraftsTab(val site: SiteModel, val pageId: Int) : SiteNavigationAction()
+    data class OpenPagesScheduledTab(val site: SiteModel, val pageId: Int) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
+import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.quickstart.QuickStartTracker
 import org.wordpress.android.ui.quickstart.QuickStartType
@@ -50,11 +51,14 @@ class CardsTracker @Inject constructor(
     }
 
     enum class ActivityLogSubtype(val label: String) {
-        ACTIVITY_LOG("activity_log"),
+        ACTIVITY_LOG("activity_log")
     }
 
     enum class PagesSubType(val label: String) {
         CREATE_PAGE("create_page"),
+        DRAFT("draft"),
+        SCHEDULED("scheduled"),
+        PUBLISHED("published")
     }
 
     fun trackQuickStartCardItemClicked(quickStartTaskType: QuickStartTaskType) {
@@ -87,6 +91,10 @@ class CardsTracker @Inject constructor(
 
     fun trackActivityCardFooterClicked() {
         trackCardFooterLinkClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
+    }
+
+    fun trackPagesItemClicked(pageCardType: PagesCardContentType) {
+        trackCardItemClicked(Type.PAGES.label, pageCardType.toSubtypeValue().label)
     }
 
     fun trackPagesCardFooterClicked() {
@@ -155,6 +163,14 @@ fun PostCardType.toSubtypeValue(): PostSubtype {
         PostCardType.CREATE_NEXT -> PostSubtype.CREATE_NEXT
         PostCardType.DRAFT -> PostSubtype.DRAFT
         PostCardType.SCHEDULED -> PostSubtype.SCHEDULED
+    }
+}
+
+fun PagesCardContentType.toSubtypeValue(): CardsTracker.PagesSubType {
+    return when (this) {
+        PagesCardContentType.DRAFT -> CardsTracker.PagesSubType.DRAFT
+        PagesCardContentType.PUBLISH -> CardsTracker.PagesSubType.PUBLISHED
+        PagesCardContentType.SCHEDULED -> CardsTracker.PagesSubType.SCHEDULED
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
@@ -6,6 +6,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.CreateNewPageItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.PageContentItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams.PagesItemClickParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.config.DashboardCardPagesConfig
@@ -13,6 +14,7 @@ import javax.inject.Inject
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType.DRAFT
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType.PUBLISH
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType.SCHEDULED
+import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.DateTimeUtilsWrapper
 
 private const val REQUIRED_PAGES_IN_CARD: Int = 3
@@ -30,7 +32,9 @@ class PagesCardBuilder @Inject constructor(
 
     private fun convertToPagesItems(params: PagesCardBuilderParams): PagesCard.PagesCardWithData {
         val pages = params.pageCard?.pages
-        val content = pages?.filterByPagesCardSupportedStatus()?.let { getPagesContentItems(pages) } ?: emptyList()
+        val content =
+            pages?.filterByPagesCardSupportedStatus()?.let { getPagesContentItems(pages, params.onPagesItemClick) }
+                ?: emptyList()
         val createPageCard = getCreatePageCard(content, params.onFooterLinkClick)
         return PagesCard.PagesCardWithData(
             title = UiStringRes(R.string.dashboard_pages_card_title),
@@ -42,14 +46,21 @@ class PagesCardBuilder @Inject constructor(
     private fun List<PagesCardModel.PageCardModel>.filterByPagesCardSupportedStatus() =
         this.filter { it.status in PagesCardContentType.getList() }
 
-    private fun getPagesContentItems(pages: List<PagesCardModel.PageCardModel>): List<PageContentItem> {
+    private fun getPagesContentItems(
+        pages: List<PagesCardModel.PageCardModel>,
+        onPageItemClick: (params: PagesItemClickParams) -> Unit
+    ): List<PageContentItem> {
+        PagesCardContentType
         return pages.map { page ->
             PageContentItem(
                 title = getPageTitle(page.title),
                 statusIcon = getStatusIcon(page.status),
                 status = getStatusText(page.status),
                 lastEditedOrScheduledTime = getLastEditedOrScheduledTime(page),
-                onCardClick = { }
+                onClick = ListItemInteraction.create(
+                    PagesItemClickParams(PagesCardContentType.fromString(page.status), page.id),
+                    onPageItemClick
+                )
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.mysite.cards.dashboard.pages
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.CreatNewPageItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.CreateNewPageItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.PageContentItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -85,7 +85,7 @@ class PagesCardBuilder @Inject constructor(
         )
     }
 
-    private fun getCreatePageCard(pages: List<PageContentItem>, onFooterLinkClick: () -> Unit): CreatNewPageItem {
+    private fun getCreatePageCard(pages: List<PageContentItem>, onFooterLinkClick: () -> Unit): CreateNewPageItem {
         // Create new page button is shown with image if there is
         // less than three pages for a user
         return if (pages.isEmpty()) {
@@ -97,8 +97,8 @@ class PagesCardBuilder @Inject constructor(
         }
     }
 
-    private fun createNewPageCardWithAddPageMessage(onFooterLinkClick: () -> Unit): CreatNewPageItem {
-        return CreatNewPageItem(
+    private fun createNewPageCardWithAddPageMessage(onFooterLinkClick: () -> Unit): CreateNewPageItem {
+        return CreateNewPageItem(
             label = UiStringRes(R.string.dashboard_pages_card_no_pages_create_page_button),
             description = UiStringRes(R.string.dashboard_pages_card_create_another_page_description),
             imageRes = R.drawable.illustration_page_card_create_page,
@@ -106,8 +106,8 @@ class PagesCardBuilder @Inject constructor(
         )
     }
 
-    private fun createNewPageCardWithAddAnotherPageMessage(onFooterLinkClick: () -> Unit): CreatNewPageItem {
-        return CreatNewPageItem(
+    private fun createNewPageCardWithAddAnotherPageMessage(onFooterLinkClick: () -> Unit): CreateNewPageItem {
+        return CreateNewPageItem(
             label = UiStringRes(R.string.dashboard_pages_card_create_another_page_button),
             description = UiStringRes(R.string.dashboard_pages_card_create_another_page_description),
             imageRes = R.drawable.illustration_page_card_create_page,
@@ -115,8 +115,8 @@ class PagesCardBuilder @Inject constructor(
         )
     }
 
-    private fun createNewPageCardWithOnlyButton(onFooterLinkClick: () -> Unit): CreatNewPageItem {
-        return CreatNewPageItem(
+    private fun createNewPageCardWithOnlyButton(onFooterLinkClick: () -> Unit): CreateNewPageItem {
+        return CreateNewPageItem(
             label = UiStringRes(R.string.dashboard_pages_card_create_another_page_button),
             onClick = onFooterLinkClick
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardContentType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardContentType.kt
@@ -12,5 +12,9 @@ enum class PagesCardContentType(val status: String) {
                 it.toString()
             }
         }
+
+        fun fromString(status: String): PagesCardContentType {
+            return values().first { it.status == status }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewHolder.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.databinding.MySitePagesCardFooterLinkBinding
 import org.wordpress.android.databinding.MySitePagesCardWithPageItemsBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.CreatNewPageItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData.CreateNewPageItem
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
@@ -37,7 +37,7 @@ class PagesCardViewHolder(
         uiHelpers.setTextOrHide(mySiteCardToolbarTitle, title)
     }
 
-    private fun MySitePagesCardFooterLinkBinding.setUpFooter(footer: CreatNewPageItem) {
+    private fun MySitePagesCardFooterLinkBinding.setUpFooter(footer: CreateNewPageItem) {
         uiHelpers.setTextOrHide(linkLabel, footer.label)
         uiHelpers.setTextOrHide(linkDescription, footer.description)
         uiHelpers.setImageOrHide(linkIcon, footer.imageRes)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesItemViewHolder.kt
@@ -15,6 +15,7 @@ class PagesItemViewHolder(
     parent.viewBinding(PagesItemBinding::inflate)
 ) {
     fun bind(item: PageContentItem) = with(binding) {
+        pagesContentContainer.setOnClickListener { item.onClick.click() }
         uiHelpers.setTextOrHide(title, item.title)
         setStatusIcon(item.status, item.statusIcon)
         uiHelpers.setTextOrHide(lastEditedOrScheduledTime, item.lastEditedOrScheduledTime)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -93,9 +93,11 @@ import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.viewmodel.observeEvent
+import org.wordpress.android.viewmodel.pages.PageListViewModel
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("LargeClass")
 class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
     TextInputDialogFragment.Callback,
     QuickStartPromptClickInterface,
@@ -455,6 +457,16 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             action.isRewindable
         )
         is SiteNavigationAction.TriggerCreatePageFlow -> Unit // no-op
+        is SiteNavigationAction.OpenPagesDraftsTab -> ActivityLauncher.viewCurrentBlogPagesOfType(
+            requireActivity(),
+            action.site,
+            PageListViewModel.PageListType.DRAFTS
+        )
+        is SiteNavigationAction.OpenPagesScheduledTab -> ActivityLauncher.viewCurrentBlogPagesOfType(
+            requireActivity(),
+            action.site,
+            PageListViewModel.PageListType.SCHEDULED
+        )
     }
 
     private fun showJetpackPoweredBottomSheet() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesActivity.kt
@@ -13,10 +13,12 @@ import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
+import org.wordpress.android.viewmodel.pages.PageListViewModel
 import javax.inject.Inject
 
 const val EXTRA_PAGE_REMOTE_ID_KEY = "extra_page_remote_id_key"
 const val EXTRA_PAGE_PARENT_ID_KEY = "extra_page_parent_id_key"
+const val EXTRA_PAGE_LIST_TYPE_KEY = "extra_page_list_type_key"
 
 class PagesActivity : LocaleAwareActivity(),
     BasicDialogPositiveClickInterface,
@@ -50,6 +52,15 @@ class PagesActivity : LocaleAwareActivity(),
             val pageId = intent.getLongExtra(EXTRA_PAGE_REMOTE_ID_KEY, -1)
             supportFragmentManager.findFragmentById(R.id.fragment_container)?.let {
                 (it as PagesFragment).onSpecificPageRequested(pageId)
+            }
+        }
+
+        if (intent.hasExtra(EXTRA_PAGE_LIST_TYPE_KEY)) {
+            val pageListType = requireNotNull(
+                intent.getSerializableExtraCompat<PageListViewModel.PageListType>(EXTRA_PAGE_LIST_TYPE_KEY)
+            )
+            supportFragmentManager.findFragmentById(R.id.fragment_container)?.let {
+                (it as PagesFragment).onSpecificPageListTypeRequested(pageListType)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -24,7 +24,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
@@ -378,6 +377,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         )
     }
 
+    @Suppress("LongMethod")
     private fun PagesFragmentBinding.setupObservers(activity: FragmentActivity) {
         viewModel.listState.observe(viewLifecycleOwner) {
             refreshProgressBars(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -136,8 +136,8 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         val nonNullActivity = requireActivity()
         (nonNullActivity.application as? WordPress)?.component()?.inject(this)
 
-        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory).get(PagesViewModel::class.java)
-        mlpViewModel = ViewModelProvider(nonNullActivity, viewModelFactory).get(ModalLayoutPickerViewModel::class.java)
+        viewModel = ViewModelProvider(nonNullActivity, viewModelFactory)[PagesViewModel::class.java]
+        mlpViewModel = ViewModelProvider(nonNullActivity, viewModelFactory)[ModalLayoutPickerViewModel::class.java]
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -163,7 +163,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         binding = null
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.EDIT_POST && resultCode == Activity.RESULT_OK && data != null) {
             if (EditPostActivity.checkToRestart(data)) {
@@ -332,7 +332,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
             }
         )
 
-        viewModel.authorUIState.observe(activity, Observer { state ->
+        viewModel.authorUIState.observe(activity) { state ->
             state?.let {
                 uiHelpers.updateVisibility(pagesAuthorSelection, state.isAuthorFilterVisible)
                 uiHelpers.updateVisibility(pagesTabLayoutFadingEdge, state.isAuthorFilterVisible)
@@ -349,7 +349,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     pagesAuthorSelection.setSelection(selectionIndex)
                 }
             }
-        })
+        }
 
         viewModel.start(site)
     }
@@ -379,55 +379,56 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     }
 
     private fun PagesFragmentBinding.setupObservers(activity: FragmentActivity) {
-        viewModel.listState.observe(viewLifecycleOwner, {
+        viewModel.listState.observe(viewLifecycleOwner) {
             refreshProgressBars(it)
-        })
+        }
 
-        viewModel.createNewPage.observe(viewLifecycleOwner, {
+        viewModel.createNewPage.observe(viewLifecycleOwner) {
             if (mlpViewModel.canShowModalLayoutPicker()
-                && jetpackFeatureRemovalPhaseHelper.shouldShowTemplateSelectionInPages()) {
+                && jetpackFeatureRemovalPhaseHelper.shouldShowTemplateSelectionInPages()
+            ) {
                 mlpViewModel.createPageFlowTriggered()
             } else {
                 createNewPage()
             }
-        })
+        }
 
-        viewModel.showSnackbarMessage.observe(viewLifecycleOwner, { holder ->
+        viewModel.showSnackbarMessage.observe(viewLifecycleOwner) { holder ->
             showSnackbarInActivity(activity, holder)
-        })
+        }
 
-        viewModel.editPage.observe(viewLifecycleOwner, { (site, page, loadAutoRevision) ->
+        viewModel.editPage.observe(viewLifecycleOwner) { (site, page, loadAutoRevision) ->
             page?.let {
                 ActivityLauncher.editPageForResult(this@PagesFragment, site, page.id, loadAutoRevision)
             }
-        })
+        }
 
-        viewModel.previewPage.observe(viewLifecycleOwner, { post ->
+        viewModel.previewPage.observe(viewLifecycleOwner) { post ->
             post?.let {
                 previewPage(activity, post)
             }
-        })
+        }
 
-        viewModel.browsePreview.observe(viewLifecycleOwner, { preview ->
+        viewModel.browsePreview.observe(viewLifecycleOwner) { preview ->
             preview?.let {
                 ActivityLauncher.previewPostOrPageForResult(activity, viewModel.site, preview.post, preview.previewType)
             }
-        })
+        }
 
-        viewModel.previewState.observe(viewLifecycleOwner, {
+        viewModel.previewState.observe(viewLifecycleOwner) {
             progressDialog = progressDialogHelper.updateProgressDialogState(
                 activity,
                 progressDialog,
                 it.progressDialogUiState,
                 uiHelpers
             )
-        })
+        }
 
-        viewModel.setPageParent.observe(viewLifecycleOwner, { page ->
+        viewModel.setPageParent.observe(viewLifecycleOwner) { page ->
             page?.let { ActivityLauncher.viewPageParentForResult(this@PagesFragment, it.site, it.remoteId) }
-        })
+        }
 
-        viewModel.isNewPageButtonVisible.observe(viewLifecycleOwner, { isVisible ->
+        viewModel.isNewPageButtonVisible.observe(viewLifecycleOwner) { isVisible ->
             isVisible?.let {
                 if (isVisible) {
                     newPageButton.show()
@@ -435,22 +436,22 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     newPageButton.hide()
                 }
             }
-        })
+        }
 
-        viewModel.scrollToPage.observe(viewLifecycleOwner, { requestedPage ->
+        viewModel.scrollToPage.observe(viewLifecycleOwner) { requestedPage ->
             requestedPage?.let { page ->
                 val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(PageListType.fromPageStatus(page.status))
                 pagesPager.currentItem = pagerIndex
                 (pagesPager.adapter as PagesPagerAdapter).scrollToPage(page)
             }
-        })
+        }
 
-        viewModel.launchPageListType.observe(viewLifecycleOwner, { pageListType ->
+        viewModel.launchPageListType.observe(viewLifecycleOwner) { pageListType ->
             pageListType?.let {
                 val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(pageListType)
                 pagesPager.currentItem = pagerIndex
             }
-        })
+        }
     }
 
     private fun showSnackbarInActivity(
@@ -485,11 +486,11 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
     }
 
     private fun setupActions(activity: FragmentActivity) {
-        viewModel.dialogAction.observe(viewLifecycleOwner, {
+        viewModel.dialogAction.observe(viewLifecycleOwner) {
             it?.show(activity, activity.supportFragmentManager, uiHelpers)
-        })
+        }
 
-        viewModel.postUploadAction.observe(viewLifecycleOwner, {
+        viewModel.postUploadAction.observe(viewLifecycleOwner) {
             it?.let { (post, site, data) ->
                 uploadUtilsWrapper.handleEditPostResultSnackbars(
                     activity,
@@ -507,13 +508,13 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     }
                 )
             }
-        })
+        }
 
-        viewModel.publishAction.observe(viewLifecycleOwner, {
+        viewModel.publishAction.observe(viewLifecycleOwner) {
             it?.let {
                 uploadUtilsWrapper.publishPost(activity, it.post, it.site)
             }
-        })
+        }
 
         viewModel.navigateToBlazeOverlay.observe(viewLifecycleOwner) {
             it?.let { page ->
@@ -525,7 +526,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
             }
         }
 
-        viewModel.uploadFinishedAction.observe(viewLifecycleOwner, {
+        viewModel.uploadFinishedAction.observe(viewLifecycleOwner) {
             it?.let { (page, isError, isFirstTimePublish) ->
                 uploadUtilsWrapper.onPostUploadedSnackbarHandler(
                     activity,
@@ -537,14 +538,14 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     page.site
                 )
             }
-        })
+        }
     }
 
     private fun setupMlpObservers(activity: FragmentActivity) {
-        mlpViewModel.onCreateNewPageRequested.observe(viewLifecycleOwner, { request ->
+        mlpViewModel.onCreateNewPageRequested.observe(viewLifecycleOwner) { request ->
             createNewPage(request.title, "", request.template)
-        })
-        mlpViewModel.isModalLayoutPickerShowing.observeEvent(viewLifecycleOwner, { isShowing ->
+        }
+        mlpViewModel.isModalLayoutPickerShowing.observeEvent(viewLifecycleOwner) { isShowing ->
             val fm = activity.supportFragmentManager
             var mlpFragment = fm.findFragmentByTag(MODAL_LAYOUT_PICKER_TAG) as ModalLayoutPickerFragment?
             if (isShowing && mlpFragment == null) {
@@ -553,7 +554,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
             } else if (!isShowing && mlpFragment != null) {
                 mlpFragment.dismiss()
             }
-        })
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -201,6 +201,10 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         viewModel.onSpecificPageRequested(remotePageId)
     }
 
+    fun onSpecificPageListTypeRequested(pageListType: PageListType) {
+        viewModel.onSpecificPageListTypeRequested(pageListType)
+    }
+
     private fun onPageParentSet(pageId: Long, parentId: Long) {
         viewModel.onPageParentSet(pageId, parentId)
     }
@@ -438,6 +442,13 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                 val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(PageListType.fromPageStatus(page.status))
                 pagesPager.currentItem = pagerIndex
                 (pagesPager.adapter as PagesPagerAdapter).scrollToPage(page)
+            }
+        })
+
+        viewModel.launchPageListType.observe(viewLifecycleOwner, { pageListType ->
+            pageListType?.let {
+                val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(pageListType)
+                pagesPager.currentItem = pagerIndex
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -176,6 +176,9 @@ class PagesViewModel
     private val _publishAction = SingleLiveEvent<PageModel>()
     val publishAction = _publishAction
 
+    private val _launchPageListType = SingleLiveEvent<PageListType>()
+    val launchPageListType = _launchPageListType
+
     private val _navigateToBlazeOverlay = SingleLiveEvent<PageModel>()
     val navigateToBlazeOverlay = _navigateToBlazeOverlay
 
@@ -345,6 +348,10 @@ class PagesViewModel
                 setParent(page, parentId)
             }
         }
+    }
+
+    fun onSpecificPageListTypeRequested(pageListType: PageListType) {
+        _launchPageListType.postValue(pageListType)
     }
 
     fun onPageTypeChanged(type: PageListType) {

--- a/WordPress/src/main/res/layout/pages_item.xml
+++ b/WordPress/src/main/res/layout/pages_item.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pages_content_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipChildren="false"

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -704,7 +704,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             isSiteUsingWpComRestApi = true
         )
 
-        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isTrue()
+        assertThat((uiModels.last().state as SiteSelected).tabsUiState.showTabs).isTrue
     }
 
     @Test
@@ -3848,7 +3848,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T = this@invokeOnCleared as T
         })
-        viewModelProvider.get(this@invokeOnCleared::class.java)
+        viewModelProvider[this@invokeOnCleared::class.java]
         viewModelStore.clear()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2795,9 +2795,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given site select exists, then cardAndItem lists are not empty`() {
         initSelectedSite(isQuickStartDynamicCardEnabled = false)
 
-        assertThat(getLastItems().isNotEmpty())
-        assertThat(getDashboardTabLastItems().isNotEmpty())
-        assertThat(getSiteMenuTabLastItems().isNotEmpty())
+        assertThat(getLastItems()).isNotEmpty
+        assertThat(getDashboardTabLastItems()).isNotEmpty
+        assertThat(getSiteMenuTabLastItems()).isNotEmpty
     }
 
     @Test
@@ -3041,7 +3041,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite(isMySiteTabsBuildConfigEnabled = false, isMySiteDashboardTabsEnabled = false)
 
         viewModel.refresh(true)
-        assertThat(analyticsTrackerWrapper.track(Stat.MY_SITE_PULL_TO_REFRESH))
+
+        verify(analyticsTrackerWrapper).track(Stat.MY_SITE_PULL_TO_REFRESH, emptyMap())
     }
 
     @Test
@@ -3087,7 +3088,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(quickActionsStatsClickAction).invoke()
 
         assertThat(trackWithTabSource).isEmpty()
-        assertThat(analyticsTrackerWrapper.track(Stat.QUICK_ACTION_STATS_TAPPED))
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_ACTION_STATS_TAPPED, emptyMap())
     }
 
     @Test
@@ -3097,7 +3098,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(quickActionsPagesClickAction).invoke()
 
         assertThat(trackWithTabSource).isEmpty()
-        assertThat(analyticsTrackerWrapper.track(Stat.QUICK_ACTION_PAGES_TAPPED))
+
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_ACTION_PAGES_TAPPED, emptyMap())
     }
 
     @Test
@@ -3107,7 +3109,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(quickActionsPostsClickAction).invoke()
 
         assertThat(trackWithTabSource).isEmpty()
-        assertThat(analyticsTrackerWrapper.track(Stat.QUICK_ACTION_POSTS_TAPPED))
+
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_ACTION_POSTS_TAPPED, emptyMap())
     }
 
     @Test
@@ -3117,7 +3120,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(quickActionsMediaClickAction).invoke()
 
         assertThat(trackWithTabSource).isEmpty()
-        assertThat(analyticsTrackerWrapper.track(Stat.QUICK_ACTION_MEDIA_TAPPED))
+
+        verify(analyticsTrackerWrapper).track(Stat.QUICK_ACTION_MEDIA_TAPPED, emptyMap())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.StatsSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
+import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.quickstart.QuickStartTracker
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -140,6 +141,27 @@ class CardsTrackerTest {
         cardsTracker.trackPagesCardFooterClicked()
 
         verifyFooterLinkClickedTracked(Type.PAGES, PagesSubType.CREATE_PAGE.label)
+    }
+
+    @Test
+    fun `when page draft item is clicked, then page item event is tracked`() {
+        cardsTracker.trackPagesItemClicked(PagesCardContentType.DRAFT)
+
+        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.DRAFT.label)
+    }
+
+    @Test
+    fun `when page published item is clicked, then page item event is tracked`() {
+        cardsTracker.trackPagesItemClicked(PagesCardContentType.PUBLISH)
+
+        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.PUBLISHED.label)
+    }
+
+    @Test
+    fun `when page scheduled item is clicked, then page item event is tracked`() {
+        cardsTracker.trackPagesItemClicked(PagesCardContentType.SCHEDULED)
+
+        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.SCHEDULED.label)
     }
 
     private fun verifyFooterLinkClickedTracked(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilderTest.kt
@@ -196,21 +196,21 @@ class PagesCardBuilderTest : BaseUnitTest() {
         )
     }
 
-    private val createPageCardWhenNoPagesPresent = PagesCardWithData.CreatNewPageItem(
+    private val createPageCardWhenNoPagesPresent = PagesCardWithData.CreateNewPageItem(
         label = UiStringRes(R.string.dashboard_pages_card_no_pages_create_page_button),
         description = UiStringRes(R.string.dashboard_pages_card_create_another_page_description),
         imageRes = R.drawable.illustration_page_card_create_page,
         onClick = onPagesCardFooterClick
     )
 
-    private val createPageCardWhenLessThanThreePagePresent = PagesCardWithData.CreatNewPageItem(
+    private val createPageCardWhenLessThanThreePagePresent = PagesCardWithData.CreateNewPageItem(
         label = UiStringRes(R.string.dashboard_pages_card_create_another_page_button),
         description = UiStringRes(R.string.dashboard_pages_card_create_another_page_description),
         imageRes = R.drawable.illustration_page_card_create_page,
         onClick = onPagesCardFooterClick
     )
 
-    private val createPageCardWhenThreePagePresent = PagesCardWithData.CreatNewPageItem(
+    private val createPageCardWhenThreePagePresent = PagesCardWithData.CreateNewPageItem(
         label = UiStringRes(R.string.dashboard_pages_card_create_another_page_button),
         onClick = onPagesCardFooterClick
     )

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -63,6 +63,8 @@ import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FET
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.REFRESHING
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
+import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.SCHEDULED
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import java.util.Date
 import java.util.SortedMap
@@ -119,6 +121,7 @@ class PagesViewModelTest : BaseUnitTest() {
     private lateinit var authorSelectionUpdated: MutableLiveData<AuthorFilterSelection>
     private lateinit var authorUIState: MutableLiveData<PagesAuthorFilterUIState>
     private lateinit var blazeSiteEligibility: MutableLiveData<Boolean>
+    private lateinit var launchPageListType: MutableLiveData<PageListType>
     private lateinit var postStore: PostStore
 
     private val mockedPageId = 1
@@ -161,12 +164,14 @@ class PagesViewModelTest : BaseUnitTest() {
         authorSelectionUpdated = MutableLiveData<AuthorFilterSelection>()
         authorUIState = MutableLiveData<PagesAuthorFilterUIState>()
         blazeSiteEligibility = MutableLiveData<Boolean>()
+        launchPageListType = MutableLiveData<PageListType>()
         viewModel.listState.observeForever { if (it != null) listStates.add(it) }
         viewModel.pages.observeForever { if (it != null) pages.add(it) }
         viewModel.searchPages.observeForever { if (it != null) searchPages.add(it) }
         viewModel.authorSelectionUpdated.observeForever { if (it != null) authorSelectionUpdated.value = it }
         viewModel.authorUIState.observeForever { if (it != null) authorUIState.value = it }
         viewModel.blazeSiteEligibility.observeForever { if (it != null) blazeSiteEligibility.value = it }
+        viewModel.launchPageListType.observeForever { if (it != null) launchPageListType.value = it }
         whenever(networkUtils.isNetworkAvailable()).thenReturn(true)
         whenever(postSqlUtils.insertPostForResult(any())).thenAnswer { invocation ->
             (invocation.arguments[0] as PostModel).apply { setId(copyPageId) }
@@ -591,5 +596,32 @@ class PagesViewModelTest : BaseUnitTest() {
         // Assert
         val message = snackbarMessages[0].message as UiStringRes
         assertThat(message.stringRes).isEqualTo(R.string.page_is_posts_page_warning)
+    }
+
+    @Test
+    fun `given draft tab requested, when view is launched, then darft is shown`() = test {
+        // Act
+        viewModel.onSpecificPageListTypeRequested(DRAFTS)
+
+        // Assert
+        assertThat(launchPageListType.value).isEqualTo(DRAFTS)
+    }
+
+    @Test
+    fun `given published tab requested, when view is launched, then published is shown`() = test {
+        // Act
+        viewModel.onSpecificPageListTypeRequested(PUBLISHED)
+
+        // Assert
+        assertThat(launchPageListType.value).isEqualTo(PUBLISHED)
+    }
+
+    @Test
+    fun `given scheduled tab requested, when view is launched, then scheduled is shown`() = test {
+        // Act
+        viewModel.onSpecificPageListTypeRequested(SCHEDULED)
+
+        // Assert
+        assertThat(launchPageListType.value).isEqualTo(SCHEDULED)
     }
 }


### PR DESCRIPTION
Closes #18216 

This PR handles the Pages item click actions
- Track the page item tap event
- Navigate user to the correct tab in the pages view
- Created two new NavigationActions `OpenPagesDraftsTab` and `OpenPagesScheduledTab`
- Update Pages to support opening to a specific tab
- Updated and wrote new unit tests

**To test:**

Setup
1. Install the Jetpack app (do a fresh install - want to make sure the DB is clear)
2. Login with a wp account
3. Select a site in which you have access to manage content/admin
4. Create the following pages: Draft, Published, and Scheduled
5. Navigate to App Setting > Debug Settings 
6. Enable `dashboard_card_page` and restart the app

**Tapping on a Draft page item within the card navigates to Pages "Draft" tab **
1. Navigate to Home tab
2. Scroll to the pages card 
3. Tap on the Drafts page item 
4. ✅ Verify you are taken to the Pages "draft" tab
5. ✅ Verify log contains: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"pages","subtype":"draft"}
----------------
**Tapping on a Scheduled page item within the card navigates to Pages "Scheduled" tab **
1. Navigate to Home tab
2. Scroll to the pages card 
3. Tap on the Scheduled page item 
4. ✅ Verify you are taken to the Pages "scheduled" tab
5. ✅ Verify log contains: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"pages","subtype":"scheduled"}
---------------
**Tapping on a Published page item within the card navigates to Pages "Published" tab **
1. Navigate to Home tab
2. Scroll to the pages card 
3. Tap on the Published page item 
4. ✅ Verify you are taken to the Pages "published" tab
5. ✅ Verify log contains: 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"pages","subtype":"published"}

## Regression Notes
1. Potential unintended areas of impact
The pages click items do not navigate properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add tests to `CardsTrackerTest` and `MySiteViewModelTest`

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
