### PR TITLE
Adds: Missing text size resource

### DIFF
--- a/WordPress/src/main/res/layout/plans_purchase_success_fragment.xml
+++ b/WordPress/src/main/res/layout/plans_purchase_success_fragment.xml
@@ -36,7 +36,7 @@
             android:text="@string/dashboard_card_plans_checkout_success_title"
             android:textAlignment="viewStart"
             android:textFontWeight="700"
-            android:textSize="@dimen/m3_sys_typescale_headline_large_text_size"
+            android:textSize="@dimen/plans_purchase_success_title"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/illustration_view"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -773,4 +773,7 @@
     <dimen name="dashboard_card_plans_layout_padding">16dp</dimen>
     <dimen name="dashboard_card_plans_top_margin">48dp</dimen>
     <dimen name="dashboard_card_plans_done_button_bottom_margin">16dp</dimen>
+
+    <!-- Jetpack plans purchase -->
+    <dimen name="plans_purchase_success_title">32sp</dimen>
 </resources>


### PR DESCRIPTION
## Fixes 
This PR fixes the Build issue on the `trunk` due to missing dimen resource `@dimen/m3_sys_typescale_headline_large_text_size` after updating [Material to 1.9.0](https://github.com/wordpress-mobile/WordPress-Android/pull/18433),

##Explanation of changes 
This PR adds a dimen for the missing resource(`plans_purchase_success_title`) and updates the XML - `plans_purchase_success_fragment.xml` to reference it

## To test:
1. Check if the build is passing on CI 
2. Check if the code changes are correct 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and running local tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)