### PR TITLE
Merge 22.4 editorialized release notes to trunk

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -10,30 +10,32 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Jetpack - Apps - Android - Release Notes\n"
 
+msgctxt "release_note_224"
+msgid ""
+"22.4:\n"
+"- Added dashboard cards for Activity Log and Pages\n"
+"- Removed ability to convert deleted/undefined reusable blocks to regular blocks\n"
+"- Updated nested blocks to allow immediate editing without tapping through nested levels\n"
+"- Corrected “editing not supported” message in reusable blocks\n"
+msgstr ""
+
 msgctxt "release_note_223"
 msgid ""
 "22.3:\n"
 "No updates this week, but we’re hard at work on a pressing feature we know you’ll enjoy.\n"
 msgstr ""
 
-msgctxt "release_note_222"
-msgid ""
-"22.2:\n"
-"- Added warning message for when push notifications are turned off\n"
-"- Updated media access permissions to align with Android 13 update\n"
-"- Added card to dashboard for purchasing custom domains\n"
-"- Added other users’ responses to blogging prompts\n"
-msgstr ""
-
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!
 msgctxt "play_store_app_title"
-msgid "Jetpack – Website Builder"
+msgid "Jetpack – Website Builder
+"
 msgstr ""
 
 #. translators: Short description of the Jetpack app to be displayed in the Play Store. Limit to 80 characters including spaces and commas!
 msgctxt "play_store_promo"
-msgid "Build your WordPress website & blog; create posts, add photos & track analytics!"
+msgid "Build your WordPress website & blog; create posts, add photos & track analytics!
+"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Play Store. Limit to 4000 characters including spaces and commas!
@@ -85,7 +87,7 @@ msgid ""
 "\n"
 "Learn more at https://jetpack.com/mobile\n"
 "\n"
-"California users privacy notice: https://automattic.com/privacy/#california-consumer-privacy-act-ccpa\n"
+"California users privacy notice: https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"
 msgstr ""
 
 #. Description for the first app store image

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,8 +1,4 @@
-* [**] [Jetpack-only] Adds a dashboard card for viewing activity log [https://github.com/wordpress-mobile/WordPress-Android/pull/18306]
-* [**] [Jetpack-only] Adds a dashboard card for viewing pages [https://github.com/wordpress-mobile/WordPress-Android/pull/18337]
-* [**] [internal] Block editor: Add fullscreen embed preview to Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5743]
-* [*] [Jetpack-only] Block editor: Fix crash when trying to convert to regular blocks an undefined/deleted reusable block [https://github.com/WordPress/gutenberg/pull/50475]
-* [**] Block editor: Tapping on a nested block now gets focus directly instead of having to tap multiple times depending on the nesting levels. [https://github.com/WordPress/gutenberg/pull/50108]
-* [*] [Jetpack-only] Block editor: Use host app namespace in reusable block message [https://github.com/WordPress/gutenberg/pull/50478]
-* [*] [internal] [Jetpack-only] Enables domain purchases in site creation A/B experiment. [https://github.com/wordpress-mobile/WordPress-Android/pull/18414]
-
+- Added dashboard cards for Activity Log and Pages
+- Removed ability to convert deleted/undefined reusable blocks to regular blocks
+- Updated nested blocks to allow immediate editing without tapping through nested levels
+- Corrected “editing not supported” message in reusable blocks

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -10,17 +10,16 @@ msgstr ""
 "X-Generator: VsCode\n"
 "Project-Id-Version: Release Notes & Play Store Descriptions\n"
 
+msgctxt "release_note_224"
+msgid ""
+"22.4:\n"
+"When you tap on a nested block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)\n"
+msgstr ""
+
 msgctxt "release_note_223"
 msgid ""
 "22.3:\n"
 "No updates this week, but we’re hard at work on a pressing feature we know you’ll enjoy.\n"
-msgstr ""
-
-msgctxt "release_note_222"
-msgid ""
-"22.2:\n"
-"- We added a yellow warning box telling you when notifications and blogging reminders are no longer being sent to your device as push notifications.\n"
-"- We updated media access permissions for photos, videos, and audio to align with the Android 13 update.\n"
 msgstr ""
 
 #. translators: Release notes for this version to be displayed in the Play Store. Limit to 500 characters including spaces and commas!
@@ -92,7 +91,7 @@ msgid ""
 "\n"
 "Whether you need a website builder to create your website, or a simple blog maker, WordPress can help. It gives you beautiful designs, powerful features, and the freedom to build anything you want.\n"
 "\n"
-"California users privacy notice: https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa.\n"
+"California users privacy notice: https://wp.me/Pe4R-d/#california-consumer-privacy-act-ccpa."
 msgstr ""
 
 #. translators: Title to be displayed in the Play Store. Limit to 30 characters including spaces and commas!

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,3 +1,1 @@
-* [**] [internal] Block editor: Add fullscreen embed preview to Android [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5743]
-* [**] Block editor: Tapping on a nested block now gets focus directly instead of having to tap multiple times depending on the nesting levels. [https://github.com/WordPress/gutenberg/pull/50108]
-
+When you tap on a nested block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)


### PR DESCRIPTION
The app store strings were updated by CI in https://github.com/wordpress-mobile/WordPress-Android/pull/18442.