### PR TITLE
[UI Tests] Restored the teardowns in Login and Signup tests.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BuildConfig

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/LoginTests.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.BuildConfig
@@ -57,5 +58,9 @@ class LoginTests : BaseTest() {
                 BuildConfig.E2E_SELF_HOSTED_USER_PASSWORD
             )
             .confirmLogin(true)
+    }
+    @After
+    fun tearDown() {
+        logoutIfNecessary()
     }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/SignUpTests.kt
@@ -15,6 +15,11 @@ class SignUpTests : BaseTest() {
         logoutIfNecessary()
     }
 
+    @After
+    fun tearDown() {
+        logoutIfNecessary()
+    }
+
     @Test
     fun e2eSignUpWithMagicLink() {
         SignupFlow().chooseContinueWithWpCom(super.mComposeTestRule)


### PR DESCRIPTION
### Description

In #18349 I [removed](https://github.com/wordpress-mobile/WordPress-Android/pull/18349/commits/85ffcbf367eb579e0f99ef8796cbe73bc94756c1) teardowns from Login and Signup tests, assuming they are redundant. The tests still passed locally and also on CI, in the mentioned PR.

However, there were a number of fails in #18364 and #18378 in the Login area, which made me think that the change might be making the logout workflow less stable, because after its removal, the tests will try to log out in a new app session. And I suspect that the app is not in a proper state when it's re-launched after MagicLink tests in combination with WireMock.

I added the tearDowns back in this PR.

### Testing
- CI is 🟢