### PR TITLE
[Gutenberg] Upgrade Android 13

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 22.6
 -----
 
+* [*] [internal] Block editor: Upgrade Android 13 [https://github.com/wordpress-mobile/WordPress-Android/pull/18477]
 
 22.5
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.96.0'
+    gutenbergMobileVersion = '5789-ec7dd0a5524b6e37bbc082ffbe1d3b9b791ee163'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5789-ec7dd0a5524b6e37bbc082ffbe1d3b9b791ee163'
+    gutenbergMobileVersion = 'v1.97.0-alpha1'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.96.0'
-    wordPressAztecVersion = 'v1.6.3'
+    wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5556.

**Related PRs:**
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/5789
* https://github.com/WordPress/gutenberg/pull/50731

This PR incorporates a new version of Gutenberg Mobile which contain the upgrade Android 13. Additionally, in order to match the Aztec version between GB-Mobile and WPAndroid, the Aztec version has been updated too.

**To test:**
This change doesn't affect a specific area, hence to test it we should basically smoke test the editor and check that works as expected. We could also cover [the writing flow test cases](https://github.com/wordpress-mobile/test-cases/tree/trunk/test-cases/gutenberg/writing-flow) to ensure the basic actions of the editor work:

<details><summary>Click here to display testing instructions</summary>

#### General
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/copy-paste.md#tc001) - Paste formatted text copied from website
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/multiline-components.md#tc001) - Multiline components
  - [ ] Quote block
  - [ ] Verse block
  - [ ] Preformatted block
  - [ ] Code block (DEV only)
  - [ ] Pullquote block
#### Rich Text Format
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Bold, Italic, strikethrough buttons
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Highlight selected text
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc001) - Highlight text without selection
- [ ] [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc002) - Alignment buttons
- [ ] [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc003) - Alignment Split
- [ ] [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc004) - Link button works without selection
- [ ] [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc005) - Link button works with a selected word
- [ ] [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc006) - Adding a link from a copied URL
- [ ] [TC007](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc007) - Test format detection under the cursor
- [ ] [TC008](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc008) - Test formatting doesn't remove leading or trailing whitespace
- [ ] [TC009](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc009) - Test autocorrection doesn't apply formatting to Heading
- [ ] [TC010](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/rich-text-formatting.md#tc010) - Test autocorrection doesn't remove formatting from Heading
##### Splitting and merging
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc001) - Merge after writing
  - [ ] Paragraph
  - [ ] Heading
- [ ] [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc002) - Merge after selection
  - [ ] Paragraph
  - [ ] Heading
- [ ] [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc003) - Merge after deleting text
  - [ ] Paragraph
  - [ ] Heading
- [ ] [TC004](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc004) - Merge after deleting all
  - [ ] Paragraph
  - [ ] Heading
- [ ] [TC005](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc005) - Merge multiple blocks
  - [ ] Paragraph
  - [ ] Heading
- [ ] [TC006](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/splitting-merging.md#tc006) - Splitting/merge list block
#### Undo / Redo - Test Cases
- [ ] [TC001](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/undo-redo.md#tc001) - Undo/redo block actions
- [ ] [TC002](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/undo-redo.md#tc002) - Undo/redo text
- [ ] [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/writing-flow/undo-redo.md#tc003) - Undo/redo text format

</details> 


## Regression Notes
1. Potential unintended areas of impact
The classic editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
