### PR TITLE
Fixes: Null pointer crash on blaze parent activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/ui/blazeoverlay/BlazeViewModel.kt
@@ -51,10 +51,11 @@ class BlazeViewModel @Inject constructor(
     private fun initializePromotePostUIState(postModel: PostUIModel) {
         val updatedPostModel = postModel.copy(
             url = UrlUtils.removeScheme(postModel.url),
-            featuredImageUrl = featuredImageTracker.getFeaturedImageUrl(
-                siteSelectedSiteRepository.getSelectedSite()!!,
-                postModel.featuredImageId
-            )
+            featuredImageUrl = siteSelectedSiteRepository.getSelectedSite()?.let {
+                featuredImageTracker.getFeaturedImageUrl(
+                    it,
+                    postModel.featuredImageId)
+            }
         )
         _uiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
         _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.blaze
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.store.MediaStore
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
+import org.wordpress.android.ui.blaze.BlazeFlowSource
+import org.wordpress.android.ui.blaze.PostUIModel
+import org.wordpress.android.ui.blaze.ui.blazeoverlay.BlazeViewModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class BlazeViewModelTest : BaseUnitTest() {
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var blazeFeatureUtils: BlazeFeatureUtils
+
+    @Mock
+    lateinit var mediaStore: MediaStore
+
+    @Mock
+    private lateinit var dispatcher: Dispatcher
+
+    private lateinit var blazeViewModel: BlazeViewModel
+
+    @Before
+    fun setUp() {
+        blazeViewModel = BlazeViewModel(
+            blazeFeatureUtils,
+            dispatcher,
+            mediaStore,
+            selectedSiteRepository
+        )
+    }
+
+    @Test
+    fun `given getSelectedSite is null, when xx, then exception`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+        val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
+            url = "url", featuredImageUrl = "featuredImageUrl"
+        )
+        val result = blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+
+
+        Assertions.assertThat(result).isNotNull
+    }
+}


### PR DESCRIPTION
## Related Issue 
#18462

## Description 
This PR fixes the crash on Blaze parent activity when the selected site is null


## Explanation of changes 
- Add null check on BlazeViewModel 
- Adds missing Unit test class `BlazeViewModelTest`

## To test:
- Make sure that the unit tests in `BlazeViewModelTest` pass
- Regression testing - Make sure that Blaze flow works as expected

## Regression Notes
1. Potential unintended areas of impact
Blaze flow doesn't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)