### PR TITLE
Dashboard cards: implement whether the activity card should be requested or not

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -101,7 +101,6 @@ sealed class MySiteCardAndItemBuilderParams {
     }
 
     data class ActivityCardBuilderParams(
-        val site: SiteModel,
         val activityCardModel: CardModel.ActivityCardModel?,
         val onActivityItemClick: (activityCardItemClickParams: ActivityCardItemClickParams) -> Unit,
         val onFooterLinkClick: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -618,7 +618,6 @@ class MySiteViewModel @Inject constructor(
                     onFooterLinkClick = this::onPagesCardFooterLinkClick
                 ),
                 activityCardBuilderParams = ActivityCardBuilderParams(
-                    site = site,
                     activityCardModel = cardsUpdate?.cards?.firstOrNull {
                         it is ActivityCardModel
                     } as? ActivityCardModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -15,8 +15,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityFeatureUtils
-import org.wordpress.android.util.config.DashboardCardActivityLogConfig
+import org.wordpress.android.ui.mysite.cards.dashboard.activity.DashboardActivityLogCardFeatureUtils
 import org.wordpress.android.util.config.DashboardCardPagesConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
 import javax.inject.Inject
@@ -27,7 +26,7 @@ const val REFRESH_DELAY = 500L
 class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardsStore: CardsStore,
-    private val activityFeatureUtils: ActivityFeatureUtils
+    private val dashboardActivityLogCardFeatureUtils: DashboardActivityLogCardFeatureUtils,
     todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     dashboardCardPagesConfig: DashboardCardPagesConfig,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
@@ -107,7 +106,7 @@ class CardsSource @Inject constructor(
     private fun getCardTypes(selectedSite: SiteModel) = mutableListOf<Type>().apply {
         if (isTodaysStatsCardFeatureConfigEnabled) add(Type.TODAYS_STATS)
         if (shouldRequestPagesCard(selectedSite)) add(Type.PAGES)
-        if (activityFeatureUtils.shouldRequestActivityCard(selectedSite)) add(Type.ACTIVITY)
+        if (dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(selectedSite)) add(Type.ACTIVITY)
         add(Type.POSTS)
     }.toList()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityFeatureUtils
 import org.wordpress.android.util.config.DashboardCardActivityLogConfig
 import org.wordpress.android.util.config.DashboardCardPagesConfig
 import org.wordpress.android.util.config.MySiteDashboardTodaysStatsCardFeatureConfig
@@ -26,16 +27,14 @@ const val REFRESH_DELAY = 500L
 class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardsStore: CardsStore,
+    private val activityFeatureUtils: ActivityFeatureUtils
     todaysStatsCardFeatureConfig: MySiteDashboardTodaysStatsCardFeatureConfig,
     dashboardCardPagesConfig: DashboardCardPagesConfig,
-    dashboardCardActivityLogConfig: DashboardCardActivityLogConfig,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : MySiteRefreshSource<CardsUpdate> {
     private val isTodaysStatsCardFeatureConfigEnabled = todaysStatsCardFeatureConfig.isEnabled()
 
     private val isDashboardCardPagesConfigEnabled = dashboardCardPagesConfig.isEnabled()
-
-    private val isDashboardCardActivityLogConfigEnabled = dashboardCardActivityLogConfig.isEnabled()
 
     override val refresh = MutableLiveData(false)
 
@@ -108,7 +107,7 @@ class CardsSource @Inject constructor(
     private fun getCardTypes(selectedSite: SiteModel) = mutableListOf<Type>().apply {
         if (isTodaysStatsCardFeatureConfigEnabled) add(Type.TODAYS_STATS)
         if (shouldRequestPagesCard(selectedSite)) add(Type.PAGES)
-        if (isDashboardCardActivityLogConfigEnabled) add(Type.ACTIVITY)
+        if (activityFeatureUtils.shouldRequestActivityCard(selectedSite)) add(Type.ACTIVITY)
         add(Type.POSTS)
     }.toList()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
@@ -21,8 +21,7 @@ private const val MAX_ITEMS_IN_CARD: Int = 3
 
 class ActivityCardBuilder @Inject constructor(
     private val dashboardCardActivityLogConfig: DashboardCardActivityLogConfig,
-    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
-    private val siteUtilsWrapper: SiteUtilsWrapper,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
 ) {
     fun build(params: ActivityCardBuilderParams): ActivityCard? {
         return shouldBuildActivityCard(params).takeIf { it }?.let { buildActivityCard(params) }
@@ -66,9 +65,6 @@ class ActivityCardBuilder @Inject constructor(
             return false
         }
 
-        val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(
-            params.site
-        ) || params.site.isJetpackConnected
-        return params.site.hasCapabilityManageOptions && isWpComOrJetpack && !params.site.isWpForTeamsSite
+       return true
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilder.kt
@@ -12,15 +12,12 @@ import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
-import org.wordpress.android.util.SiteUtilsWrapper
-import org.wordpress.android.util.config.DashboardCardActivityLogConfig
 import java.util.Date
 import javax.inject.Inject
 
 private const val MAX_ITEMS_IN_CARD: Int = 3
 
 class ActivityCardBuilder @Inject constructor(
-    private val dashboardCardActivityLogConfig: DashboardCardActivityLogConfig,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper
 ) {
     fun build(params: ActivityCardBuilderParams): ActivityCard? {
@@ -59,8 +56,7 @@ class ActivityCardBuilder @Inject constructor(
     private fun buildDateLine(published: Date) = dateTimeUtilsWrapper.javaDateToTimeSpan(published)
 
     private fun shouldBuildActivityCard(params: ActivityCardBuilderParams) : Boolean {
-        if (!dashboardCardActivityLogConfig.isEnabled() ||
-            params.activityCardModel == null ||
+        if (params.activityCardModel == null ||
             params.activityCardModel.activities.isEmpty()) {
             return false
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityFeatureUtils.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.activity
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.SiteUtilsWrapper
+
+class ActivityFeatureUtils(
+    private val isDashboardCardActivityLogConfigEnabled: Boolean,
+    private val siteUtilsWrapper: SiteUtilsWrapper
+) {
+    fun shouldRequestActivityCard(selectedSite: SiteModel): Boolean {
+        if (!isDashboardCardActivityLogConfigEnabled) return false
+        val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(selectedSite) ||
+                selectedSite.isJetpackConnected
+        return selectedSite.hasCapabilityManageOptions
+                && isWpComOrJetpack
+                && !selectedSite.isWpForTeamsSite
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/DashboardActivityLogCardFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/DashboardActivityLogCardFeatureUtils.kt
@@ -2,13 +2,15 @@ package org.wordpress.android.ui.mysite.cards.dashboard.activity
 
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.DashboardCardActivityLogConfig
+import javax.inject.Inject
 
-class ActivityFeatureUtils(
-    private val isDashboardCardActivityLogConfigEnabled: Boolean,
+class DashboardActivityLogCardFeatureUtils @Inject constructor(
+    private val dashboardCardActivityLogConfig: DashboardCardActivityLogConfig,
     private val siteUtilsWrapper: SiteUtilsWrapper
 ) {
     fun shouldRequestActivityCard(selectedSite: SiteModel): Boolean {
-        if (!isDashboardCardActivityLogConfigEnabled) return false
+        if (!dashboardCardActivityLogConfig.isEnabled()) return false
         val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(selectedSite) ||
                 selectedSite.isJetpackConnected
         return selectedSite.hasCapabilityManageOptions

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -225,7 +225,7 @@ class CardsBuilderTest {
                 promoteWithBlazeCardBuilderParams = PromoteWithBlazeCardBuilderParams(true, mock(), mock(), mock()),
                 dashboardCardDomainBuilderParams = DashboardCardDomainBuilderParams(true, mock(), mock(), mock()),
                 pagesCardBuilderParams = PagesCardBuilderParams(mock(), mock(), mock()),
-                activityCardBuilderParams = ActivityCardBuilderParams(mock(), mock(), mock(), mock()),
+                activityCardBuilderParams = ActivityCardBuilderParams(mock(), mock(), mock()),
             ),
             quickLinkRibbonBuilderParams = QuickLinkRibbonBuilderParams(
                 siteModel = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -340,7 +340,6 @@ class CardsBuilderTest : BaseUnitTest() {
                 activityCardBuilderParams = MySiteCardAndItemBuilderParams.ActivityCardBuilderParams(
                     mock(),
                     mock(),
-                    mock(),
                     mock()
                 )
             )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
@@ -100,7 +100,6 @@ class ActivityCardBuilderTest : BaseUnitTest() {
 
     private fun buildActivityCard(model: ActivityCardModel) = builder.build(
         ActivityCardBuilderParams(
-            site = siteModel,
             activityCardModel = model,
             onFooterLinkClick = onActivityCardFooterLinkClick,
             onActivityItemClick = onActivityItemClick

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
@@ -8,7 +8,6 @@ import org.mockito.Mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.activity.ActivityLogModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.ActivityCardModel
 import org.wordpress.android.fluxc.network.rest.wpcom.dashboard.CardsUtils
@@ -23,9 +22,6 @@ import org.wordpress.android.util.DateTimeUtilsWrapper
 class ActivityCardBuilderTest : BaseUnitTest() {
     @Mock
     private lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
-
-    @Mock
-    private lateinit var siteModel: SiteModel
 
     private lateinit var builder: ActivityCardBuilder
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/ActivityCardBuilderTest.kt
@@ -18,19 +18,11 @@ import org.wordpress.android.fluxc.tools.FormattableContent
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams
 import org.wordpress.android.util.DateTimeUtilsWrapper
-import org.wordpress.android.util.SiteUtilsWrapper
-import org.wordpress.android.util.config.DashboardCardActivityLogConfig
 
 @ExperimentalCoroutinesApi
 class ActivityCardBuilderTest : BaseUnitTest() {
     @Mock
-    private lateinit var dashboardCardActivityLogConfig: DashboardCardActivityLogConfig
-
-    @Mock
     private lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
-
-    @Mock
-    private lateinit var siteUtilsWrapper: SiteUtilsWrapper
 
     @Mock
     private lateinit var siteModel: SiteModel
@@ -66,7 +58,8 @@ class ActivityCardBuilderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        builder = ActivityCardBuilder(dashboardCardActivityLogConfig, dateTimeUtilsWrapper, siteUtilsWrapper)
+        builder = ActivityCardBuilder(dateTimeUtilsWrapper)
+        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn(displayDate)
     }
 
     @Test
@@ -88,76 +81,7 @@ class ActivityCardBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given feature flag is disabled, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(false)
-
-        val result = buildActivityCard(activityCardModel)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `given activities list is empty, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        val activity = ActivityCardModel(activities = emptyList())
-
-        val result = buildActivityCard(activity)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `given site accessed is not via wpComOrJetpack, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(any())).thenReturn(false)
-        whenever(siteModel.isJetpackConnected).thenReturn(true)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(true)
-        whenever(siteModel.isWpForTeamsSite).thenReturn(true)
-
-        val result = buildActivityCard(activityCardModel)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `given site is not Jetpack connected, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteModel.isJetpackConnected).thenReturn(false)
-
-        val result = buildActivityCard(activityCardModel)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `given does not hasCapabilityManageOptions for site, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(any())).thenReturn(true)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(false)
-
-        val result = buildActivityCard(activityCardModel)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `given is wp for teams site, when build is called, then null is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(any())).thenReturn(true)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(true)
-        whenever(siteModel.isWpForTeamsSite).thenReturn(true)
-
-        val result = buildActivityCard(activityCardModel)
-
-        assertThat(result).isNull()
-    }
-
-    @Test
     fun `given feature flag enabled, when build is called, then card is returned`() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(any())).thenReturn(true)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(true)
-        whenever(siteModel.isWpForTeamsSite).thenReturn(false)
         whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn(displayDate)
 
         val result = buildActivityCard(activityCardModel)
@@ -167,20 +91,11 @@ class ActivityCardBuilderTest : BaseUnitTest() {
 
     @Test
     fun `given activities list size is greater than 3, when build is called, then only 3 activities are selected`() {
-        setShouldBuildActivityCard()
         val activityModelWithFiveItems = ActivityCardModel(activities = List(5) { activityLogModel })
 
         val result = buildActivityCard(activityModelWithFiveItems)
 
         assertThat((result as ActivityCard.ActivityCardWithItems).activityItems.size).isEqualTo(maxItemsInCard)
-    }
-
-    private fun setShouldBuildActivityCard() {
-        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
-        whenever(siteUtilsWrapper.isAccessedViaWPComRest(any())).thenReturn(true)
-        whenever(siteModel.hasCapabilityManageOptions).thenReturn(true)
-        whenever(siteModel.isWpForTeamsSite).thenReturn(false)
-        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any())).thenReturn(displayDate)
     }
 
     private fun buildActivityCard(model: ActivityCardModel) = builder.build(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/DashboardActivityLogCardFeatureUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/DashboardActivityLogCardFeatureUtilsTest.kt
@@ -1,0 +1,81 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.activity
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.DashboardCardActivityLogConfig
+
+@ExperimentalCoroutinesApi
+class DashboardActivityLogCardFeatureUtilsTest : BaseUnitTest() {
+    @Mock
+    private lateinit var dashboardCardActivityLogConfig: DashboardCardActivityLogConfig
+
+    @Mock
+    private lateinit var siteUtilsWrapper: SiteUtilsWrapper
+
+    @Mock
+    private lateinit var siteModel: SiteModel
+
+    private lateinit var dashboardActivityLogCardFeatureUtils: DashboardActivityLogCardFeatureUtils
+
+    @Before
+    fun setUp() {
+        dashboardActivityLogCardFeatureUtils = DashboardActivityLogCardFeatureUtils(
+            dashboardCardActivityLogConfig,
+            siteUtilsWrapper
+        )
+        setUpMocks()
+    }
+
+    private fun setUpMocks() {
+        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(true)
+        whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(true)
+        whenever(siteModel.hasCapabilityManageOptions).thenReturn(true)
+        whenever(siteModel.isJetpackConnected).thenReturn(true)
+        whenever(siteModel.isWpForTeamsSite).thenReturn(false)
+    }
+
+    @Test
+    fun `given feature flag is disabled, when isEnaled is called, then false is returned`() {
+        whenever(dashboardCardActivityLogConfig.isEnabled()).thenReturn(false)
+
+        val result = dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(siteModel)
+
+        Assertions.assertThat(result).isFalse
+    }
+
+
+    @Test
+    fun `given site accessed is not via wpComOrJetpack, when build is called, then null is returned`() {
+        whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(false)
+        whenever(siteModel.isJetpackConnected).thenReturn(false)
+
+        val result = dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(siteModel)
+
+        Assertions.assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given does not hasCapabilityManageOptions for site, when build is called, then null is returned`() {
+        whenever(siteModel.hasCapabilityManageOptions).thenReturn(false)
+
+        val result = dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(siteModel)
+
+        Assertions.assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given is wp for teams site, when build is called, then null is returned`() {
+        whenever(siteModel.isWpForTeamsSite).thenReturn(true)
+
+        val result = dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(siteModel)
+
+        Assertions.assertThat(result).isFalse
+    }
+}


### PR DESCRIPTION
## Related issue
Closes #18373 

## Description 
This PR checks whether the activity log card should be fetched before calling the dashboard cards endpoint.

## Explanation of changes 
- ⊕ Adds [DashboardActivityLogCardFeatureUtils.kt](https://github.com/wordpress-mobile/WordPress-Android/blob/d1b7ce95c58542476ade977b9764ba017f7d7334/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/activity/DashboardActivityLogCardFeatureUtils.kt) to check if the activity log card should be requested or not 
- ⊕ Adds [DashboardActivityLogCardFeatureUtilsTest.kt]([DashboardActivityLogCardFeatureUtilsTest.kt](https://github.com/wordpress-mobile/WordPress-Android/pull/18376/files#diff-82667a681c6c0069e7e660e19dd660f459c2223b6cae0436a2eb439470a5fb9b) for testing `DashboardActivityLogCardFeatureUtils`
- ⊖ Removes: the check to build the activity log card from [ActivityCardBuilder.kt](https://github.com/wordpress-mobile/WordPress-Android/pull/18376/files#diff-fe2dba287feaba9f312010fc399170b1021e4761fbe140121f270ead7d62c72b)
-  ⊜ Refactors [ActivityCardBuilderTest.kt](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/18373-dashboard-cards-implement-whether-the-activity-card-should-be-requested-or-not?expand=1#diff-f47059f5a7462a283b8c87b309b589b88ea04ce3d7bb5804ead0843ebd753ec0) to remove the redundant tests 
- ⊜ Refactors [CardsSource.kt](https://github.com/wordpress-mobile/WordPress-Android/pull/18376/files#diff-ba3634ca1a7f140710e55ce17efcc1df6a2b8a827c29a0c367b39310a59805e7) to use the `DashboardActivityLogCardFeatureUtils`
-  ⊜ Refactors [CardsSourceTest.kt](https://github.com/wordpress-mobile/WordPress-Android/pull/18376/files#diff-138ee92581f16edc914087ac91f8a464f0608961914a562a18a5eee599d48667) to add missing tests and updates the current tests 
- ⊖ Removes site model from [MySiteCardAndItemBuilderParams.kt](https://github.com/wordpress-mobile/WordPress-Android/pull/18376/files#diff-0242d97465712b70b85047f7d375ff1b7a4ca70b4c353a28da3ae1f89763e6c7)

## Test 
#### Prerequisite
<details><summary>◐ Toggle the <code>dashboard_card_activity_log</code> flag</summary>
1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
</details>

## Check if the activity log works as expected 
- Go to app → Login with activity logs card enabled 
- Go to dashboard 
- Verify that Activity log card is shown 
- Disable the feature flag 
- Verify that Activity log card is not requested or shown 

## Regression Notes
1. Potential unintended areas of impact
- Activity Log card is not shown when the site is eligible and flag is enabled
- Activity Log card is requested even when the site is not eligible and flag is disabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Unit tests 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
