### PR TITLE
Update events tracking in site creation domain purchasing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
@@ -63,9 +63,9 @@ class DomainRegistrationMainViewModel @Inject constructor(
         }
     }
 
-    @Suppress("ForbiddenComment")
     fun finishDomainRegistration(event: DomainRegistrationCompletedEvent) {
-        analyticsTracker.trackDomainsPurchaseDomainSuccess() // TODO: is it a success or just a back press
+        // In Menu→ Domains this gets called either on continue btn click or on back press
+        analyticsTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = false)
         _onNavigation.value = Event(FinishDomainRegistration(event))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModel.kt
@@ -53,6 +53,7 @@ class DomainRegistrationMainViewModel @Inject constructor(
     }
 
     fun completeDomainRegistration(event: DomainRegistrationCompletedEvent) {
+        // Called on checkout result
         _onNavigation.value = when (domainRegistrationPurpose) {
             CTA_DOMAIN_CREDIT_REDEMPTION, DOMAIN_PURCHASE -> {
                 analyticsTracker.trackDomainsRegistrationFormSubmitted()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsRegistrationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsRegistrationTracker.kt
@@ -25,7 +25,7 @@ class DomainsRegistrationTracker @Inject constructor(
         if (purchasingFeatureConfig.isEnabledOrManuallyOverridden()) {
             val origin = if (isSiteCreation) VALUE.ORIGIN_SITE_CREATION.key else VALUE.ORIGIN_MENU.key
             tracker.track(
-                AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site, mutableMapOf(PROPERTY.ORIGIN.key to origin)
+                AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site, mapOf(PROPERTY.ORIGIN.key to origin)
             )
         } else {
             tracker.track(AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site)
@@ -44,8 +44,9 @@ class DomainsRegistrationTracker @Inject constructor(
         tracker.track(AnalyticsTracker.Stat.DOMAINS_REGISTRATION_FORM_SUBMITTED)
     }
 
-    fun trackDomainsPurchaseDomainSuccess() {
-        tracker.track(AnalyticsTracker.Stat.DOMAINS_PURCHASE_DOMAIN_SUCCESS)
+    fun trackDomainsPurchaseDomainSuccess(isSiteCreation: Boolean) {
+        val origin = if (isSiteCreation) VALUE.ORIGIN_SITE_CREATION.key else VALUE.ORIGIN_MENU.key
+        tracker.track(AnalyticsTracker.Stat.DOMAINS_PURCHASE_DOMAIN_SUCCESS, mapOf(PROPERTY.ORIGIN.key to origin))
     }
 
     fun trackDomainCreditNameSelected() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -142,12 +142,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
             onBackPressedDispatcher.onBackPressedCompat(backPressedCallback)
         }
         mainViewModel.showDomainCheckout.observe(this, domainCheckoutActivityLauncher::launch)
-        siteCreationIntentsViewModel.onBackButtonPressed.observe(this) {
-            mainViewModel.onBackPressed()
-        }
-        siteCreationIntentsViewModel.onSkipButtonPressed.observe(this) {
-            mainViewModel.onSiteIntentSkipped()
-        }
+        siteCreationIntentsViewModel.onBackButtonPressed.observe(this) { mainViewModel.onBackPressed() }
+        siteCreationIntentsViewModel.onSkipButtonPressed.observe(this) { mainViewModel.onSiteIntentSkipped() }
         siteCreationSiteNameViewModel.onBackButtonPressed.observe(this) {
             mainViewModel.onBackPressed()
             ActivityUtils.hideKeyboard(this)
@@ -156,20 +152,12 @@ class SiteCreationActivity : LocaleAwareActivity(),
             ActivityUtils.hideKeyboard(this)
             mainViewModel.onSiteNameSkipped()
         }
-        hppViewModel.onBackButtonPressed.observe(this) {
-            mainViewModel.onBackPressed()
-        }
-        hppViewModel.onDesignActionPressed.observe(this) { design ->
-            mainViewModel.onSiteDesignSelected(design.template)
-        }
-        progressViewModel.onCancelWizardClicked.observe(this) {
-            mainViewModel.onWizardCancelled()
-        }
+        hppViewModel.onBackButtonPressed.observe(this) { mainViewModel.onBackPressed() }
+        hppViewModel.onDesignActionPressed.observe(this) { mainViewModel.onDesignSelected(it.template) }
+        progressViewModel.onCancelWizardClicked.observe(this) { mainViewModel.onWizardCancelled() }
         progressViewModel.onFreeSiteCreated.observe(this, mainViewModel::onFreeSiteCreated)
         progressViewModel.onCartCreated.observe(this, mainViewModel::onCartCreated)
-        previewViewModel.onOkButtonClicked.observe(this) { result ->
-            mainViewModel.onWizardFinished(result)
-        }
+        previewViewModel.onOkButtonClicked.observe(this, mainViewModel::onWizardFinished)
         observeOverlayEvents()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -301,6 +301,7 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
         if (event == null) return onBackPressed()
+        domainsRegistrationTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = true)
         siteCreationState = siteCreationState.run {
             check(result is CreatedButNotFetched.InCart)
             copy(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -237,7 +237,7 @@ class SiteCreationMainVM @Inject constructor(
         wizardManager.showNextStep()
     }
 
-    fun onSiteDesignSelected(siteDesign: String) {
+    fun onDesignSelected(siteDesign: String) {
         siteCreationState = siteCreationState.copy(siteDesign = siteDesign)
         wizardManager.showNextStep()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -134,7 +134,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
         val domain = requireNotNull(selectedDomain) {
             "Create site button should not be visible if a domain is not selected"
         }
-        tracker.trackDomainSelected(domain.domainName, currentQuery?.value ?: "")
+        tracker.trackDomainSelected(domain.domainName, currentQuery?.value.orEmpty(), domain.cost)
         _createSiteBtnClicked.value = domain
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationMainViewModelTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.verify
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistrationPurpose.AUTOMATED_TRANSFER
@@ -72,5 +73,12 @@ class DomainRegistrationMainViewModelTest : BaseUnitTest() {
         viewModel.completeDomainRegistration(domainRegisteredEvent)
 
         assertThat(navigationActions.last()).isEqualTo(FinishDomainRegistration(domainRegisteredEvent))
+    }
+
+    @Test
+    fun `completing domain registration is tracked`() {
+        viewModel.start(site, DOMAIN_PURCHASE)
+        viewModel.finishDomainRegistration(domainRegisteredEvent)
+        verify(tracker).trackDomainsPurchaseDomainSuccess(isSiteCreation = false)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -202,6 +202,14 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         }
     }
 
+
+    @Test
+    fun `on checkout result when not null tracks domain purchase success`() {
+        viewModel.onCartCreated(CHECKOUT_DETAILS)
+        viewModel.onCheckoutResult(CHECKOUT_EVENT)
+        verify(domainsRegistrationTracker).trackDomainsPurchaseDomainSuccess(true)
+    }
+
     @Test
     fun `on site created updates result`() = test {
         viewModel.onDomainsScreenFinished(FREE_DOMAIN)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -303,6 +303,30 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `click on the create site button tracks the selected free domain`() = testWithSuccessResponse {
+        val selectedDomain = mockDomain("test.domain")
+        val expectedCost = "Free"
+        whenever(selectedDomain.cost).thenReturn(expectedCost)
+        viewModel.onDomainSelected(selectedDomain)
+
+        viewModel.onCreateSiteBtnClicked()
+
+        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost)
+    }
+
+    @Test
+    fun `click on the create site button tracks the selected paid domain`() = testWithSuccessResponse {
+        val selectedDomain = mockDomain("test.domain", free = false)
+        val expectedCost = "1.23 USD"
+        whenever(selectedDomain.cost).thenReturn(expectedCost)
+        viewModel.onDomainSelected(selectedDomain)
+
+        viewModel.onCreateSiteBtnClicked()
+
+        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost)
+    }
+
+    @Test
     fun verifyFetchFreeDomainsWhenPurchasingFeatureConfigIsDisabled() = testWithSuccessResponse {
         viewModel.start()
 


### PR DESCRIPTION
Resolves #18389

This PR:
- ★ Updates events tracking to ensure proper analysis can be done on the performance of the experimental feature.

## To Test
#### Prerequisite
<details><summary>◐ Toggle the <code>SiteCreationDomainPurchasingFeatureConfig</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Features in development` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button
<img width="315" src="https://user-images.githubusercontent.com/4588074/233447831-b3ec505c-8fcd-4776-9f43-0c070cdc17da.png">

</details>

### ● Treatment Variation

#### 1. **Verify** the following sequence of events is tracked for **free** domains:
```python
🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"my_site"}
…
🔵 Tracked: enhanced_site_creation_domains_accessed
🔵 Tracked: enhanced_site_creation_domains_selected, Properties: {"chosen_domain":"*.wordpress.com","search_term":"*"}
…
🔵 Tracked: site_created
…
🔵 Tracked: enhanced_site_creation_preview_ok_button_tapped
```

#### 2. **Verify** the following sequence of events is tracked for **paid** domains:
```py
🔵 Tracked: enhanced_site_creation_accessed, Properties: {"source":"my_site"}
🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment, Properties: {"variation":"control"}
…
🔵 Tracked: enhanced_site_creation_domains_accessed
🔵 Tracked: enhanced_site_creation_domains_selected, Properties: {"chosen_domain":"*.*","search_term":"*","domain_cost":"*"}
…
🔵 Tracked: site_created
🔵 Tracked: domains_purchase_webview_viewed, Properties: {"origin":"site_creation"}
🔵 Tracked: webview_displayed
🔵 Tracked: domains_purchase_domain_success, Properties: {"origin":"site_creation"}
…
🔵 Tracked: enhanced_site_creation_preview_ok_button_tapped
```

### ○ Control Variation
#### 3. **Verify** the same sequence of events is tracked as for **free** domains (see ●1)
#### 4. **Verify** the following sequence of events is tracked in `My Site Menu → Domains`:
```py
🔵 Tracked: domains_dashboard_select_domain_tapped, Properties: {"blog_id":*,"site_type":"*","is_jetpack":*}
🔵 Tracked: domains_purchase_webview_viewed, Properties: {"origin":"menu","blog_id":*,"is_jetpack":*,"site_type":"*"}
🔵 Tracked: domains_registration_form_viewed
🔵 Tracked: webview_displayed
🔵 Tracked: domains_registration_form_submitted
🔵 Tracked: domains_purchase_domain_success, Properties: {"origin":"menu"}
```

## Regression Notes
1. Potential unintended areas of impact
   `My Site Menu` → `Domains` tracking

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

8. What automated tests I added (or what prevented me from doing so)
   Unit tests for the updated code

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] No UI Changes → no changes checklist