### PR TITLE
Add a confirmation dialog for account closure (addendum)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -314,6 +315,19 @@ class AccountSettingsViewModel @Inject constructor(
     }
     fun dismissAccountClosureDialog() {
         _accountClosureUiState.value = Dismissed
+    }
+
+    fun closeAccount() {
+        (accountClosureUiState.value as? Default)?.let { uiState ->
+            _accountClosureUiState.value = uiState.copy(isPending = true)
+
+            launch {
+                delay(3000)
+                (accountClosureUiState.value as? Default)?.let { uiState ->
+                    _accountClosureUiState.value = uiState.copy(isPending = false)
+                }
+            }
+        }
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -323,9 +323,7 @@ class AccountSettingsViewModel @Inject constructor(
 
             launch {
                 delay(3000)
-                (accountClosureUiState.value as? Default)?.let { uiState ->
-                    _accountClosureUiState.value = uiState.copy(isPending = false)
-                }
+                _accountClosureUiState.value = uiState.copy(isPending = false)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -297,7 +297,8 @@ class AccountSettingsViewModel @Inject constructor(
         object Dismissed: AccountClosureUiState()
 
         sealed class Opened: AccountClosureUiState() {
-            data class Default(val username: String?): Opened()
+            data class Default(val username: String?, val isPending: Boolean = false): Opened()
+
             object Atomic: Opened()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -322,6 +322,7 @@ class AccountSettingsViewModel @Inject constructor(
             _accountClosureUiState.value = uiState.copy(isPending = true)
 
             launch {
+                @Suppress("MagicNumber")
                 delay(3000)
                 _accountClosureUiState.value = uiState.copy(isPending = false)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
@@ -36,6 +35,8 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 fun AccountClosureDialog(
     onDismissRequest: () -> Unit,
     currentUsername: String,
+    onConfirm: () -> Unit,
+    isPending: Boolean,
 ) {
     var username by remember { mutableStateOf("") }
     val padding = 10.dp
@@ -82,7 +83,8 @@ fun AccountClosureDialog(
                     text = stringResource(R.string.confirm),
                     modifier = Modifier.weight(1f),
                     enabled = username.isNotEmpty() && username == currentUsername,
-                    onClick = {},
+                    isPending = isPending,
+                    onClick = onConfirm,
                     colors = ButtonDefaults.buttonColors(
                         contentColor = MaterialTheme.colors.error,
                         backgroundColor = Color.Transparent,
@@ -101,6 +103,8 @@ fun PreviewAccountClosureDialog() {
         AccountClosureDialog(
             onDismissRequest = {},
             currentUsername = "previewUser",
+            onConfirm = {},
+            isPending = false,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -17,6 +17,8 @@ fun AccountClosureUi(viewModel: AccountSettingsViewModel, onHelpRequested: () ->
                AccountClosureDialog(
                    onDismissRequest = { viewModel.dismissAccountClosureDialog() },
                    currentUsername,
+                   onConfirm = { viewModel.closeAccount() },
+                   isPending = it.isPending,
                )
            }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
@@ -5,12 +5,10 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.LocalContentColor
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.theme.AppColor
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
@@ -1,8 +1,11 @@
 package org.wordpress.android.ui.prefs.accountsettings.components
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -40,6 +43,7 @@ fun FlatOutlinedButton(
     modifier: Modifier = Modifier,
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     enabled: Boolean = true,
+    isPending: Boolean = false,
 ) = OutlinedButton(
     modifier = modifier,
     onClick = onClick,
@@ -48,7 +52,14 @@ fun FlatOutlinedButton(
         defaultElevation = 0.dp,
         pressedElevation = 0.dp,
     ),
-    enabled = enabled,
+    enabled = enabled && !isPending,
 ) {
-    Text(text)
+    if (isPending) {
+        CircularProgressIndicator(
+            strokeWidth = 2.dp,
+            modifier = Modifier.size(20.dp),
+        )
+    } else {
+        Text(text)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/IneligibleClosureDialog.kt
@@ -2,9 +2,7 @@ package org.wordpress.android.ui.prefs.accountsettings.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding


### PR DESCRIPTION
### Description

This is an addendum to #18386 to include commits that were not pushed. It should address [the second issue reported there](https://github.com/wordpress-mobile/WordPress-Android/pull/18386#pullrequestreview-1418293065). I forgot to push these commits yesterday :upside_down_face: .

To test:

Same as: https://github.com/wordpress-mobile/WordPress-Android/pull/18386