### PR TITLE
Add a confirmation dialog for account closure

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -363,7 +363,8 @@ class HelpActivity : LocaleAwareActivity() {
         JETPACK_MIGRATION_HELP("origin:jetpack-migration-help"),
         JETPACK_INSTALL_FULL_PLUGIN_ONBOARDING("origin:jp-install-full-plugin-overlay"),
         JETPACK_INSTALL_FULL_PLUGIN_ERROR("origin:jp-install-full-plugin-error"),
-        JETPACK_REMOTE_INSTALL_PLUGIN_ERROR("origin:jp-remote-install-plugin-error");
+        JETPACK_REMOTE_INSTALL_PLUGIN_ERROR("origin:jp-remote-install-plugin-error"),
+        ACCOUNT_CLOSURE_DIALOG("origin:account-closure-dialog");
 
         override fun toString(): String {
             return stringValue

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -22,6 +22,8 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -165,7 +167,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     AppTheme {
-                        AccountClosureUi(viewModel)
+                        AccountClosureUi(viewModel, ::viewHelp)
                     }
                 }
             })
@@ -368,4 +370,11 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
             }
         }
     }
+
+    fun viewHelp() = ActivityLauncher.viewHelp(
+        context,
+        HelpActivity.Origin.ACCOUNT_CLOSURE_DIALOG,
+        null,
+        null,
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -44,7 +44,7 @@ import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.C
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.EmailSettingsUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.PrimarySiteSettingsUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.UserNameSettingsUiState
-import org.wordpress.android.ui.prefs.accountsettings.components.CloseAccountButton
+import org.wordpress.android.ui.prefs.accountsettings.components.AccountClosureUi
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.SETTINGS
@@ -165,7 +165,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     AppTheme {
-                        CloseAccountButton()
+                        AccountClosureUi(viewModel)
                     }
                 }
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -18,6 +18,8 @@ import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType.SETTINGS_
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Dismissed
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened
 import org.wordpress.android.ui.prefs.accountsettings.usecase.FetchAccountSettingsUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetAccountUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetSitesUseCase
@@ -47,6 +49,8 @@ class AccountSettingsViewModel @Inject constructor(
     private var fetchNewSettingsJob: Job? = null
     private var _accountSettingsUiState = MutableStateFlow(getAccountSettingsUiState(true))
     val accountSettingsUiState: StateFlow<AccountSettingsUiState> = _accountSettingsUiState.asStateFlow()
+    private var _accountClosureUiState = MutableStateFlow<AccountClosureUiState>(Dismissed)
+    val accountClosureUiState: StateFlow<AccountClosureUiState> = _accountClosureUiState
 
     init {
         viewModelScope.launch {
@@ -287,6 +291,18 @@ class AccountSettingsViewModel @Inject constructor(
         val changePasswordSettingsUiState: ChangePasswordSettingsUiState,
         val toastMessage: String?
     )
+
+    sealed class AccountClosureUiState {
+        object Dismissed: AccountClosureUiState()
+        data class Opened(val username: String?): AccountClosureUiState()
+    }
+
+    fun openAccountClosureDialog() {
+        _accountClosureUiState.value = Opened(username = getAccountUseCase.account.userName)
+    }
+    fun dismissAccountClosureDialog() {
+        _accountClosureUiState.value = Dismissed
+    }
 
     override fun onCleared() {
         pushAccountSettingsUseCase.onCleared()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -9,9 +9,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
@@ -21,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -66,20 +68,26 @@ fun AccountClosureDialog(
                     .fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceAround,
             ) {
-                Button(
-                    modifier = Modifier.weight(1f),
+                FlatOutlinedButton(
+                    text = stringResource(R.string.cancel),
                     onClick = onDismissRequest,
-                ) {
-                    Text("Cancel")
-                }
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        contentColor = MaterialTheme.colors.onSurface,
+                        backgroundColor = Color.Transparent,
+                    ),
+                )
                 Spacer(Modifier.size(padding))
-                Button(
+                FlatOutlinedButton(
+                    text = stringResource(R.string.confirm),
                     modifier = Modifier.weight(1f),
                     enabled = username.isNotEmpty() && username == currentUsername,
                     onClick = {},
-                ) {
-                    Text("Confirm")
-                }
+                    colors = ButtonDefaults.buttonColors(
+                        contentColor = MaterialTheme.colors.error,
+                        backgroundColor = Color.Transparent,
+                    ),
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -19,7 +20,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,13 +40,17 @@ fun AccountClosureDialog(
     Dialog(onDismissRequest = onDismissRequest) {
         Column(
             modifier = Modifier
+                .clip(shape = RoundedCornerShape(padding))
                 .background(MaterialTheme.colors.background)
-                .padding(padding)
+                .padding(padding),
         ) {
             Text(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = padding),
                 textAlign = TextAlign.Center,
                 text = stringResource(R.string.account_closure_dialog_title),
+                fontWeight = FontWeight.Bold,
             )
             Text(stringResource(R.string.account_closure_dialog_message))
             TextField(
@@ -85,8 +92,7 @@ fun PreviewAccountClosureDialog() {
     AppTheme {
         AccountClosureDialog(
             onDismissRequest = {},
-            currentUsername = "previewUser"
+            currentUsername = "previewUser",
         )
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.ui.prefs.accountsettings.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+@Composable
+fun AccountClosureDialog(
+    onDismissRequest: () -> Unit,
+    currentUsername: String,
+) {
+    var username by remember { mutableStateOf("") }
+    val padding = 10.dp
+    Dialog(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colors.background)
+                .padding(padding)
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = stringResource(R.string.account_closure_dialog_title),
+            )
+            Text(stringResource(R.string.account_closure_dialog_message))
+            TextField(
+                modifier = Modifier
+                    .padding(vertical = padding)
+                    .fillMaxWidth(),
+                value = username,
+                onValueChange = { username = it },
+            )
+            Row(
+                modifier = Modifier
+                    .padding(vertical = padding)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround,
+            ) {
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = onDismissRequest,
+                ) {
+                    Text("Cancel")
+                }
+                Spacer(Modifier.size(padding))
+                Button(
+                    modifier = Modifier.weight(1f),
+                    enabled = username.isNotEmpty() && username == currentUsername,
+                    onClick = {},
+                ) {
+                    Text("Confirm")
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewAccountClosureDialog() {
+    AppTheme {
+        AccountClosureDialog(
+            onDismissRequest = {},
+            currentUsername = "previewUser"
+        )
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.prefs.accountsettings.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel
+
+@Composable
+fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
+    val uiState = viewModel.accountClosureUiState.collectAsState()
+
+    CloseAccountButton(onClick = { viewModel.openAccountClosureDialog() })
+    (uiState.value as? AccountSettingsViewModel.AccountClosureUiState.Opened)?.username?.let { currentUsername ->
+        AccountClosureDialog(
+            onDismissRequest = { viewModel.dismissAccountClosureDialog() },
+            currentUsername,
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -3,16 +3,26 @@ package org.wordpress.android.ui.prefs.accountsettings.components
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened
 
 @Composable
 fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
     val uiState = viewModel.accountClosureUiState.collectAsState()
 
     CloseAccountButton(onClick = { viewModel.openAccountClosureDialog() })
-    (uiState.value as? AccountSettingsViewModel.AccountClosureUiState.Opened)?.username?.let { currentUsername ->
-        AccountClosureDialog(
-            onDismissRequest = { viewModel.dismissAccountClosureDialog() },
-            currentUsername,
-        )
+
+    (uiState.value as? Opened)?.let {
+        when(it) {
+           is Opened.Default -> it.username?.let { currentUsername ->
+               AccountClosureDialog(
+                   onDismissRequest = { viewModel.dismissAccountClosureDialog() },
+                   currentUsername,
+               )
+           }
+
+            Opened.Atomic -> IneligibleClosureDialog(
+                onDismissRequest = { viewModel.dismissAccountClosureDialog() },
+            )
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -6,7 +6,7 @@ import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened
 
 @Composable
-fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
+fun AccountClosureUi(viewModel: AccountSettingsViewModel, onHelpRequested: () -> Unit) {
     val uiState = viewModel.accountClosureUiState.collectAsState()
 
     CloseAccountButton(onClick = { viewModel.openAccountClosureDialog() })
@@ -22,6 +22,7 @@ fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
 
             Opened.Atomic -> IneligibleClosureDialog(
                 onDismissRequest = { viewModel.dismissAccountClosureDialog() },
+                onHelpRequested = onHelpRequested,
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
@@ -7,7 +7,6 @@ import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.theme.AppColor
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
@@ -1,0 +1,54 @@
+package org.wordpress.android.ui.prefs.accountsettings.components
+
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.theme.AppColor
+
+@Composable
+fun FlatButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.buttonColors(
+        contentColor = AppColor.White,
+    ),
+    enabled: Boolean = true,
+) = Button(
+    modifier = modifier,
+    onClick = onClick,
+    colors = colors,
+    elevation = ButtonDefaults.elevation(
+        defaultElevation = 0.dp,
+        pressedElevation = 0.dp,
+    ),
+    enabled = enabled,
+) {
+    Text(text)
+}
+
+@Composable
+fun FlatOutlinedButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    enabled: Boolean = true,
+) = OutlinedButton(
+    modifier = modifier,
+    onClick = onClick,
+    colors = colors,
+    elevation = ButtonDefaults.elevation(
+        defaultElevation = 0.dp,
+        pressedElevation = 0.dp,
+    ),
+    enabled = enabled,
+) {
+    Text(text)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 @Composable
 fun IneligibleClosureDialog(
     onDismissRequest: () -> Unit,
+    onHelpRequested: () -> Unit,
 ) {
     val padding = 10.dp
     Dialog(onDismissRequest = onDismissRequest) {
@@ -60,7 +61,7 @@ fun IneligibleClosureDialog(
             Spacer(Modifier.size(padding))
             FlatButton(
                 text = stringResource(R.string.contact_support),
-                onClick = {},
+                onClick = onHelpRequested,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -74,6 +75,7 @@ fun PreviewIneligibleClosureDialog() {
     AppTheme {
         IneligibleClosureDialog(
             onDismissRequest = {},
+            onHelpRequested = {},
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
@@ -2,9 +2,7 @@ package org.wordpress.android.ui.prefs.accountsettings.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.ui.prefs.accountsettings.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+@Composable
+fun IneligibleClosureDialog(
+    onDismissRequest: () -> Unit,
+) {
+    val padding = 10.dp
+    Dialog(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .clip(shape = RoundedCornerShape(padding))
+                .background(MaterialTheme.colors.background)
+                .padding(padding),
+        ) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = padding),
+                textAlign = TextAlign.Center,
+                text = stringResource(R.string.account_closure_dialog_title),
+                fontWeight = FontWeight.Bold,
+            )
+            Text(stringResource(R.string.account_closure_dialog_active_purchases))
+            Spacer(Modifier.size(padding))
+            FlatOutlinedButton(
+                text = stringResource(R.string.dismiss),
+                onClick = onDismissRequest,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    contentColor = MaterialTheme.colors.primary,
+                    backgroundColor = Color.Transparent,
+                ),
+            )
+            Spacer(Modifier.size(padding))
+            FlatButton(
+                text = stringResource(R.string.contact_support),
+                onClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewIneligibleClosureDialog() {
+    AppTheme {
+        IneligibleClosureDialog(
+            onDismissRequest = {},
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt
@@ -15,4 +15,6 @@ class GetSitesUseCase @Inject constructor(
     suspend fun get(): List<SiteModel> = withContext(ioDispatcher) {
         siteStore.sitesAccessedViaWPComRest
     }
+
+    suspend fun getAtomic() = get().filter { it.isWPComAtomic }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="update_now">Update Now</string>
     <string name="status_and_visibility">Status &amp; Visibility</string>
     <string name="free">Free</string>
+    <string name="dismiss">Dismiss</string>
 
     <string name="button_not_now">Not now</string>
     <string name="button_skip">Skip</string>
@@ -2757,6 +2758,7 @@
     <string name="close_account">Close Account</string>
     <string name="account_closure_dialog_message">To confirm, please re-enter your username before closing.</string>
     <string name="account_closure_dialog_title">Confirm Close Account…</string>
+    <string name="account_closure_dialog_active_purchases">This user account cannot be closed immediately because it has active purchases. Please contact our support team to finish deleting the account.</string>
 
     <!-- Plans -->
     <string name="plan">Plan</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2755,6 +2755,8 @@
     <string name="export_your_content">Export your content</string>
     <string name="export_your_content_message">Your posts, pages, and settings will be emailed to you at %s.</string>
     <string name="close_account">Close Account</string>
+    <string name="account_closure_dialog_message">To confirm, please re-enter your username before closing.</string>
+    <string name="account_closure_dialog_title">Confirm Close Account…</string>
 
     <!-- Plans -->
     <string name="plan">Plan</string>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/18381

### Description

This PR adds a dialog for account closure. It requires the user to confirm the action by entering their username. If the account cannot be closed because of active purchases (e.g. if the account has atomic sites), it will display a message with an explanation, and it will also include a button to contact support.


### To test:

#### Account with atomic site(s)

Prerequisite: Log in with an account that has at least one atomic site

1. Go to the account settings screen (Me :arrow_right:  Account Settings)
2. Tap "Close Account" button
3. Expect to see a dialog with a message explaining why the account cannot be closed
   * <details><summary>Screenshot</summary><img src="https://user-images.githubusercontent.com/8507675/237015859-e4908e2a-1bc8-4fcd-a276-61ab71d73d9f.png" width="360"></details>
5. Tap "Contact Support"
6. Expect to be brought to the help screen
   * <details><summary>Screenshot</summary><img src="https://user-images.githubusercontent.com/8507675/237016177-d057f35e-1334-47a9-8d59-6bd7b47fa5e0.png" width="360"></details>
7. Repeat steps 1 and 2 (or tap back from the help screen)
8. Tap "Dismiss"
9. Expect the dialog to be dismissed


**Note**: It is a known issue that the help screen requires an additional tap to "Contact Support" from that screen. Addressing this may be a "nice to have", if there is time - otherwise, I think it could be tackled in a later iteration.

#### Account without atomic site(s)

Prerequisite: Log in with an account that has no atomic sites

<details>
<summary>For convenience, this patch can be applied to simulate having no atomic sites</summary>

```patch
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt
index 25bfd00335..4c51c73cf9 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/GetSitesUseCase.kt
@@ -16,5 +16,5 @@ class GetSitesUseCase @Inject constructor(
         siteStore.sitesAccessedViaWPComRest
     }
 
-    suspend fun getAtomic() = get().filter { it.isWPComAtomic }
+    suspend fun getAtomic() = emptyList<SiteModel>()
 }
```
</details>

1. Go to the account settings screen (Me :arrow_right:  Account Settings)
2. Tap "Close Account" button
3. Expect to see a dialog requesting confirmation by entering the username (with the "Confirm" button disabled)
   * <details><summary>Screenshot</summary><img src="https://user-images.githubusercontent.com/8507675/237016586-492c75d6-cb2a-4d01-a77d-a9db910fd952.png" width="360"></details>
4. Enter the username for the account
5. Expect to see the "Confirm" button become enabled
   * <details><summary>Screenshot</summary><img src="https://user-images.githubusercontent.com/8507675/237016598-e3da15c5-476f-499a-a4ba-f4d1fbad87d5.png" width="360"></details>
6. Tap the "Confirm" button
10. Expect a pending indicator to be displayed, briefly, while the button is disabled, followed by resuming the normal state
   * **Note**: This is a temporary "fake" implementation to test the UI, and will later be connected to the real API
   * <details><summary>Screenshot</summary><img src="https://user-images.githubusercontent.com/8507675/237016595-5855e5fb-932c-4e2c-a264-c3e29a50b03d.png" width="360"></details>
11. Tap "Cancel"
12. Expect the dialog to be dismissed

## Regression Notes
1. Potential unintended areas of impact
Account settings screen

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

4. What automated tests I added (or what prevented me from doing so)
Automated tests will be added with the view model changes in later PRs.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
