### PR TITLE
Add notifications runtime permission to the migration flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.main.jetpack.migration
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -30,6 +32,7 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FinishActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.RequestNotificationPermission
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Error
@@ -44,6 +47,7 @@ import org.wordpress.android.ui.utils.PreMigrationDeepLinkData
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.LocaleManager
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.extensions.getParcelableCompat
 import javax.inject.Inject
 
@@ -113,6 +117,7 @@ class JetpackMigrationFragment : Fragment() {
             }
             is Logout -> (requireActivity().application as? WordPress)?.let { viewModel.signOutWordPress(it) }
             is ShowHelp -> launchHelpScreen()
+            is RequestNotificationPermission -> requestNotificationPermission()
             is FinishActivity -> requireActivity().finish()
         }
     }
@@ -124,6 +129,23 @@ class JetpackMigrationFragment : Fragment() {
             null,
             null
         )
+    }
+
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            @Suppress("DEPRECATION")
+            requestPermissions(
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        if (requestCode == WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE) {
+            WPPermissionUtils.setPermissionListAsked(requireActivity(), requestCode, permissions, grantResults, false)
+            viewModel.onPermissionChange()
+        }
     }
 
     private fun initBackPressHandler(showDeleteWpState: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -132,12 +132,18 @@ class JetpackMigrationFragment : Fragment() {
     }
 
     private fun requestNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !WPPermissionUtils.isPermissionAlwaysDenied(requireActivity(), Manifest.permission.POST_NOTIFICATIONS)
+        ) {
             @Suppress("DEPRECATION")
             requestPermissions(
                 arrayOf(Manifest.permission.POST_NOTIFICATIONS),
                 WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE
             )
+        } else {
+            // This case is not expected. But just in case, behave as if permission has been changed to continue the
+            // flow.
+            viewModel.onPermissionChange()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -1,9 +1,13 @@
 package org.wordpress.android.ui.main.jetpack.migration
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.text.TextUtils
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -21,8 +25,8 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -44,9 +48,9 @@ import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
-import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FinishActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FallbackToLogin
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.FinishActivity
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.Logout
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.ShowHelp
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState.Content.Delete
@@ -293,10 +297,19 @@ class JetpackMigrationViewModel @Inject constructor(
         }
     }
 
+    private fun hasNotificationPermission(): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || ContextCompat.checkSelfPermission(
+            contextProvider.getContext(),
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
     private fun onContinueFromNotificationsClicked() {
         if (preventDuplicateNotifsFeatureConfig.isEnabled()) disableNotificationsOnWP()
         migrationAnalyticsTracker.trackNotificationsScreenContinueButtonTapped()
-        notificationContinueClickedFlow.value = true
+        if (hasNotificationPermission()) {
+            notificationContinueClickedFlow.value = true
+        }
     }
 
     private fun disableNotificationsOnWP() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -309,7 +309,13 @@ class JetpackMigrationViewModel @Inject constructor(
         migrationAnalyticsTracker.trackNotificationsScreenContinueButtonTapped()
         if (hasNotificationPermission()) {
             notificationContinueClickedFlow.value = true
+        } else {
+            postActionEvent(JetpackMigrationActionEvent.RequestNotificationPermission)
         }
+    }
+
+    fun onPermissionChange() {
+        notificationContinueClickedFlow.value = true
     }
 
     private fun disableNotificationsOnWP() {
@@ -542,6 +548,8 @@ class JetpackMigrationViewModel @Inject constructor(
 
     sealed class JetpackMigrationActionEvent {
         object ShowHelp : JetpackMigrationActionEvent()
+
+        object RequestNotificationPermission : JetpackMigrationActionEvent()
 
         data class CompleteFlow(
             val deepLinkData: PreMigrationDeepLinkData? = null,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -411,7 +411,7 @@ class JetpackMigrationViewModel @Inject constructor(
             ) : Content(
                 primaryActionButton = primaryActionButton,
                 screenIconRes = R.drawable.ic_jetpack_migration_notifications,
-                title = UiStringRes(R.string.jp_migration_notifications_title),
+                title = UiStringRes(R.string.jp_migration_notifications_allow_title),
                 subtitle = UiStringRes(R.string.jp_migration_notifications_subtitle),
                 message = UiStringRes(R.string.jp_migration_notifications_disabled_in_wp_message),
             )

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4347,7 +4347,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_welcome_site_found_message">We found your site. Continue to transfer all your data and sign in to Jetpack automatically.</string>
     <string name="jp_migration_continue_button">Continue</string>
     <string name="jp_migration_help_button">Need help?</string>
-    <string name="jp_migration_notifications_title">Notifications now come from Jetpack</string>
+    <string name="jp_migration_notifications_allow_title">Allow notifications to keep up with your site</string>
     <string name="jp_migration_notifications_subtitle">You’ll get all the same notifications but now they’ll come from the Jetpack app.</string>
     <string name="jp_migration_notifications_disabled_in_wp_message">We\'ll turn off notifications from the WordPress app.</string>
     <string name="jp_migration_done_title">Thanks for switching to Jetpack!</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -17,8 +17,8 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.action.AccountAction
+import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
@@ -422,7 +422,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     fun `Should have correct title for Notifications Content`() {
         val notificationsContent = Content.Notifications(NotificationsPrimaryButton {})
         val actual = notificationsContent.title
-        val expected = UiStringRes(R.string.jp_migration_notifications_title)
+        val expected = UiStringRes(R.string.jp_migration_notifications_allow_title)
         assertThat(actual).isEqualTo(expected)
     }
 


### PR DESCRIPTION
This PR introduces notifications runtime permission to the migration flow.
- On Android 13 devices, when the user taps the Continue button on the notifications screen, it will open the permission dialog. The flow will continue as usual after the dialog is closed, either with approval or denial.
- Additionally, the title has been updated.

> **Note**
> I have added @ravishanker since he is familiar with my previous permission PRs, and @ovitrif since he is the author of the notifications screen in the flow. One review is sufficient.

[notifications-runtime-permission-migration-flow.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/f03b3768-6644-4135-b16c-0302c73d9cb4)

To test:
**Allow case**
1. Launch the WP app on an Android 13 device and log in.
2. Install the JP app.
3. Verify that the migration flow has started.
4. Tap on Continue.
5. Confirm that the notifications screen opens and the new title appears as "Allow notifications to keep up with your site".
6. Tap on Continue.
7. Verify that the notifications permission dialog opens.
8. Allow permission. 
9. Confirm that the success screen opens.

**Don't allow case**
1. Repeat steps 1-7 from the Allow case.
2. Don't allow permission.
3. Verify that the success screen opens.

## Regression Notes
1. Potential unintended areas of impact
None, I couldn't find any case.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
I updated the existing tests, but I did not add a new test case specifically to validate the new dialog. I considered it unnecessary to add a test for the case.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.