### PR TITLE
[UI Tests] Roll back to `Pixel2.arm API 30` & enable 5 UI tests.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
@@ -29,7 +29,6 @@ class BlockEditorTests : BaseTest() {
 """
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2ePublishSimplePost() {
         val title = "publishSimplePost"
         MySitesPage()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.e2e
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -22,7 +21,6 @@ class DashboardTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. Test fails to scroll to the card.")
     fun e2eDomainsCardNavigation() {
         MySitesPage()
             .scrollToDomainsCard()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.ReaderPage
 import org.wordpress.android.support.BaseTest
@@ -17,7 +16,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eNavigateThroughPosts() {
         ReaderPage()
             .tapFollowingTab()
@@ -31,7 +29,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eLikePost() {
         ReaderPage()
             .tapFollowingTab()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -39,7 +38,6 @@ class StatsTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 32,
+      version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',


### PR DESCRIPTION
### Description

Approximately on 17 of May, a consistent subset of the Instrumented UI Tests started to fail on FTL. In all cases, the fail was caused either by the inability to scroll to an element (scroll to a post, scroll to a Stats card), or to swipe away an element (e.g. to remove a blogging reminders prompt). This was not reproducible locally. I disabled these 5 tests with #18446 and #18464 back then.

After some time, I realized that we use `Pixel2.arm API 32` for WP/JP Android, and for WCAndroid, we still use `Pixel2.arm API 30`, and the scrolling/swiping related issues do not occur to WCA.

With this PR, I enable back the 5 disabled tests, and also roll back to using `Pixel2.arm API 30`.

P.S. Firebase mentioned an [API32-affecting incident](https://status.firebase.google.com/incidents/A8YnQHg4k6rfxW4jWgnx) that took place on 18 May, and according to them, the issue is already solved, however, the tests still fail for us on FTL, if we use API 32.

### To Test
- CI in this PR is 🟢 
- First and third commits of [this dedicated testing PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18483/commits) pass (where `API 30` is used), and the second commit fails (where `API 32` is used).