### PR TITLE
[Site Editor] Add remote FF to SiteEditorMVP and default to on

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 22.5
 -----
-
+* [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [https://github.com/wordpress-mobile/WordPress-Android/pull/18454]
 
 22.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteEditorMVPFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteEditorMVPFeatureConfig.kt
@@ -1,13 +1,16 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val SITE_EDITOR_MVP_REMOTE_FIELD = "site_editor_mvp"
+
+@Feature(SITE_EDITOR_MVP_REMOTE_FIELD, true)
 class SiteEditorMVPFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
     appConfig,
     BuildConfig.SITE_EDITOR_MVP,
+    SITE_EDITOR_MVP_REMOTE_FIELD
 )


### PR DESCRIPTION
Fixes #18441 

Add remote field to Site Editor MVP FF (`site_editor_mvp`) and default it to ON.

Not ready for merge: we probably need to add something to the release notes.

To test:
Verify that on a clean install, the Site Editor MVP feature (virtual homepage item for block-based sites in the Pages List) is on by default. Also, check that the `site_editor_mvp` is available in the Debug Settings.

Instructions to test the feature itself can be found here: https://github.com/wordpress-mobile/WordPress-Android/pull/18436

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] N/A UI Changes testing checklist
