### PR TITLE
Follow up to Adds Sentry Performance Monitoring Capabilities

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,5 +1,6 @@
 import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
 import se.bjurr.violations.lib.model.SEVERITY
+import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 plugins {
     id "com.android.application"
@@ -11,6 +12,16 @@ plugins {
     id "se.bjurr.violations.violation-comments-to-github-gradle-plugin"
     id "com.google.gms.google-services"
     id 'dagger.hilt.android.plugin'
+}
+
+sentry {
+    tracingInstrumentation {
+        enabled = true
+        features = [io.sentry.android.gradle.extensions.InstrumentationFeature.DATABASE]
+    }
+    autoInstallation {
+        enabled = false
+    }
 }
 
 repositories {

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1081,6 +1081,8 @@
             android:screenOrientation="portrait"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
+
     </application>
     <queries>
         <intent>

--- a/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/FirebaseRemoteConfigWrapper.kt
@@ -14,6 +14,6 @@ class FirebaseRemoteConfigWrapper @Inject constructor() {
     companion object {
         private const val PERFORMANCE_MONITORING_SAMPLE_RATE_KEY = "wp_android_performance_monitoring_sample_rate"
 
-        const val OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY = "open_web_links_with_jetpack_flow_frequency"
+        private const val OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY = "open_web_links_with_jetpack_flow_frequency"
     }
 }


### PR DESCRIPTION
This PR is a follow up to #18496.

* [As suggested here](https://github.com/wordpress-mobile/WordPress-Android/pull/18496#issuecomment-1560896477), I enabled database transaction spans in 8c696e0721d8aa58cf5f1f2a534361399342570a. I also took the opportunity to disable `autoInstallation` to match the [behavior in WCAndroid](https://github.com/woocommerce/woocommerce-android/blob/13.6/WooCommerce/build.gradle#L21-L23).
* It's worth noting that 8c696e0721d8aa58cf5f1f2a534361399342570a also [disables the default OKHTTP instrumentation.](https://docs.sentry.io/platforms/android/configuration/integrations/okhttp/#disable) We don't want to send our network requests to Sentry without filtering & obfuscating them.
* I've set the `OPEN_WEB_LINKS_WITH_JETPACK_FLOW_FREQUENCY_KEY` `const` to `private` to follow up on [this suggestion](https://github.com/wordpress-mobile/WordPress-Android/pull/18496#discussion_r1203825296).
* I've also disabled the default Activity's instrumentation in d627cf01bd7a6e91cffd19290095ca1b35c77478. I had a quick chat with @wzieba on Slack and this was suggested by him to lower the total cost as he said he didn't find these particularly useful for WCAndroid and plans to disable them. I don't fully understand why this needs to be set in `AndroidManifest` and can't be done in the plugin settings, but this is the only way presented in the [docs](https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/) unless I am missing something.

**To test:**

I don't think there is anything new in this PR that we need to test, but please correct me if I am wrong @wzieba.

**Edit:**

I got worried about the [dependencies change posted by 'wpmobilebot`](https://github.com/wordpress-mobile/WordPress-Android/pull/18507#issuecomment-1561774447) as I wasn't expecting it. I checked the Build scan and the Sentry dependencies are still there, although I am not completely sure why there is a diff. [I also verified that we are still reporting the crashes to Sentry](https://a8c.sentry.io/share/issue/efb8a23eb68f4d71b8f5eea2ad3e2ab8/).

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

**UI Changes testing checklist:**

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)