### PR TITLE
Declare gallery v2 field as optional

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [**] Block editor: Fix undo/redo history when inserting a link configured to open in a new tab [https://github.com/WordPress/gutenberg/pull/50460]
 * [**] [Jetpack-only] Block editor: Disable details settings for not belonged VideoPress videos [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5782]
 * [*] Block editor: [List block] Fix an issue when merging a list item into a Paragraph would remove its nested list items [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5785]
+* [*] Block editor: [Gallery block] Fixes a compatibility issue with Gallery block [https://github.com/wordpress-mobile/WordPress-Android/pull/18519]
 
 22.4
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2354,7 +2354,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         boolean enableXPosts = mSite.isUsingWpComRestApi() && (mIsXPostsCapable == null || mIsXPostsCapable);
 
         EditorTheme editorTheme = mEditorThemeStore.getEditorThemeForSite(mSite);
-        Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle() : null;
+        Bundle themeBundle = (editorTheme != null) ? editorTheme.getThemeSupport().toBundle(mSite) : null;
 
         boolean isUnsupportedBlockEditorEnabled =
                 mSite.isWPCom() || mIsJetpackSsoEnabled;
@@ -3715,7 +3715,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         if (editorTheme == null) return;
         EditorThemeSupport editorThemeSupport = editorTheme.getThemeSupport();
         ((EditorThemeUpdateListener) mEditorFragment)
-                    .onEditorThemeUpdated(editorThemeSupport.toBundle());
+                    .onEditorThemeUpdated(editorThemeSupport.toBundle(mSite));
 
         mPostEditorAnalyticsSession
                 .editorSettingsFetched(editorThemeSupport.isBlockBasedTheme(), event.getEndpoint().getValue());

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.96.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = '2740-3a14c028ab13e6802f282f4dd4e140a10db80685'
+    wordPressFluxCVersion = 'trunk-e1e7ea67d5591186620e7a16d7b4f10227d724a3'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.96.0'
     wordPressAztecVersion = 'v1.6.3'
-    wordPressFluxCVersion = 'trunk-3fe318a6de3463bf2444b0d798067546e9a18db0'
+    wordPressFluxCVersion = '2740-3a14c028ab13e6802f282f4dd4e140a10db80685'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
Related PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2740

Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/17712

### Description

This PR declares the `galleryWithImageBlocks` field to be optional, since it is sometimes omitted from the API response. In that case, this falls back to using the WordPress core version to determine whether v2 gallery support is enabled.

To test:

For each scenario, open and / or create a gallery on mobile, and save the post. The contents should not be lost after saving.

* WordPress version < 5.9, Gutenberg plugin not active
* WordPress version >= 5.9 Gutenberg plugin not active
* WordPress version < 5.9 Gutenberg plugin active
* WordPress version >= 5.9 Gutenberg plugin active

## Regression Notes
1. Potential unintended areas of impact
Editor settings / editor themes

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and automated (unit) tests

3. What automated tests I added (or what prevented me from doing so)
I updated the relevant unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
