### PR TITLE
[Pages] Track virtual homepage actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -206,12 +206,10 @@ sealed class PageItem(open val type: Type) {
                 }
             }
 
-            class OpenExternalLink(
-                val url: String = TEMPLATE_SUPPORT_URL
+            sealed class OpenExternalLink(
+                val url: String
             ) : Action() {
-                companion object {
-                    const val TEMPLATE_SUPPORT_URL = "https://wordpress.com/support/templates/"
-                }
+                object TemplateSupport : OpenExternalLink("https://wordpress.com/support/templates/")
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.ParentPage
 import org.wordpress.android.ui.pages.PageItem.VirtualHomepage
+import org.wordpress.android.ui.pages.PageItem.VirtualHomepage.Action
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.DateTimeUtils
@@ -292,7 +293,7 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
 
     class VirtualHomepageViewHolder(
         parentView: ViewGroup,
-        private val onAction: (VirtualHomepage.Action) -> Unit,
+        private val onAction: (Action) -> Unit,
     ) : PageItemViewHolder(parentView, R.layout.page_virtual_homepage_item) {
         private val pageItemContainer = itemView.findViewById<ViewGroup>(R.id.page_item)
         private val pageItemInfo = itemView.findViewById<ImageButton>(R.id.page_info_icon)
@@ -300,10 +301,10 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
         override fun onBind(pageItem: PageItem) {
             itemView.setOnClickListener {
                 QuickStartUtils.removeQuickStartFocusPoint(pageItemContainer)
-                onAction(VirtualHomepage.Action.OpenSiteEditor())
+                onAction(Action.OpenSiteEditor())
             }
             pageItemInfo.setOnClickListener {
-                onAction(VirtualHomepage.Action.OpenExternalLink())
+                onAction(Action.OpenExternalLink.TemplateSupport)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.pages.PageItem.Divider
 import org.wordpress.android.ui.pages.PageItem.Empty
 import org.wordpress.android.ui.pages.PageItem.Page
 import org.wordpress.android.ui.pages.PageItem.ParentPage
-import org.wordpress.android.ui.pages.PageItem.VirtualHomepage
 import org.wordpress.android.ui.pages.PageItem.VirtualHomepage.Action
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.utils.UiHelpers

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -739,6 +739,7 @@ class PagesViewModel
     }
 
     fun onVirtualHomepageAction(action: VirtualHomepage.Action) {
+        trackVirtualHomepageAction(action)
         when (action) {
             is VirtualHomepage.Action.OpenExternalLink -> {
                 _openExternalLink.postValue(action.url)
@@ -754,6 +755,16 @@ class PagesViewModel
                 )
             }
         }.exhaustive
+    }
+
+    private fun trackVirtualHomepageAction(action: VirtualHomepage.Action) {
+        val stat = when (action) {
+            VirtualHomepage.Action.OpenExternalLink.TemplateSupport ->
+                AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_INFO_PRESSED
+
+            is VirtualHomepage.Action.OpenSiteEditor -> AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_ITEM_PRESSED
+        }
+        analyticsTracker.track(stat, site)
     }
 
     fun onNewPageButtonTapped() {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
@@ -57,6 +58,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.DONE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListState.FETCHING
@@ -86,6 +88,9 @@ class PagesViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var networkUtils: NetworkUtilsWrapper
+
+    @Mock
+    lateinit var analyticsTracker: AnalyticsTrackerWrapper
 
     @Mock
     lateinit var uploadStarter: UploadStarter
@@ -142,7 +147,7 @@ class PagesViewModelTest : BaseUnitTest() {
             actionPerformer = actionPerformer,
             networkUtils = networkUtils,
             previewStateHelper = mock(),
-            analyticsTracker = mock(),
+            analyticsTracker = analyticsTracker,
             uploadStatusTracker = mock(),
             autoSaveConflictResolver = mock(),
             uiDispatcher = testDispatcher(),
@@ -626,7 +631,7 @@ class PagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when OpenSiteEditor action requested,then openSiteEditorWebView is set correctly for wpcom`() = test {
+    fun `when OpenSiteEditor action requested, then openSiteEditorWebView is set correctly for wpcom`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         whenever(site.adminUrl).thenReturn("https://example.com/wp-admin/")
@@ -647,7 +652,7 @@ class PagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when OpenSiteEditor action requested,then openSiteEditorWebView is set correctly for wpcom atomic`() = test {
+    fun `when OpenSiteEditor action requested, then openSiteEditorWebView is set correctly for wpcom atomic`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         whenever(site.adminUrl).thenReturn("https://example.com/wp-admin/")
@@ -669,7 +674,7 @@ class PagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when OpenSiteEditor action requested,then openSiteEditorWebView is set correctly for self-hosted`() = test {
+    fun `when OpenSiteEditor action requested, then openSiteEditorWebView is set correctly for self-hosted`() = test {
         // Arrange
         setUpPageStoreWithEmptyPages()
         whenever(site.adminUrl).thenReturn("https://example.com/wp-admin/")
@@ -691,13 +696,48 @@ class PagesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when OpenExternalLink action requested,then openExternalLink is set correctly`() = test {
+    fun `when OpenExternalLink action requested, then openExternalLink is set correctly`() = test {
+        // Arrange
+        setUpPageStoreWithEmptyPages()
+        viewModel.start(site)
+
         // Act
-        val action = PageItem.VirtualHomepage.Action.OpenExternalLink()
+        val action = PageItem.VirtualHomepage.Action.OpenExternalLink.TemplateSupport
         viewModel.onVirtualHomepageAction(action)
 
         // Assert
-        val expected = PageItem.VirtualHomepage.Action.OpenExternalLink.TEMPLATE_SUPPORT_URL
-        assertThat(viewModel.openExternalLink.value).isEqualTo(expected)
+        assertThat(viewModel.openExternalLink.value).isEqualTo(action.url)
+    }
+
+    @Test
+    fun `when OpenSiteEditor action requested, then event is tracked`() = test {
+        // Arrange
+        setUpPageStoreWithEmptyPages()
+        whenever(site.adminUrl).thenReturn("https://example.com/wp-admin/")
+        whenever(site.isWPCom).thenReturn(true)
+        viewModel.start(site)
+
+        // Act
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        viewModel.onVirtualHomepageAction(action)
+
+        // Assert
+        val expected = AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_ITEM_PRESSED
+        verify(analyticsTracker).track(expected, site)
+    }
+
+    @Test
+    fun `when OpenExternalLink action requested, the event is tracked`() = test {
+        // Arrange
+        setUpPageStoreWithEmptyPages()
+        viewModel.start(site)
+
+        // Act
+        val action = PageItem.VirtualHomepage.Action.OpenExternalLink.TemplateSupport
+        viewModel.onVirtualHomepageAction(action)
+
+        // Assert
+        val expected = AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_INFO_PRESSED
+        verify(analyticsTracker).track(expected, site)
     }
 }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -448,6 +448,8 @@ public final class AnalyticsTracker {
         PAGES_TAB_PRESSED,
         PAGES_OPTIONS_PRESSED,
         PAGES_SEARCH_ACCESSED,
+        PAGES_EDIT_HOMEPAGE_INFO_PRESSED,
+        PAGES_EDIT_HOMEPAGE_ITEM_PRESSED,
         // This stat is part of a funnel that provides critical information.  Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         SIGNUP_BUTTON_TAPPED,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1315,6 +1315,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "site_pages_options_pressed";
             case PAGES_SEARCH_ACCESSED:
                 return "site_pages_search_accessed";
+            case PAGES_EDIT_HOMEPAGE_INFO_PRESSED:
+                return "site_pages_edit_homepage_info_pressed";
+            case PAGES_EDIT_HOMEPAGE_ITEM_PRESSED:
+                return "site_pages_edit_homepage_item_pressed";
             case SIGNUP_BUTTON_TAPPED:
                 // This stat is part of a funnel that provides critical information.  Before
                 // making ANY modification to this stat please refer to: p4qSXL-35X-p2


### PR DESCRIPTION
Part of #18371 

This implements tracking for the virtual homepage callbacks and actions:
- `site_pages_edit_homepage_item_pressed`
- `site_pages_edit_homepage_info_pressed`

## To test

Requirements:
- At least 1 site using a block-based theme, such as `Vetro`, with the homepage set to display "your latest posts" (on the web you can find it at `Appearance > Customize > Homepage Settings`

1. Login with your account
2. Select a site with a block-based theme
3. Go to `Debug Settings`
4. Enable the `SiteEditorMVPFeatureConfig`
5. Go to `App Setting`
6. Make sure data collection is enabled under `Privacy`
7. Go back to the `My Site` screen
8. Tap on `Pages`
9. **Verify** the "virtual" homepage item is shown
10. Tap the card
11. **Verify** the log: `🔵 Tracked: site_pages_edit_homepage_item_pressed` with site properties
12. Go back to the `Pages` screen
13. Tap the info icon
14. **Verify** the log: `🔵 Tracked: site_pages_edit_homepage_info_pressed` with site properties

## Regression Notes
1. Potential unintended areas of impact
Issues in the action behavior.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and confirm no unit test regression.

3. What automated tests I added (or what prevented me from doing so)
Added some unit tests for the tracking.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
**There were no UI changes, just analytics tracking.**
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
