### PR TITLE
Revert "[Pages List] Detect block-based theme on PageListViewModel"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -4,14 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
-import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.util.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,8 +17,7 @@ import javax.inject.Singleton
 class SelectedSiteRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val siteSettingsInterfaceFactory: SiteSettingsInterfaceWrapper.Factory,
-    private val appPrefsWrapper: AppPrefsWrapper,
-    private val globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private var siteSettings: SiteSettingsInterfaceWrapper? = null
     private val _selectedSiteChange = MutableLiveData<SiteModel?>(null)
@@ -29,7 +25,6 @@ class SelectedSiteRepository @Inject constructor(
     val selectedSiteChange = _selectedSiteChange as LiveData<SiteModel?>
     val siteSelected = _selectedSiteChange.map { it?.id }.distinctUntilChanged()
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
-
     fun updateSite(selectedSite: SiteModel) {
         if (getSelectedSite()?.iconUrl != selectedSite.iconUrl) {
             showSiteIconProgressBar(false)
@@ -84,12 +79,6 @@ class SelectedSiteRepository @Inject constructor(
         getSelectedSite()?.id ?: UNAVAILABLE
     }
 
-    private fun fetchEditorTheme(site: SiteModel) {
-        EditorThemeStore.FetchEditorThemePayload(site, globalStyleSupportFeatureConfig.isEnabled()).let {
-            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(it))
-        }
-    }
-
     fun updateSiteSettingsIfNecessary() {
         // If the selected site is null, we can't update its site settings
         val selectedSite = getSelectedSite() ?: return
@@ -115,8 +104,6 @@ class SelectedSiteRepository @Inject constructor(
 
             siteSettings?.init(true)
         }
-        // Fetch editor theme to update block-based-theme flag
-        fetchEditorTheme(selectedSite)
     }
 
     fun isSiteIconUploadInProgress(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3718,7 +3718,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     .onEditorThemeUpdated(editorThemeSupport.toBundle());
 
         mPostEditorAnalyticsSession
-                .editorSettingsFetched(editorThemeSupport.isBlockBasedTheme(), event.getEndpoint().getValue());
+                .editorSettingsFetched(editorThemeSupport.isFSETheme(), event.getEndpoint().getValue());
     }
     // EditPostActivityHook methods
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -32,7 +32,7 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_SESSION_ID = "session_id";
     private static final String KEY_STARTUP_TIME = "startup_time_ms";
     private static final String KEY_TEMPLATE = "template";
-    private static final String KEY_IS_BLOCK_BASED_THEME = "is_block_based_theme";
+    private static final String KEY_FULL_SITE_EDITING = "full_site_editing";
     private static final String KEY_ENDPOINT = "endpoint";
     private static final String KEY_ENTRY_POINT = "entry_point";
 
@@ -177,9 +177,9 @@ public class PostEditorAnalyticsSession implements Serializable {
                 properties);
     }
 
-    public void editorSettingsFetched(Boolean isBlockBasedTheme, String endpoint) {
+    public void editorSettingsFetched(Boolean fullSiteEditing, String endpoint) {
         final Map<String, Object> properties = getCommonProperties();
-        properties.put(KEY_IS_BLOCK_BASED_THEME, isBlockBasedTheme);
+        properties.put(KEY_FULL_SITE_EDITING, fullSiteEditing);
         properties.put(KEY_ENDPOINT, endpoint);
         AnalyticsUtils
                 .trackWithSiteDetails(mAnalyticsTrackerWrapper, Stat.EDITOR_SETTINGS_FETCHED, mSiteModel, properties);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -7,21 +7,16 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.EditorThemeStore
-import org.wordpress.android.fluxc.store.EditorThemeStore.FetchEditorThemePayload
-import org.wordpress.android.fluxc.store.EditorThemeStore.OnEditorThemeChanged
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
@@ -41,7 +36,6 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.SiteUtils
-import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.util.extensions.toFormattedDateString
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -66,9 +60,7 @@ class PageListViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     private val localeManagerWrapper: LocaleManagerWrapper,
     private val accountStore: AccountStore,
-    @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher,
-    private val globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig,
-    private val editorThemeStore: EditorThemeStore,
+    @Named(BG_THREAD) private val coroutineDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(coroutineDispatcher) {
     private val _pages: MutableLiveData<List<PageItem>> = MutableLiveData()
     val pages: LiveData<Triple<List<PageItem>, Boolean, Boolean>> = Transformations.map(_pages) {
@@ -79,7 +71,6 @@ class PageListViewModel @Inject constructor(
     private var retryScrollToPage: LocalId? = null
     private var isStarted: Boolean = false
     private lateinit var listType: PageListType
-    private val isBlockBasedTheme = MutableStateFlow(false)
 
     private lateinit var pagesViewModel: PagesViewModel
 
@@ -145,27 +136,6 @@ class PageListViewModel @Inject constructor(
             pagesViewModel.blazeSiteEligibility.observeForever(blazeSiteEligibilityObserver)
 
             dispatcher.register(this)
-
-            refreshEditorTheme()
-        }
-    }
-
-    private fun refreshEditorTheme() {
-        // Get isBlockBasedTheme (cached) value from local db
-        isBlockBasedTheme.value = editorThemeStore.getIsBlockBasedTheme(pagesViewModel.site)
-
-        // Dispatch action to refresh the values from the remote
-        FetchEditorThemePayload(pagesViewModel.site, globalStyleSupportFeatureConfig.isEnabled()).let {
-            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(it))
-        }
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
-    fun onEditorThemeChanged(event: OnEditorThemeChanged) {
-        if (pagesViewModel.site.id == event.siteId) {
-            event.editorTheme?.themeSupport?.let { themeSupport ->
-                isBlockBasedTheme.value = themeSupport.isEditorThemeBlockBased()
-            }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -15,13 +15,11 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.EditorThemeAction
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
-import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 
 @ExperimentalCoroutinesApi
 class SelectedSiteRepositoryTest : BaseUnitTest() {
@@ -36,10 +34,6 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
-
-    @Mock
-    lateinit var globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig
-
     private lateinit var siteModel: SiteModel
     private var siteIconProgressBarVisible: Boolean = false
     private var selectedSite: SiteModel? = null
@@ -52,12 +46,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        selectedSiteRepository = SelectedSiteRepository(
-            dispatcher,
-            siteSettingsInterfaceFactory,
-            appPrefsWrapper,
-            globalStyleSupportFeatureConfig
-        )
+        selectedSiteRepository = SelectedSiteRepository(dispatcher, siteSettingsInterfaceFactory, appPrefsWrapper)
         selectedSiteRepository.showSiteIconProgressBar.observeForever { siteIconProgressBarVisible = it == true }
         selectedSiteRepository.selectedSiteChange.observeForever { selectedSite = it }
         siteModel = SiteModel()
@@ -128,6 +117,7 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
         selectedSiteRepository.updateTitle(updatedTitle)
 
         assertThat(siteModel.name).isEqualTo(updatedTitle)
+        verify(dispatcher).dispatch(any())
         assertThat(actions.last().payload).isEqualTo(siteModel)
         assertThat(actions.last().type).isEqualTo(SiteAction.UPDATE_SITE)
 
@@ -226,15 +216,6 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
         selectedSiteRepository.siteSelected.observeForever { emptySiteIdEmitted = true }
 
         assertThat(emptySiteIdEmitted).isTrue
-    }
-
-    @Test
-    fun `Should fetch EditorTheme when updateSiteSettingsIfNecessary is called`() {
-        initializeSiteAndSiteSettings()
-
-        selectedSiteRepository.updateSiteSettingsIfNecessary()
-
-        assertThat(actions.last().type).isEqualTo(EditorThemeAction.FETCH_EDITOR_THEME)
     }
 
     private fun initializeSiteAndSiteSettings() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -8,15 +8,10 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.EditorThemeAction
-import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.LocalOrRemoteId.LocalId
 import org.wordpress.android.fluxc.model.PostModel
@@ -25,7 +20,6 @@ import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Divider
@@ -36,7 +30,6 @@ import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
 import org.wordpress.android.ui.posts.AuthorFilterSelection.ME
 import org.wordpress.android.util.LocaleManagerWrapper
-import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
@@ -75,16 +68,9 @@ class PageListViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var accountStore: AccountStore
 
-    @Mock
-    lateinit var globalStyleSupportFeatureConfig: GlobalStyleSupportFeatureConfig
-
-    @Mock
-    lateinit var editorThemeStore: EditorThemeStore
-
     private lateinit var viewModel: PageListViewModel
     private val site = SiteModel()
     private val pageListState = MutableLiveData<PageListState>()
-    private lateinit var actions: MutableList<Action<*>>
 
     @Before
     fun setUp() {
@@ -97,9 +83,7 @@ class PageListViewModelTest : BaseUnitTest() {
             dispatcher,
             localeManagerWrapper,
             accountStore,
-            testDispatcher(),
-            globalStyleSupportFeatureConfig,
-            editorThemeStore,
+            testDispatcher()
         )
 
         whenever(pageItemProgressUiStateUseCase.getProgressStateForPage(any())).thenReturn(
@@ -131,11 +115,6 @@ class PageListViewModelTest : BaseUnitTest() {
 
         val blazeSiteEligibility = MutableLiveData<Boolean>()
         whenever(pagesViewModel.blazeSiteEligibility).thenReturn(blazeSiteEligibility)
-
-        doAnswer {
-            actions.add(it.getArgument(0))
-        }.whenever(dispatcher).dispatch(any())
-        actions = mutableListOf()
     }
 
     @Test
@@ -494,22 +473,6 @@ class PageListViewModelTest : BaseUnitTest() {
         val pageItems = pagesResult[1].first
         val pageItem = pageItems[0] as PublishedPage
         assertThat(pageItem.author).isNull()
-    }
-
-    @Test
-    fun `Should refresh EditorTheme when start is called the first time`() {
-        val pages = MutableLiveData<List<PageModel>>()
-        whenever(pagesViewModel.pages).thenReturn(pages)
-        viewModel.start(PUBLISHED, pagesViewModel)
-        assertThat(actions.last().type).isEqualTo(EditorThemeAction.FETCH_EDITOR_THEME)
-    }
-
-    @Test
-    fun `Should call EditorThemeStore getIsBlockBasedTheme when start is called the first time`() {
-        val pages = MutableLiveData<List<PageModel>>()
-        whenever(pagesViewModel.pages).thenReturn(pages)
-        viewModel.start(PUBLISHED, pagesViewModel)
-        verify(editorThemeStore).getIsBlockBasedTheme(site)
     }
 
     private fun buildPageModel(

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '2.2.0'
     gutenbergMobileVersion = 'v1.95.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = 'trunk-7d44ea7eecabc32200d900b8065760964de04d10'
+    wordPressFluxCVersion = 'trunk-2d2bf4a52d3d1bcc434529a3700213c376206f7f'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#18385

Unfortunately, the changes on FluxC introduced a SQLite statement (`RENAME COLUMN`) that is only supported in more recent SQLite versions ([3.25+](https://www.sqlite.org/changes.html#version_3_25_0)) which is only present on Android [API 30 and newer](https://developer.android.com/reference/android/database/sqlite/package-summary), so it causes a crash when updating in older APIs.