### PR TITLE
Adds Sentry Performance Monitoring Capabilities

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
@@ -8,8 +8,12 @@ import javax.inject.Singleton
 class FirebaseRemoteConfigWrapper @Inject constructor() {
     fun getOpenWebLinksWithJetpackFlowFrequency() =
         FirebaseRemoteConfig.getInstance().getLong(OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY)
+    fun getPerformanceMonitoringSampleRate(): Double =
+        FirebaseRemoteConfig.getInstance().getDouble(PERFORMANCE_MONITORING_SAMPLE_RATE_KEY)
 
     companion object {
+        private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wp_android_performance_monitoring_sample_rate"
+
         const val OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY = "open_web_links_with_jetpack_flow_frequency"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsTrackerWrapper.kt
@@ -12,6 +12,8 @@ import javax.inject.Inject
 @Reusable
 class AnalyticsTrackerWrapper
 @Inject constructor() {
+    val hasUserOptedOut get() = AnalyticsTracker.hasUserOptedOut()
+
     fun track(stat: Stat) {
         AnalyticsTracker.track(stat)
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
@@ -5,7 +5,6 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
-import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -36,6 +35,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     private val logFileProvider: LogFileProviderWrapper,
     private val buildConfig: BuildConfigWrapper,
     @Named(APPLICATION_SCOPE) private val appScope: CoroutineScope,
+    wpPerformanceMonitoringConfig: WPPerformanceMonitoringConfig,
     dispatcher: Dispatcher,
 ) : CrashLoggingDataProvider {
     init {
@@ -113,8 +113,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
 
     override val user = MutableStateFlow(accountStore.account?.toCrashLoggingUser())
 
-    override val performanceMonitoringConfig: PerformanceMonitoringConfig
-        get() = PerformanceMonitoringConfig.Disabled
+    override val performanceMonitoringConfig = wpPerformanceMonitoringConfig()
 
     @Suppress("unused", "unused_parameter")
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfig.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.util.crashlogging
+
+import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import org.wordpress.android.util.BuildConfigWrapper
+import javax.inject.Inject
+import org.wordpress.android.util.FirebaseRemoteConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+class WPPerformanceMonitoringConfig @Inject constructor(
+    private val remoteConfigWrapper: FirebaseRemoteConfigWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper
+) {
+    operator fun invoke(): PerformanceMonitoringConfig {
+        val sampleRate = remoteConfigWrapper.getPerformanceMonitoringSampleRate()
+        val hasUserOptedOut = analyticsTrackerWrapper.hasUserOptedOut
+
+        return when {
+            hasUserOptedOut || buildConfigWrapper.isDebug() -> PerformanceMonitoringConfig.Disabled
+            sampleRate <= 0.0 || sampleRate > 1.0 -> PerformanceMonitoringConfig.Disabled
+            else -> PerformanceMonitoringConfig.Enabled(sampleRate)
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.util.crashlogging
 
 import android.content.SharedPreferences
 import com.automattic.android.tracks.crashlogging.EventLevel.DEBUG
+import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -59,6 +60,10 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     private val buildConfig: BuildConfigWrapper = mock()
     private val sharedPreferences: SharedPreferences = mock()
 
+    private val wpPerformanceMonitoringConfig: WPPerformanceMonitoringConfig = mock {
+        on { invoke() } doReturn PerformanceMonitoringConfig.Enabled(1.0)
+    }
+
     @Before
     fun setUp() {
         sut = WPCrashLoggingDataProvider(
@@ -70,6 +75,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
             logFileProvider = logFileProvider,
             buildConfig = buildConfig,
             appScope = testScope(),
+            wpPerformanceMonitoringConfig = wpPerformanceMonitoringConfig,
             dispatcher = Dispatcher()
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
@@ -1,0 +1,65 @@
+package org.wordpress.android.util.crashlogging
+
+import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.assertj.core.api.Assertions.assertThat
+import org.wordpress.android.util.FirebaseRemoteConfigWrapper
+
+private const val VALID_SAMPLE_RATE = 0.01
+private const val INVALID_SAMPLE_RATE = 0.0
+
+class WPPerformanceMonitoringConfigTest {
+    private val remoteConfig: FirebaseRemoteConfigWrapper = mock()
+    private val analytics: AnalyticsTrackerWrapper = mock()
+    private val buildConfig: BuildConfigWrapper = mock()
+
+    private val sut = WPPerformanceMonitoringConfig(remoteConfig, analytics, buildConfig)
+
+    @Test
+    fun `given the user disabled tracking, disable performance monitoring`() {
+        whenever(buildConfig.isDebug()).thenReturn(false)
+        whenever(analytics.hasUserOptedOut).thenReturn(true)
+        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).thenReturn(VALID_SAMPLE_RATE)
+
+        val result = sut.invoke()
+
+        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Disabled)
+    }
+
+    @Test
+    fun `given the debug app, disable performance monitoring`() {
+        whenever(buildConfig.isDebug()).thenReturn(true)
+        whenever(analytics.hasUserOptedOut).thenReturn(false)
+        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).thenReturn(VALID_SAMPLE_RATE)
+
+        val result = sut.invoke()
+
+        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Disabled)
+    }
+
+    @Test
+    fun `given the app is not debug and user did not disabled tracking, enable performance monitoring`() {
+        whenever(buildConfig.isDebug()).thenReturn(false)
+        whenever(analytics.hasUserOptedOut).thenReturn(false)
+        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).thenReturn(VALID_SAMPLE_RATE)
+
+        val result = sut.invoke()
+
+        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Enabled(VALID_SAMPLE_RATE))
+    }
+
+    @Test
+    fun `given invalid sample rate, disable performance monitoring`() {
+        whenever(buildConfig.isDebug()).thenReturn(false)
+        whenever(analytics.hasUserOptedOut).thenReturn(false)
+        whenever(remoteConfig.getPerformanceMonitoringSampleRate()).thenReturn(INVALID_SAMPLE_RATE)
+
+        val result = sut.invoke()
+
+        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Disabled)
+    }
+}

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1065,6 +1065,10 @@ public final class AnalyticsTracker {
         }
     }
 
+    public static boolean hasUserOptedOut() {
+        return mHasUserOptedOut;
+    }
+
     public static void setHasUserOptedOut(boolean hasUserOptedOut) {
         if (hasUserOptedOut != mHasUserOptedOut) {
             mHasUserOptedOut = hasUserOptedOut;


### PR DESCRIPTION
This PR adds Sentry Performance Monitoring capabilities that's managed through a Firebase remote config. It's disabled for debug builds as well as for users who has tracking disabled. It's also disabled by default and will only work if we set the `wp_android_performance_monitoring_sample_rate` remote config value in the range of `0 < sampleRate <=1.0`. The implementation closely follows it's counterpart from `WooCommerce-Android` project.

The remote config value is set to `0.0` for now. I intend to keep it this way and let folks who are interested in this capability to change the sampling rate as they see fit. This is to prevent us from accidentally sending too many events and getting a large bill to pay.

Note that the `TransactionLauncher`s and transactions for HTTP requests are out of scope for this PR. We'll need to have an internal discussion about that before we add them.

**To test:**

Admittedly I don't know how we should test this implementation. The implementation is unit tested and following the implementation from WCAndroid, so I am hopeful that it will work. However, if there is a good way to test this, I'd like to do that before we merge the PR.

@wzieba I'd love to hear your thoughts on testing since you worked on this for WCAndroid. Thanks in advance!

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

**UI Changes testing checklist:**

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)

