### PR TITLE
Adds domain registration card on dashboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -820,7 +820,6 @@ class MySiteViewModel @Inject constructor(
             if (defaultTab == MySiteTabType.SITE_MENU) {
                 add(Type.QUICK_START_CARD)
             }
-            add(Type.DOMAIN_REGISTRATION_CARD)
             add(Type.QUICK_ACTIONS_CARD)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -814,6 +814,7 @@ class MySiteViewModel @Inject constructor(
             }
             add(Type.QUICK_LINK_RIBBON)
             add(Type.JETPACK_INSTALL_FULL_PLUGIN_CARD)
+            add(Type.DOMAIN_REGISTRATION_CARD)
         }
 
         MySiteTabType.DASHBOARD -> mutableListOf<Type>().apply {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2970,7 +2970,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site with domain credit, when site menu cards and items, then domain reg card does not exist`() {
+    fun `given selected site with domain credit, when site menu cards and items, then domain reg card doesn't exist`() {
         initSelectedSite()
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2970,13 +2970,13 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site with domain credit, when site menu cards and items, then domain reg card exists`() {
+    fun `given selected site with domain credit, when site menu cards and items, then domain reg card does not exist`() {
         initSelectedSite()
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
         val items = (uiModels.last().state as SiteSelected).siteMenuCardsAndItems
 
-        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isNotEmpty
+        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isEmpty()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -2960,13 +2960,13 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given selected site with domain credit, when dashboard cards + items, then domain reg card does not exist`() {
+    fun `given selected site with domain credit, when dashboard cards + items, then domain reg card exists`() {
         initSelectedSite()
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
         val items = (uiModels.last().state as SiteSelected).dashboardCardsAndItems
 
-        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isEmpty()
+        assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isNotEmpty
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds domain registration prompt on the dashboard/home (internal ref: p1684238476616049-slack-C04M1NX8YCR)

|Before|After|
|---|---|
|![Screenshot_20230518_191620](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/6d37179a-c3a3-4182-9059-995281173b93)|![Screenshot_20230518_192158](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/79916276-ce6f-45c8-b685-f709e7ca0765)|

## To test:
1. Launch the app
2. Login with an account that has a site with domain credit
3. Select site with domain credit from the login epilogue view
4. **Verify** that the domain registration card is visible on the dashboard

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and relied on existing tests

6. What automated tests I added (or what prevented me from doing so)
I updated an existing test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)