### PR TITLE
[Dependency Updates] Update `androidxComposeBomVersion` to 2023.05.00

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.Jetpa
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenInstallJetpackFullPlugin
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.OpenTermsAndConditions
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
-import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.state.LoadedState
+import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.state.loadedState
 import org.wordpress.android.util.WPUrlUtils
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.onBackPressedCompat
@@ -78,7 +78,7 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
         val uiState by viewModel.uiState.collectAsState()
         uiState.apply {
             when (this) {
-                is UiState.Loaded -> LoadedState(
+                is UiState.Loaded -> loadedState(
                     content = this,
                     onTermsAndConditionsClick = { viewModel.onTermsAndConditionsClick() },
                     onInstallFullPluginClick = { viewModel.onInstallFullPluginClick() },

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/state/LoadedState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/state/LoadedState.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compo
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.TermsAndConditions
 
 @Composable
-fun LoadedState(
+fun loadedState(
     content: UiState.Loaded,
     onTermsAndConditionsClick: () -> Unit,
     onInstallFullPluginClick: () -> Unit,
@@ -118,6 +118,6 @@ private fun PreviewLoadedState() {
             siteUrl = "wordpress.com",
             pluginNames = listOf("Jetpack Search"),
         )
-        LoadedState(uiState, {}, {}, {}, {})
+        loadedState(uiState, {}, {}, {}, {})
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
     androidVolleyVersion = '1.2.1'
     androidxAppcompatVersion = '1.6.1'
     androidxArchCoreVersion = '2.2.0'
-    androidxComposeBomVersion = '2023.01.00'
+    androidxComposeBomVersion = '2023.05.00'
     androidxComposeCompilerVersion = '1.4.6'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '1.1.3'


### PR DESCRIPTION
Parent #17563
Batch Branch: [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin)

This PR updates `androidxComposeBomVersion` to [2023.05.00](https://developer.android.com/jetpack/androidx/releases/compose#2023.05.00).

-----

PS: @ovitrif I added you as the main reviewer, but not so randomly ([context](https://github.com/wordpress-mobile/WordPress-Android/pull/18303#issuecomment-1519988237)), since I just wanted someone from the WordPress team to be aware of and sign-off on that change for WPAndroid. I also added the @wordpress-mobile/apps-infrastructure team, but this in done only for monitoring purposes, as such, I am not expecting any active review from that team. Thus, feel free to merge this PR if you deem so.

-----

Lint Warnings Resolution List:

1. [Resolve composable naming lint warning on loaded state](https://github.com/wordpress-mobile/WordPress-Android/commit/5c36fb479d8a6f58c284e273870fb6c8b64f6bcf)

-----

## To test:

1. See the dependency tree diff result and verify correctness.
2. Thoroughly smoke test any `Compose` related screen, on both, the WordPress and Jetpack apps, and see if everything is working as expected.
3. In addition to the above smoke test, you can expand the below and follow the inner and more explicitly test steps within:


<details>
    <summary>1. Login Screen [LoginPrologueRevampedFragment.kt]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.

- Log out of the app (if already logged-in).
- Verify that the `Login` screen is shown and functioning as expected.

</details>

<details>
    <summary>2. QR Code Auth Screen [QRCodeAuthFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
ℹ️ You don't have to follow all 3 steps, just logging in with a non `A8C` and non `2FA` enabled
account, followed by tapping the `Scan Login Code` item on the `Me` screen should be enough, which
is effectively just `Step.1` and the beginning of `Step.3`.

Step.1:
- Build and install the `Jetpack` app (note that you don't need a release build, a debug build will
suffice).
- Login to the `Jetpack` app with a `WP.com` account (note that you need to use a non `A8C` account
and a non `2FA` enabled account).
- Navigate to the `Me` screen (click on avatar at top-right).
(STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to `wordpress.com` (note that if you are logged-in, log-out first).
- Tap the `Log In` link (top-right).
- Tap the `Login via the mobile app` link in the list of options below the main Continue button
(bottom-middle).
- Verify you are on the `Login via the mobile app` view and `Use QR Code to login` is shown, along with
a QR code for you to scan.
- (STOP)

Step.3:
- Head back to your mobile.
- Tap the `Scan Login Code` item on the `Me` screen you are currently at.
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to login to WordPress on your web browser (desktop),
verify that you have successfully logged-in and are able to use WordPress as expected.

</details>

<details>
    <summary>3a. Jetpack Static Poster Screen [JetpackStaticPosterActivity.kt + JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Stats` option.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Stats` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>3b. Jetpack Static Poster Screen [JetpackStaticPosterFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.

- Go to `Reader` or `Notifications` tab.
- Verify that the `Jetpack Static Poster` screen is shown and functioning as expected, that is,
instead of showing the `Reader` or `Notifications` screen (like it is done with the `Jetpack` app).

</details>

<details>
    <summary>4a. Jetpack Migration Screen [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the card on top that prompts the user to uninstall the WordPress app and click on it.
- Verify that the `Jetpack Migration` screen is shown and functioning as expected.

</details>

<details>
    <summary>4a. Jetpack Migration Flow [JetpackMigrationFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Install both apps.
- Clear cache/data of the `Jetpack` app and restart it.
- The migration flow should appear, verify that it is shown and functioning as expected.

</details>

<details>
    <summary>5. Blaze Screen [BlazeOverlayFragment.kt + BlazeWebViewFragment.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `MENU` sub-tab.
- Find the `Traffic` section in the middle and click on its `Blaze` option.
- Verify that the `Blaze` screen is shown and functioning as expected.

</details>

<details>
    <summary>6. Blogging Prompts Screen [BloggingPromptsListActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Go to `My Site` tab -> `HOME` sub-tab.
- Find the `Prompts` card on top and click on its options (top right).
- From the options menu, select `View more prompts`.
- Verify that the `Blogging Prompts` screen is shown and functioning as expected.

</details>

<details>
    <summary>7. Individual Plugin Screen [WPJetpackIndividualPluginFragment.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [individual.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309662/individual.patch) patch to quickly test this screen.

- Go to `My Site` tab -> `Site Picker` (down-arrow).
- Let `individual.patch` patch do its magic... 🪄
- Verify that the `Individual Plugin` screen is shown and functioning as expected.

</details>

<details>
    <summary>8a. Jetpack Full Plugin Install Screen [JetpackFullPluginInstallOnboardingDialogFragment.kt + JetpackFullPluginInstallActivity.kt]</summary>

ℹ️ This test applies to the `WordPress` app.
❗️ Apply the provided [full.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11309714/full.patch) patch to quickly test this screen.

- Go to `My Site` tab.
- Let `full.patch` patch do its magic... 🪄
- Verify that the `Jetpack Full Plugin Install` dialog is shown and functioning as expected.
- Click on `Install the full plugin` button.
- Verify that the `Jetpack Full Plugin Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>8b. Jetpack Install Full Plugin View [JetpackInstallFullPluginCardViewHolder.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.
❗️ Apply the provided [card.patch](https://github.com/wordpress-mobile/WordPress-Android/files/11332106/card.patch) patch to quickly test this screen.

- Go to `Debug Settings` and make sure to enable only `jetpack_removal_one` from all the Jetpack
removal flags.
- Go to `My Site` tab -> `HOME` sub-tab.
- Let `full.patch` patch do its magic... 🪄
- Find the card in the middle that prompts the user to install the full Jetpack plugin and click on
`Learn more`.
- Verify that the `Jetpack Full Plugin Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>9. Jetpack Remove Install Screen [JetpackRemoteInstallActivity.kt]</summary>

ℹ️ This test applies to the `Jetpack` app.

- Spin up a self-hosted site via `Jurassic Ninja` with no `Jetpack` plugins at all.
https://fieldguide.automattic.com/jurassic-ninja/
- Login to the app using the credentials of the new site and then go to `Stats`.
- Tap `Install Jetpack` button.
- Verify that the `Jetpack Remove Install` screen is shown and functioning as expected.

</details>

<details>
    <summary>10. Site Creation Domain View [SiteCreationDomainViewHolder.kt]</summary>

- Go to `Debug Settings` and enable the `SiteCreationDomainPurchasingFeatureConfig` feature flag.
- Go to `Site Picker` -> Click the `+` button -> Chose `Create WordPress.com site` ->
Click the `SKIP` button -> And again, click the `SKIP` button.
- Enter any search query in the input (eg. 'awesome').
- Verify the list of domain suggestions is presented (the item UI is compose)
- Verify that the `Site Creation Domain` view and its list is shown and functioning as expected.

</details>

<details>
    <summary>11. About App Screen [com.automattic:about]</summary>

ℹ️ This test applies to both, the `WordPress` and `Jetpack` apps.
❗️ This test makes sure that the `About App` screen, which comes from the [com.automattic:about](https://github.com/Automattic/about-automattic-android)
library is also working as expected and that any transitive dependency changes aren't affecting
this `Compose` related screen.

- Go to `My Site` tab and navigate to the `Me` screen (click on avatar at top-right).
- Tap the `About App` item on the `Me` screen you are currently at.
- Verify that the `About App` screen is shown and functioning as expected.

</details>

-----

## Merge instructions

- [x] Wait for [this other](https://github.com/wordpress-mobile/WordPress-Android/pull/18366) PR to be reviewed, tested and approved.
- [x] Update PR's base [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) branch with latest `trunk`.
- [x] Update this PR with latest [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin) and make sure everything is still working as expected.
- [x] Remove `[PR] Not Ready For Merge]` label.
- [x] Merge PR to [deps/main-batch-androidx-compose-kotlin](https://github.com/wordpress-mobile/WordPress-Android/tree/deps/main-batch-androidx-compose-kotlin).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour on any or all `Compose` related screens, like the `Login` screen, the `Jetpack Migration` screens or the `Blaze` green (to name a few).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)