### PR TITLE
[Site Editor] Remove CSS injection for site editor and WebView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -22,7 +22,6 @@ import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItem.kt
@@ -192,18 +192,8 @@ sealed class PageItem(open val type: Type) {
 
     object VirtualHomepage : PageItem(VIRTUAL_HOMEPAGE) {
         sealed class Action {
-            class OpenSiteEditor : Action() {
-                val customCss: String get() = SITE_EDITOR_CSS
-
+            object OpenSiteEditor : Action() {
                 fun getUrl(site: SiteModel): String = site.adminUrl + "site-editor.php?canvas=edit"
-
-                companion object {
-                    const val SITE_EDITOR_CSS = ".edit-site-header-edit-mode { padding-left: 0px } " +
-                            ".edit-site-site-hub { display: none } " +
-                            ".edit-site-template-details " +
-                            ".edit-site-template-details__show-all-button.components-button " +
-                            "{ display: none }"
-                }
             }
 
             sealed class OpenExternalLink(

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PageItemViewHolder.kt
@@ -300,7 +300,7 @@ sealed class PageItemViewHolder(internal val parent: ViewGroup, @LayoutRes layou
         override fun onBind(pageItem: PageItem) {
             itemView.setOnClickListener {
                 QuickStartUtils.removeQuickStartFocusPoint(pageItemContainer)
-                onAction(Action.OpenSiteEditor())
+                onAction(Action.OpenSiteEditor)
             }
             pageItemInfo.setOnClickListener {
                 onAction(Action.OpenExternalLink.TemplateSupport)

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -565,11 +565,10 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(
                         activity,
                         url,
-                        css,
                         WPWebViewSource.PAGE_LIST_EDIT_HOMEPAGE
                     )
                 } else {
-                    WPWebViewActivity.openURL(activity, url, css, WPWebViewSource.PAGE_LIST_EDIT_HOMEPAGE)
+                    WPWebViewActivity.openURL(activity, url, WPWebViewSource.PAGE_LIST_EDIT_HOMEPAGE)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -249,7 +249,6 @@ class PagesViewModel
 
     data class SiteEditorData(
         val url: String,
-        val css: String,
         val useWpComCredentials: Boolean,
     )
 
@@ -745,11 +744,10 @@ class PagesViewModel
                 _openExternalLink.postValue(action.url)
             }
 
-            is VirtualHomepage.Action.OpenSiteEditor -> {
+            VirtualHomepage.Action.OpenSiteEditor -> {
                 _openSiteEditorWebView.postValue(
                     SiteEditorData(
-                        action.getUrl(site),
-                        action.customCss,
+                        VirtualHomepage.Action.OpenSiteEditor.getUrl(site),
                         useWpComCredentials = site.isWPCom || site.isWPComAtomic || site.isPrivateWPComAtomic
                     )
                 )
@@ -762,7 +760,7 @@ class PagesViewModel
             VirtualHomepage.Action.OpenExternalLink.TemplateSupport ->
                 AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_INFO_PRESSED
 
-            is VirtualHomepage.Action.OpenSiteEditor -> AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_ITEM_PRESSED
+            VirtualHomepage.Action.OpenSiteEditor -> AnalyticsTracker.Stat.PAGES_EDIT_HOMEPAGE_ITEM_PRESSED
         }
         analyticsTracker.track(stat, site)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/pages/PageItemVirtualHomepageActionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/pages/PageItemVirtualHomepageActionTest.kt
@@ -14,7 +14,7 @@ class PageItemVirtualHomepageActionTest {
 
         testSites.forEach { testSite ->
             val site = SiteModel().apply { adminUrl = testSite }
-            val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+            val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
 
             val url = action.getUrl(site)
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PageListViewModelTest.kt
@@ -587,7 +587,7 @@ class PageListViewModelTest : BaseUnitTest() {
 
         viewModel.start(PUBLISHED, pagesViewModel)
 
-        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
         viewModel.onVirtualHomepageAction(action)
 
         verify(pagesViewModel).onVirtualHomepageAction(action)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -639,13 +639,12 @@ class PagesViewModelTest : BaseUnitTest() {
         viewModel.start(site)
 
         // Act
-        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
         viewModel.onVirtualHomepageAction(action)
 
         // Assert
         val expected = PagesViewModel.SiteEditorData(
             "https://example.com/wp-admin/site-editor.php?canvas=edit",
-            PageItem.VirtualHomepage.Action.OpenSiteEditor.SITE_EDITOR_CSS,
             true
         )
         assertThat(viewModel.openSiteEditorWebView.value).isEqualTo(expected)
@@ -661,13 +660,12 @@ class PagesViewModelTest : BaseUnitTest() {
         viewModel.start(site)
 
         // Act
-        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
         viewModel.onVirtualHomepageAction(action)
 
         // Assert
         val expected = PagesViewModel.SiteEditorData(
             "https://example.com/wp-admin/site-editor.php?canvas=edit",
-            PageItem.VirtualHomepage.Action.OpenSiteEditor.SITE_EDITOR_CSS,
             true
         )
         assertThat(viewModel.openSiteEditorWebView.value).isEqualTo(expected)
@@ -683,13 +681,12 @@ class PagesViewModelTest : BaseUnitTest() {
         viewModel.start(site)
 
         // Act
-        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
         viewModel.onVirtualHomepageAction(action)
 
         // Assert
         val expected = PagesViewModel.SiteEditorData(
             "https://example.com/wp-admin/site-editor.php?canvas=edit",
-            PageItem.VirtualHomepage.Action.OpenSiteEditor.SITE_EDITOR_CSS,
             false
         )
         assertThat(viewModel.openSiteEditorWebView.value).isEqualTo(expected)
@@ -718,7 +715,7 @@ class PagesViewModelTest : BaseUnitTest() {
         viewModel.start(site)
 
         // Act
-        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor()
+        val action = PageItem.VirtualHomepage.Action.OpenSiteEditor
         viewModel.onVirtualHomepageAction(action)
 
         // Assert


### PR DESCRIPTION
Fixes #18515

To test:
1. Open WP/JP app
2. Login with an account that has a site using block-based theme
3. Select that site
4. Go to "Pages"
5. Tap on the "Homepage" card
6. Verify some navigation elements still appear, such as the black WordPress logo on the top left, and the "Manage all templates" button under the template drop-down

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/8b798186-6c7e-455d-9bd2-5fb8b3933137)

## Regression Notes
1. Potential unintended areas of impact
N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

9. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
