### PR TITLE
Fixes: No Such element exception in Pages Dashboard Card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilder.kt
@@ -41,7 +41,7 @@ class PagesCardBuilder @Inject constructor(
     private fun convertToPagesItems(params: PagesCardBuilderParams): PagesCard.PagesCardWithData {
         val pages = params.pageCard?.pages
         val content =
-            pages?.filterByPagesCardSupportedStatus()?.let { getPagesContentItems(pages, params.onPagesItemClick) }
+            pages?.filterByPagesCardSupportedStatus()?.let { getPagesContentItems(it, params.onPagesItemClick) }
                 ?: emptyList()
         val createPageCard = getCreatePageCard(content, params.onFooterLinkClick)
         return PagesCard.PagesCardWithData(
@@ -52,7 +52,7 @@ class PagesCardBuilder @Inject constructor(
     }
 
     private fun List<PagesCardModel.PageCardModel>.filterByPagesCardSupportedStatus() =
-        this.filter { it.status in PagesCardContentType.getList() }
+        this.filter { it.status.lowercase() in PagesCardContentType.getList() }
 
     private fun getPagesContentItems(
         pages: List<PagesCardModel.PageCardModel>,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardContentType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardContentType.kt
@@ -9,7 +9,7 @@ enum class PagesCardContentType(val status: String) {
     companion object {
         fun getList(): List<String> {
             return values().map {
-                it.toString()
+                it.status
             }
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardBuilderTest.kt
@@ -18,10 +18,12 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.DashboardCardPagesConfig
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 const val PAGE_STATUS_PUBLISH = "publish"
 const val PAGE_STATUS_DRAFT = "draft"
 const val PAGE_STATUS_SCHEDULED = "future"
+const val PAGE_STATUS_DELETED = "deleted"
 
 const val PAGE_ID = 1
 const val PAGE_TITLE = "title"
@@ -42,6 +44,8 @@ private val PAGE_MODEL_PUBLISHED = PagesCardModel.PageCardModel(
 private val PAGE_MODEL_DRAFT = PAGE_MODEL_PUBLISHED.copy(id = 2, status = PAGE_STATUS_DRAFT)
 
 private val PAGE_MODEL_SCHEDULED = PAGE_MODEL_PUBLISHED.copy(id = 3, status = PAGE_STATUS_SCHEDULED)
+
+private val PAGE_MODEL_DELETED = PAGE_MODEL_PUBLISHED.copy(id = 3, status = PAGE_STATUS_DELETED)
 
 // pages with one item
 private val PAGES_MODEL = PagesCardModel(
@@ -100,6 +104,15 @@ class PagesCardBuilderTest : BaseUnitTest() {
         val result = builder.build(params) as PagesCardWithData
 
         assert(result.pages.isEmpty())
+    }
+
+    @Test
+    fun `given a page with unknown status, when card is built, then no pages item is present`() {
+        val params = getPagesBuildParams(PagesCardModel(pages = listOf(PAGE_MODEL_DELETED)))
+
+        val result = builder.build(params) as PagesCardWithData
+
+        assertTrue(result.pages.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Related issue 
#18472

## Description 
This PR 
- udpdates the filtering logic in `PagesCardBuilder`
- adds test for incorrect status from BE 

## To test:
- Make sure that pages card are shown as expected 
- Make sure that there is no crash on dashboard 
- Make sure that unit tests in `PagesCardBuilderTest` pass 

## Regression Notes
1. Potential unintended areas of impact
Pages card are not shown on dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unti testing 

3. What automated tests I added (or what prevented me from doing so)
N/A


PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)