### PR TITLE
Fix stale height issue in account closure dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -333,18 +333,17 @@ class AccountSettingsViewModel @Inject constructor(
             _accountClosureUiState.value = uiState.copy(isPending = true)
 
             launch {
-                accountClosureUseCase.closeAccount(
-                    onResult = {
-                        when(it) {
-                            is CloseAccountResult.Success -> {
-                                _accountClosureUiState.value = Success
-                            }
-                            is CloseAccountResult.Failure -> {
-                                _accountClosureUiState.value = Error(it.error.errorType)
-                            }
+                accountClosureUseCase.closeAccount { result ->
+                    when (result) {
+                        is CloseAccountResult.Success -> {
+                            _accountClosureUiState.value = Success
+                        }
+
+                        is CloseAccountResult.Failure -> {
+                            _accountClosureUiState.value = Error(result.error.errorType)
                         }
                     }
-                )
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -4,23 +4,33 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun AccountClosureDialog(
     onDismissRequest: () -> Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val padding = 10.dp
-    Dialog(onDismissRequest = onDismissRequest) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
         Column(
             modifier = Modifier
+                .widthIn(max = 320.dp)
                 .clip(shape = RoundedCornerShape(padding))
                 .background(MaterialTheme.colors.background)
                 .padding(padding),

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -2,11 +2,13 @@ package org.wordpress.android.ui.prefs.accountsettings.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.Companion.AccountClosureAction.ACCOUNT_CLOSED
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.Companion.AccountClosureAction.HELP_VIEWED
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
     val uiState = viewModel.accountClosureUiState.collectAsState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/DialogUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/DialogUi.kt
@@ -56,6 +56,7 @@ fun DialogUi(
             .focusRequester(focusRequester),
         value = username,
         onValueChange = { username = it },
+        enabled = !isPending,
     )
     Row(
         modifier = Modifier

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/DialogUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/DialogUi.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -92,6 +93,7 @@ fun DialogUi(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Preview
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable


### PR DESCRIPTION
Fixes #18468, #18469

### Description

This PR fixes a stale height issue in the success dialog of the account closure flow. It also makes a minor enhancement by disabling the username text input while the closure is in the pending state.

To test:

To make testing easier, it can be useful to apply the following patch, which will make account closure "fake". This makes it easier to try the flow multiple times without the need to keep creating and destroying accounts.

<details>
<summary>Fake closure patch</summary>

```patch
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
index 420f6f3ca0..c087f69693 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -333,17 +334,20 @@ class AccountSettingsViewModel @Inject constructor(
             _accountClosureUiState.value = uiState.copy(isPending = true)
 
             launch {
-                accountClosureUseCase.closeAccount { result ->
-                    when (result) {
-                        is CloseAccountResult.Success -> {
-                            _accountClosureUiState.value = Success
-                        }
-
-                        is CloseAccountResult.Failure -> {
-                            _accountClosureUiState.value = Error(result.error.errorType)
-                        }
-                    }
-                }
+                delay(5000)
+                _accountClosureUiState.value = Success
+
+//                accountClosureUseCase.closeAccount { result ->
+//                    when (result) {
+//                        is CloseAccountResult.Success -> {
+//                            _accountClosureUiState.value = Success
+//                        }
+//
+//                        is CloseAccountResult.Failure -> {
+//                            _accountClosureUiState.value = Error(result.error.errorType)
+//                        }
+//                    }
+//                }
             }
         }
     }
diff --git a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
index 43f742a29d..5652c24e93 100644
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -35,7 +35,8 @@ fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
                     it.errorType,
                 )
                 is Opened.Success -> DialogSuccessUi(
-                    onDismissRequest = { viewModel.userAction(ACCOUNT_CLOSED) }
+//                    onDismissRequest = { viewModel.userAction(ACCOUNT_CLOSED) }
+                    onDismissRequest = { viewModel.dismissAccountClosureDialog() },
                 )
             }
         }
```

</details>

1. Create or login with a disposable account (or any account without active purchases or Atomic sites)
2. Navigate to the account settings (Me :arrow_right: Account Settings)
3. Tap "Close Account"
4. Expect that a dialog is displayed requesting the user to type their username for confirmation
5. Enter the username
6. Expect a the dialog to go into a pending state briefly (spinner), and that the username input field becomes disabled
7. Expect a success dialog is displayed with an Ok button
8. Expect that the success dialog has a height that fits the contents (i.e. it should be shorter)

## Regression Notes
1. Potential unintended areas of impact
Closure dialog behavior

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

5. What automated tests I added (or what prevented me from doing so)
Adding UI tests for this task is out of scope

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

