### PR TITLE
Plans on JP: Analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt
@@ -272,7 +272,7 @@ class DomainSuggestionsViewModel @Inject constructor(
     private fun openPlans(selectedSuggestion: DomainSuggestionItem) {
         val domainProductDetails = DomainProductDetails(selectedSuggestion.productId, selectedSuggestion.domainName)
         _onFreeDomainSelected.postValue(Event(domainProductDetails))
-        // add tracking here
+        domainsRegistrationTracker.trackDomainsPurchaseWebviewViewed(site, isSiteCreation = false)
     }
 
     private fun selectDomain(selectedSuggestion: DomainSuggestionItem) {

--- a/WordPress/src/main/res/layout/plans_purchase_success_fragment.xml
+++ b/WordPress/src/main/res/layout/plans_purchase_success_fragment.xml
@@ -36,7 +36,7 @@
             android:text="@string/dashboard_card_plans_checkout_success_title"
             android:textAlignment="viewStart"
             android:textFontWeight="700"
-            android:textSize="@dimen/m3_sys_typescale_headline_large_text_size"
+            android:textSize="@dimen/text_sz_extra_extra_large"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/illustration_view"


### PR DESCRIPTION
This PR adds a missing track `domains_purchase_webview_viewed` .  The other tracks have already been added before

Fixes #18424 

To test:

Feature Flag
- Launch Jetpack app
- Go to **App Settings** (Tap on Avatar at the top right hand corner on My Site -> Find App Settings)
- Tap **Debug Settings**
- Find **dashboard_card_free_to_paid_plans** [under Remote features](https://github.com/wordpress-mobile/WordPress-Android/pull/18418)
- Enable the flag, and restart the app (scroll down)

Store sandbox
- Connect android emulator/device to sandbox paqN3M-5m-p2
- Use sandbox on Jetpack app to test for free with test cards pc8HXX-14D-p2
- If the app is connected to store sandbox, could verify that plans card doesn't show anymore
- Otherwise, go to store admin, change to sandbox (if Live), find the site, and verify the plan subscription is added

>**Note**
>Verify tracks events in Android Studio Logcat or Jetpack app Log (Me -> Help -> Logs)

- Ensure **plans card** appears as shown above on dashboard
- Verify `🔵 Tracked: free_to_paid_plan_dashboard_card_shown` is logged
- Tap on **plans card**
- Ensure it navigates to **Register domain** screen, and domains show label **Free for the first year**
- Verify `🔵 Tracked: free_to_paid_plan_dashboard_card_tapped` is logged
- Select a domain, and Tap on **Select domain** button
- Verify `🔵 Tracked: domains_dashboard_select_domain_tapped` is logged
- Ensure that it goes to **Plans page** on the web
- Verify `🔵 Tracked: domains_purchase_webview_viewed` is logged
- Tap on Upgrade button of a Personal or Premium Plan
- Ensure it takes to checkout screen
- Use the test card numbers to purchase
- Verify the Success screen is shown as in after image above
- Verify `🔵 Tracked: domains_purchase_domain_success` is logged
- Tap on Done button, return to dashboard

On a separate site (or cancel the plan purchased on the site used above)
- Ensure **plans card** appears as shown above on dashboard
- Tap on overflow (three dots) menu
- Verify `🔵 Tracked: free_to_paid_plan_dashboard_card_menu_tapped` is logged
- Ensure it pops up menu with **Hide this** option
- Tap on Hide this
- Ensure, the card gets hidden 
- Verify `🔵 Tracked: free_to_paid_plan_dashboard_card_hidden` is logged


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
tested manually

3. What automated tests I added (or what prevented me from doing so)
existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.