### PR TITLE
Updates the copy of the Jetpack static poster

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackPoweredScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackPoweredScreen.kt
@@ -15,11 +15,7 @@ sealed interface JetpackPoweredScreen {
     }
 
     @Parcelize
-    enum class WithStaticPoster(
-        val screen: WithDynamicText,
-        val animResLtr: Int = R.raw.wp2jp_left,
-        val animResRtl: Int = R.raw.wp2jp_rtl,
-    ) : Parcelable {
+    enum class WithStaticPoster(val screen: WithDynamicText) : Parcelable {
         STATS(screen = WithDynamicText.STATS),
         READER(screen = WithDynamicText.READER),
         NOTIFICATIONS(screen = WithDynamicText.NOTIFICATIONS),

--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackPoweredScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackPoweredScreen.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.models
 
 import android.os.Parcelable
-import androidx.annotation.AnimRes
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.ui.utils.UiString
@@ -18,24 +17,12 @@ sealed interface JetpackPoweredScreen {
     @Parcelize
     enum class WithStaticPoster(
         val screen: WithDynamicText,
-        @AnimRes val animResLtr: Int,
-        @AnimRes val animResRtl: Int,
+        val animResLtr: Int = R.raw.wp2jp_left,
+        val animResRtl: Int = R.raw.wp2jp_rtl,
     ) : Parcelable {
-        STATS(
-            screen = WithDynamicText.STATS,
-            animResLtr = R.raw.jp_stats_left,
-            animResRtl = R.raw.jp_stats_rtl,
-        ),
-        READER(
-            screen = WithDynamicText.READER,
-            animResLtr = R.raw.jp_reader_left,
-            animResRtl = R.raw.jp_reader_rtl,
-        ),
-        NOTIFICATIONS(
-            screen = WithDynamicText.NOTIFICATIONS,
-            animResLtr = R.raw.jp_notifications_left,
-            animResRtl = R.raw.jp_notifications_rtl,
-        ),
+        STATS(screen = WithDynamicText.STATS),
+        READER(screen = WithDynamicText.READER),
+        NOTIFICATIONS(screen = WithDynamicText.NOTIFICATIONS),
     }
 
     enum class WithStaticText(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterViewModel.kt
@@ -72,8 +72,7 @@ sealed class UiState {
     data class Content(
         val showTopBar: Boolean,
         val featureName: UiString,
-        val showPluralTitle: Boolean,
-        val animResLtrToRtl: Pair<Int, Int>,
+        val showPluralTitle: Boolean
         ) : UiState()
 }
 
@@ -87,6 +86,5 @@ typealias UiData = JetpackPoweredScreen.WithStaticPoster
 fun UiData.toContentUiState() = UiState.Content(
     showTopBar = this == UiData.STATS,
     featureName = screen.featureName,
-    showPluralTitle = screen.isPlural,
-    animResLtrToRtl = animResLtr to animResRtl,
+    showPluralTitle = screen.isPlural
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -88,7 +88,7 @@ fun JetpackStaticPoster(
                     .padding(bottom = 20.dp)
                     .fillMaxWidth(),
             ) {
-                val animRes = if (LocalContext.current.isRtl()) animResLtrToRtl.second else animResLtrToRtl.first
+                val animRes = if (LocalContext.current.isRtl()) R.raw.wp2jp_rtl else R.raw.wp2jp_left
                 val lottieComposition by rememberLottieComposition(LottieCompositionSpec.RawRes(animRes))
                 LottieAnimation(lottieComposition)
                 Text(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4332,8 +4332,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="login_magic_links_sent_label_short" tools:ignore="UnusedResources" a8c-src-lib="login">Check your email on this device!</string>
     <string name="login_magic_links_email_sent" tools:ignore="UnusedResources" a8c-src-lib="login">We just sent a magic link to</string>
     <string name="gutenberg_native_link_rel" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Link Rel</string>
-    <string name="wp_jp_static_poster_title">Use WordPress with %s in the Jetpack app.</string>
-    <string name="wp_jp_static_poster_title_plural">Use WordPress with %s in the Jetpack app.</string>
+    <string name="wp_jp_static_poster_title">Use WordPress with %s in the Jetpack\u00A0app.</string>
+    <string name="wp_jp_static_poster_title_plural">Use WordPress with %s in the Jetpack\u00A0app.</string>
     <string name="wp_jp_static_poster_button_primary">Switch to the Jetpack app</string>
     <string name="wp_jp_static_poster_button_secondary">Learn more at Jetpack.com</string>
     <string name="wp_jp_static_poster_message">The Jetpack app has all the WordPress app’s functionality, and now exclusive access to Stats, Reader, Notifications and more.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4332,11 +4332,11 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="login_magic_links_sent_label_short" tools:ignore="UnusedResources" a8c-src-lib="login">Check your email on this device!</string>
     <string name="login_magic_links_email_sent" tools:ignore="UnusedResources" a8c-src-lib="login">We just sent a magic link to</string>
     <string name="gutenberg_native_link_rel" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Link Rel</string>
-    <string name="wp_jp_static_poster_title">%s has moved to the Jetpack app.</string>
-    <string name="wp_jp_static_poster_title_plural">%s have moved to the Jetpack app.</string>
+    <string name="wp_jp_static_poster_title">Switch to the Jetpack app for %s (and everything else)</string>
+    <string name="wp_jp_static_poster_title_plural">Switch to the Jetpack app for %s (and everything else)</string>
     <string name="wp_jp_static_poster_button_primary">Switch to the Jetpack app</string>
     <string name="wp_jp_static_poster_button_secondary">Learn more at Jetpack.com</string>
-    <string name="wp_jp_static_poster_message">Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app, and can now only be found in the Jetpack app.</string>
+    <string name="wp_jp_static_poster_message">The Jetpack app does everything the WordPress app can do, and now exclusive access to Stats, Reader, Notifications and more.</string>
     <string name="wp_jp_static_poster_footnote">Switching is free and only takes a minute.</string>
 
     <!-- Jetpack Welcome Screen -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4332,11 +4332,11 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="login_magic_links_sent_label_short" tools:ignore="UnusedResources" a8c-src-lib="login">Check your email on this device!</string>
     <string name="login_magic_links_email_sent" tools:ignore="UnusedResources" a8c-src-lib="login">We just sent a magic link to</string>
     <string name="gutenberg_native_link_rel" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Link Rel</string>
-    <string name="wp_jp_static_poster_title">Switch to the Jetpack app for %s (and everything else)</string>
-    <string name="wp_jp_static_poster_title_plural">Switch to the Jetpack app for %s (and everything else)</string>
+    <string name="wp_jp_static_poster_title">Use WordPress with %s in the Jetpack app.</string>
+    <string name="wp_jp_static_poster_title_plural">Use WordPress with %s in the Jetpack app.</string>
     <string name="wp_jp_static_poster_button_primary">Switch to the Jetpack app</string>
     <string name="wp_jp_static_poster_button_secondary">Learn more at Jetpack.com</string>
-    <string name="wp_jp_static_poster_message">The Jetpack app does everything the WordPress app can do, and now exclusive access to Stats, Reader, Notifications and more.</string>
+    <string name="wp_jp_static_poster_message">The Jetpack app has all the WordPress app’s functionality, and now exclusive access to Stats, Reader, Notifications and more.</string>
     <string name="wp_jp_static_poster_footnote">Switching is free and only takes a minute.</string>
 
     <!-- Jetpack Welcome Screen -->


### PR DESCRIPTION
## Description
Updates the copy of the Jetpack static poster

### Internal refs
* pbArwn-650-p2#comment-7637
* p1683628287128089-slack-C0180B5PRJ4

## To test:
1. Delete the Jetpack app (of the current build flavour) if present or delete the local data of the app
2. Run the WP app from this branch or the CI build
3. Visit the Stats, Reader, and Notifications page
4. **Verify** that the updated copy is diplayed

|Reader Before|Reader After|
|---|---|
|![Screenshot_20230509_140434](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/ff0d1560-da43-4842-b128-275df7376769)|![Screenshot_20230510_183801](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/44d65eb5-5830-49a7-b9ae-451c2af77f87)|

|Notifications Before|Notifications After|
|---|---|
|![Screenshot_20230509_140446](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/6bd6fd30-202e-4a4e-adf0-dee1ec634f3d)|![Screenshot_20230510_152317](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/489ae0b4-18e6-45a8-8828-b1e11e7a99a4)|

|Stats Before|Stats After|
|---|---|
|![Screenshot_20230509_140510](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/4b47ca34-7b9f-498c-8453-fab9b92c192d)|![Screenshot_20230510_183726](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/818f44ae-268f-4550-8d6c-4c622b1f2db4)|

|Notifications After Light-Landscape|Notifications After Dark-Landscape|
|---|---|
|![Screenshot_20230510_152344](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/d4a4a558-0684-49aa-9d5f-679ccfdb52b9)|![Screenshot_20230510_152410](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/5e00aa95-52b9-4628-a788-35fa2e657a43)|

## Animation LTR
https://github.com/wordpress-mobile/WordPress-Android/assets/304044/a609ad17-9c39-4b37-b22b-e5adc3b9a399 

## Animation RTL
https://github.com/wordpress-mobile/WordPress-Android/assets/304044/2582ca2a-e857-4422-90a5-3f17010e8015


## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

6. What automated tests I added (or what prevented me from doing so)
Relied on existing tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)