### PR TITLE
[Jetpack Social] Implement Twitter deprecation notice container on Details screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -18,11 +18,16 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.models.PublicizeService.Status;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
+import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.util.ToastUtils;
 
 import javax.inject.Inject;
+
+import static org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeConstantsKt.TWITTER_DEPRECATION_FIND_OUT_MORE_URL;
+
+import kotlin.Unit;
 
 public class PublicizeDetailFragment extends PublicizeBaseFragment
         implements PublicizeConnectionAdapter.OnAdapterLoadedListener {
@@ -36,6 +41,8 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
     private View mConnectionsContainer;
     private ViewGroup mServiceContainer;
     private View mNestedScrollView;
+    private PublicizeTwitterDeprecationNoticeWarningView mTwitterDeprecationNoticeWarningContainer;
+    private TextView mConnectedAccounts;
 
     @Inject AccountStore mAccountStore;
 
@@ -87,6 +94,9 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
         mConnectBtn = mServiceContainer.findViewById(R.id.button_connect);
         mRecycler = rootView.findViewById(R.id.recycler_view);
         mNestedScrollView = rootView.findViewById(R.id.publicize_details_nested_scroll_View);
+        mTwitterDeprecationNoticeWarningContainer =
+                rootView.findViewById(R.id.publicize_twitter_deprecation_notice_detail_warning);
+        mConnectedAccounts = rootView.findViewById(R.id.connected_accounts);
 
         return rootView;
     }
@@ -117,7 +127,14 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
         // disable the ability to add another G+ or Twitter connection
         if (isGooglePlus() || isTwitterUnsupported()) {
             mServiceContainer.setVisibility(View.GONE);
+            if (isTwitterUnsupported()) {
+                showTwitterDeprecationContainer();
+            } else {
+                mTwitterDeprecationNoticeWarningContainer.setVisibility(View.GONE);
+            }
         } else {
+            mTwitterDeprecationNoticeWarningContainer.setVisibility(View.GONE);
+            mConnectedAccounts.setVisibility(View.VISIBLE);
             mServiceContainer.setVisibility(View.VISIBLE);
             String serviceLabel = String.format(getString(R.string.connection_service_label), mService.getLabel());
             TextView txtService = mServiceContainer.findViewById(R.id.text_service);
@@ -136,6 +153,19 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
 
         mRecycler.setAdapter(adapter);
         adapter.refresh();
+    }
+
+    private void showTwitterDeprecationContainer() {
+        mConnectedAccounts.setVisibility(View.GONE);
+        mTwitterDeprecationNoticeWarningContainer.setVisibility(View.VISIBLE);
+        mTwitterDeprecationNoticeWarningContainer.setTitle(getString(R.string.connected_accounts_label));
+        mTwitterDeprecationNoticeWarningContainer.setDescription(
+                getString(R.string.sharing_twitter_deprecation_notice_description),
+                getString(R.string.sharing_twitter_deprecation_notice_find_out_more),
+                () -> {
+                    WPWebViewActivity.openURL(getActivity(), TWITTER_DEPRECATION_FIND_OUT_MORE_URL);
+                    return Unit.INSTANCE;
+                });
     }
 
     private boolean isGooglePlus() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -16,6 +16,7 @@ import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeService;
+import org.wordpress.android.models.PublicizeService.Status;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
@@ -113,10 +114,11 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
 
         setTitle(mService.getLabel());
 
-        // disable the ability to add another G+ connection
-        if (isGooglePlus()) {
+        // disable the ability to add another G+ or Twitter connection
+        if (isGooglePlus() || isTwitterUnsupported()) {
             mServiceContainer.setVisibility(View.GONE);
         } else {
+            mServiceContainer.setVisibility(View.VISIBLE);
             String serviceLabel = String.format(getString(R.string.connection_service_label), mService.getLabel());
             TextView txtService = mServiceContainer.findViewById(R.id.text_service);
             txtService.setText(serviceLabel);
@@ -138,6 +140,11 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
 
     private boolean isGooglePlus() {
         return mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID);
+    }
+
+    private boolean isTwitterUnsupported() {
+        return mService.getId().equals(PublicizeService.TWITTER_SERVICE_ID)
+               && mService.getStatus() == Status.UNSUPPORTED;
     }
 
     private boolean hasOnPublicizeActionListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.Detail;
-import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.List;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.util.ToastUtils;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -20,6 +20,8 @@ import org.wordpress.android.models.PublicizeService.Status;
 import org.wordpress.android.ui.ScrollableViewInitializedListener;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
+import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.Detail;
+import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.List;
 import org.wordpress.android.ui.publicize.adapters.PublicizeConnectionAdapter;
 import org.wordpress.android.util.ToastUtils;
 
@@ -45,6 +47,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
     private TextView mConnectedAccounts;
 
     @Inject AccountStore mAccountStore;
+    @Inject PublicizeTwitterDeprecationNoticeAnalyticsTracker mPublicizeTwitterDeprecationNoticeAnalyticsTracker;
 
     public static PublicizeDetailFragment newInstance(@NonNull SiteModel site, @NonNull PublicizeService service) {
         Bundle args = new Bundle();
@@ -163,6 +166,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
                 getString(R.string.sharing_twitter_deprecation_notice_description),
                 getString(R.string.sharing_twitter_deprecation_notice_find_out_more),
                 () -> {
+                    mPublicizeTwitterDeprecationNoticeAnalyticsTracker.trackTwitterNoticeLinkTapped(Detail.INSTANCE);
                     WPWebViewActivity.openURL(getActivity(), TWITTER_DEPRECATION_FIND_OUT_MORE_URL);
                     return Unit.INSTANCE;
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -35,7 +35,6 @@ import org.wordpress.android.ui.publicize.PublicizeListViewModel.ActionEvent;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.ActionEvent.OpenServiceDetails;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.UIState;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.UIState.ShowTwitterDeprecationNotice;
-import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source;
 import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.List;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -35,6 +35,8 @@ import org.wordpress.android.ui.publicize.PublicizeListViewModel.ActionEvent;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.ActionEvent.OpenServiceDetails;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.UIState;
 import org.wordpress.android.ui.publicize.PublicizeListViewModel.UIState.ShowTwitterDeprecationNotice;
+import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source;
+import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source.List;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnServiceClickListener;
@@ -83,6 +85,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     @Inject UiHelpers mUiHelpers;
     @Inject ImageManager mImageManager;
     @Inject ViewModelProvider.Factory mViewModelFactory;
+    @Inject PublicizeTwitterDeprecationNoticeAnalyticsTracker mPublicizeTwitterDeprecationNoticeAnalyticsTracker;
 
     PublicizeListViewModel mPublicizeListViewModel;
 
@@ -235,6 +238,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
             warningView.setTitle(getString(uiState.getTitle()));
             warningView.setDescription(getString(uiState.getDescription()), getString(uiState.getFindOutMore()),
                     () -> {
+                        mPublicizeTwitterDeprecationNoticeAnalyticsTracker.trackTwitterNoticeLinkTapped(List.INSTANCE);
                         WPWebViewActivity.openURL(getActivity(), uiState.getFindOutMoreUrl());
                         return Unit.INSTANCE;
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -3,10 +3,6 @@ package org.wordpress.android.ui.publicize;
 import android.app.Activity;
 import android.os.Bundle;
 import android.text.Spannable;
-import android.text.SpannableString;
-import android.text.method.LinkMovementMethod;
-import android.text.style.ClickableSpan;
-import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,7 +12,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -63,6 +58,7 @@ import javax.inject.Inject;
 import static org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.ENABLE_POST_SHARING;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import kotlin.Unit;
 
 @AndroidEntryPoint
 public class PublicizeListFragment extends PublicizeBaseFragment {
@@ -224,44 +220,24 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         }
     }
 
-    private void showTwitterDeprecationNotice(final ShowTwitterDeprecationNotice uiState) {
+    private void showTwitterDeprecationNotice(@NonNull final ShowTwitterDeprecationNotice uiState) {
         final View rootView = getView();
         if (rootView != null) {
             final View twitterContainer = rootView.findViewById(R.id.twitter_deprecation_notice_container);
             twitterContainer.setVisibility(View.VISIBLE);
-            final TextView title = rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_service);
+            final TextView title = rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_title);
             title.setText(uiState.getTitle());
-            final TextView description =
-                    rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_description);
-            final String space = " ";
-            final String descriptionText = getString(uiState.getDescription()) + space;
-            final String findOutMoreText = getString(uiState.getFindOutMore());
-            final SpannableString spannableTitle = new SpannableString(descriptionText + findOutMoreText);
-            final int descriptionColor = description.getCurrentTextColor();
-            spannableTitle.setSpan(
-                    new ForegroundColorSpan(descriptionColor),
-                    0,
-                    descriptionText.length(),
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            );
-            spannableTitle.setSpan(
-                    new ForegroundColorSpan(ContextCompat.getColor(getContext(), R.color.jetpack_green)),
-                    descriptionText.length(),
-                    spannableTitle.length(),
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            );
-            spannableTitle.setSpan(
-                    new ClickableSpan() {
-                        @Override public void onClick(@NonNull View view) {
-                            WPWebViewActivity.openURL(getActivity(), uiState.getFindOutMoreUrl());
-                        }
-                    },
-                    descriptionText.length(),
-                    spannableTitle.length(),
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            );
-            description.setMovementMethod(LinkMovementMethod.getInstance());
-            description.setText(spannableTitle);
+            final TextView serviceName =
+                    rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_service);
+            serviceName.setText(uiState.getServiceName());
+            final PublicizeTwitterDeprecationNoticeWarningView warningView =
+                    rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_warning);
+            warningView.setTitle(getString(uiState.getTitle()));
+            warningView.setDescription(getString(uiState.getDescription()), getString(uiState.getFindOutMore()),
+                    () -> {
+                        WPWebViewActivity.openURL(getActivity(), uiState.getFindOutMoreUrl());
+                        return Unit.INSTANCE;
+                    });
             final ImageView icon = rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_icon);
             mImageManager.load(icon, ImageType.AVATAR_WITH_BACKGROUND, uiState.getIconUrl());
             final TextView connectedUser = rootView.findViewById(R.id.publicize_twitter_deprecation_notice_header_user);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListViewModel.kt
@@ -73,7 +73,8 @@ class PublicizeListViewModel @Inject constructor(
                 }
                 if (isTwitterDeprecated && twitterConnection != null) {
                     _uiState.value = UIState.ShowTwitterDeprecationNotice(
-                        title = twitterConnection.label,
+                        title = R.string.sharing_twitter_deprecation_notice_title,
+                        serviceName = twitterConnection.label,
                         description = R.string.sharing_twitter_deprecation_notice_description,
                         findOutMore = R.string.sharing_twitter_deprecation_notice_find_out_more,
                         findOutMoreUrl = TWITTER_DEPRECATION_FIND_OUT_MORE_URL,
@@ -89,7 +90,8 @@ class PublicizeListViewModel @Inject constructor(
 
     sealed class UIState {
         data class ShowTwitterDeprecationNotice(
-            val title: String,
+            @StringRes val title: Int,
+            val serviceName: String,
             @StringRes val description: Int,
             @StringRes val findOutMore: Int,
             val findOutMoreUrl: String,
@@ -100,10 +102,5 @@ class PublicizeListViewModel @Inject constructor(
 
     sealed class ActionEvent {
         data class OpenServiceDetails(val service: PublicizeService) : ActionEvent()
-    }
-
-    companion object {
-        private const val TWITTER_DEPRECATION_FIND_OUT_MORE_URL =
-            "https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeAnalyticsTracker.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.publicize
+
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+
+class PublicizeTwitterDeprecationNoticeAnalyticsTracker @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper
+) {
+    fun trackTwitterNoticeLinkTapped(source: Source) = analyticsTracker.track(
+        AnalyticsTracker.Stat.TWITTER_NOTICE_LINK_TAPPED, mapOf(SOURCE_KEY to source.value)
+    )
+
+    sealed class Source(val value: String) {
+        object List : Source("social_connection_list")
+        object Detail : Source("social_connection_detail")
+    }
+}
+
+private const val SOURCE_KEY = "source"

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeConstants.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeConstants.kt
@@ -1,0 +1,4 @@
+package org.wordpress.android.ui.publicize
+
+const val TWITTER_DEPRECATION_FIND_OUT_MORE_URL =
+    "https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/"

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeWarningView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeWarningView.kt
@@ -1,0 +1,66 @@
+package org.wordpress.android.ui.publicize
+
+import android.content.Context
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.util.AttributeSet
+import android.view.View
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
+import org.wordpress.android.R
+
+class PublicizeTwitterDeprecationNoticeWarningView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+    init {
+        inflate(context, R.layout.publicize_twitter_deprecation_notice_warning, this)
+    }
+
+    fun setTitle(text: String) {
+        val title = findViewById<TextView>(R.id.publicize_twitter_deprecation_notice_header_title)
+        title.text = text
+    }
+
+    fun setDescription(
+        description: String,
+        findOutMore: String,
+        findOutMoreClick: () -> Unit,
+    ) {
+        val descriptionTextView = findViewById<TextView>(R.id.publicize_twitter_deprecation_notice_header_description)
+        val space = " "
+        val descriptionText: String = description + space
+        val findOutMoreText: String = findOutMore
+        val spannableTitle = SpannableString(descriptionText + findOutMoreText)
+        val descriptionTextViewColor = descriptionTextView.currentTextColor
+        spannableTitle.setSpan(
+            ForegroundColorSpan(descriptionTextViewColor),
+            0,
+            descriptionText.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        spannableTitle.setSpan(
+            ForegroundColorSpan(ContextCompat.getColor(getContext(), R.color.jetpack_green)),
+            descriptionText.length,
+            spannableTitle.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        spannableTitle.setSpan(
+            object : ClickableSpan() {
+                override fun onClick(view: View) {
+                    findOutMoreClick()
+                }
+            },
+            descriptionText.length,
+            spannableTitle.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        descriptionTextView.movementMethod = LinkMovementMethod.getInstance()
+        descriptionTextView.text = spannableTitle
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -26,6 +26,11 @@ import org.wordpress.android.util.image.ImageType;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.models.PublicizeConnection.ConnectStatus.MUST_DISCONNECT;
+import static org.wordpress.android.models.PublicizeConnection.ConnectStatus.OK;
+import static org.wordpress.android.models.PublicizeService.Status.UNSUPPORTED;
+import static org.wordpress.android.ui.publicize.PublicizeConstants.TWITTER_ID;
+
 public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeConnectionAdapter.ConnectionViewHolder> {
     public interface OnAdapterLoadedListener {
         void onAdapterLoaded(boolean isEmpty);
@@ -112,24 +117,23 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
 
     private void bindButton(ConnectButton btnConnect, final PublicizeConnection connection) {
         ConnectStatus status = connection.getStatusEnum();
-        switch (status) {
-            case OK:
-            case MUST_DISCONNECT:
-                btnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
-                btnConnect.setOnClickListener(v -> {
-                    if (mActionListener != null) {
-                        mActionListener.onRequestDisconnect(connection);
-                    }
-                });
-                break;
-            case BROKEN:
-            default:
-                btnConnect.setAction(ConnectAction.RECONNECT);
-                btnConnect.setOnClickListener(view -> {
-                    if (mActionListener != null) {
-                        mActionListener.onRequestReconnect(mService, connection);
-                    }
-                });
+        final boolean isTwitterConnection = TWITTER_ID.equals(connection.getService());
+        final boolean isServiceUnsupported = mService != null && UNSUPPORTED.equals(mService.getStatus());
+        if (OK.equals(status) || MUST_DISCONNECT.equals(status)
+            || (isTwitterConnection && isServiceUnsupported)) {
+            btnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);
+            btnConnect.setOnClickListener(v -> {
+                if (mActionListener != null) {
+                    mActionListener.onRequestDisconnect(connection);
+                }
+            });
+        } else {
+            btnConnect.setAction(ConnectAction.RECONNECT);
+            btnConnect.setOnClickListener(view -> {
+                if (mActionListener != null) {
+                    mActionListener.onRequestReconnect(mService, connection);
+                }
+            });
         }
     }
 

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -13,6 +13,15 @@
         android:orientation="vertical"
         android:paddingBottom="@dimen/content_margin">
 
+        <org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeWarningView
+            android:id="@+id/publicize_twitter_deprecation_notice_detail_warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
         <LinearLayout
             android:id="@+id/connections_container"
             android:layout_width="match_parent"
@@ -22,6 +31,7 @@
             tools:visibility="visible">
 
             <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/connected_accounts"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/publicize_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_detail_fragment.xml
@@ -44,7 +44,8 @@
             android:id="@+id/service_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:visibility="gone">
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_service"

--- a/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_header.xml
+++ b/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_header.xml
@@ -76,8 +76,12 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <include
+    <org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeWarningView
         android:id="@+id/publicize_twitter_deprecation_notice_header_warning"
-        layout="@layout/publicize_twitter_deprecation_notice_warning" />
-    
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_header.xml
+++ b/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_header.xml
@@ -12,18 +12,6 @@
     android:visibility="gone"
     tools:visibility="visible">
 
-    <ImageView
-        android:id="@+id/publicize_twitter_deprecation_notice_header_error"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_medium"
-        android:importantForAccessibility="no"
-        android:src="@drawable/ic_notice_red_24dp"
-        app:layout_constraintBottom_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_title"
-        app:layout_constraintEnd_toStartOf="@+id/publicize_twitter_deprecation_notice_header_title"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/publicize_twitter_deprecation_notice_item_container"
         android:layout_width="0dp"
@@ -36,7 +24,7 @@
         android:paddingTop="@dimen/margin_extra_small_large"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_description">
+        app:layout_constraintTop_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_warning">
 
         <ImageView
             android:id="@+id/publicize_twitter_deprecation_notice_header_icon"
@@ -88,28 +76,8 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/publicize_twitter_deprecation_notice_header_description"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:textAppearance="?attr/textAppearanceCaption"
-        app:layout_constraintBottom_toTopOf="@+id/publicize_twitter_deprecation_notice_item_container"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_title"
-        tools:text="@string/sharing_twitter_deprecation_notice_description" />
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/publicize_twitter_deprecation_notice_header_title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/sharing_twitter_deprecation_notice_title"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="?attr/colorPrimary"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/publicize_twitter_deprecation_notice_header_error"
-        app:layout_constraintTop_toTopOf="parent" />
-
-
+    <include
+        android:id="@+id/publicize_twitter_deprecation_notice_header_warning"
+        layout="@layout/publicize_twitter_deprecation_notice_warning" />
+    
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_warning.xml
+++ b/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_warning.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/publicize_twitter_deprecation_notice_header_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_notice_red_24dp"
+        app:layout_constraintBottom_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_title"
+        app:layout_constraintEnd_toStartOf="@+id/publicize_twitter_deprecation_notice_header_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/publicize_twitter_deprecation_notice_header_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAppearance="?attr/textAppearanceCaption"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/publicize_twitter_deprecation_notice_header_title"
+        tools:text="@string/sharing_twitter_deprecation_notice_description" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/publicize_twitter_deprecation_notice_header_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/sharing_twitter_deprecation_notice_title"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/publicize_twitter_deprecation_notice_header_error"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_warning.xml
+++ b/WordPress/src/main/res/layout/publicize_twitter_deprecation_notice_warning.xml
@@ -33,11 +33,11 @@
         android:id="@+id/publicize_twitter_deprecation_notice_header_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/sharing_twitter_deprecation_notice_title"
         android:textAppearance="?attr/textAppearanceSubtitle1"
         android:textColor="?attr/colorPrimary"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/publicize_twitter_deprecation_notice_header_error"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@string/sharing_twitter_deprecation_notice_title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeListViewModelTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.publicize.services.PublicizeUpdateServicesV2
 import org.wordpress.android.util.EventBusWrapper
 
@@ -18,9 +19,11 @@ import org.wordpress.android.util.EventBusWrapper
 class PublicizeListViewModelTest : BaseUnitTest() {
     private val publicizeUpdateServicesV2: PublicizeUpdateServicesV2 = mock()
     private val eventBusWrapper: EventBusWrapper = mock()
+    private val accountStore: AccountStore = mock()
     private val classToTest = PublicizeListViewModel(
         publicizeUpdateServicesV2 = publicizeUpdateServicesV2,
         eventBusWrapper = eventBusWrapper,
+        accountStore = accountStore,
         bgDispatcher = testDispatcher(),
     )
     private val actionObserver: Observer<PublicizeListViewModel.ActionEvent> = mock()

--- a/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeTwitterDeprecationNoticeAnalyticsTrackerTest.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.publicize
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeAnalyticsTracker.Source
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+class PublicizeTwitterDeprecationNoticeAnalyticsTrackerTest {
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper = mock()
+    private val classToTest = PublicizeTwitterDeprecationNoticeAnalyticsTracker(
+        analyticsTracker = analyticsTrackerWrapper,
+    )
+
+    @Test
+    fun `Should track Twitter notice link tapped when trackTwitterNoticeLinkTapped is called with Source List`() {
+        classToTest.trackTwitterNoticeLinkTapped(Source.List)
+        verify(analyticsTrackerWrapper)
+            .track(
+                AnalyticsTracker.Stat.TWITTER_NOTICE_LINK_TAPPED,
+                mapOf("source" to "social_connection_list")
+            )
+    }
+
+    @Test
+    fun `Should track Twitter notice link tapped when trackTwitterNoticeLinkTapped is called with Source Detail`() {
+        classToTest.trackTwitterNoticeLinkTapped(Source.Detail)
+        verify(analyticsTrackerWrapper)
+            .track(
+                AnalyticsTracker.Stat.TWITTER_NOTICE_LINK_TAPPED,
+                mapOf("source" to "social_connection_detail")
+            )
+    }
+}

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1041,7 +1041,8 @@ public final class AnalyticsTracker {
         DASHBOARD_CARD_DOMAIN_SHOWN,
         DASHBOARD_CARD_DOMAIN_TAPPED,
         DASHBOARD_CARD_DOMAIN_MORE_MENU_TAPPED,
-        DASHBOARD_CARD_DOMAIN_HIDDEN
+        DASHBOARD_CARD_DOMAIN_HIDDEN,
+        TWITTER_NOTICE_LINK_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2577,6 +2577,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "direct_domains_purchase_dashboard_card_menu_tapped";
             case DASHBOARD_CARD_DOMAIN_HIDDEN:
                 return "direct_domains_purchase_dashboard_card_hidden";
+            case TWITTER_NOTICE_LINK_TAPPED:
+                return "twitter_notice_link_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #18431 and #18429

To test the publicize details UI:
1 - Install JP app and log in;
2 - Select a site that has Twitter connected;
3 - Open Sharing screen;
4 - Observe the services list: Twitter should not be listed with the other services, but Twitter deprecation container should be shown below;
5 - Tap the Twitter row: publicize details screen should be opened, and Twitter deprecation notice should be shown there too. `Disconnect` button should be shown.
6 - Repeat the same with WP app.

To test the analytics events:
1 - Install JP app and log in;
2 - Select a site that has Twitter connected;
3 - Open Sharing screen;
4 - Tap the `Find out more` button: the event `twitter_notice_link_tapped` should be tracked with the property `{"source":"social_connection_list"}`
<img width="874" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/cf96aeae-5124-45c2-8f79-bf32cbf304c1">


5 - Go back to the publicize list screen and tap the Twitter row;
6 - Tap the `Find out more` button in the publicize details screen: the event `twitter_notice_link_tapped` should be tracked with the property `{"source":"social_connection_detail"}`
<img width="879" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/4fba7af8-c97c-4922-a2d6-7a53be27edee">

## Regression Notes
1. Potential unintended areas of impact
Publicize details screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests

3. What automated tests I added (or what prevented me from doing so)
Implemented `PublicizeTwitterDeprecationNoticeAnalyticsTrackerTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
