### PR TITLE
Enable domain purchases in site creation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] [Jetpack-only] Block editor: Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [https://github.com/WordPress/gutenberg/pull/50475]
 * [**] Block editor: Tapping on a nested block now gets focus directly instead of having to tap multiple times depending on the nesting levels. [https://github.com/WordPress/gutenberg/pull/50108]
 * [*] [Jetpack-only] Block editor: Use host app namespace in reusable block message [https://github.com/WordPress/gutenberg/pull/50478]
+* [*] [internal] [Jetpack-only] Enables domain purchases in site creation A/B experiment. [https://github.com/wordpress-mobile/WordPress-Android/pull/18414]
 
 22.3
 -----

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -200,7 +200,7 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
-            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
+            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "true"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
 


### PR DESCRIPTION
This PR enables the **Site Creation Domain Purchases** experimental feature in the Jetpack app.

## To Test

### ○ Control Variation

#### Verify free sites can be created as before (regression test)
1. Install the Jetpack app & login
2. Tap the `▽` icon at the right of the site name on the `My Site` screen
3. Tap the `+` icon at the top right on the `Site picker` screen
4. Select `⊕ Create WordPress.com site` on the modal dialog
5. Tap `Skip` at top right on the first step (topic screen)
6. Tap `Skip` at top right on the next step (theme screen)
7. Enter a random search query
8. Select a domain suggestion
9. Tap the green button that appears at the bottom
10. **Expect** to see the success screen
11. Tap the green button at the bottom
12. **Expect** to see the quick start full screen modal
13. Tap `No Thanks` button
14. **Verify** you end up on `My Site` viewing the newly created site

### ● Treatment Variation

#### Verify sites with paid domain can be created
0. ◐ Assign the treatment variant of the `Site Creation Domain Purchasing v1` A/B experiment to your user
   [internal ref: 21060-explat-experiment]
1. Repeat steps `1`-`7` from control variation test case above
2. Select a **.blog** paid domain suggestion
3. Tap the green button that appears at the bottom
4. **Expect** to see the checkout page
5. Enter your payment details and submit for purchase
6. Repeat steps `10`-`14` from the control variation test case above

## Regression Notes
1. Potential unintended areas of impact
   `Site Creation`

7. What I did to test those areas of impact (or what existing automated tests I relied on)
      Manual testing after enabling the flag. The feature was thoroughly tested during development by enabling the flag via debug settings.

15. What automated tests I added (or what prevented me from doing so)
   N/a - The feature was tested with manual and automated tests during development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] ~~UI Changes testing checklist~~