### PR TITLE
Disable overscroll animation on main plugins screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [https://github.com/wordpress-mobile/WordPress-Android/pull/18454]
 * [*] Adds a button to enable account closure from the account settings screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18412]
+* [*] Fixes an issue on the plugins screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18498]
 
 22.4
 -----

--- a/WordPress/src/main/res/layout/plugin_browser_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_browser_activity.xml
@@ -24,7 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        android:overScrollMode="never">
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #14087

# Description

This PR disables the overscroll animation on the main plugin screen. This is done because it seems that the animation may lead to the expectation that swiping down will refresh the contents of this screen. In fact, this screen does not have a multi-list refresh implemented, and each individual plugins list can be refreshed by tapping into the detail view.

To test:

1. Login to an account with an Atomic site (with plugins enabled)
2. Select that Atomic site from the My Sites list
3. Navigate to the main plugins screen (Menu tab -> Plugins)
4. Wait for the plugins screen to load
5. Swipe down
6. Expect that the overscroll animation is disabled

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
