### PR TITLE
Adds: Check in request for fetching the dashboard cards stats/posts 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite
 import androidx.lifecycle.LiveData
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteSource.SiteIndependentSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState
@@ -33,7 +34,8 @@ class MySiteSourceManager @Inject constructor(
     private val bloggingPromptCardSource: BloggingPromptCardSource,
     promoteWithBlazeCardSource: PromoteWithBlazeCardSource,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val dashboardCardDomainSource: DashboardCardDomainSource
+    private val dashboardCardDomainSource: DashboardCardDomainSource,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 ) {
     private val mySiteSources: List<MySiteSource<*>> = listOf(
         selectedSiteSource,
@@ -50,7 +52,8 @@ class MySiteSourceManager @Inject constructor(
     )
 
     private val showDashboardCards: Boolean
-        get() = selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true
+        get() = selectedSiteRepository.getSelectedSite()?.isUsingWpComRestApi == true &&
+                jetpackFeatureRemovalPhaseHelper.shouldShowDashboard()
 
     private val allSupportedMySiteSources: List<MySiteSource<*>>
         get() = if (showDashboardCards) {


### PR DESCRIPTION
## Related issue 
Closes #18427 

## Description 
This PR fixes the issue where the dashboard cards data was requested in the Jetpack feature removal phase in WP.

## Explanation of changes 
- ⊕ Adds [Check for whether the app is in jetpack removal before API call](https://github.com/wordpress-mobile/WordPress-Android/commit/f3f29257c214ea4ad25eb33721e0de4ba6d72d0b)
- ⊕ Adds [test for the jetpack removal phase cards source endpoint call](https://github.com/wordpress-mobile/WordPress-Android/commit/10287eb2a2f11190404517550f3b9f2d0b328dbc)

## To test:

### Verify that dashboard card data is not requested in WP in the Jetpack removal phase 
-  Login to the WP app
-  Add a log statement or add a debugger in the code at the endpoint or database call in CardSource
-  Notice in the log or debugger that the Cards dashboard endpoint/ Cards database data is not fetched

### REgression testing- Verify that dashboard card data for JP app is fetched
-  Login to the Jetpack app 
- Verify that today's stats + posts card is shown as before

## Regression Notes
1. Potential unintended areas of impact
- Dashboard cards are not shown on Jetpack app
- Dashboard cards are requested on WP app in Jetpack feature removal phase

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added Unit tests and did manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)