### PR TITLE
Integrate gutenberg-mobile release 1.95.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,8 @@
 
 22.4
 -----
-[**] [Jetpack-only] Adds a dashboard card for viewing activity log [https://github.com/wordpress-mobile/WordPress-Android/pull/18306]
-[**] [Jetpack-only] Adds a dashboard card for viewing pages [https://github.com/wordpress-mobile/WordPress-Android/pull/18337]
+* [**] [Jetpack-only] Adds a dashboard card for viewing activity log [https://github.com/wordpress-mobile/WordPress-Android/pull/18306]
+* [**] [Jetpack-only] Adds a dashboard card for viewing pages [https://github.com/wordpress-mobile/WordPress-Android/pull/18337]
 
 22.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,10 @@
 -----
 * [**] [Jetpack-only] Adds a dashboard card for viewing activity log [https://github.com/wordpress-mobile/WordPress-Android/pull/18306]
 * [**] [Jetpack-only] Adds a dashboard card for viewing pages [https://github.com/wordpress-mobile/WordPress-Android/pull/18337]
+* [**] [internal] Block editor: Add fullscreen embed preview to Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5743]
+* [*] [Jetpack-only] Block editor: Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [https://github.com/WordPress/gutenberg/pull/50475]
+* [**] Block editor: Tapping on a nested block now gets focus directly instead of having to tap multiple times depending on the nesting levels. [https://github.com/WordPress/gutenberg/pull/50108]
+* [*] [Jetpack-only] Block editor: Use host app namespace in reusable block message [https://github.com/WordPress/gutenberg/pull/50478]
 
 22.3
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = '5763-5fcc53249cd6d5413e4dde858d8a0bec411d14de'
+    gutenbergMobileVersion = 'v1.95.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-2d2bf4a52d3d1bcc434529a3700213c376206f7f'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '2.2.0'
-    gutenbergMobileVersion = 'v1.95.0-alpha1'
+    gutenbergMobileVersion = '5763-5fcc53249cd6d5413e4dde858d8a0bec411d14de'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-2d2bf4a52d3d1bcc434529a3700213c376206f7f'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.95.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5763

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.