### PR TITLE
[Tool] Configure Dependabot to Ignore React Native Related Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
       - dependency-name: "com.github.tomakehurst:wiremock"
+      # List of React Native related dependencies that should be explicitly updated alongside a
+      # React Native upgrade. For more details, see
+      # https://github.com/wordpress-mobile/WordPress-Android/pull/18494#issuecomment-1566922244
+      - dependency-name: "com.facebook.react:react-native"
+      - dependency-name: "com.facebook.react:hermes-engine"
+      - dependency-name: "com.facebook.fresco:fresco"
+      - dependency-name: "com.facebook.fresco:imagepipeline-okhttp3"
+      - dependency-name: "com.facebook.fbjni:fbjni"
       # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with
       # dependapot.
       - dependency-name: "org.wordpress:fluxc"

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ ext {
 
     // react native
     facebookSoloaderVersion = '0.10.4'
+    facebookFrescoVersion = '2.5.0'
 
     // test
     assertjVersion = '3.23.1'

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ ext {
     uCropVersion = '2.2.8'
     zendeskVersion = '5.1.2'
 
+    // react native
+    facebookSoloaderVersion = '0.10.4'
+
     // test
     assertjVersion = '3.23.1'
     junitVersion = '4.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ ext {
     zendeskVersion = '5.1.2'
 
     // react native
+    facebookReactVersion = '0.69.4:release@aar'
     facebookSoloaderVersion = '0.10.4'
     facebookFrescoVersion = '2.5.0'
     facebookFbjniVersion = '0.2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ ext {
     // react native
     facebookSoloaderVersion = '0.10.4'
     facebookFrescoVersion = '2.5.0'
+    facebookFbjniVersion = '0.2.2'
 
     // test
     assertjVersion = '3.23.1'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     // To be removed with React Native 0.70+
     implementation("com.facebook.soloader:soloader") {
         version {
-            strictly '0.10.4'
+            strictly facebookSoloaderVersion
         }
     }
 

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -79,8 +79,8 @@ dependencies {
     implementation "com.facebook.fresco:fresco:$facebookFrescoVersion"
     implementation "com.facebook.fresco:imagepipeline-okhttp3:$facebookFrescoVersion"
     implementation "com.facebook.fbjni:fbjni:$facebookFbjniVersion"
-    implementation 'com.facebook.react:hermes-engine:0.69.4:release@aar'
-    implementation 'com.facebook.react:react-native:0.69.4:release@aar'
+    implementation "com.facebook.react:hermes-engine:$facebookReactVersion"
+    implementation "com.facebook.react:react-native:$facebookReactVersion"
 
     // This dependency will be substituted if the `local-builds.gradle` file contains
     // `localGutenbergMobilePath`. Details for this can be found in the `settings.gradle` file.

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -76,8 +76,8 @@ dependencies {
         }
     }
 
-    implementation 'com.facebook.fresco:fresco:2.5.0'
-    implementation 'com.facebook.fresco:imagepipeline-okhttp3:2.5.0'
+    implementation "com.facebook.fresco:fresco:$facebookFrescoVersion"
+    implementation "com.facebook.fresco:imagepipeline-okhttp3:$facebookFrescoVersion"
     implementation 'com.facebook.fbjni:fbjni:0.2.2'
     implementation 'com.facebook.react:hermes-engine:0.69.4:release@aar'
     implementation 'com.facebook.react:react-native:0.69.4:release@aar'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 
     implementation "com.facebook.fresco:fresco:$facebookFrescoVersion"
     implementation "com.facebook.fresco:imagepipeline-okhttp3:$facebookFrescoVersion"
-    implementation 'com.facebook.fbjni:fbjni:0.2.2'
+    implementation "com.facebook.fbjni:fbjni:$facebookFbjniVersion"
     implementation 'com.facebook.react:hermes-engine:0.69.4:release@aar'
     implementation 'com.facebook.react:react-native:0.69.4:release@aar'
 

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     // Forcing version due to https://github.com/facebook/SoLoader/issues/94
     // To be removed with React Native 0.70+
-    implementation("com.facebook.soloader:soloader") {
+    implementation("com.facebook.soloader:soloader:$facebookSoloaderVersion") {
         version {
             strictly facebookSoloaderVersion
         }


### PR DESCRIPTION
This PR disables `Dependabot` alerts for React Native related dependencies.  The list of React Native related dependencies that should be explicitly updated alongside a React Native upgrade.

For more info see: https://github.com/wordpress-mobile/WordPress-Android/pull/18494#issuecomment-1566922244

-----

## To test:

No need to explicitly test this change (like done [here](https://github.com/wordpress-mobile/WordPress-Android/pull/18335)), verifying that no [such](https://github.com/wordpress-mobile/WordPress-Android/pull/18494#issuecomment-1566895163) or [such](https://github.com/wordpress-mobile/WordPress-Android/pull/18501) `Dependabot` PR will end-up being opened in the future would be enough for now.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A
-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
