### PR TITLE
Refactor concurrent uploading of local changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -24,6 +24,7 @@
 * [*] Block editor: [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5785]
 * [*] Block editor: [Gallery block] Fixes a compatibility issue with Gallery block [https://github.com/wordpress-mobile/WordPress-Android/pull/18519]
 * [**] Block editor: Tapping any type of nested block moves focus to the nested block directly, rather than requiring multiple taps to navigate down each nesting levels. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5781]
+* [*] Fixed an error when syncing offline data to the cloud. [https://github.com/wordpress-mobile/WordPress-Android/pull/18449]
 
 22.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ThreadModule.kt
@@ -7,8 +7,10 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
 import org.wordpress.android.util.helpers.Debouncer
 import javax.inject.Named
+import javax.inject.Singleton
 
 const val APPLICATION_SCOPE = "APPLICATION_SCOPE"
 
@@ -52,5 +54,11 @@ class ThreadModule {
     @Provides
     fun provideDebouncer(): Debouncer {
         return Debouncer()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMutex(): Mutex {
+        return Mutex()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ProcessLifecycleOwner
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -48,6 +47,7 @@ import kotlin.coroutines.CoroutineContext
  */
 @Singleton
 @OpenForTesting
+@Suppress("LongParameterList")
 class UploadStarter @Inject constructor(
     private val appContext: Context,
     private val dispatcher: Dispatcher,
@@ -94,9 +94,7 @@ class UploadStarter @Inject constructor(
     fun activateAutoUploading(processLifecycleOwner: ProcessLifecycleOwner) {
         // We're skipping the first emitted value because the processLifecycleObserver below will also trigger an
         // immediate upload.
-        connectionStatus.skip(1).observe(processLifecycleOwner, Observer {
-            queueUploadFromAllSites()
-        })
+        connectionStatus.skip(1).observe(processLifecycleOwner) { queueUploadFromAllSites() }
 
         processLifecycleOwner.lifecycle.addObserver(processLifecycleObserver)
     }
@@ -161,7 +159,7 @@ class UploadStarter @Inject constructor(
                     .forEach { (post, action) ->
                         trackAutoUploadAction(action, post.status, post.isPage)
                         AppLog.d(
-                            AppLog.T.POSTS,
+                            T.POSTS,
                             "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
                         )
                         dispatcher.dispatch(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -152,11 +152,7 @@ class UploadStarter @Inject constructor(
 
     private fun PostModel.toStringLog() = "${if (isPage) "page" else "post"} with title: $title"
 
-    private fun trackAutoUploadAction(
-        action: UploadAction,
-        status: String,
-        isPage: Boolean
-    ) {
+    private fun trackAutoUploadAction(action: UploadAction, status: String, isPage: Boolean) {
         tracker.track(
             if (isPage) Stat.AUTO_UPLOAD_PAGE_INVOKED else Stat.AUTO_UPLOAD_POST_INVOKED,
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -45,7 +45,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * The method [activateAutoUploading] must be called once, preferably during app creation, for the auto-uploads to work.
  *
- * @param mutex When the app comes to foreground both `queueUploadFromAllSites` and `queueUploadFromSite` are invoked.
+ * @param mutex When the app comes to foreground both [queueUploadFromAllSites] and [queueUploadFromSite] are invoked.
  * The problem is that they can run in parallel and `uploadServiceFacade.isPostUploadingOrQueued(it)` might return
  * out-of-date result and a same post is added twice.
  */

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -49,10 +49,7 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 @OpenForTesting
 class UploadStarter @Inject constructor(
-    /**
-     * The Application context
-     */
-    private val context: Context,
+    private val appContext: Context,
     private val dispatcher: Dispatcher,
     private val postStore: PostStore,
     private val pageStore: PageStore,
@@ -173,7 +170,7 @@ class UploadStarter @Inject constructor(
                             )
                         )
                         uploadServiceFacade.uploadPost(
-                            context = context,
+                            context = appContext,
                             post = post,
                             trackAnalytics = false
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -148,7 +148,10 @@ class UploadStarter @Inject constructor(
                         trackAutoUploadAction(action, post.status, post.isPage)
                         AppLog.d(
                             T.POSTS,
-                            "UploadStarter for post (isPage: ${post.isPage}) title: ${post.title}, action: $action"
+                            "UploadStarter for post " +
+                                    "(isPage: ${post.isPage.compareTo(false)}) " +
+                                    "title: ${post.title}, " +
+                                    "action: $action"
                         )
                         dispatcher.dispatch(
                             UploadActionBuilder.newIncrementNumberOfAutoUploadAttemptsAction(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ProcessLifecycleOwner
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -145,7 +144,7 @@ class UploadStarter @Inject constructor(
                 }
                 .toList()
                 .forEach { (post, action) ->
-                    try {
+                    runCatching {
                         trackAutoUploadAction(action, post.status, post.isPage)
                         AppLog.d(
                             T.POSTS,
@@ -161,9 +160,9 @@ class UploadStarter @Inject constructor(
                             post = post,
                             trackAnalytics = false
                         )
-                    } catch (exception: CancellationException) {
-                        AppLog.e(T.POSTS, exception)
-                        throwable = exception
+                    }.onFailure {
+                        AppLog.e(T.POSTS, it)
+                        throwable = it
                     }
                 }
             throwable?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -109,7 +109,7 @@ class UploadStarter @Inject constructor(
      * If there is an internet connection, uploads all posts with local changes belonging to [sites].
      *
      * This coroutine will suspend until all the [upload] operations have completed. If one of them fails, all query
-     * and queuing attempts ([upload]) will be canceled. The exception will be thrown by this method.
+     * and queuing attempts ([upload]) will continue. The last exception will be thrown by this method.
      */
     private suspend fun checkConnectionAndUpload(sites: List<SiteModel>) = coroutineScope {
         if (!networkUtilsWrapper.isNetworkAvailable()) return@coroutineScope

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadFixtures.kt
@@ -56,11 +56,5 @@ internal object UploadFixtures {
             setIsPage(page)
         }
 
-    fun createSimpleLocallyChangedPostModel() = PostModel().apply {
-        setStatus(PostStatus.DRAFT.toString())
-        setIsLocallyChanged(true)
-        setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(Date().time / 1000))
-    }
-
     fun createSiteModel(isWpCom: Boolean = true) = SiteModel().apply { setIsWPCom(isWpCom) }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadFixtures.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.ui.uploads
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ProcessLifecycleOwner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.store.UploadStore
+import org.wordpress.android.ui.posts.PostUtilsWrapper
+import org.wordpress.android.util.DateTimeUtils
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.helpers.ConnectionStatus
+import java.util.Date
+
+internal object UploadFixtures {
+    private var postIdIndex = 0
+
+    private fun makePostTitleFromId() = postIdIndex.toString().padStart(2, '0')
+
+    fun resetTestPostIdIndex() { postIdIndex = 0 }
+
+    fun createMockedNetworkUtilsWrapper() = mock<NetworkUtilsWrapper> { on { isNetworkAvailable() } doReturn true }
+
+    fun createConnectionStatusLiveData(initialValue: ConnectionStatus?): MutableLiveData<ConnectionStatus> {
+        return MutableLiveData<ConnectionStatus>().apply { value = initialValue }
+    }
+
+    fun createMockedPostUtilsWrapper() = mock<PostUtilsWrapper> {
+        on { isPublishable(any()) } doReturn true
+        on { isPostInConflictWithRemote(any()) } doReturn false
+    }
+
+    fun createMockedUploadStore(numberOfAutoUploadAttempts: Int) = mock<UploadStore> {
+        on { getNumberOfPostAutoUploadAttempts(any()) } doReturn numberOfAutoUploadAttempts
+    }
+
+    fun createMockedUploadServiceFacade() = mock<UploadServiceFacade> {
+        on { isPostUploadingOrQueued(any()) } doReturn false
+    }
+
+    fun createMockedProcessLifecycleOwner(lifecycle: Lifecycle = mock()) = mock<ProcessLifecycleOwner> {
+        on { this.lifecycle } doReturn lifecycle
+    }
+
+    fun createLocallyChangedPostModel(postStatus: PostStatus = PostStatus.DRAFT, page: Boolean = false) =
+        PostModel().apply {
+            setId(++postIdIndex)
+            setTitle(makePostTitleFromId())
+            setStatus(postStatus.toString())
+            setIsLocallyChanged(true)
+            setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(Date().time / 1000))
+            setIsPage(page)
+        }
+
+    fun createSimpleLocallyChangedPostModel() = PostModel().apply {
+        setStatus(PostStatus.DRAFT.toString())
+        setIsLocallyChanged(true)
+        setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(Date().time / 1000))
+    }
+
+    fun createSiteModel(isWpCom: Boolean = true) = SiteModel().apply { setIsWPCom(isWpCom) }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -74,6 +74,7 @@ class UploadStarterConcurrentTest : BaseUnitTest() {
         uploadServiceFacade = uploadServiceFacade,
         uploadActionUseCase = UploadActionUseCase(mock(), createMockedPostUtilsWrapper(), uploadServiceFacade),
         tracker = mock(),
-        dispatcher = mock()
+        dispatcher = mock(),
+        mutex = mock(),
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -11,15 +11,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.PageStore
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.ui.posts.PostUtilsWrapper
-import org.wordpress.android.util.DateTimeUtils
-import org.wordpress.android.util.NetworkUtilsWrapper
-import java.util.Date
+import org.wordpress.android.ui.uploads.UploadFixtures.createSimpleLocallyChangedPostModel
+import org.wordpress.android.ui.uploads.UploadFixtures.createMockedNetworkUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadFixtures.createMockedPostUtilsWrapper
+import org.wordpress.android.ui.uploads.UploadFixtures.createSiteModel
+import org.wordpress.android.ui.uploads.UploadFixtures.createMockedUploadServiceFacade
 
 /**
  * Tests for structured concurrency in [UploadStarter].
@@ -31,11 +29,11 @@ import java.util.Date
 class UploadStarterConcurrentTest : BaseUnitTest() {
     private val site = createSiteModel()
     private val draftPosts = listOf(
-        createLocallyChangedPostModel(),
-        createLocallyChangedPostModel(),
-        createLocallyChangedPostModel(),
-        createLocallyChangedPostModel(),
-        createLocallyChangedPostModel()
+        createSimpleLocallyChangedPostModel(),
+        createSimpleLocallyChangedPostModel(),
+        createSimpleLocallyChangedPostModel(),
+        createSimpleLocallyChangedPostModel(),
+        createSimpleLocallyChangedPostModel()
     )
 
     private val postStore = mock<PostStore> {
@@ -78,27 +76,4 @@ class UploadStarterConcurrentTest : BaseUnitTest() {
         tracker = mock(),
         dispatcher = mock()
     )
-
-    private companion object Fixtures {
-        fun createMockedNetworkUtilsWrapper() = mock<NetworkUtilsWrapper> {
-            on { isNetworkAvailable() } doReturn true
-        }
-
-        fun createMockedUploadServiceFacade() = mock<UploadServiceFacade> {
-            on { isPostUploadingOrQueued(any()) } doReturn false
-        }
-
-        fun createMockedPostUtilsWrapper() = mock<PostUtilsWrapper> {
-            on { isPublishable(any()) } doReturn true
-            on { isPostInConflictWithRemote(any()) } doReturn false
-        }
-
-        fun createLocallyChangedPostModel() = PostModel().apply {
-            setStatus(PostStatus.DRAFT.toString())
-            setIsLocallyChanged(true)
-            setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(Date().time / 1000))
-        }
-
-        fun createSiteModel(): SiteModel = SiteModel().apply { setIsWPCom(true) }
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -24,8 +24,7 @@ import java.util.Date
 /**
  * Tests for structured concurrency in [UploadStarter].
  *
- * This is intentionally a separate class from [UploadStarterTest] because this contains non-deterministic
- * tests.
+ * Intentionally separated from [UploadStarterTest] because it contains non-deterministic tests.
  */
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -66,7 +66,7 @@ class UploadStarterConcurrentTest : BaseUnitTest() {
     }
 
     private fun createUploadStarter(uploadServiceFacade: UploadServiceFacade) = UploadStarter(
-        context = mock(),
+        appContext = mock(),
         postStore = postStore,
         pageStore = pageStore,
         siteStore = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -213,7 +213,7 @@ class UploadStarterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given a failure, when uploading all sites, all other uploads could succeed`() {
+    fun `given a failure, when uploading all sites, all other posts & pages are uploaded`() {
         // Given
         val connectionStatus = createConnectionStatusLiveData(null)
         val uploadServiceFacade = createMockedUploadServiceFacade()

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -261,6 +261,9 @@ class UploadStarterTest : BaseUnitTest() {
                 queueUploadFromAllSites()
             }
         }
+
+        val expectedInvocations = 1 // 1 blog * 2 sites - 1 failed upload
+        verify(uploadServiceFacade, times(expectedInvocations)).uploadPost(any(), any<PostModel>(), any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -193,6 +193,25 @@ class UploadStarterTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when uploading all sites, posts & pages of the sites are uploaded`() {
+        // Given
+        val connectionStatus = createConnectionStatusLiveData(null)
+        val uploadServiceFacade = createMockedUploadServiceFacade()
+        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
+
+        // When
+        starter.queueUploadFromAllSites()
+
+        // Then
+        val expectedUploadPostExecutions = draftPosts.size + draftPages.size
+        verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
+            context = any(),
+            post = any(),
+            trackAnalytics = any()
+        )
+    }
+
+    @Test
     fun `when uploading a single site, only posts & pages of that site are uploaded`() {
         // Given
         val site: SiteModel = sites[1]

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -498,7 +498,7 @@ class UploadStarterTest : BaseUnitTest() {
         uploadStore: UploadStore = createMockedUploadStore(0),
         dispatcher: Dispatcher = mock()
     ) = UploadStarter(
-        context = mock(),
+        appContext = mock(),
         postStore = postStore,
         pageStore = pageStore,
         siteStore = siteStore,

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -532,19 +532,22 @@ class UploadStarterTest : BaseUnitTest() {
         postUtilsWrapper: PostUtilsWrapper = createMockedPostUtilsWrapper(),
         uploadStore: UploadStore = createMockedUploadStore(0),
         dispatcher: Dispatcher = mock()
-    ) = UploadStarter(
-        appContext = mock(),
-        postStore = postStore,
-        pageStore = pageStore,
-        siteStore = siteStore,
-        bgDispatcher = testDispatcher(),
-        ioDispatcher = testDispatcher(),
-        networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
-        connectionStatus = connectionStatus,
-        uploadServiceFacade = uploadServiceFacade,
-        uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade),
-        tracker = mock(),
-        dispatcher = dispatcher,
-        mutex = mock(),
-    ).also { resetTestPostIdIndex() }
+    ) = run {
+        resetTestPostIdIndex()
+        UploadStarter(
+            appContext = mock(),
+            postStore = postStore,
+            pageStore = pageStore,
+            siteStore = siteStore,
+            bgDispatcher = testDispatcher(),
+            ioDispatcher = testDispatcher(),
+            networkUtilsWrapper = createMockedNetworkUtilsWrapper(),
+            connectionStatus = connectionStatus,
+            uploadServiceFacade = uploadServiceFacade,
+            uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade),
+            tracker = mock(),
+            dispatcher = dispatcher,
+            mutex = mock(),
+        )
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
@@ -248,7 +247,6 @@ class UploadStarterTest : BaseUnitTest() {
             siteStore = mock { on { this@on.sites } doReturn sites.toList() },
         )
         whenever(uploadServiceFacade.uploadPost(any(), eq(post), any())).thenAnswer { mutex.unlock() }
-
         with(starter) {
             launch {
                 queueUploadFromSite(sites.first)
@@ -262,7 +260,6 @@ class UploadStarterTest : BaseUnitTest() {
                 queueUploadFromAllSites()
             }
         }
-        advanceUntilIdle()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -544,6 +544,7 @@ class UploadStarterTest : BaseUnitTest() {
         uploadServiceFacade = uploadServiceFacade,
         uploadActionUseCase = UploadActionUseCase(uploadStore, postUtilsWrapper, uploadServiceFacade),
         tracker = mock(),
-        dispatcher = dispatcher
+        dispatcher = dispatcher,
+        mutex = mock(),
     ).also { resetTestPostIdIndex() }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -195,15 +195,10 @@ class UploadStarterTest : BaseUnitTest() {
 
     @Test
     fun `when uploading all sites, posts & pages of the sites are uploaded`() {
-        // Given
-        val connectionStatus = createConnectionStatusLiveData(null)
-        val uploadServiceFacade = createMockedUploadServiceFacade()
-        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
+        val starter = createUploadStarter()
 
-        // When
         starter.queueUploadFromAllSites()
 
-        // Then
         val expectedUploadPostExecutions = draftPosts.size + draftPages.size
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
             context = any(),
@@ -213,19 +208,15 @@ class UploadStarterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given a failure, when uploading all sites, all other posts & pages are uploaded`() {
-        // Given
-        val connectionStatus = createConnectionStatusLiveData(null)
-        val uploadServiceFacade = createMockedUploadServiceFacade()
+    fun `given a failure, when uploading all sites, all other posts & pages are uploaded`() = test {
+        val starter = createUploadStarter()
+        draftPages.first().let {
+            whenever(uploadServiceFacade.uploadPost(any(), eq(it), any()))
+                .thenThrow(CancellationException("Upload error in test for post: " + it.title))
+        }
 
-        val starter = createUploadStarter(connectionStatus, uploadServiceFacade)
-        whenever(uploadServiceFacade.uploadPost(any(), eq(draftPosts.first()), any()))
-            .thenThrow(CancellationException("fake upload error"))
-
-        // When
         starter.queueUploadFromAllSites()
 
-        // Then
         val expectedUploadPostExecutions = draftPosts.size + draftPages.size
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
             context = any(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -555,6 +555,10 @@ class UploadStarterTest : BaseUnitTest() {
     )
 
     private companion object Fixtures {
+
+        var postIdIndex = 0
+        fun makePostTitleFromId() = postIdIndex.toString().padStart(2, '0')
+
         fun createMockedNetworkUtilsWrapper() = mock<NetworkUtilsWrapper> {
             on { isNetworkAvailable() } doReturn true
         }
@@ -583,8 +587,8 @@ class UploadStarterTest : BaseUnitTest() {
         }
 
         fun createLocallyChangedPostModel(postStatus: PostStatus = DRAFT, page: Boolean = false) = PostModel().apply {
-            setId(Random.nextInt())
-            setTitle(UUID.randomUUID().toString())
+            setId(++postIdIndex)
+            setTitle(makePostTitleFromId())
             setStatus(postStatus.toString())
             setIsLocallyChanged(true)
             setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(Date().time / 1000))

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -236,17 +236,17 @@ class UploadStarterTest : BaseUnitTest() {
     @Test
     fun `given an unexpected mutex unlock, when uploading, then all other sites are uploaded`() = test {
         val (first, last) = createLocallyChangedPostModel() to createLocallyChangedPostModel()
-        val page = createLocallyChangedPostModel(page = true)
+        val (firstSite, lastSite) = createSiteModel() to createSiteModel()
         whenever(uploadServiceFacade.uploadPost(any(), eq(first), any())).thenAnswer {
             mutex.unlock()
         }
-        val (firstSite, lastSite) = createSiteModel() to createSiteModel()
+
         createUploadStarter(
             postStore = mock {
                 on { getPostsWithLocalChanges(firstSite) } doReturn listOf(first)
                 on { getPostsWithLocalChanges(lastSite) } doReturn listOf(last)
             },
-            pageStore = mock { onBlocking { getPagesWithLocalChanges(any()) } doReturn listOf(page) },
+            pageStore = mock { onBlocking { getPagesWithLocalChanges(any()) } doReturn emptyList() },
             siteStore = mock { on { sites } doReturn sites.toList() },
         ).run {
             launch {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -41,7 +41,6 @@ import org.wordpress.android.fluxc.store.SiteOptionsStore.SiteOptionsError
 import org.wordpress.android.fluxc.store.SiteOptionsStore.SiteOptionsErrorType.INVALID_PARAMETERS
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.blaze.BlazeStore
-import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.Action.COPY
@@ -99,9 +98,6 @@ class PagesViewModelTest : BaseUnitTest() {
     lateinit var siteOptionsStore: SiteOptionsStore
 
     @Mock
-    lateinit var appLogWrapper: AppLogWrapper
-
-    @Mock
     lateinit var siteStore: SiteStore
 
     @Mock
@@ -131,6 +127,7 @@ class PagesViewModelTest : BaseUnitTest() {
 
     private val mockedPageId = 1
     private val copyPageId = 2
+    private val remoteId = 1L
 
     @Before
     fun setUp() {
@@ -156,7 +153,7 @@ class PagesViewModelTest : BaseUnitTest() {
             uploadStarter = uploadStarter,
             pageListEventListenerFactory = mock(),
             siteOptionsStore = siteOptionsStore,
-            appLogWrapper = appLogWrapper,
+            appLogWrapper = mock(),
             siteStore = siteStore,
             accountStore = accountStore,
             prefs = appPrefsWrapper,
@@ -357,18 +354,17 @@ class PagesViewModelTest : BaseUnitTest() {
     @Test
     fun `SET_AS_HOMEPAGE sets page as Homepage`() = test {
         // Arrange
-        val homepageId = 1L
         val snackbarMessages = mutableListOf<SnackbarMessageHolder>()
         setupPageOnFrontUpdate(
             snackbarMessages = snackbarMessages,
             showOnFront = PAGE,
-            updatedPageOnFrontId = homepageId
+            updatedPageOnFrontId = remoteId
         )
 
         // Act
         viewModel.onMenuAction(
             SET_AS_HOMEPAGE,
-            getPublishedPage(homepageId)
+            getPublishedPage()
         )
 
         // Assert
@@ -379,19 +375,18 @@ class PagesViewModelTest : BaseUnitTest() {
     @Test
     fun `SET_AS_HOMEPAGE shows error store returns an error`() = test {
         // Arrange
-        val homepageId = 1L
         val snackbarMessages = mutableListOf<SnackbarMessageHolder>()
         setupPageOnFrontUpdate(
             snackbarMessages = snackbarMessages,
             showOnFront = PAGE,
-            updatedPageOnFrontId = homepageId,
+            updatedPageOnFrontId = remoteId,
             isError = true
         )
 
         // Act
         viewModel.onMenuAction(
             SET_AS_HOMEPAGE,
-            getPublishedPage(homepageId)
+            getPublishedPage()
         )
 
         // Assert
@@ -402,18 +397,17 @@ class PagesViewModelTest : BaseUnitTest() {
     @Test
     fun `SET_AS_POSTS_PAGE sets page as Posts page`() = test {
         // Arrange
-        val pageForPostsId = 1L
         val snackbarMessages = mutableListOf<SnackbarMessageHolder>()
         setupPageForPostsUpdate(
             snackbarMessages = snackbarMessages,
             showOnFront = PAGE,
-            updatedPageForPostsId = pageForPostsId
+            updatedPageForPostsId = remoteId
         )
 
         // Act
         viewModel.onMenuAction(
             SET_AS_POSTS_PAGE,
-            getPublishedPage(pageForPostsId)
+            getPublishedPage()
         )
 
         // Assert
@@ -424,19 +418,18 @@ class PagesViewModelTest : BaseUnitTest() {
     @Test
     fun `SET_AS_POSTS_PAGE shows error store returns an error`() = test {
         // Arrange
-        val pageForPostsId = 1L
         val snackbarMessages = mutableListOf<SnackbarMessageHolder>()
         setupPageForPostsUpdate(
             snackbarMessages = snackbarMessages,
             showOnFront = PAGE,
-            updatedPageForPostsId = pageForPostsId,
+            updatedPageForPostsId = remoteId,
             isError = true
         )
 
         // Act
         viewModel.onMenuAction(
             SET_AS_POSTS_PAGE,
-            getPublishedPage(pageForPostsId)
+            getPublishedPage()
         )
 
         // Assert
@@ -444,7 +437,7 @@ class PagesViewModelTest : BaseUnitTest() {
         assertThat(message.stringRes).isEqualTo(R.string.page_posts_page_update_failed)
     }
 
-    private fun getPublishedPage(remoteId: Long): PublishedPage = PublishedPage(
+    private fun getPublishedPage(): PublishedPage = PublishedPage(
         remoteId = remoteId,
         localId = 2,
         title = "Published page",
@@ -605,7 +598,7 @@ class PagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given draft tab requested, when view is launched, then darft is shown`() = test {
+    fun `given draft tab requested, when view is launched, then draft is shown`() = test {
         // Act
         viewModel.onSpecificPageListTypeRequested(DRAFTS)
 


### PR DESCRIPTION
Resolves #17463

This PR adapts the logic for uploading local changes to the cloud and introduces unit tests for the batch job of uploading all local sites posts & pages.

We've [noticed in Sentry](https://a8c.sentry.io/discover/results/?name=CompletionHandlerException&project=5731682&query=issue:JETPACK-ANDROID-1VC&sort=-release&statsPeriod=90d) the crash still occurs, and attempted to fix it via the `mutex.withLock { … }` workaround that we've merged via PR #18067 into `22.4`. Unfortunately it didn't eradicate the crash as seen in [this Sentry report](https://a8c.sentry.io/discover/results/?environment=debug&environment=prod&environment=release&field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&name=All+Events&project=5731682&query=release%3A22.4-rc-1+title%3A%22CompletionHandlerException%3A+Exception+in+resume+onCancellation+handler+for+CancellableContinuation%28DispatchedContinuation%5BDis...%22&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) for `22.4-rc-1`.

> **Note** To reviewers
> Would love your input on steps 2 & 3 from below. Please don't merge, I will handle the merge after collecting more input.

## To Test

1. **Verify** local draft posts and pages are uploaded
2. **Review** thoroughly the code changes and [this unit test](https://github.com/wordpress-mobile/WordPress-Android/pull/18449/files#diff-ac70facd6149acaa6c5c582c70cdcb36b7150a4422586cc0bfe291de429258d3R215-R235)
3. **Brainstorm** what other tests / ideas I could try
4. **Verify** CI unit tests job succeeded

## Regression Notes
1. Potential unintended areas of impact
   Offline posts and pages upload

7. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing and unit testing

8. What automated tests I added (or what prevented me from doing so)
   Unit tests for the updated code

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] UI Changes testing checklist: n/a
