### PR TITLE
[MediaPreview] Calculate media type of content URI by omitting query params

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -138,8 +138,10 @@ public class MediaPreviewFragment extends Fragment {
         mAutoPlay = args.getBoolean(ARG_AUTOPLAY);
         mVideoThumbnailUrl = args.getString(ARG_VIDEO_THUMB);
 
-        mIsVideo = MediaUtils.isVideo(mContentUri);
-        mIsAudio = MediaUtils.isAudio(mContentUri);
+        Uri contentUri = Uri.parse(mContentUri);
+        String contentFilePath = contentUri.getLastPathSegment();
+        mIsVideo = MediaUtils.isVideo(contentFilePath);
+        mIsAudio = MediaUtils.isAudio(contentFilePath);
 
         if (savedInstanceState != null) {
             mPosition = savedInstanceState.getInt(ARG_POSITION, 0);


### PR DESCRIPTION
I noticed that if URLs passed to `MediaViewFragment` contain query parameters, it doesn't calculate properly the media type (i.e. if it's an image, a video, or an audio file). This is caused because the `isVideo` and `isAudio` don't expect a URL with query parameters. In order to solve this, I updated the logic to extract only the last segment of the URL's path (similar to what we do [here](https://github.com/wordpress-mobile/WordPress-Android/blob/e22254c07af964b02279f3da179e5442c8168103/libs/editor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java#L380-L383)).

**To test:**
[TBD]

## Regression Notes
1. Potential unintended areas of impact
[TBD]

2. What I did to test those areas of impact (or what existing automated tests I relied on)
[TBD]

3. What automated tests I added (or what prevented me from doing so)
[TBD]

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
