### PR TITLE
Merge 22.4 editorialized release notes to trunk

### DIFF
--- a/WordPress/jetpack_metadata/PlayStoreStrings.po
+++ b/WordPress/jetpack_metadata/PlayStoreStrings.po
@@ -15,7 +15,7 @@ msgid ""
 "22.4:\n"
 "- Added dashboard cards for Activity Log and Pages\n"
 "- Removed ability to convert deleted/undefined reusable blocks to regular blocks\n"
-"- Updated nested blocks to allow immediate editing without tapping through nested levels\n"
+"- Updated nested text blocks for faster editing without tapping through nested levels\n"
 "- Corrected “editing not supported” message in reusable blocks\n"
 msgstr ""
 

--- a/WordPress/jetpack_metadata/release_notes.txt
+++ b/WordPress/jetpack_metadata/release_notes.txt
@@ -1,4 +1,4 @@
 - Added dashboard cards for Activity Log and Pages
 - Removed ability to convert deleted/undefined reusable blocks to regular blocks
-- Updated nested blocks to allow immediate editing without tapping through nested levels
+- Updated nested text blocks for faster editing without tapping through nested levels
 - Corrected “editing not supported” message in reusable blocks

--- a/WordPress/metadata/PlayStoreStrings.po
+++ b/WordPress/metadata/PlayStoreStrings.po
@@ -13,7 +13,7 @@ msgstr ""
 msgctxt "release_note_224"
 msgid ""
 "22.4:\n"
-"When you tap on a nested block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)\n"
+"When you tap on a nested text block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)\n"
 msgstr ""
 
 msgctxt "release_note_223"

--- a/WordPress/metadata/release_notes.txt
+++ b/WordPress/metadata/release_notes.txt
@@ -1,1 +1,1 @@
-When you tap on a nested block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)
+When you tap on a nested text block, you can immediately edit content in that block—no more tapping through every nesting level to get where you want to go. (Our fingers were getting tired, too.)


### PR DESCRIPTION
Note that this is the second editorialized release notes PR for 22.4, #18443 being the first one. This was necessary because there was a request to update the release notes after we already merged #18443.
