### PR TITLE
Check required WordPress version to set galleryWithImageBlocks flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,7 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
+22.5
+-----
+* [**] Check required WordPress version to set galleryWithImageBlocks flag [https://github.com/wordpress-mobile/WordPress-Android/pull/18518]
 
 22.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,5 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
-22.5
+22.6
 -----
 * [**] Check required WordPress version to set galleryWithImageBlocks flag [https://github.com/wordpress-mobile/WordPress-Android/pull/18518]
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -206,6 +206,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.VersionUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
@@ -2435,6 +2436,16 @@ public class EditPostActivity extends LocaleAwareActivity implements
         if (editorTheme == null) {
             return null;
         }
+
+        /**
+         * If site is using WP 5.9+ then return true as galleryWithImageBlocks is supported in WP 5.9+.
+         * Once support for WP 5.8 is dropped, this can be removed.
+         * https://github.com/WordPress/gutenberg/issues/47782
+         */
+        if (VersionUtils.checkMinimalVersion(mSite.getSoftwareVersion(), "5.9")) {
+            return true;
+        }
+
         return editorTheme.getThemeSupport().getGalleryWithImageBlocks();
     }
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/47782:
* https://github.com/WordPress/gutenberg/issues/47782

The `galleryWithImageBlocks` param determines which version of the Gallery block should be used in the editor (v1 or v2). Gallery block v2 is supported in WordPress 5.9+ and should be used for all sites on WordPress 5.9 and above. This fix addresses an edge-case for self-hosted sites on WP 5.9+ that do not have the Gutenberg plugin installed. In this case, Gallery block v1 is the default, but Gallery block v2 should actually be used.

This code change checks the WordPress version and sets the param to true for any site using WP 5.9+, and keeps the original logic for sites not using WP 5.9+. Once WordPress 5.9 becomes the minimum supported version, this change can be removed.

An easy way to verify which version of the Gallery block is being used is to switch to HTML mode and check the tags in the markup.

Gallery block v2 syntax (`figure` + `image`):

```
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped">
    <!-- wp:image {"id":3326,"sizeSlug":"large","linkDestination":"none"} -->
    <figure class="wp-block-image size-large"><img
            src="https://****.files.wordpress.com/2022/05/image.jpg?w=1024" alt="" class="wp-image-3326" />
    </figure>
    <!-- /wp:image -->
</figure>
<!-- /wp:gallery -->
```

Gallery block v1 syntax (`figure` + `ul` + `li` + `image`):

```
<!-- wp:gallery {"ids":[38],"linkTo":"none"} -->
<figure class="wp-block-gallery columns-1 is-cropped">
    <ul class="blocks-gallery-grid">
        <li class="blocks-gallery-item">
            <figure><img src="http://localhost:8888/wp-content/uploads/2022/06/265-5000x5000-1-scaled.jpeg" data-id="38"
                    class="wp-image-38" /></figure>
        </li>
    </ul>
</figure>
<!-- /wp:gallery -->
```

To test:

1. Create a self-hosted site with WordPress version 5.9 or above.
2. Check that the Gutenberg plugin is not installed. If not, uninstall it.
3. Create a post.
4. Insert a Gallery block.
5. Observe that the Gallery block is using v2 (content is not rendered using inner blocks).

Bonus testing:
1. Create a self-hosted site with WordPress version 5.8 or below. (The [WP Downgrade](https://wordpress.org/plugins/wp-downgrade/) plugin can be used to quickly switch between WordPress versions.)
2. Repeat steps above and note that Gallery block v1 is used. 

Alternatively, when running locally, the value of `galleryWithImageBlocks` can be logged in the [editor](https://github.com/WordPress/gutenberg/blob/d3cf857e79b1c3359e94301b8a79564fb8ef0f85/packages/edit-post/src/editor.native.js#L36) to verify.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A
