### PR TITLE
[UI Tests] Disabled four recently flaky tests.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
@@ -29,6 +29,7 @@ class BlockEditorTests : BaseTest() {
 """
 
     @Test
+    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2ePublishSimplePost() {
         val title = "publishSimplePost"
         MySitesPage()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.ReaderPage
 import org.wordpress.android.support.BaseTest
@@ -16,6 +17,7 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
+    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eNavigateThroughPosts() {
         ReaderPage()
             .tapFollowingTab()
@@ -29,6 +31,7 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
+    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eLikePost() {
         ReaderPage()
             .tapFollowingTab()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -38,6 +39,7 @@ class StatsTests : BaseTest() {
     }
 
     @Test
+    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()


### PR DESCRIPTION
### Fixes
There's an increase of fails in `e2eAllDayStatsLoad`, `e2eLikePost`, `e2eNavigateThroughPosts` and `e2ePublishSimplePost` taking place in the recent days. See p1684256862513919-slack-C04TBSWP09M, p1684300963865409-slack-C5ALGJYEP and several messages after that.

Since these fails are not reproducible locally, I don't have the bandwidth to spend too much time on this today, I'm disabling them temporarily.

### To test
- Instrumented tests are 🟢  on FTL.