### PR TITLE
[UI Tests] Disabled `e2eDomainsCardNavigation`.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.e2e
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assume.assumeTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -21,6 +22,7 @@ class DashboardTests : BaseTest() {
     }
 
     @Test
+    @Ignore("Skipped due to increased flakiness. Test fails to scroll to the card.")
     fun e2eDomainsCardNavigation() {
         MySitesPage()
             .scrollToDomainsCard()


### PR DESCRIPTION
### Description

Similar to four tests disabled in #18446, `e2eDomainsCardNavigation` [fails](https://console.firebase.google.com/u/0/project/api-project-108380595987/testlab/histories/bh.3ce77db975c1f0c9/matrices/7613024940819156843/details?stepId=bs.3b0c25d3c9f6ff0d&testCaseId=20) because Espresso fails to scroll to the card. So far, I have no ideas for a workaround, since the fail does not occur locally. I'm disabling the test. 

Hopefully, finding a fix/workaround will mean enabling all 5 tests back, because the reason of their fail is the same.

### To test
- Instrumented tests are 🟢 on FTL.