### PR TITLE
[UI Tests] Enable 5 UI tests... once again.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/BlockEditorTests.kt
@@ -29,7 +29,6 @@ class BlockEditorTests : BaseTest() {
 """
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2ePublishSimplePost() {
         val title = "publishSimplePost"
         MySitesPage()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.e2e
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
@@ -22,7 +21,6 @@ class DashboardTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. Test fails to scroll to the card.")
     fun e2eDomainsCardNavigation() {
         MySitesPage()
             .scrollToDomainsCard()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/ReaderTests.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.e2e.pages.ReaderPage
 import org.wordpress.android.support.BaseTest
@@ -17,7 +16,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eNavigateThroughPosts() {
         ReaderPage()
             .tapFollowingTab()
@@ -31,7 +29,6 @@ class ReaderTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eLikePost() {
         ReaderPage()
             .tapFollowingTab()

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -39,7 +38,6 @@ class StatsTests : BaseTest() {
     }
 
     @Test
-    @Ignore("Skipped due to increased flakiness. See build-and-ship channel for 17.05.2023")
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()


### PR DESCRIPTION
### Description

Even though these tests have been already enabled in #18482, a recent merge of `merge/22.4-rc-2-to-trunk` (#18506) over rid those changes. I suppose the process of "rc" branches merging does not include updating from `trunk` before merge, this is why this ended like this.

This PR contains one cherry-picked commit 4a6e33babb9ca7e85b07118be93337f42480f78c from already reviewed/merged #18482.

### To Test
- CI is 🟢, as well as 5 enabled tests:
    - `e2ePublishSimplePost`
    - `e2eDomainsCardNavigation`
    - `e2eNavigateThroughPosts`
    - `e2eLikePost`
    - `e2eAllDayStatsLoad`
