### PR TITLE
[UI Tests] POC: Roll back to Pixel2.arm API 30 for Instrumented Tests

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
@@ -29,7 +29,6 @@ class BlockEditorTests : BaseTest() {
 """
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2ePublishSimplePost() {
         val title = "publishSimplePost"
         MySitesPage()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.e2e
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -22,7 +21,6 @@ class DashboardTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. Test fails to scroll to the card.")
     fun e2eDomainsCardNavigation() {
         MySitesPage()
             .scrollToDomainsCard()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.ReaderPage
 import org.wordpress.android.support.BaseTest
@@ -17,7 +16,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eNavigateThroughPosts() {
         ReaderPage()
             .tapFollowingTab()
@@ -31,7 +29,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eLikePost() {
         ReaderPage()
             .tapFollowingTab()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -39,7 +38,6 @@ class StatsTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 32,
+      version: 30,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',

--- a/fastlane/lanes/test.rb
+++ b/fastlane/lanes/test.rb
@@ -28,7 +28,7 @@ platform :android do
       project_id: firebase_secret(name: 'project_id'),
       key_file: GOOGLE_FIREBASE_SECRETS_PATH,
       model: 'Pixel2.arm',
-      version: 30,
+      version: 32,
       test_apk_path: File.join(apk_dir, 'androidTest', "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug-androidTest.apk"),
       apk_path: File.join(apk_dir, "#{app}Vanilla", 'debug', "org.wordpress.android-#{app}-vanilla-debug.apk"),
       test_targets: 'notPackage org.wordpress.android.ui.screenshots',


### PR DESCRIPTION
This is a testing PR. See #18482.