### PR TITLE
[Dependency Updates] Main Batch - AndroidX Core (V2)

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
@@ -25,21 +25,17 @@ public class UserAgentTest {
     public InitializationRule initRule = new InitializationRule();
 
     @Test
-    public void testGetDefaultUserAgent() {
-        String defaultUserAgent = WordPress.getDefaultUserAgent();
-        assertNotNull("Default User-Agent must be set", defaultUserAgent);
-        assertTrue("Default User-Agent must not be an empty string", defaultUserAgent.length() > 0);
-        assertFalse("Default User-Agent must not contain app name", defaultUserAgent.contains(USER_AGENT_APPNAME));
-    }
-
-    @Test
-    public void testGetUserAgent() {
+    public void testGetUserAgentAndGetDefaultUserAgent() {
         String userAgent = WordPress.getUserAgent();
         assertNotNull("User-Agent must be set", userAgent);
         assertTrue("User-Agent must not be an empty string", userAgent.length() > 0);
         assertTrue("User-Agent must contain app name substring", userAgent.contains(USER_AGENT_APPNAME));
 
         String defaultUserAgent = WordPress.getDefaultUserAgent();
+        assertNotNull("Default User-Agent must be set", defaultUserAgent);
+        assertTrue("Default User-Agent must not be an empty string", defaultUserAgent.length() > 0);
+        assertFalse("Default User-Agent must not contain app name", defaultUserAgent.contains(USER_AGENT_APPNAME));
+
         assertTrue("User-Agent must be derived from default User-Agent", userAgent.contains(defaultUserAgent));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
@@ -29,8 +29,8 @@ class HelpViewModel @Inject constructor(
     private val _showSigningOutDialog = MutableLiveData<Event<Boolean>>()
     val showSigningOutDialog: LiveData<Event<Boolean>> = _showSigningOutDialog
 
-    private val _onSignOutCompleted = SingleLiveEvent<Unit>()
-    val onSignOutCompleted: LiveData<Unit> = _onSignOutCompleted
+    private val _onSignOutCompleted = SingleLiveEvent<Unit?>()
+    val onSignOutCompleted: LiveData<Unit?> = _onSignOutCompleted
 
     fun signOutWordPress(application: WordPress) {
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginNoSitesFragment.kt
@@ -42,7 +42,9 @@ class LoginNoSitesFragment : Fragment(R.layout.jetpack_login_empty_view) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            viewModel.onBackPressed()
+        }
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             initContentViews()
             initClickListeners()

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/jetpack/LoginSiteCheckErrorFragment.kt
@@ -54,7 +54,9 @@ class LoginSiteCheckErrorFragment : Fragment(R.layout.jetpack_login_empty_view) 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            viewModel.onBackPressed()
+        }
         with(JetpackLoginEmptyViewBinding.bind(view)) {
             ActivityUtils.hideKeyboardForced(view)
             initErrorMessageView()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -23,6 +23,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
@@ -119,6 +120,7 @@ import javax.inject.Inject;
 
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
+import kotlinx.coroutines.DelicateCoroutinesApi;
 import kotlinx.coroutines.Dispatchers;
 import kotlinx.coroutines.GlobalScope;
 
@@ -1424,6 +1426,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
+    @OptIn(markerClass = DelicateCoroutinesApi.class)
     public void onCommentChanged(OnCommentChanged event) {
         setProgressVisible(false);
         // requesting local comment cache refresh

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
@@ -35,6 +35,7 @@ class CommentListActionModeCallback(
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.menu_unified_comments_list, menu)
 
+        @Suppress("DEPRECATION")
         lifecycleScope.launchWhenStarted {
             viewModel.uiState.collect { uiState ->
                 when (val uiModel = uiState.actionModeUiModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
@@ -25,12 +25,11 @@ class CommentListActionModeCallback(
     private val activityViewModel: UnifiedCommentActivityViewModel
 ) : Callback,
     LifecycleOwner {
-    private lateinit var lifecycleRegistry: LifecycleRegistry
+    private val lifecycleRegistry = LifecycleRegistry(this)
     override fun onCreateActionMode(
         actionMode: ActionMode,
         menu: Menu
     ): Boolean {
-        lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.menu_unified_comments_list, menu)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
@@ -130,7 +130,7 @@ class CommentListActionModeCallback(
         lifecycleRegistry.handleLifecycleEvent(ON_STOP)
     }
 
-    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    override val lifecycle: Lifecycle = lifecycleRegistry
 
     companion object {
         const val ICON_ALPHA_ENABLED = 255

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentListFragment.kt
@@ -107,6 +107,7 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
 
     private fun UnifiedCommentListFragmentBinding.setupObservers() {
         var isShowingActionMode = false
+        @Suppress("DEPRECATION")
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
             viewModel.uiState.collect { uiState ->
                 setupCommentsList(uiState.commentsListUiModel)
@@ -126,6 +127,7 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
             }
         }
 
+        @Suppress("DEPRECATION")
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
             viewModel.onSnackbarMessage.collect { snackbarMessage ->
                 snackbarSequencer.enqueue(
@@ -151,6 +153,7 @@ class UnifiedCommentListFragment : Fragment(R.layout.unified_comment_list_fragme
             }
         }
 
+        @Suppress("DEPRECATION")
         viewLifecycleOwner.lifecycleScope.launchWhenStarted {
             viewModel.onCommentDetailsRequested.collect { selectedComment ->
                 showCommentDetails(selectedComment.remoteCommentId, selectedComment.status)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnifiedCommentsActivity.kt
@@ -98,6 +98,7 @@ class UnifiedCommentsActivity : LocaleAwareActivity() {
     }
 
     private fun UnifiedCommentActivityBinding.setupObservers() {
+        @Suppress("DEPRECATION")
         lifecycleScope.launchWhenStarted {
             viewModel.uiState.collect { uiState ->
                 viewPager.isUserInputEnabled = uiState.isTabBarEnabled

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModel.kt
@@ -88,8 +88,8 @@ class DomainRegistrationDetailsViewModel @Inject constructor(
     val handleCompletedDomainRegistration: LiveData<DomainRegistrationCompletedEvent>
         get() = _handleCompletedDomainRegistration
 
-    private val _showTos = SingleLiveEvent<Unit>()
-    val showTos: LiveData<Unit>
+    private val _showTos = SingleLiveEvent<Unit?>()
+    val showTos: LiveData<Unit?>
         get() = _showTos
 
     data class DomainRegistrationDetailsUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationResultFragment.kt
@@ -50,7 +50,9 @@ class DomainRegistrationResultFragment : Fragment(R.layout.domain_registration_r
         with(DomainRegistrationResultFragmentBinding.bind(view)) {
             setupViews(domainName, email)
         }
-        requireActivity().onBackPressedDispatcher.addCallback(this) { finishRegistration(domainName, email) }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            finishRegistration(domainName, email)
+        }
     }
 
     private fun setupWindow() = with(requireAppCompatActivity()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.domains
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -59,7 +59,7 @@ class DomainSuggestionsViewModel @Inject constructor(
 
     private val _selectedSuggestion = MutableLiveData<DomainSuggestionItem?>()
 
-    val selectDomainButtonEnabledState = Transformations.map(_selectedSuggestion) { it is DomainSuggestionItem }
+    val selectDomainButtonEnabledState = _selectedSuggestion.map { it is DomainSuggestionItem }
 
     private val _isIntroVisible = MutableLiveData(true)
     val isIntroVisible: LiveData<Boolean> = _isIntroVisible

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListViewModel.kt
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -62,7 +62,7 @@ class EngagedPeopleListViewModel @Inject constructor(
     private val _onServiceRequestEvent = MutableLiveData<Event<EngagedListServiceRequestEvent>>()
 
     val onSnackbarMessage: LiveData<Event<SnackbarMessageHolder>> = _onSnackbarMessage
-    val uiState: LiveData<EngagedPeopleListUiState> = _updateLikesState.map { state ->
+    val uiState: LiveData<EngagedPeopleListUiState> = _updateLikesState.mapSafe { state ->
         buildUiState(state, listScenario)
     }
     val onNavigationEvent: LiveData<Event<EngagedListNavigationEvent>> = _onNavigationEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadFragment.kt
@@ -52,7 +52,7 @@ class BackupDownloadFragment : Fragment(R.layout.jetpack_backup_restore_fragment
         super.onViewCreated(view, savedInstanceState)
         with(JetpackBackupRestoreFragmentBinding.bind(view)) {
             initDagger()
-            requireActivity().onBackPressedDispatcher.addCallback(this@BackupDownloadFragment) {
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
                 viewModel.onBackPressed()
             }
             initAdapter()

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpack/restore/RestoreFragment.kt
@@ -51,7 +51,9 @@ class RestoreFragment : Fragment(R.layout.jetpack_backup_restore_fragment) {
         super.onViewCreated(view, savedInstanceState)
         with(JetpackBackupRestoreFragmentBinding.bind(view)) {
             initDagger()
-            requireActivity().onBackPressedDispatcher.addCallback(this@RestoreFragment) { viewModel.onBackPressed() }
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+                viewModel.onBackPressed()
+            }
             initAdapter()
             initViewModel(savedInstanceState)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPickerViewModel.kt
@@ -45,8 +45,8 @@ abstract class LayoutPickerViewModel(
     private val _previewState: MutableLiveData<PreviewUiState> = MutableLiveData()
     val previewState: LiveData<PreviewUiState> = _previewState
 
-    private val _onPreviewModeButtonPressed = SingleLiveEvent<Unit>()
-    val onPreviewModeButtonPressed: LiveData<Unit> = _onPreviewModeButtonPressed
+    private val _onPreviewModeButtonPressed = SingleLiveEvent<Unit?>()
+    val onPreviewModeButtonPressed: LiveData<Unit?> = _onPreviewModeButtonPressed
 
     private val _onPreviewActionPressed = SingleLiveEvent<DesignPreviewAction>()
     val onPreviewActionPressed: LiveData<DesignPreviewAction> = _onPreviewActionPressed
@@ -54,8 +54,8 @@ abstract class LayoutPickerViewModel(
     private val _onCategorySelectionChanged = MutableLiveData<Event<Unit>>()
     val onCategorySelectionChanged: LiveData<Event<Unit>> = _onCategorySelectionChanged
 
-    private val _onThumbnailModeButtonPressed = SingleLiveEvent<Unit>()
-    val onThumbnailModeButtonPressed: LiveData<Unit> = _onThumbnailModeButtonPressed
+    private val _onThumbnailModeButtonPressed = SingleLiveEvent<Unit?>()
+    val onThumbnailModeButtonPressed: LiveData<Unit?> = _onThumbnailModeButtonPressed
 
     val isLoading: Boolean
         get() = _uiState.value === LayoutPickerUiState.Loading

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -128,7 +128,9 @@ class JetpackMigrationFragment : Fragment() {
 
     private fun initBackPressHandler(showDeleteWpState: Boolean) {
         if (showDeleteWpState) return
-        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.logoutAndFallbackToLogin() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            viewModel.logoutAndFallbackToLogin()
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
@@ -98,5 +98,5 @@ class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel)
         lifecycleRegistry.handleLifecycleEvent(ON_STOP)
     }
 
-    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    override val lifecycle: Lifecycle = lifecycleRegistry
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
@@ -19,12 +19,11 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 
 class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel) : Callback,
     LifecycleOwner {
-    private lateinit var lifecycleRegistry: LifecycleRegistry
+    private val lifecycleRegistry = LifecycleRegistry(this)
     override fun onCreateActionMode(
         actionMode: ActionMode,
         menu: Menu
     ): Boolean {
-        lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         val inflater = actionMode.menuInflater
         inflater.inflate(R.menu.photo_picker_action_mode, menu)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -147,7 +147,7 @@ import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
 import org.wordpress.android.util.config.QuickStartDynamicCardsFeatureConfig
 import org.wordpress.android.util.filter
 import org.wordpress.android.util.getEmailValidationMessage
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.merge
 import org.wordpress.android.util.publicdata.AppStatus
 import org.wordpress.android.util.publicdata.WordPressPublicData
@@ -328,7 +328,7 @@ class MySiteViewModel @Inject constructor(
             }
             // We want to filter out the empty state where we have a site ID but site object is missing.
             // Without this check there is an emission of a NoSites state even if we have the site
-            result.filter { it.siteId == null || it.state.site != null }.map { it.state }
+            result.filter { it.siteId == null || it.state.site != null }.mapSafe { it.state }
         }
 
     val uiModel: LiveData<UiModel> = merge(tabsUiState, state) { tabsUiState, mySiteUiState ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,7 +23,7 @@ class SelectedSiteRepository @Inject constructor(
     private val _selectedSiteChange = MutableLiveData<SiteModel?>(null)
     private val _showSiteIconProgressBar = MutableLiveData<Boolean>()
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel?>
-    val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
+    val siteSelected = _selectedSiteChange.mapSafe { it?.id }.distinctUntilChanged()
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
     fun updateSite(selectedSite: SiteModel) {
         if (getSelectedSite()?.iconUrl != selectedSite.iconUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteSource.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.SelectedSite
 import org.wordpress.android.util.filter
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
 
 class SelectedSiteSource @Inject constructor(
@@ -33,7 +33,7 @@ class SelectedSiteSource @Inject constructor(
     ) = selectedSiteRepository.selectedSiteChange
         .filter { it == null || it.id == siteLocalId }
         .apply { onRefreshedMainThread() }
-        .map { SelectedSite(it) }
+        .mapSafe { SelectedSite(it) }
 
     override fun refresh() {
         updateSiteSettingsIfNecessary()

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -510,20 +510,16 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
             }
         }
 
-        viewModel.publishAction.observe(viewLifecycleOwner) {
-            it?.let {
-                uploadUtilsWrapper.publishPost(activity, it.post, it.site)
-            }
+        viewModel.publishAction.observe(viewLifecycleOwner) { page ->
+            uploadUtilsWrapper.publishPost(activity, page.post, page.site)
         }
 
-        viewModel.navigateToBlazeOverlay.observe(viewLifecycleOwner) {
-            it?.let { page ->
-                ActivityLauncher.openPromoteWithBlaze(
-                    activity,
-                    page,
-                    BlazeFlowSource.PAGES_LIST
-                )
-            }
+        viewModel.navigateToBlazeOverlay.observe(viewLifecycleOwner) { page ->
+            ActivityLauncher.openPromoteWithBlaze(
+                activity,
+                page,
+                BlazeFlowSource.PAGES_LIST
+            )
         }
 
         viewModel.uploadFinishedAction.observe(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -447,10 +447,8 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         }
 
         viewModel.launchPageListType.observe(viewLifecycleOwner) { pageListType ->
-            pageListType?.let {
-                val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(pageListType)
-                pagesPager.currentItem = pagerIndex
-            }
+            val pagerIndex = PagesPagerAdapter.pageTypes.indexOf(pageListType)
+            pagesPager.currentItem = pagerIndex
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteViewModel.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -62,7 +62,7 @@ class PeopleInviteViewModel @Inject constructor(
 
     private val _inviteLinksState = MediatorLiveData<InviteLinksState>()
     val inviteLinksUiState: LiveData<InviteLinksUiState> =
-        _inviteLinksState.map { state -> buildInviteLinksUiState(state) }
+        _inviteLinksState.mapSafe { state -> buildInviteLinksUiState(state) }
 
     private val _shareLink = MutableLiveData<Event<InviteLinksItem>>()
     val shareLink: LiveData<Event<InviteLinksItem>> = _shareLink

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
@@ -75,5 +75,5 @@ class PhotoPickerActionModeCallback(
         lifecycleRegistry.handleLifecycleEvent(ON_STOP)
     }
 
-    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    override val lifecycle: Lifecycle = lifecycleRegistry
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
@@ -23,14 +23,13 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 class PhotoPickerActionModeCallback(
     private val viewModel: PhotoPickerViewModel
 ) : Callback, LifecycleOwner {
-    private lateinit var lifecycleRegistry: LifecycleRegistry
+    private val lifecycleRegistry = LifecycleRegistry(this)
 
     @Suppress("DEPRECATION")
     override fun onCreateActionMode(
         actionMode: ActionMode,
         menu: Menu
     ): Boolean {
-        lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.handleLifecycleEvent(ON_START)
         viewModel.uiState.observe(this, Observer { uiState ->
             when (val uiModel = uiState.actionModeUiModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -97,9 +97,7 @@ class PostListMainViewModel @Inject constructor(
 ) : ViewModel(), CoroutineScope {
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle {
-            return lifecycleRegistry
-        }
+        override val lifecycle: Lifecycle = lifecycleRegistry
     }
     private var isSiteBlazeEligible = false
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -25,7 +25,7 @@ import androidx.lifecycle.coroutineScope
  */
 @Suppress("DEPRECATION")
 open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwner {
-    private val lifecycleRegistry = LifecycleRegistry(this)
+    @Suppress("LeakingThis") private val lifecycleRegistry = LifecycleRegistry(this)
 
     val lifecycleScope: LifecycleCoroutineScope
         get() = lifecycle.coroutineScope

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -25,7 +25,7 @@ import androidx.lifecycle.coroutineScope
  */
 @Suppress("DEPRECATION")
 open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwner {
-    private lateinit var lifecycleRegistry: LifecycleRegistry
+    private val lifecycleRegistry = LifecycleRegistry(this)
 
     val lifecycleScope: LifecycleCoroutineScope
         get() = lifecycle.coroutineScope
@@ -33,7 +33,6 @@ open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwn
     @Suppress("OVERRIDE_DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.handleLifecycleEvent(ON_CREATE)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PreferenceFragmentLifeCycleOwner.kt
@@ -61,7 +61,5 @@ open class PreferenceFragmentLifeCycleOwner : PreferenceFragment(), LifecycleOwn
         lifecycleRegistry.handleLifecycleEvent(ON_DESTROY)
     }
 
-    override fun getLifecycle(): Lifecycle {
-        return lifecycleRegistry
-    }
+    override val lifecycle: Lifecycle = lifecycleRegistry
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerViewModel.kt
@@ -3,9 +3,9 @@ package org.wordpress.android.ui.prefs.language
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.switchMap
 import org.wordpress.android.R.array
 import org.wordpress.android.ui.prefs.language.LocalePickerListItem.ClickAction
 import org.wordpress.android.ui.prefs.language.LocalePickerListItem.LocaleRow
@@ -43,7 +43,7 @@ class LocalePickerViewModel @Inject constructor(
 
     private val searchInput = MutableLiveData<String>()
     private val _filteredLocales: LiveData<List<LocalePickerListItem>> =
-        Transformations.switchMap(searchInput) { term ->
+        searchInput.switchMap { term ->
             filterLocales(term)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/language/LocalePickerViewModel.kt
@@ -21,17 +21,17 @@ class LocalePickerViewModel @Inject constructor(
 ) : ViewModel() {
     private val cachedLocales = mutableListOf<LocalePickerListItem>()
 
-    private val _expandBottomSheet = SingleLiveEvent<Unit>()
-    val expandBottomSheet: LiveData<Unit> = _expandBottomSheet
+    private val _expandBottomSheet = SingleLiveEvent<Unit?>()
+    val expandBottomSheet: LiveData<Unit?> = _expandBottomSheet
 
-    private val _hideKeyboard = SingleLiveEvent<Unit>()
-    val hideKeyboard: LiveData<Unit> = _hideKeyboard
+    private val _hideKeyboard = SingleLiveEvent<Unit?>()
+    val hideKeyboard: LiveData<Unit?> = _hideKeyboard
 
-    private val _clearSearchField = SingleLiveEvent<Unit>()
-    val clearSearchField: LiveData<Unit> = _clearSearchField
+    private val _clearSearchField = SingleLiveEvent<Unit?>()
+    val clearSearchField: LiveData<Unit?> = _clearSearchField
 
-    private val _dismissBottomSheet = SingleLiveEvent<Unit>()
-    val dismissBottomSheet: LiveData<Unit> = _dismissBottomSheet
+    private val _dismissBottomSheet = SingleLiveEvent<Unit?>()
+    val dismissBottomSheet: LiveData<Unit?> = _dismissBottomSheet
 
     private val _isEmptyViewVisible = SingleLiveEvent<Boolean>()
     private val _suggestedLocale = MutableLiveData<CurrentLocale>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneViewModel.kt
@@ -6,9 +6,9 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.switchMap
 import com.android.volley.Response
 import com.android.volley.VolleyError
 import com.android.volley.toolbox.StringRequest
@@ -57,7 +57,7 @@ class SiteSettingsTimezoneViewModel @Inject constructor(
     private val _timezones = MutableLiveData<List<TimezonesList>>()
 
     private val searchInput = MutableLiveData<String>()
-    private val timezoneSearch: LiveData<List<TimezonesList>> = Transformations.switchMap(searchInput) { term ->
+    private val timezoneSearch: LiveData<List<TimezonesList>> = searchInput.switchMap { term ->
         filterTimezones(term)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/timezone/SiteSettingsTimezoneViewModel.kt
@@ -42,11 +42,11 @@ class SiteSettingsTimezoneViewModel @Inject constructor(
     private val _showProgressView = SingleLiveEvent<Boolean>()
     val showProgressView: LiveData<Boolean> = _showProgressView
 
-    private val _dismissWithError = SingleLiveEvent<Unit>()
-    val dismissWithError: LiveData<Unit> = _dismissWithError
+    private val _dismissWithError = SingleLiveEvent<Unit?>()
+    val dismissWithError: LiveData<Unit?> = _dismissWithError
 
-    private val _dismissBottomSheet = SingleLiveEvent<Unit>()
-    val dismissBottomSheet: LiveData<Unit> = _dismissBottomSheet
+    private val _dismissBottomSheet = SingleLiveEvent<Unit?>()
+    val dismissBottomSheet: LiveData<Unit?> = _dismissBottomSheet
 
     private val _suggestedTimezone = MutableLiveData<String>()
     val suggestedTimezone = _suggestedTimezone

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -115,7 +115,7 @@ class QRCodeAuthFragment : Fragment() {
     }
 
     private fun initBackPressHandler() {
-        requireActivity().onBackPressedDispatcher.addCallback(this) {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             qrCodeAuthViewModel.onBackPressed()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ConversationNotificationsViewModel.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.Foll
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.FollowStateChanged
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.Loading
 import org.wordpress.android.ui.reader.usecases.ReaderCommentsFollowUseCase.FollowCommentsState.UserNotAuthenticated
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -47,11 +47,11 @@ class ConversationNotificationsViewModel @Inject constructor(
 
     private val _updateFollowStatus = MediatorLiveData<FollowCommentsState>()
     val updateFollowUiState: LiveData<FollowConversationUiState> =
-        _updateFollowStatus.map { state -> buildFollowCommentsUiState(state) }
+        _updateFollowStatus.mapSafe { state -> buildFollowCommentsUiState(state) }
 
     private val _pushNotificationsStatusUpdate = MediatorLiveData<FollowStateChanged>()
     val pushNotificationsStatusUpdate: LiveData<Event<Boolean>> =
-        _pushNotificationsStatusUpdate.map { state -> buildPushNotificationsUiState(state) }
+        _pushNotificationsStatusUpdate.mapSafe { state -> buildPushNotificationsUiState(state) }
 
     private var blogId: Long = 0
     private var postId: Long = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -90,7 +90,7 @@ import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WpUrlUtilsWrapper
 import org.wordpress.android.util.config.CommentsSnippetFeatureConfig
 import org.wordpress.android.util.config.LikesEnhancementsFeatureConfig
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -142,12 +142,12 @@ class ReaderPostDetailViewModel @Inject constructor(
     val snackbarEvents: LiveData<Event<SnackbarMessageHolder>> = _snackbarEvents
 
     private val _updateLikesState = MediatorLiveData<GetLikesState>()
-    val likesUiState: LiveData<TrainOfFacesUiState> = _updateLikesState.map { state ->
+    val likesUiState: LiveData<TrainOfFacesUiState> = _updateLikesState.mapSafe { state ->
         buildLikersUiState(state)
     }
 
     private val _commentSnippetState = MutableLiveData<CommentSnippetState>()
-    val commentSnippetState: LiveData<CommentSnippetUiState> = _commentSnippetState.map { state ->
+    val commentSnippetState: LiveData<CommentSnippetUiState> = _commentSnippetState.mapSafe { state ->
         postDetailUiStateBuilder.buildCommentSnippetUiState(state, post, ::onCommentSnippetClicked)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -119,7 +119,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
 
     @Suppress("LongMethod")
     private fun observeVMState() {
-        mainViewModel.navigationTargetObservable.observe(this) { it?.let(::showStep) }
+        mainViewModel.navigationTargetObservable.observe(this, ::showStep)
         mainViewModel.onCompleted.observe(this) { (result, isTitleTaskComplete) ->
             val intent = Intent().apply {
                 putExtra(SitePickerActivity.KEY_SITE_LOCAL_ID, (result as? Created)?.site?.id)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -6,8 +6,8 @@ import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -132,7 +132,7 @@ class SiteCreationMainVM @Inject constructor(
 
     val navigationTargetObservable: SingleEventObservable<NavigationTarget> by lazy {
         SingleEventObservable(
-            Transformations.map(wizardManager.navigatorLiveData) {
+            wizardManager.navigatorLiveData.map {
                 clearOldSiteCreationState(it)
                 WizardNavigationTarget(it, siteCreationState)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -145,11 +145,11 @@ class SiteCreationMainVM @Inject constructor(
     private val _onCompleted = SingleLiveEvent<SiteCreationCompletionEvent>()
     val onCompleted: LiveData<SiteCreationCompletionEvent> = _onCompleted
 
-    private val _exitFlowObservable = SingleLiveEvent<Unit>()
-    val exitFlowObservable: LiveData<Unit> = _exitFlowObservable
+    private val _exitFlowObservable = SingleLiveEvent<Unit?>()
+    val exitFlowObservable: LiveData<Unit?> = _exitFlowObservable
 
-    private val _onBackPressedObservable = SingleLiveEvent<Unit>()
-    val onBackPressedObservable: LiveData<Unit> = _onBackPressedObservable
+    private val _onBackPressedObservable = SingleLiveEvent<Unit?>()
+    val onBackPressedObservable: LiveData<Unit?> = _onBackPressedObservable
 
     private val _showJetpackOverlay = MutableLiveData<Event<Boolean>>()
     val showJetpackOverlay: LiveData<Event<Boolean>> = _showJetpackOverlay

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -91,11 +91,11 @@ class SiteCreationDomainsViewModel @Inject constructor(
     private val _createSiteBtnClicked = SingleLiveEvent<DomainModel>()
     val createSiteBtnClicked: LiveData<DomainModel> = _createSiteBtnClicked
 
-    private val _clearBtnClicked = SingleLiveEvent<Unit>()
+    private val _clearBtnClicked = SingleLiveEvent<Unit?>()
     val clearBtnClicked = _clearBtnClicked
 
-    private val _onHelpClicked = SingleLiveEvent<Unit>()
-    val onHelpClicked: LiveData<Unit> = _onHelpClicked
+    private val _onHelpClicked = SingleLiveEvent<Unit?>()
+    val onHelpClicked: LiveData<Unit?> = _onHelpClicked
 
     init {
         dispatcher.register(fetchDomainsUseCase)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -74,11 +74,11 @@ class SiteCreationProgressViewModel @Inject constructor(
     private val _startCreateSiteService: SingleLiveEvent<StartServiceData> = SingleLiveEvent()
     val startCreateSiteService: LiveData<StartServiceData> = _startCreateSiteService
 
-    private val _onHelpClicked = SingleLiveEvent<Unit>()
-    val onHelpClicked: LiveData<Unit> = _onHelpClicked
+    private val _onHelpClicked = SingleLiveEvent<Unit?>()
+    val onHelpClicked: LiveData<Unit?> = _onHelpClicked
 
-    private val _onCancelWizardClicked = SingleLiveEvent<Unit>()
-    val onCancelWizardClicked: LiveData<Unit> = _onCancelWizardClicked
+    private val _onCancelWizardClicked = SingleLiveEvent<Unit?>()
+    val onCancelWizardClicked: LiveData<Unit?> = _onCancelWizardClicked
 
     private val _onFreeSiteCreated = SingleLiveEvent<SiteModel>()
     val onFreeSiteCreated: LiveData<SiteModel> = _onFreeSiteCreated

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/sitename/SiteCreationSiteNameViewModel.kt
@@ -25,11 +25,11 @@ class SiteCreationSiteNameViewModel @Inject constructor(
 
     private var isInitialized = false
 
-    private val _onSkipButtonPressed = SingleLiveEvent<Unit>()
-    val onSkipButtonPressed: LiveData<Unit> = _onSkipButtonPressed
+    private val _onSkipButtonPressed = SingleLiveEvent<Unit?>()
+    val onSkipButtonPressed: LiveData<Unit?> = _onSkipButtonPressed
 
-    private val _onBackButtonPressed = SingleLiveEvent<Unit>()
-    val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
+    private val _onBackButtonPressed = SingleLiveEvent<Unit?>()
+    val onBackButtonPressed: LiveData<Unit?> = _onBackButtonPressed
 
     private val _onSiteNameEntered = SingleLiveEvent<String>()
     val onSiteNameEntered: LiveData<String> = _onSiteNameEntered

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModel.kt
@@ -38,8 +38,8 @@ class HomePagePickerViewModel @Inject constructor(
     private val _onDesignActionPressed = SingleLiveEvent<DesignSelectionAction>()
     val onDesignActionPressed: LiveData<DesignSelectionAction> = _onDesignActionPressed
 
-    private val _onBackButtonPressed = SingleLiveEvent<Unit>()
-    val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
+    private val _onBackButtonPressed = SingleLiveEvent<Unit?>()
+    val onBackButtonPressed: LiveData<Unit?> = _onBackButtonPressed
 
     private var vertical: String = ""
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/verticals/SiteCreationIntentsViewModel.kt
@@ -36,11 +36,11 @@ class SiteCreationIntentsViewModel @Inject constructor(
     private val _uiState: MutableLiveData<IntentsUiState> = MutableLiveData()
     val uiState: LiveData<IntentsUiState> = _uiState
 
-    private val _onSkipButtonPressed = SingleLiveEvent<Unit>()
-    val onSkipButtonPressed: LiveData<Unit> = _onSkipButtonPressed
+    private val _onSkipButtonPressed = SingleLiveEvent<Unit?>()
+    val onSkipButtonPressed: LiveData<Unit?> = _onSkipButtonPressed
 
-    private val _onBackButtonPressed = SingleLiveEvent<Unit>()
-    val onBackButtonPressed: LiveData<Unit> = _onBackButtonPressed
+    private val _onBackButtonPressed = SingleLiveEvent<Unit?>()
+    val onBackButtonPressed: LiveData<Unit?> = _onBackButtonPressed
 
     private val _onIntentSelected = SingleLiveEvent<String?>()
     val onIntentSelected: LiveData<String?> = _onIntentSelected

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.throttle
 import org.wordpress.android.viewmodel.Event
@@ -42,7 +42,7 @@ class StatsViewAllViewModel(
 
     val navigationTarget: LiveData<Event<NavigationTarget>> = useCase.navigationTarget
 
-    val data: LiveData<StatsBlock> = useCase.liveData.map { useCaseModel ->
+    val data: LiveData<StatsBlock> = useCase.liveData.mapSafe { useCaseModel ->
         when (useCaseModel.state) {
             SUCCESS -> StatsBlock.Success(useCaseModel.type, useCaseModel.data ?: listOf())
             ERROR -> StatsBlock.Error(useCaseModel.type, useCaseModel.stateData ?: useCaseModel.data ?: listOf())
@@ -57,7 +57,7 @@ class StatsViewAllViewModel(
     private val _showSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     val showSnackbarMessage: LiveData<Event<SnackbarMessageHolder>> = _showSnackbarMessage
 
-    val toolbarHasShadow = dateSelectorData.map { !it.isVisible }
+    val toolbarHasShadow = dateSelectorData.mapSafe { !it.isVisible }
 
     fun start(startDate: SelectedDate?) {
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -22,7 +22,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.PackageUtils
 import org.wordpress.android.util.combineMap
 import org.wordpress.android.util.distinct
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mapAsync
 import org.wordpress.android.util.mergeAsyncNotNull
 import org.wordpress.android.util.mergeNotNull
@@ -70,7 +70,7 @@ class BaseListUseCase(
     )
 
     private val mutableSnackbarMessage = MutableLiveData<Int?>()
-    val snackbarMessage: LiveData<SnackbarMessageHolder> = mutableSnackbarMessage.map {
+    val snackbarMessage: LiveData<SnackbarMessageHolder> = mutableSnackbarMessage.mapSafe {
         it?.let { SnackbarMessageHolder(UiStringRes(it)) }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -74,8 +74,8 @@ class BaseListUseCase(
         it?.let { SnackbarMessageHolder(UiStringRes(it)) }
     }
 
-    private val mutableListSelected = SingleLiveEvent<Unit>()
-    val listSelected: LiveData<Unit> = mutableListSelected
+    private val mutableListSelected = SingleLiveEvent<Unit?>()
+    val listSelected: LiveData<Unit?> = mutableListSelected
 
     private val mutableScrollTo = MutableLiveData<Event<StatsType>>()
     val scrollTo: LiveData<Event<StatsType>> = mutableScrollTo

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementFragment.kt
@@ -35,7 +35,9 @@ class InsightsManagementFragment : Fragment(R.layout.insights_management_fragmen
             initializeViews()
             initializeViewModels(requireActivity(), siteId)
         }
-        requireActivity().onBackPressedDispatcher.addCallback(this) { viewModel.onBackPressed() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            viewModel.onBackPressed()
+        }
     }
 
     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/management/InsightsManagementViewModel.kt
@@ -36,8 +36,8 @@ class InsightsManagementViewModel @Inject constructor(
     private val _addedInsights = MutableLiveData<List<InsightListItem>>()
     val addedInsights: LiveData<List<InsightListItem>> = _addedInsights
 
-    private val _closeInsightsManagement = SingleLiveEvent<Unit>()
-    val closeInsightsManagement: LiveData<Unit> = _closeInsightsManagement
+    private val _closeInsightsManagement = SingleLiveEvent<Unit?>()
+    val closeInsightsManagement: LiveData<Unit?> = _closeInsightsManagement
 
     private val _isMenuVisible = MutableLiveData<Boolean>()
     val isMenuVisible: LiveData<Boolean> = _isMenuVisible

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/StoryComposerViewModel.kt
@@ -45,7 +45,7 @@ class StoryComposerViewModel @Inject constructor(
 ) : ViewModel() {
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+        override val lifecycle: Lifecycle = lifecycleRegistry
     }
 
     private lateinit var editPostRepository: EditPostRepository

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/intro/StoriesIntroViewModel.kt
@@ -16,11 +16,11 @@ class StoriesIntroViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(mainDispatcher) {
-    private val _onDialogClosed = SingleLiveEvent<Unit>()
-    val onDialogClosed: LiveData<Unit> = _onDialogClosed
+    private val _onDialogClosed = SingleLiveEvent<Unit?>()
+    val onDialogClosed: LiveData<Unit?> = _onDialogClosed
 
-    private val _onCreateButtonClicked = SingleLiveEvent<Unit>()
-    val onCreateButtonClicked: LiveData<Unit> = _onCreateButtonClicked
+    private val _onCreateButtonClicked = SingleLiveEvent<Unit?>()
+    val onCreateButtonClicked: LiveData<Unit?> = _onCreateButtonClicked
 
     private val _onStoryOpenRequested = SingleLiveEvent<String>()
     val onStoryOpenRequested: LiveData<String> = _onStoryOpenRequested

--- a/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/whatsnew/FeatureAnnouncementViewModel.kt
@@ -32,8 +32,8 @@ class FeatureAnnouncementViewModel @Inject constructor(
     private val _uiModel = MediatorLiveData<FeatureAnnouncementUiModel>()
     val uiModel: LiveData<FeatureAnnouncementUiModel> = _uiModel
 
-    private val _onDialogClosed = SingleLiveEvent<Unit>()
-    val onDialogClosed: LiveData<Unit> = _onDialogClosed
+    private val _onDialogClosed = SingleLiveEvent<Unit?>()
+    val onDialogClosed: LiveData<Unit?> = _onDialogClosed
 
     private val _onAnnouncementDetailsRequested = SingleLiveEvent<String>()
     val onAnnouncementDetailsRequested: LiveData<String> = _onAnnouncementDetailsRequested

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -332,7 +332,7 @@ fun <T, U> LiveData<T>.mapAsync(scope: CoroutineScope, mapper: suspend (T) -> U?
  * Calls the specified function [block] with `this` value as its receiver and returns new instance of LiveData.
  */
 fun <T> LiveData<T>.perform(block: LiveData<T>.(T) -> Unit): LiveData<T> {
-    return Transformations.map(this) {
+    return this.map {
         block(it)
         return@map it
     }
@@ -342,7 +342,7 @@ fun <T> LiveData<T>.perform(block: LiveData<T>.(T) -> Unit): LiveData<T> {
  * Simple wrapper of the map utility method that is null safe
  */
 fun <T, U> LiveData<T>.mapNullable(mapper: (T?) -> U?): LiveData<U> {
-    return Transformations.map(this) { mapper(it) }
+    return this.map { mapper(it)!! }
 }
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LiveDataUtils.kt
@@ -105,7 +105,7 @@ fun <T, U, V> merge(sourceA: LiveData<T>, sourceB: LiveData<U>, merger: (T?, U?)
     mediator.addSource(sourceB) {
         mediator.value = Pair(mediator.value?.first, it)
     }
-    return mediator.map { (dataA, dataB) -> merger(dataA, dataB) }
+    return mediator.mapSafe { (dataA, dataB) -> merger(dataA, dataB) }
 }
 
 /**
@@ -161,7 +161,7 @@ fun <S, T, U, V> merge(
             mediator.value = container?.copy(third = it)
         }
     }
-    return mediator.map { (first, second, third) -> merger(first, second, third) }
+    return mediator.mapSafe { (first, second, third) -> merger(first, second, third) }
 }
 
 /**
@@ -214,7 +214,7 @@ fun <S, T, U, V, W> merge(
             mediator.value = container?.copy(fourth = it)
         }
     }
-    return mediator.map { (first, second, third, fourth) -> merger(first, second, third, fourth) }
+    return mediator.mapSafe { (first, second, third, fourth) -> merger(first, second, third, fourth) }
 }
 
 /**
@@ -276,7 +276,7 @@ fun <S, T, U, V, W, X> merge(
             mediator.value = container?.copy(fifth = it)
         }
     }
-    return mediator.map { (first, second, third, fourth, fifth) -> merger(first, second, third, fourth, fifth) }
+    return mediator.mapSafe { (first, second, third, fourth, fifth) -> merger(first, second, third, fourth, fifth) }
 }
 
 /**
@@ -300,13 +300,13 @@ fun <Key, Value> combineMap(sources: Map<Key, LiveData<Value>>): MediatorLiveDat
             }
         }
     }
-    return mediator.map { it.toMap() }
+    return mediator.mapSafe { it.toMap() }
 }
 
 /**
  * Simple wrapper of the map utility method that is null safe
  */
-fun <T, U> LiveData<T>.map(mapper: (T) -> U?): MediatorLiveData<U> {
+fun <T, U> LiveData<T>.mapSafe(mapper: (T) -> U?): MediatorLiveData<U> {
     val result = MediatorLiveData<U>()
     result.addSource(this) { x -> result.value = x?.let { mapper(x) } }
     return result

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -11,6 +11,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
+import androidx.core.os.ParcelCompat
 import java.io.Serializable
 
 /**
@@ -29,17 +32,12 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressedCallback.isEnabled = true
 }
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableExtra(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableExtra(key) as T?
-    }
+    IntentCompat.getParcelableExtra(
+        this,
+        key,
+        T::class.java
+    )
 
 /**
  * This is an Android 13 compatibility function that is not included in IntentCompat.
@@ -52,29 +50,19 @@ inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: Str
         getSerializableExtra(key) as T?
     }
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelable(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelable(key)
-    }
+    BundleCompat.getParcelable(
+        this,
+        key,
+        T::class.java
+    )
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String): ArrayList<T>? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableArrayList(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableArrayList(key)
-    }
+    BundleCompat.getParcelableArrayList(
+        this,
+        key,
+        T::class.java
+    )
 
 /**
  * This is an Android 13 compatibility function that is not included in BundleCompat.
@@ -87,30 +75,20 @@ inline fun <reified T : Serializable?> Bundle.getSerializableCompat(key: String)
         getSerializable(key) as T?
     }
 
-/**
- * TODO: Remove this when upgrading to androidx.core 1.9.0. Use ParcelCompat instead.
- */
-@Suppress("ForbiddenComment")
-inline fun <reified T : Parcelable> Parcel.readParcelableCompat(loader: ClassLoader?): T? {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        readParcelable(loader, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        readParcelable(loader)
-    }
-}
+inline fun <reified T : Parcelable> Parcel.readParcelableCompat(loader: ClassLoader?): T? =
+    ParcelCompat.readParcelable(
+        this,
+        loader,
+        T::class.java
+    )
 
-/**
- * TODO: Remove this when upgrading to androidx.core 1.9.0. Use ParcelCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T> Parcel.readListCompat(outVal: MutableList<T?>, loader: ClassLoader?) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        readList(outVal, loader, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        readList(outVal, loader)
-    }
+    ParcelCompat.readList(
+        this,
+        outVal,
+        loader,
+        T::class.java
+    )
 }
 
 fun PackageManager.getActivityInfoCompat(componentName: ComponentName, flags: Int): ActivityInfo =

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/CompatExtensions.kt
@@ -16,6 +16,8 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.ParcelCompat
 import java.io.Serializable
 
+/* ON BACK PRESSED */
+
 /**
  * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
  * This function temporary disables the callback to allow the system to handle the back pressed event.
@@ -31,6 +33,8 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressed()
     onBackPressedCallback.isEnabled = true
 }
+
+/* INTENT */
 
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
     IntentCompat.getParcelableExtra(
@@ -49,6 +53,8 @@ inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: Str
         @Suppress("DEPRECATION")
         getSerializableExtra(key) as T?
     }
+
+/* BUNDLE */
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
     BundleCompat.getParcelable(
@@ -75,6 +81,8 @@ inline fun <reified T : Serializable?> Bundle.getSerializableCompat(key: String)
         getSerializable(key) as T?
     }
 
+/* PARCEL */
+
 inline fun <reified T : Parcelable> Parcel.readParcelableCompat(loader: ClassLoader?): T? =
     ParcelCompat.readParcelable(
         this,
@@ -90,6 +98,8 @@ inline fun <reified T> Parcel.readListCompat(outVal: MutableList<T?>, loader: Cl
         T::class.java
     )
 }
+
+/* PACKAGE MANAGER */
 
 fun PackageManager.getActivityInfoCompat(componentName: ComponentName, flags: Int): ActivityInfo =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -103,8 +103,8 @@ class ActivityLogViewModel @Inject constructor(
     val showDateRangePicker: LiveData<ShowDateRangePicker>
         get() = _showDateRangePicker
 
-    private val _moveToTop = SingleLiveEvent<Unit>()
-    val moveToTop: SingleLiveEvent<Unit>
+    private val _moveToTop = SingleLiveEvent<Unit?>()
+    val moveToTop: SingleLiveEvent<Unit?>
         get() = _moveToTop
 
     private val _showItemDetail = SingleLiveEvent<ActivityLogListItem>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -76,9 +76,7 @@ class HistoryViewModel @Inject constructor(
 
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle {
-            return lifecycleRegistry
-        }
+        override val lifecycle: Lifecycle = lifecycleRegistry
     }
 
     init {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -45,7 +45,7 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.SiteUtils.hasFullAccessToContent
 import org.wordpress.android.util.SiteUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
-import org.wordpress.android.util.map
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mapNullable
 import org.wordpress.android.util.merge
 import org.wordpress.android.viewmodel.Event
@@ -133,7 +133,7 @@ class WPMainActivityViewModel @Inject constructor(
     val onFocusPointVisibilityChange = quickStartRepository.activeTask
         .mapNullable { getExternalFocusPointInfo(it) }
         .distinctUntilChanged()
-        .map { Event(it) } as LiveData<Event<List<FocusPointInfo>>>
+        .mapSafe { Event(it) } as LiveData<Event<List<FocusPointInfo>>>
 
     val hasMultipleSites: Boolean
         get() = siteStore.sitesCount > ONE_SITE

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -121,14 +121,14 @@ class WPMainActivityViewModel @Inject constructor(
     private val _switchToMySite = MutableLiveData<Event<Unit>>()
     val switchToMySite: LiveData<Event<Unit>> = _switchToMySite
 
-    private val _onFeatureAnnouncementRequested = SingleLiveEvent<Unit>()
-    val onFeatureAnnouncementRequested: LiveData<Unit> = _onFeatureAnnouncementRequested
+    private val _onFeatureAnnouncementRequested = SingleLiveEvent<Unit?>()
+    val onFeatureAnnouncementRequested: LiveData<Unit?> = _onFeatureAnnouncementRequested
 
     private val _createPostWithBloggingPrompt = SingleLiveEvent<Int>()
     val createPostWithBloggingPrompt: LiveData<Int> = _createPostWithBloggingPrompt
 
-    private val _openBloggingPromptsOnboarding = SingleLiveEvent<Unit>()
-    val openBloggingPromptsOnboarding: LiveData<Unit> = _openBloggingPromptsOnboarding
+    private val _openBloggingPromptsOnboarding = SingleLiveEvent<Unit?>()
+    val openBloggingPromptsOnboarding: LiveData<Unit?> = _openBloggingPromptsOnboarding
 
     val onFocusPointVisibilityChange = quickStartRepository.activeTask
         .mapNullable { getExternalFocusPointInfo(it) }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -5,7 +5,7 @@ import androidx.annotation.ColorRes
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.Transformations
+import androidx.lifecycle.map
 import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -63,7 +63,7 @@ class PageListViewModel @Inject constructor(
     @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(coroutineDispatcher) {
     private val _pages: MutableLiveData<List<PageItem>> = MutableLiveData()
-    val pages: LiveData<Triple<List<PageItem>, Boolean, Boolean>> = Transformations.map(_pages) {
+    val pages: LiveData<Triple<List<PageItem>, Boolean, Boolean>> = _pages.map {
         Triple(it, isSitePhotonCapable, isSitePrivateAt)
     }
     private val _scrollToPosition = SingleLiveEvent<Int>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -174,20 +174,16 @@ class PageListViewModel @Inject constructor(
     }
 
     private val pagesObserver = Observer<List<PageModel>> { pages ->
-        pages?.let {
-            loadPagesAsync(pages)
-            pagesViewModel.checkIfNewPageButtonShouldBeVisible()
-        }
+        loadPagesAsync(pages)
+        pagesViewModel.checkIfNewPageButtonShouldBeVisible()
     }
 
     private val uploadStatusObserver = Observer<List<LocalId>> { ids ->
         pagesViewModel.uploadStatusTracker.invalidateUploadStatus(ids.map { localId -> localId.value })
     }
 
-    private val authorSelectionChangedObserver = Observer<AuthorFilterSelection> { authorSelection ->
-        authorSelection?.let {
-            pagesViewModel.pages.value?.let { loadPagesAsync(it) }
-        }
+    private val authorSelectionChangedObserver = Observer<AuthorFilterSelection> {
+        pagesViewModel.pages.value?.let { loadPagesAsync(it) }
     }
 
     private val blazeSiteEligibilityObserver = Observer<Boolean> { _ ->

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageParentViewModel.kt
@@ -52,8 +52,8 @@ class PageParentViewModel
     private val _isSaveButtonVisible = MutableLiveData<Boolean>()
     val isSaveButtonVisible: LiveData<Boolean> = _isSaveButtonVisible
 
-    private val _saveParent = SingleLiveEvent<Unit>()
-    val saveParent: LiveData<Unit> = _saveParent
+    private val _saveParent = SingleLiveEvent<Unit?>()
+    val saveParent: LiveData<Unit?> = _saveParent
 
     private val _searchPages: MutableLiveData<List<PageItem>?> = MutableLiveData()
     val searchPages: LiveData<List<PageItem>?> = _searchPages

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -143,8 +143,8 @@ class PagesViewModel
     private val _searchPages: MutableLiveData<SortedMap<PageListType, List<PageModel>>?> = MutableLiveData()
     val searchPages: LiveData<SortedMap<PageListType, List<PageModel>>?> = _searchPages
 
-    private val _createNewPage = SingleLiveEvent<Unit>()
-    val createNewPage: LiveData<Unit> = _createNewPage
+    private val _createNewPage = SingleLiveEvent<Unit?>()
+    val createNewPage: LiveData<Unit?> = _createNewPage
 
     private val _editPage = SingleLiveEvent<Triple<SiteModel, PostModel?, LoadAutoSaveRevision>>()
     val editPage: LiveData<Triple<SiteModel, PostModel?, LoadAutoSaveRevision>> = _editPage

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -123,7 +123,7 @@ class PostListViewModel @Inject constructor(
 
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+        override val lifecycle: Lifecycle = lifecycleRegistry
     }
 
     fun start(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -66,7 +66,7 @@ class WPWebViewViewModel
 
     private val lifecycleOwner = object : LifecycleOwner {
         val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+        override val lifecycle: Lifecycle = lifecycleRegistry
     }
 
     private val defaultPreviewMode: PreviewMode

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/wpwebview/WPWebViewViewModel.kt
@@ -43,17 +43,17 @@ class WPWebViewViewModel
     private val _loadNeeded = SingleLiveEvent<Boolean>()
     val loadNeeded: LiveData<Boolean> = _loadNeeded
 
-    private val _navigateBack = SingleLiveEvent<Unit>()
-    val navigateBack: LiveData<Unit> = _navigateBack
+    private val _navigateBack = SingleLiveEvent<Unit?>()
+    val navigateBack: LiveData<Unit?> = _navigateBack
 
-    private val _navigateForward = SingleLiveEvent<Unit>()
-    val navigateForward: LiveData<Unit> = _navigateForward
+    private val _navigateForward = SingleLiveEvent<Unit?>()
+    val navigateForward: LiveData<Unit?> = _navigateForward
 
-    private val _share = SingleLiveEvent<Unit>()
-    val share: LiveData<Unit> = _share
+    private val _share = SingleLiveEvent<Unit?>()
+    val share: LiveData<Unit?> = _share
 
-    private val _openInExternalBrowser = SingleLiveEvent<Unit>()
-    val openExternalBrowser: LiveData<Unit> = _openInExternalBrowser
+    private val _openInExternalBrowser = SingleLiveEvent<Unit?>()
+    val openExternalBrowser: LiveData<Unit?> = _openInExternalBrowser
 
     private val _previewModeSelector = MutableLiveData<PreviewModeSelectorStatus>()
     val previewModeSelector: LiveData<PreviewModeSelectorStatus> = _previewModeSelector

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/HelpViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/HelpViewModelTest.kt
@@ -26,7 +26,7 @@ class HelpViewModelTest : BaseUnitTest() {
     lateinit var wordPress: WordPress
 
     @Mock
-    private lateinit var onSignoutCompletedObserver: Observer<Unit>
+    private lateinit var onSignoutCompletedObserver: Observer<Unit?>
 
     private val accountStore = mock<AccountStore>()
     private val siteStore = mock<SiteStore>()

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationDetailsViewModelTest.kt
@@ -86,7 +86,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
     private lateinit var statePickerDialogObserver: Observer<List<SupportedStateResponse>>
 
     @Mock
-    private lateinit var tosLinkObserver: Observer<Unit>
+    private lateinit var tosLinkObserver: Observer<Unit?>
 
     @Mock
     private lateinit var completedDomainRegistrationObserver: Observer<DomainRegistrationCompletedEvent>
@@ -354,7 +354,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         validateFetchSupportedCountriesAction(actionsDispatched[0])
         validateFetchDomainContactAction(actionsDispatched[1])
 
-        verify(errorMessageObserver).onChanged(domainContactInformationFetchError.message)
+        verify(errorMessageObserver).onChanged(domainContactInformationFetchError.message ?: "")
 
         assertThat(uiStateResults.size).isEqualTo(3)
 
@@ -388,7 +388,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         validateFetchDomainContactAction(actionsDispatched[1])
         validateFetchStatesAction(actionsDispatched[2], primaryCountry.code)
 
-        verify(errorMessageObserver).onChanged(domainSupportedStatesFetchError.message)
+        verify(errorMessageObserver).onChanged(domainSupportedStatesFetchError.message ?: "")
 
         assertThat(uiStateResults.size).isEqualTo(5)
 
@@ -605,7 +605,7 @@ class DomainRegistrationDetailsViewModelTest : BaseUnitTest() {
         val errorFetchingSiteState = uiStateResults[1]
         assertThat(errorFetchingSiteState.isRegistrationProgressIndicatorVisible).isEqualTo(false)
 
-        verify(errorMessageObserver).onChanged(siteChangedError.message)
+        verify(errorMessageObserver).onChanged(siteChangedError.message ?: "")
 
         verify(completedDomainRegistrationObserver).onChanged(domainRegistrationCompletedEvent)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelCopyPostTest.kt
@@ -35,7 +35,7 @@ class PostListMainViewModelCopyPostTest : BaseUnitTest() {
     lateinit var postSqlUtils: PostSqlUtils
 
     @Mock
-    lateinit var onPostListActionObserver: Observer<PostListAction>
+    lateinit var onPostListActionObserver: Observer<PostListAction?>
 
     private lateinit var viewModel: PostListMainViewModel
     private lateinit var postStore: PostStore

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/locale/LocalePickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/locale/LocalePickerViewModelTest.kt
@@ -36,16 +36,16 @@ class LocalePickerViewModelTest : BaseUnitTest() {
     lateinit var selectedLocaleObserver: Observer<String>
 
     @Mock
-    lateinit var dismissBottomSheetObserver: Observer<Unit>
+    lateinit var dismissBottomSheetObserver: Observer<Unit?>
 
     @Mock
-    lateinit var expandBottomSheetObserver: Observer<Unit>
+    lateinit var expandBottomSheetObserver: Observer<Unit?>
 
     @Mock
-    lateinit var hideKeyboardObserver: Observer<Unit>
+    lateinit var hideKeyboardObserver: Observer<Unit?>
 
     @Mock
-    lateinit var clearSearchFieldObserver: Observer<Unit>
+    lateinit var clearSearchFieldObserver: Observer<Unit?>
 
     private lateinit var viewModel: LocalePickerViewModel
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -67,13 +67,13 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     lateinit var onCompletedObserver: Observer<SiteCreationCompletionEvent>
 
     @Mock
-    lateinit var wizardExitedObserver: Observer<Unit>
+    lateinit var wizardExitedObserver: Observer<Unit?>
 
     @Mock
     lateinit var dialogActionsObserver: Observer<DialogHolder>
 
     @Mock
-    lateinit var onBackPressedObserver: Observer<Unit>
+    lateinit var onBackPressedObserver: Observer<Unit?>
 
     @Mock
     lateinit var savedInstanceState: Bundle

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -72,7 +72,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     private lateinit var tracker: SiteCreationTracker
 
     @Mock
-    private lateinit var uiStateObserver: Observer<DomainsUiState>
+    private lateinit var uiStateObserver: Observer<DomainsUiState?>
 
     @Mock
     private lateinit var createSiteBtnObserver: Observer<DomainModel>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -78,10 +78,10 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     private lateinit var createSiteBtnObserver: Observer<DomainModel>
 
     @Mock
-    private lateinit var clearBtnObserver: Observer<Unit>
+    private lateinit var clearBtnObserver: Observer<Unit?>
 
     @Mock
-    private lateinit var onHelpClickedObserver: Observer<Unit>
+    private lateinit var onHelpClickedObserver: Observer<Unit?>
 
     @Mock
     private lateinit var networkUtils: NetworkUtilsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -63,8 +63,8 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
 
     private val uiStateObserver = mock<Observer<SiteProgressUiState>>()
     private val startServiceObserver = mock<Observer<StartServiceData>>()
-    private val onHelpClickedObserver = mock<Observer<Unit>>()
-    private val onCancelWizardClickedObserver = mock<Observer<Unit>>()
+    private val onHelpClickedObserver = mock<Observer<Unit?>>()
+    private val onCancelWizardClickedObserver = mock<Observer<Unit?>>()
     private val onRemoteSiteCreatedObserver = mock<Observer<SiteModel>>()
     private val onCartCreatedObserver = mock<Observer<CheckoutDetails>>()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/theme/HomePagePickerViewModelTest.kt
@@ -54,16 +54,16 @@ class HomePagePickerViewModelTest : BaseUnitTest() {
     lateinit var fetchHomePageLayoutsUseCase: FetchHomePageLayoutsUseCase
 
     @Mock
-    lateinit var uiStateObserver: Observer<LayoutPickerUiState>
+    lateinit var uiStateObserver: Observer<LayoutPickerUiState?>
 
     @Mock
-    lateinit var onDesignActionObserver: Observer<DesignSelectionAction>
+    lateinit var onDesignActionObserver: Observer<DesignSelectionAction?>
 
     @Mock
-    lateinit var onPreviewActionObserver: Observer<DesignPreviewAction>
+    lateinit var onPreviewActionObserver: Observer<DesignPreviewAction?>
 
     @Mock
-    lateinit var previewModeObserver: Observer<PreviewMode>
+    lateinit var previewModeObserver: Observer<PreviewMode?>
 
     @Mock
     lateinit var analyticsTracker: SiteCreationTracker

--- a/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stories/StoriesIntroViewModelTest.kt
@@ -24,10 +24,10 @@ class StoriesIntroViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: StoriesIntroViewModel
 
     @Mock
-    lateinit var onDialogClosedObserver: Observer<Unit>
+    lateinit var onDialogClosedObserver: Observer<Unit?>
 
     @Mock
-    lateinit var onCreateButtonClickedObserver: Observer<Unit>
+    lateinit var onCreateButtonClickedObserver: Observer<Unit?>
 
     @Mock
     lateinit var onStoryOpenRequestedObserver: Observer<String>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -81,7 +81,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     lateinit var featureAnnouncementProvider: FeatureAnnouncementProvider
 
     @Mock
-    lateinit var onFeatureAnnouncementRequestedObserver: Observer<Unit>
+    lateinit var onFeatureAnnouncementRequestedObserver: Observer<Unit?>
 
     @Mock
     lateinit var buildConfigWrapper: BuildConfigWrapper
@@ -111,7 +111,7 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     lateinit var quickStartType: QuickStartType
 
     @Mock
-    private lateinit var openBloggingPromptsOnboardingObserver: Observer<Unit>
+    private lateinit var openBloggingPromptsOnboardingObserver: Observer<Unit?>
 
     @Mock
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/mlp/ModalLayoutPickerViewModelTest.kt
@@ -70,7 +70,7 @@ class ModalLayoutPickerViewModelTest : BaseUnitTest() {
     lateinit var analyticsTracker: ModalLayoutPickerTracker
 
     @Mock
-    lateinit var onCreateNewPageRequestedObserver: Observer<Create>
+    lateinit var onCreateNewPageRequestedObserver: Observer<Create?>
 
     private val aboutCategory = GutenbergLayoutCategory(
         slug = "about",

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/whatsnew/FeatureAnnouncementViewModelTest.kt
@@ -30,7 +30,7 @@ class FeatureAnnouncementViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: FeatureAnnouncementViewModel
 
     @Mock
-    lateinit var onDialogClosedObserver: Observer<Unit>
+    lateinit var onDialogClosedObserver: Observer<Unit?>
 
     @Mock
     lateinit var onAnnouncementDetailsRequestedObserver: Observer<String>

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     // main
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.2.1'
-    androidxAppcompatVersion = '1.4.2'
+    androidxAppcompatVersion = '1.5.1'
     androidxArchCoreVersion = '2.2.0'
     androidxComposeBomVersion = '2023.01.00'
     androidxComposeCompilerVersion = '1.4.6'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ ext {
     androidxConstraintlayoutComposeVersion = '1.0.1'
     androidxCoreVersion = '1.10.0'
     androidxActivityVersion = '1.7.1'
-    androidxFragmentVersion = '1.5.5'
+    androidxFragmentVersion = '1.5.7'
     androidxGridlayoutVersion = '1.0.0'
     androidxLifecycleVersion = '2.6.1'
     androidxPercentlayoutVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'
-    androidxCoreVersion = '1.9.0'
+    androidxCoreVersion = '1.10.0'
     androidxActivityVersion = '1.5.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.2.1'
     androidxAppcompatVersion = '1.4.2'
-    androidxArchCoreVersion = '2.1.0'
+    androidxArchCoreVersion = '2.2.0'
     androidxComposeBomVersion = '2023.01.00'
     androidxComposeCompilerVersion = '1.4.6'
     androidxCardviewVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     androidxActivityVersion = '1.5.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'
-    androidxLifecycleVersion = '2.5.1'
+    androidxLifecycleVersion = '2.6.1'
     androidxPercentlayoutVersion = '1.0.0'
     androidxPreferenceVersion = '1.2.0'
     androidxRecyclerviewVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     // main
     androidInstallReferrerVersion = '2.2'
     androidVolleyVersion = '1.2.1'
-    androidxAppcompatVersion = '1.5.1'
+    androidxAppcompatVersion = '1.6.1'
     androidxArchCoreVersion = '2.2.0'
     androidxComposeBomVersion = '2023.01.00'
     androidxComposeCompilerVersion = '1.4.6'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'
     androidxCoreVersion = '1.10.0'
-    androidxActivityVersion = '1.6.1'
+    androidxActivityVersion = '1.7.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'
     androidxLifecycleVersion = '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'
     androidxCoreVersion = '1.10.0'
-    androidxActivityVersion = '1.5.1'
+    androidxActivityVersion = '1.6.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'
     androidxLifecycleVersion = '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'
     androidxConstraintlayoutComposeVersion = '1.0.1'
-    androidxCoreVersion = '1.8.0'
+    androidxCoreVersion = '1.9.0'
     androidxActivityVersion = '1.5.1'
     androidxFragmentVersion = '1.5.5'
     androidxGridlayoutVersion = '1.0.0'

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -39,6 +39,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
+    implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.activity:activity:$androidxActivityVersion"
     implementation "androidx.activity:activity-ktx:$androidxActivityVersion"
     implementation "androidx.fragment:fragment:$androidxFragmentVersion"

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
@@ -8,6 +8,8 @@ import androidx.activity.OnBackPressedDispatcher
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
 
+/* ON BACK PRESSED */
+
 /**
  * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
  * This function temporary disables the callback to allow the system to handle the back pressed event.
@@ -24,6 +26,8 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressedCallback.isEnabled = true
 }
 
+/* INTENT */
+
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
     IntentCompat.getParcelableExtra(
         this,
@@ -37,6 +41,8 @@ inline fun <reified T : Parcelable> Intent.getParcelableArrayListExtraCompat(key
         key,
         T::class.java
     )
+
+/* BUNDLE */
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
     BundleCompat.getParcelable(

--- a/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
+++ b/libs/image-editor/src/main/kotlin/org/wordpress/android/imageeditor/utils/CompatExtensions.kt
@@ -1,11 +1,12 @@
 package org.wordpress.android.imageeditor.utils
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
 
 /**
  * This is a temporary workaround for the issue described here: https://issuetracker.google.com/issues/247982487
@@ -23,38 +24,23 @@ fun OnBackPressedDispatcher.onBackPressedCompat(onBackPressedCallback: OnBackPre
     onBackPressedCallback.isEnabled = true
 }
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableExtra(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableExtra(key) as T?
-    }
+    IntentCompat.getParcelableExtra(
+        this,
+        key,
+        T::class.java
+    )
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use IntentCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Intent.getParcelableArrayListExtraCompat(key: String): ArrayList<T>? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableArrayListExtra(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelableArrayListExtra(key)
-    }
+    IntentCompat.getParcelableArrayListExtra(
+        this,
+        key,
+        T::class.java
+    )
 
-/**
- * TODO: Remove this when stable androidx.core 1.10 is released. Use BundleCompat instead.
- */
-@Suppress("ForbiddenComment")
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelable(key, T::class.java)
-    } else {
-        @Suppress("DEPRECATION")
-        getParcelable(key)
-    }
+    BundleCompat.getParcelable(
+        this,
+        key,
+        T::class.java
+    )

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ pluginManagement {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
         id 'com.google.gms.google-services' version '4.3.8'
-        id "io.sentry.android.gradle" version "2.0.0"
+        id "io.sentry.android.gradle" version "3.5.0"
         id "io.gitlab.arturbosch.detekt" version gradle.ext.detektVersion
         id "se.bjurr.violations.violation-comments-to-github-gradle-plugin" version "1.67"
         id "androidx.navigation.safeargs.kotlin" version gradle.ext.navComponentVersion


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR updates:

- `androidxArchCoreVersion` to [2.2.0](https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0)
- `androidxLifecycleVersion` to [2.6.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.1).
- `androidxCoreVersion` to [1.10.0](https://developer.android.com/jetpack/androidx/releases/core#1.10.0).
- `androidxActivityVersion` to [1.7.1](https://developer.android.com/jetpack/androidx/releases/activity#1.7.1).
- `androidxFragmentVersion` to [1.5.7](https://developer.android.com/jetpack/androidx/releases/fragment#1.5.7).
- `androidxAppcompatVersion` to [1.6.1](https://developer.android.com/jetpack/androidx/releases/appcompat#1.6.1). Cc @ravishanker @irfano

[PLUS](https://github.com/wordpress-mobile/WordPress-Android/pull/18366#issuecomment-1536142747):

- `sentryVersion` to [3.5.0](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/3.5.0). Cc @oguzkocer

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

App Crashes Fix List:

1. [Resolve lateinit property lifecycle registry not init crashes](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/5b4631efb6e1d62fe0d1a794901500845a41fa98) (due to `Lifecycle` update to `2.1.0`)
2. [Resolve parameter specified as non-null is null crashes](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/d7ef92147051ff914261550cbd6df9ceb7a4d636) (due to `Lifecycle` update to `2.1.0`)

Compile Errors Fix List:

1. [Resolve main unresolved reference transformations errors](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/dc5e9d63e60a2fd45b7734dfb7d555a4f736c952) (due to `Lifecycle` update to `2.1.0`)
3. [Resolve live data utils unresolved reference transformations error](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/7aaa7ff6e51b719c79da51cdaf2edc7794e27195) (due to `Lifecycle` update to `2.1.0`)
4. [esolve main unresolved reference transformations errors](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/7c67445cd9829c6fa784bc14655ac993c846040d) (due to `Lifecycle` update to `2.1.0`)

Compile Warnings Resolution List:

1. [Resolve unnecessary safe call type warnings](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/56240f0e928d65d66607b8871fbe72a612d93a61) (due to `Lifecycle` update to `2.1.0`)
2. [Resolve unnecessary safe call type warning on pages fragment](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/264a523021067445374a7ef6ae61569af982c478) (due to `Lifecycle` update to `2.1.0`)

Compile Warnings Suppression List:

1. [Suppress launch when started lifecycle scope warnings](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/0d9a39430d2b0c88e2e3ebc875cdfb06c0486c3b) (due to `Lifecycle` update to `2.1.0`)
3. [Resolve type mismatch null vs non-null test type warnings](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/1c1d7b956fd2e9cfea80a63e64792fd0820effd4) (due to `Lifecycle` update to `2.1.0`)
4. [Suppress leaking this in constructor of non-final class warn](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/3a1a8c1222bc43c9a46d6ba41d76338c67b0181d) (due to `Lifecycle` update to `2.1.0`)

List Warnings Resolution List:

1. [Resolve fragment back pressed callback lint warnings](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/4139786f774ed95b49814a0a3491c4d70903a3e1) (due to `Activity` update to `1.7.1`)

List Warnings Suppression List:

1. [Suppress animation set start and recycle related lint warnings](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/028cdbdb0d8bf59d6df9c61393fcac1fe115b7da) (due to `Core` update to `1.9.0`)

Test Failures List:

1. [Fix captor capture must not be null test failures](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/987afe23e7cac6f5e43828c2e0d3e3896102a4ad) (due to `Lifecycle` update to `2.1.0`)
2. [Fix param. observer specified as non-null is null ui test failure](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/cf3dada5f1f54a5352cc6660bf1c7adf2e5042eb) (due to `Lifecycle` update to `2.1.0` and `Sentry` still on `2.0.0`)
3. [Update sentry plugin to 3.5.0](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/fa9b3abd401ab555baa17287751cbdd0fd055131) (due to `Lifecycle` update to `2.1.0` and `Sentry` still on `2.0.0`)

Refactor List:

1. [Rename live data utils map extension function to map safe](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/3bf46c29436c3177c44165e445d4527fda625c27) (due to `Lifecycle` update to `2.1.0`)
4. [Replace anonymous classes with lambda for wp web view activity](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/a452aaff0d60c71670406ace916b208062383b3e) (due to `Lifecycle` update to `2.1.0`)
5. [Replace custom intent, bundle and parcel code with official](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/e6f934d83d66b347dc535d7b6078c6962ec149e7) (due to `Core` update to `1.10.0`)

-----

FYI: @ovitrif, out of all the changes in this PR, I am more interested in your review on the [Lifecycle to 2.6.1](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/58fbb5c41aed39220a8b30c77c228d32d285c4d7) update, which then forced this [Unresolved Reference Transformations](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/7aaa7ff6e51b719c79da51cdaf2edc7794e27195) change, and the fact that I patched the `LiveData.mapNullable(...)` extension function with `!!` in order to avoid making a bigger change.

Plus, I want you to take a closer look at the fact that UI test were failing ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18366#issuecomment-1536142747)) and the need for the [Sentry to 3.5.0](https://github.com/wordpress-mobile/WordPress-Android/pull/18366/commits/fa9b3abd401ab555baa17287751cbdd0fd055131) update.

Let me know your thoughts on all that and whether you would have done anything differently. Also, please double check/test everything and anything `Lifecycle` related, be extra careful. It seems that this update it a bit too tricky for us to underestimate at this point.

Cc @ravishanker @irfano as additional pair of eyes here.

-----

## To test:

- See the dependency tree diff result and verify correctness.
- Thoroughly smoke test both, the WordPress and Jetpack apps, and see if they both work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential `Lifecycle` related crashes on screens and/or core functionality ([example](https://github.com/wordpress-mobile/WordPress-Android/pull/18366#issuecomment-1536142747)).
    - Potential breakage of screens and core functionality as these `AndroidX Core` libraries are being added as a transitive dependency across lots of `androidx` and `com.google` and `other` libraries.
    - Some of the transitive dependencies added might be causing some kind of misbehaviour.

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

7. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
