### PR TITLE
Fix regression crash when registering a domain via menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsRegistrationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsRegistrationTracker.kt
@@ -25,7 +25,7 @@ class DomainsRegistrationTracker @Inject constructor(
         if (purchasingFeatureConfig.isEnabledOrManuallyOverridden()) {
             val origin = if (isSiteCreation) VALUE.ORIGIN_SITE_CREATION.key else VALUE.ORIGIN_MENU.key
             tracker.track(
-                AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site, mapOf(PROPERTY.ORIGIN.key to origin)
+                AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site, mutableMapOf(PROPERTY.ORIGIN.key to origin)
             )
         } else {
             tracker.track(AnalyticsTracker.Stat.DOMAINS_PURCHASE_WEBVIEW_VIEWED, site)


### PR DESCRIPTION
Fixes a regression introduced by mistake which causes the app to crash when registering a domain via `Menu` → `Domains`.
I was aware of this crash but I had the wrong impression that I already fixed it. I might have done something and not noticed that I did not commit the local changes I had at that time, as I do remember seeing it while testing the changes of the code that ended up in the PR that introduced it.
Apparently it almost slipped through and wasn't detected during beta testing of `22.4` which is quite strange, although I'm not in the position to point fingers since I am the most to blame for introducing it in the first place 🤦🏻 .

The exception is thrown because the `AnalyticsUtils.trackWithSiteDetail` attempts to put additional properties in the immutable map. The fix is simply a revert of a change that I added by mistake while working on the Domain Purchasing during Site Creation implementation.

Here is the exception that users encounter without reverting that line of code:
```js
Process: com.jetpack.android.beta, PID: 17078
java.lang.UnsupportedOperationException
	at java.util.AbstractMap.put(AbstractMap.java:209)
	at org.wordpress.android.util.analytics.AnalyticsUtils.trackWithSiteDetails(AnalyticsUtils.java:266)
	at org.wordpress.android.util.analytics.AnalyticsTrackerWrapper.track(AnalyticsTrackerWrapper.kt:45)
	at org.wordpress.android.ui.domains.DomainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(DomainsRegistrationTracker.kt:27)
	at org.wordpress.android.ui.domains.DomainSuggestionsViewModel.selectDomain(DomainSuggestionsViewModel.kt:281)
	at org.wordpress.android.ui.domains.DomainSuggestionsViewModel.access$selectDomain(DomainSuggestionsViewModel.kt:37)
	at org.wordpress.android.ui.domains.DomainSuggestionsViewModel$createCart$1.invokeSuspend(DomainSuggestionsViewModel.kt:267)
```

I am aware it is quite late in the process and `22.4` is scheduled to be submitted to the Play Store on Friday 26th May but since this is just a revert back to the code that was tested and has run in production for over a year I still hope the release wranglers will consider creating a new beta and submitting that one to the store before the crash is released to production.

PS: The PR that introduced this regression didn't reach production yet:
- #18390

To test:
--
1. Open Jetpack app and login
2. Try to buy a domain via the `Menu` → `Domains` feature
3. **Verify** you land on the checkout web-view

> **Note**
> The crash was blocking the web-view, as seen in this recording:

https://github.com/wordpress-mobile/WordPress-Android/assets/4588074/c64666ff-1c80-47f7-844f-9ee07c47720c

## Regression Notes
1. Potential unintended areas of impact
   N/a because the PR reverts a line of code changed by mistake.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual testing - the fix is straightforward to test and it is in fact the `as-is` code

5. What automated tests I added (or what prevented me from doing so)
   N/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] UI Changes testing checklist: n/a
