### PR TITLE
[Pages List] Detect block-based theme on PageListViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -4,11 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.util.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,7 +20,8 @@ import javax.inject.Singleton
 class SelectedSiteRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig,
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null
     private val _selectedSiteChange = MutableLiveData<SiteModel?>(null)
@@ -25,6 +29,7 @@ class SelectedSiteRepository @Inject constructor(
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel?>
     val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
+
     fun updateSite(selectedSite: SiteModel) {
         if (getSelectedSite()?.iconUrl != selectedSite.iconUrl) {
             showSiteIconProgressBar(false)
@@ -79,6 +84,12 @@ class SelectedSiteRepository @Inject constructor(
         getSelectedSite()?.id ?: UNAVAILABLE
     }
 
+    private fun fetchEditorTheme(site: SiteModel) {
+        EditorThemeStore.FetchEditorThemePayload(site, globalStyleSupportFeatureConfig.isEnabled()).let {
+            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(it))
+        }
+    }
+
     fun updateSiteSettingsIfNecessary() {
         // If the selected site is null, we can't update its site settings
         val selectedSite = getSelectedSite() ?: return
@@ -104,6 +115,8 @@ class SelectedSiteRepository @Inject constructor(
 
             siteSettings?.init(true)
         }
+        // Fetch editor theme to update block-based-theme flag
+        fetchEditorTheme(selectedSite)
     }
 
     fun isSiteIconUploadInProgress(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3718,7 +3718,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     .onEditorThemeUpdated(editorThemeSupport.toBundle());
 
         mPostEditorAnalyticsSession
-                .editorSettingsFetched(editorThemeSupport.isFSETheme(), event.getEndpoint().getValue());
+                .editorSettingsFetched(editorThemeSupport.isBlockBasedTheme(), event.getEndpoint().getValue());
     }
     // EditPostActivityHook methods
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -32,7 +32,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_SESSION_ID = "session_id";
     private static final String KEY_STARTUP_TIME = "startup_time_ms";
     private static final String KEY_TEMPLATE = "template";
-    private static final String KEY_FULL_SITE_EDITING = "full_site_editing";
+    private static final String KEY_IS_BLOCK_BASED_THEME = "is_block_based_theme";
     private static final String KEY_ENDPOINT = "endpoint";
     private static final String KEY_ENTRY_POINT = "entry_point";
 
@@ -177,9 +177,9 @@ public class PostEditorAnalyticsSession implements Serializable {
                 properties);
     }
 
-    public void editorSettingsFetched(Boolean fullSiteEditing, String endpoint) {
+    public void editorSettingsFetched(Boolean isBlockBasedTheme, String endpoint) {
         final Map<String, Object> properties = getCommonProperties();
-        properties.put(KEY_FULL_SITE_EDITING, fullSiteEditing);
+        properties.put(KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme);
         properties.put(KEY_ENDPOINT, endpoint);
         AnalyticsUtils
                 .trackWithSiteDetails(mAnalyticsTrackerWrapper, Stat.EDITOR_SETTINGS_FETCHED, mSiteModel, properties);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -7,16 +7,21 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.EditorThemeStore
+import org.wordpress.android.fluxc.store.EditorThemeStore.FetchEditorThemePayload
+import org.wordpress.android.fluxc.store.EditorThemeStore.OnEditorThemeChanged
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
@@ -36,6 +41,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.util.extensions.toFormattedDateString
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -60,7 +66,9 @@ class PageListViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val localeManagerWrapper: LocaleManagerWrapper,
     private val accountStore: AccountStore,
-    @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher
+    @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher,
+    private val globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig,
+    private val editorThemeStore: EditorThemeStore,
 ) : ScopedViewModel(coroutineDispatcher) {
     private val _pages: MutableLiveData<List<PageItem>> = MutableLiveData()
     val pages: LiveData<Triple<List<PageItem>, Boolean, Boolean>> = Transformations.map(_pages) {
@@ -71,6 +79,7 @@ class PageListViewModel @Inject constructor(
     private var retryScrollToPage: LocalId? = null
     private var isStarted: Boolean = false
     private lateinit var listType: PageListType
+    private val isBlockBasedTheme = MutableStateFlow(false)
 
     private lateinit var pagesViewModel: PagesViewModel
 
@@ -136,6 +145,27 @@ class PageListViewModel @Inject constructor(
             pagesViewModel.blazeSiteEligibility.observeForever(blazeSiteEligibilityObserver)
 
             dispatcher.register(this)
+
+            refreshEditorTheme()
+        }
+    }
+
+    private fun refreshEditorTheme() {
+        // Get isBlockBasedTheme (cached) value from local db
+        isBlockBasedTheme.value = editorThemeStore.getIsBlockBasedTheme(pagesViewModel.site)
+
+        // Dispatch action to refresh the values from the remote
+        FetchEditorThemePayload(pagesViewModel.site, globalStyleSupportFeatureConfig.isEnabled()).let {
+            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(it))
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
+    fun onEditorThemeChanged(event: OnEditorThemeChanged) {
+        if (pagesViewModel.site.id == event.siteId) {
+            event.editorTheme?.themeSupport?.let { themeSupport ->
+                isBlockBasedTheme.value = editorThemeStore.getIsBlockBasedTheme(themeSupport)
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -164,7 +164,7 @@ class PageListViewModel @Inject constructor(
     fun onEditorThemeChanged(event: OnEditorThemeChanged) {
         if (pagesViewModel.site.id == event.siteId) {
             event.editorTheme?.themeSupport?.let { themeSupport ->
-                isBlockBasedTheme.value = editorThemeStore.getIsBlockBasedTheme(themeSupport)
+                isBlockBasedTheme.value = themeSupport.isEditorThemeBlockBased()
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.94.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = 'trunk-2d2bf4a52d3d1bcc434529a3700213c376206f7f'
+    wordPressFluxCVersion = '2726-ac2541d1daa78019a0db45b74456ec574543cc1b'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.94.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2726-ac2541d1daa78019a0db45b74456ec574543cc1b'
+    wordPressFluxCVersion = 'trunk-7d44ea7eecabc32200d900b8065760964de04d10'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
Fixes #18368

Thanks @antonis  and @mkevins for working on [the POC](https://github.com/wordpress-mobile/WordPress-Android/tree/try/support-block-based-themes) related to this issue. I've used much of your code 👍

FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2726

To test:
Since this is only adding the new field (and not using it yet), there's nothing to test here.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated `SelectedSiteRepositoryTest` and `PageListViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
