### PR TITLE
Integrate gutenberg-mobile release 1.96.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,10 @@
 * [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [https://github.com/wordpress-mobile/WordPress-Android/pull/18454]
 * [*] Adds a button to enable account closure from the account settings screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18412]
 * [*] Fixes an issue on the plugins screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18498]
+* [*] Add disabled style to `Cell` component [https://github.com/WordPress/gutenberg/pull/50665]
+* [**] Fix undo/redo history when inserting a link configured to open in a new tab [https://github.com/WordPress/gutenberg/pull/50460]
+* [**] Disable details settings for not belonged VideoPress videos [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5782]
+* [*] [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5785]
 
 22.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,10 +6,10 @@
 * [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [https://github.com/wordpress-mobile/WordPress-Android/pull/18454]
 * [*] Adds a button to enable account closure from the account settings screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18412]
 * [*] Fixes an issue on the plugins screen [https://github.com/wordpress-mobile/WordPress-Android/pull/18498]
-* [*] Add disabled style to `Cell` component [https://github.com/WordPress/gutenberg/pull/50665]
-* [**] Fix undo/redo history when inserting a link configured to open in a new tab [https://github.com/WordPress/gutenberg/pull/50460]
-* [**] Disable details settings for not belonged VideoPress videos [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5782]
-* [*] [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5785]
+* [*] Block editor: Add disabled style to `Cell` component [https://github.com/WordPress/gutenberg/pull/50665]
+* [**] Block editor: Fix undo/redo history when inserting a link configured to open in a new tab [https://github.com/WordPress/gutenberg/pull/50460]
+* [**] [Jetpack-only] Block editor: Disable details settings for not belonged VideoPress videos [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5782]
+* [*] Block editor: [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5785]
 
 22.4
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5800-a16ebec0839ff4037e4e0f1ae1deebcf2d54d2e5'
+    gutenbergMobileVersion = 'v1.96.0'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-3fe318a6de3463bf2444b0d798067546e9a18db0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.96.0-alpha1'
+    gutenbergMobileVersion = '5800-a16ebec0839ff4037e4e0f1ae1deebcf2d54d2e5'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = 'trunk-3fe318a6de3463bf2444b0d798067546e9a18db0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.96.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5800

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.