### PR TITLE
Add unit tests for the account closure feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -15,9 +15,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient
 import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult
-import org.wordpress.android.fluxc.network.rest.wpcom.account.closeAccount
 import org.wordpress.android.fluxc.store.AccountStore.AccountError
 import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType.SETTINGS_FETCH_GENERIC_ERROR
 import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType.SETTINGS_FETCH_REAUTHORIZATION_REQUIRED_ERROR
@@ -30,6 +28,7 @@ import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.A
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Error
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Default
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Success
+import org.wordpress.android.ui.prefs.accountsettings.usecase.AccountClosureUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.FetchAccountSettingsUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetAccountUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetSitesUseCase
@@ -56,7 +55,7 @@ class AccountSettingsViewModel @Inject constructor(
     private val getAccountUseCase: GetAccountUseCase,
     private val getSitesUseCase: GetSitesUseCase,
     private val optimisticUpdateHandler: AccountSettingsOptimisticUpdateHandler,
-    private val accountRestClient: AccountRestClient,
+    private val accountClosureUseCase: AccountClosureUseCase,
 ) : ScopedViewModel(mainDispatcher) {
     private var fetchNewSettingsJob: Job? = null
     private var _accountSettingsUiState = MutableStateFlow(getAccountSettingsUiState(true))
@@ -334,7 +333,7 @@ class AccountSettingsViewModel @Inject constructor(
             _accountClosureUiState.value = uiState.copy(isPending = true)
 
             launch {
-                accountRestClient.closeAccount(
+                accountClosureUseCase.closeAccount(
                     onResult = {
                         when(it) {
                             is CloseAccountResult.Success -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/AccountClosureUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/usecase/AccountClosureUseCase.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.ui.prefs.accountsettings.usecase
+
+import org.wordpress.android.fluxc.network.rest.wpcom.account.AccountRestClient
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult
+import org.wordpress.android.fluxc.network.rest.wpcom.account.closeAccount
+import javax.inject.Inject
+
+class AccountClosureUseCase @Inject constructor(
+    private val accountRestClient: AccountRestClient,
+) {
+    fun closeAccount(onResult: (CloseAccountResult) -> Unit) = accountRestClient.closeAccount(onResult)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
@@ -54,6 +54,9 @@ class AccountSettingsViewModelTest : BaseUnitTest() {
     @Mock
     private lateinit var account: AccountModel
 
+    @Mock
+    lateinit var accountClosureUseCase: AccountClosureUseCase
+
     private val siteViewModels = mutableListOf<SiteUiModel>().apply {
         add(SiteUiModel("HappyDay", 1L, "http://happyday.wordpress.com"))
         add(SiteUiModel("WonderLand", 2L, "http://wonderland.wordpress.com"))
@@ -443,7 +446,7 @@ class AccountSettingsViewModelTest : BaseUnitTest() {
             getAccountUseCase,
             getSitesUseCase,
             optimisticUpdateHandler,
-            mock(),
+            accountClosureUseCase,
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.accountsettings
 
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -8,17 +9,21 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R.string
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.account.CloseAccountResult
 import org.wordpress.android.fluxc.store.AccountStore.AccountError
 import org.wordpress.android.fluxc.store.AccountStore.AccountErrorType.GENERIC_ERROR
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountSettingsUiState
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.SiteUiModel
+import org.wordpress.android.ui.prefs.accountsettings.usecase.AccountClosureUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.FetchAccountSettingsUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetAccountUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.GetSitesUseCase
@@ -410,6 +415,31 @@ class AccountSettingsViewModelTest : BaseUnitTest() {
                 .isEqualTo(false)
         }
 
+    @Test
+    fun `When account closure succeeds, then the closure dialog should be in the success state`() = test {
+        mockAccountClosureWithResult(CloseAccountResult.Success)
+        viewModel.closeAccount()
+        assertTrue(viewModel.accountClosureUiState.value is AccountClosureUiState.Opened.Success)
+    }
+
+    @Test
+    fun `When account closure fails, then the closure dialog should be in the error state`() = test {
+        mockAccountClosureWithResult(CloseAccountResult.Failure(CloseAccountResult.Error(
+            CloseAccountResult.ErrorType.UNKNOWN,
+            "unknown",
+        )))
+        viewModel.closeAccount()
+        assertTrue(viewModel.accountClosureUiState.value is AccountClosureUiState.Opened.Error)
+    }
+
+    @Test
+    fun `When there is an Atomic site, then the closure dialog should open in the error state`() = test {
+        val mockAtomicSite: SiteModel = mock()
+        whenever(getSitesUseCase.getAtomic()).thenReturn(listOf(mockAtomicSite))
+        viewModel.openAccountClosureDialog()
+        assertTrue(viewModel.accountClosureUiState.value is AccountClosureUiState.Opened.Error)
+    }
+
     // Helper Methods
     private fun <T> testUiStateChanges(
         block: suspend CoroutineScope.() -> T
@@ -448,6 +478,15 @@ class AccountSettingsViewModelTest : BaseUnitTest() {
             optimisticUpdateHandler,
             accountClosureUseCase,
         )
+    }
+
+    private suspend fun mockAccountClosureWithResult(result: CloseAccountResult) {
+        whenever(getSitesUseCase.getAtomic()).thenReturn(emptyList())
+        whenever(accountClosureUseCase.closeAccount(any())).thenAnswer {
+            val completion = it.getArgument<((CloseAccountResult) -> Unit)>(0)
+            completion.invoke(result)
+        }
+        viewModel.openAccountClosureDialog()
     }
 
     private suspend fun mockSites(siteViewModels: List<SiteUiModel>) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModelTest.kt
@@ -80,7 +80,7 @@ class AccountSettingsViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `The initial primarysite is shown from cached account settings`() = test {
+    fun `The initial primary site is shown from cached account settings`() = test {
         uiState.primarySiteSettingsUiState.primarySite?.siteId?.let {
             assertThat(it).isEqualTo(getAccountUseCase.account.primarySiteId)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/GetSitesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/GetSitesUseCaseTest.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.prefs.accountsettings.usecase.GetSitesUseCase
 
 @ExperimentalCoroutinesApi
 class GetSitesUseCaseTest: BaseUnitTest() {
-
     private lateinit var useCase: GetSitesUseCase
 
     @Mock

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/GetSitesUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/accountsettings/GetSitesUseCaseTest.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.prefs.accountsettings
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.prefs.accountsettings.usecase.GetSitesUseCase
+
+@ExperimentalCoroutinesApi
+class GetSitesUseCaseTest: BaseUnitTest() {
+
+    private lateinit var useCase: GetSitesUseCase
+
+    @Mock
+    private lateinit var siteStore: SiteStore
+
+    val mockAtomicSite: SiteModel = mock()
+    val mockNonAtomicSite: SiteModel = mock()
+
+    @Before
+    fun setUp() = test {
+        useCase = GetSitesUseCase(
+            testDispatcher(),
+            siteStore,
+        )
+        whenever(mockAtomicSite.isWPComAtomic).thenReturn(true)
+        whenever(mockNonAtomicSite.isWPComAtomic).thenReturn(false)
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(listOf(
+            mockAtomicSite,
+            mockNonAtomicSite,
+        ))
+    }
+
+    @Test
+    fun `getAtomic filters for Atomic sites`() {
+        test {
+            val atomicSites = useCase.getAtomic()
+            assertThat(atomicSites.size).isEqualTo(1)
+            assertThat(atomicSites.first()).isEqualTo(mockAtomicSite)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #18456

To test:

Verify that the unit tests pass on CI.

## Regression Notes
1. Potential unintended areas of impact
Other nearby unit tests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing automated tests.

3. What automated tests I added (or what prevented me from doing so)
This PR adds unit tests for the account closure feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.