### PR TITLE
Plans on JP: feature config

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -136,6 +136,7 @@ android {
         buildConfigField "boolean", "DASHBOARD_CARD_PAGES", "false"
         buildConfigField "boolean", "DASHBOARD_CARD_ACTIVITY_LOG", "false"
         buildConfigField "boolean", "DASHBOARD_CARD_DOMAIN", "false"
+        buildConfigField "boolean", "DASHBOARD_CARD_FREE_TO_PAID_PLANS", "false"
         buildConfigField "boolean", "SITE_EDITOR_MVP", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardFreeToPaidPlansFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardCardFreeToPaidPlansFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val DASHBOARD_CARD_FREE_TO_PAID_PLANS_REMOTE_FIELD = "dashboard_card_free_to_paid_plans"
+
+@Feature(DASHBOARD_CARD_FREE_TO_PAID_PLANS_REMOTE_FIELD, false)
+class DashboardCardFreeToPaidPlansFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.DASHBOARD_CARD_FREE_TO_PAID_PLANS,
+    DASHBOARD_CARD_FREE_TO_PAID_PLANS_REMOTE_FIELD
+)


### PR DESCRIPTION
Adds Feature flag to show Dashboard Card for Plans on JP

Fixes #18417 

<img width=320 src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/2963c1e1-abb7-4559-8562-41e4c44748c4" />


To test:

1. Launch Jetpack/WordPress app
2. Go to **App Settings** (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
3. Tap **Debug Settings**
4. Find **dashboard_card_free_to_paid_plans** under Remote features as shown in the image above

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.