### PR TITLE
Add close account button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -14,6 +14,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
 import android.widget.TextView
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -21,6 +23,7 @@ import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment
+import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.DetailListPreference
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation
@@ -41,6 +44,7 @@ import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.C
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.EmailSettingsUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.PrimarySiteSettingsUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.UserNameSettingsUiState
+import org.wordpress.android.ui.prefs.accountsettings.components.CloseAccountButton
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.SETTINGS
@@ -151,6 +155,21 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
         }
         coordinator.addView(preferenceView)
         return coordinatorView
+    }
+
+    @Deprecated("Deprecated")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (view.findViewById<View>(android.R.id.list) as? ListView)?.let { listView ->
+            listView.addFooterView(ComposeView(context).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent {
+                    AppTheme {
+                        CloseAccountButton()
+                    }
+                }
+            })
+        }
     }
 
     @Deprecated("Deprecated")

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/CloseAccountButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/CloseAccountButton.kt
@@ -1,0 +1,50 @@
+package org.wordpress.android.ui.prefs.accountsettings.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+@Composable
+fun CloseAccountButton(onClick: () -> Unit = {}) = Button(
+    elevation = ButtonDefaults.elevation(
+        defaultElevation = 0.dp,
+        pressedElevation = 0.dp,
+    ),
+    colors = ButtonDefaults.buttonColors(
+        backgroundColor = Color.Transparent,
+        contentColor = MaterialTheme.colors.error,
+        disabledBackgroundColor = Color.Transparent,
+        disabledContentColor = MaterialTheme.colors.error,
+    ),
+    modifier = Modifier
+        .fillMaxWidth(),
+    onClick = onClick,
+) {
+    Text(
+        text = stringResource(R.string.close_account),
+        modifier = Modifier
+            .padding(10.dp),
+    )
+}
+
+@Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewCloseAccountButton() {
+    AppTheme {
+        CloseAccountButton()
+    }
+}
+

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2754,6 +2754,7 @@
     <string name="export_email_sent">Export email sent!</string>
     <string name="export_your_content">Export your content</string>
     <string name="export_your_content_message">Your posts, pages, and settings will be emailed to you at %s.</string>
+    <string name="close_account">Close Account</string>
 
     <!-- Plans -->
     <string name="plan">Plan</string>


### PR DESCRIPTION
Fixes #18380

### Description

This PR adds a button to the account settings screen, which will later be wired up to the account closure flow. This PR is  the first to target a feature branch which has no changes from `trunk` yet. Once this PR is merged to the main feature branch, I will draft a PR for the main feature targeting `trunk`.

To test:

1. Open the account settings (Me -> Account Settings)
2. Expect to see a button which says "Close Account" at the bottom of the list of settings


## Regression Notes
1. Potential unintended areas of impact
Account settings screen

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

4. What automated tests I added (or what prevented me from doing so)
Automated tests will be added with the view model changes in later PRs.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
