### PR TITLE
[Prompts] Re-add Prompts v2 endpoint support temporarily

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/usecase/FetchBloggingPromptsListUseCase.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.bloggingprompts.promptslist.usecase
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.config.BloggingPromptsEndpointConfig
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
@@ -11,6 +12,7 @@ import javax.inject.Inject
 class FetchBloggingPromptsListUseCase @Inject constructor(
     private val bloggingPromptsStore: BloggingPromptsStore,
     private val selectedSiteRepository: SelectedSiteRepository,
+    private val bloggingPromptsEndpointConfig: BloggingPromptsEndpointConfig,
 ) {
     suspend fun execute(): Result {
         return fetchBloggingPrompts()
@@ -35,7 +37,12 @@ class FetchBloggingPromptsListUseCase @Inject constructor(
             .let { Date.from(it) }
 
         return selectedSiteRepository.getSelectedSite()?.let { site ->
-            bloggingPromptsStore.fetchPrompts(site, NUMBER_OF_PROMPTS, fromDate)
+            bloggingPromptsStore.fetchPrompts(
+                site,
+                NUMBER_OF_PROMPTS,
+                fromDate,
+                bloggingPromptsEndpointConfig.shouldUseV2()
+            )
                 .takeUnless { it.isError }
                 ?.model
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardSource.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.BloggingPromptUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.config.BloggingPromptsEndpointConfig
 import org.wordpress.android.util.config.BloggingPromptsFeatureConfig
 import java.time.LocalDate
 import java.time.ZoneId
@@ -29,6 +30,7 @@ class BloggingPromptCardSource @Inject constructor(
     private val promptsStore: BloggingPromptsStore,
     private val bloggingPromptsFeatureConfig: BloggingPromptsFeatureConfig,
     private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
+    private val bloggingPromptsEndpointConfig: BloggingPromptsEndpointConfig,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<BloggingPromptUpdate> {
     override val refresh = MutableLiveData(false)
@@ -118,7 +120,12 @@ class BloggingPromptCardSource @Inject constructor(
         coroutineScope.launch(bgDispatcher) {
             delay(REFRESH_DELAY)
             val numOfPromptsToFetch = if (isSinglePromptRefresh) 1 else NUM_PROMPTS_TO_REQUEST
-            val result = promptsStore.fetchPrompts(selectedSite, numOfPromptsToFetch, Date())
+            val result = promptsStore.fetchPrompts(
+                selectedSite,
+                numOfPromptsToFetch,
+                Date(),
+                bloggingPromptsEndpointConfig.shouldUseV2()
+            )
             when {
                 result.isError -> postLastState()
                 else -> {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsEndpointConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BloggingPromptsEndpointConfig.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.annotation.RemoteFieldDefaultGenerater
+import org.wordpress.android.util.config.BloggingPromptsEndpointConfig.Companion.BLOGGING_PROMPTS_ENDPOINT_V2
+import javax.inject.Inject
+
+private const val BLOGGING_PROMPTS_ENDPOINT_REMOTE_FIELD = "blogging_prompts_endpoint"
+private const val BLOGGING_PROMPTS_ENDPOINT_DEFAULT = BLOGGING_PROMPTS_ENDPOINT_V2
+
+// TODO this class is temporary until we can remove v2 completely and only use the v3 endpoint
+@RemoteFieldDefaultGenerater(
+    remoteField = BLOGGING_PROMPTS_ENDPOINT_REMOTE_FIELD,
+    defaultValue = BLOGGING_PROMPTS_ENDPOINT_DEFAULT
+)
+class BloggingPromptsEndpointConfig @Inject constructor(
+    appConfig: AppConfig,
+) : RemoteConfigField<String>(
+    appConfig = appConfig,
+    remoteField = BLOGGING_PROMPTS_ENDPOINT_REMOTE_FIELD
+) {
+    // anything that is not v3 should use v2
+    fun shouldUseV2(): Boolean = getValue<String>().lowercase() != BLOGGING_PROMPTS_ENDPOINT_V3
+
+    companion object {
+        const val BLOGGING_PROMPTS_ENDPOINT_V2 = "v2"
+        const val BLOGGING_PROMPTS_ENDPOINT_V3 = "v3"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.94.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2721-ace696aeab2bec1d12d182cee4c3073d34cab982'
+    wordPressFluxCVersion = '2723-fbeec67d82a55d02a4b87d7894b7fbb6ed6cbf78'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
Part of #18257 
FluxC PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2723

This re-adds prompts v2 endpoint in a way that's easy to revert in the future. This is going to be needed together with the Prompts [v3 support PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18340) because we want to make sure we can toggle between v2 <-> v3 endpoints using the `blogging_prompts_endpoint` remote config, so we can coordinate a release of the V3 endpoint in all platforms (Android, iOS, Web) at the same time.

Some discussion about this coordination can be found here: pctCYC-KA-p2#comment-862

Like the [previous PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18340), this still relies on functionality added to the backend on this PR: https://github.com/Automattic/jetpack/pull/30255, which is merged but not deployed yet, so testing this PR is a bit tricky at the moment, requiring pulling in the backend jetpack plugin changes in a sandbox environment and point/proxy the testing device to use that sandbox for the public-api.wordpress.com calls. This is also the reason this PR is NOT READY FOR MERGE yet.

For testing the remote change between v2 and v3 endpoint, you will need to either rebuild the code changing the default value for `BloggingPromptsEndpointConfig` **or** use something like Charles Proxy to map the ´wpcom/v2/mobile/remote-config/` endpoints a add something like this to the payload:

```json
"blogging_prompts_endpoint": "v3"
```

To test:
Once the backend changes are deployed to production **or** the reviewer sets up the sandbox and pulls the backend PR mentioned above, these are the steps:

1. Open Jetpack app
2. Login with a WP.com account
3. Select a blogging site (has a few posts)
4. Go to `My Site > Home`
5. **Verify** the prompts card show up
6. **Verify** the prompt text  **DOES** match the v2 prompt, which is the one shown on older versions or the web
7. Do some smoke tests in all prompts features (responses, answer, view more, etc)
8. **Verify** the smoke tests work as expected (prompt text, tag, etc)
9. Make the app use Prompts `v3` using one of the methods described before this test section
10. Restart the app
11. Go to `My Site > Home`
5. **Verify** the prompts card show up
6. **Verify** the prompt text  **DOES NOT** match the v2 prompt, which is the one shown on older versions or the web
7. **Verify** the text matches the v3 prompt
8. Do some smoke tests in all prompts features (responses, answer, view more, etc)
8. **Verify** the smoke tests work as expected for v3 (prompt text, tag, etc)

## Regression Notes
1. Potential unintended areas of impact
Breakage in prompts-related features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Updated and added some unit tests for the v2 switching.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

**N/A. No UI changes were made!**

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)