### PR TITLE
[Gutenberg] Fix crash when showing media upload dialog

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -21,6 +21,7 @@ import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -848,6 +849,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
+    @UiThread
     private void showCancelMediaUploadDialog(final int localMediaId) {
         // Display 'cancel upload' dialog
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(getActivity());
@@ -879,6 +881,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         dialog.show();
     }
 
+    @UiThread
     private void showRetryMediaUploadDialog(final int mediaId) {
         // Display 'retry upload' dialog
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(getActivity());
@@ -908,6 +911,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         dialog.show();
     }
 
+    @UiThread
     public void showFeaturedImageConfirmationDialog(final int mediaId) {
         GutenbergDialogFragment dialog = new GutenbergDialogFragment();
         dialog.initialize(
@@ -937,6 +941,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().sendToJSFeaturedImageId(mediaId);
     }
 
+    @UiThread
     private void showCancelMediaCollectionUploadDialog(ArrayList<Object> mediaFiles) {
         // Display 'cancel upload' dialog
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(getActivity());
@@ -969,6 +974,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         dialog.show();
     }
 
+    @UiThread
     private void showRetryMediaCollectionUploadDialog(ArrayList<Object> mediaFiles) {
         // Display 'retry upload' dialog
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(getActivity());
@@ -991,6 +997,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         dialog.show();
     }
 
+    @UiThread
     private void showCancelMediaCollectionSaveDialog(ArrayList<Object> mediaFiles) {
         // Display 'cancel upload' dialog
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(getActivity());
@@ -1360,6 +1367,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public void removeMedia(String mediaId) {
     }
 
+    @UiThread
     private boolean showSavingProgressDialogIfNeeded() {
         if (!isAdded()) {
             return false;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -294,12 +294,20 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
                     @Override
                     public void onRetryUploadForMediaClicked(int mediaId) {
-                        showRetryMediaUploadDialog(mediaId);
+                        if (getActivity() != null) {
+                            getActivity().runOnUiThread(() -> {
+                                showRetryMediaUploadDialog(mediaId);
+                            });
+                        }
                     }
 
                     @Override
                     public void onCancelUploadForMediaClicked(int mediaId) {
-                        showCancelMediaUploadDialog(mediaId);
+                        if (getActivity() != null) {
+                            getActivity().runOnUiThread(() -> {
+                                showCancelMediaUploadDialog(mediaId);
+                            });
+                        }
                     }
 
                     @Override
@@ -464,15 +472,27 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     }
 
                     @Override public void onCancelUploadForMediaCollection(ArrayList<Object> mediaFiles) {
-                        showCancelMediaCollectionUploadDialog(mediaFiles);
+                        if (getActivity() != null) {
+                            getActivity().runOnUiThread(() -> {
+                                showCancelMediaCollectionUploadDialog(mediaFiles);
+                            });
+                        }
                     }
 
                     @Override public void onRetryUploadForMediaCollection(ArrayList<Object> mediaFiles) {
-                        showRetryMediaCollectionUploadDialog(mediaFiles);
+                        if (getActivity() != null) {
+                            getActivity().runOnUiThread(() -> {
+                                showRetryMediaCollectionUploadDialog(mediaFiles);
+                            });
+                        }
                     }
 
                     @Override public void onCancelSaveForMediaCollection(ArrayList<Object> mediaFiles) {
-                        showCancelMediaCollectionSaveDialog(mediaFiles);
+                        if (getActivity() != null) {
+                            getActivity().runOnUiThread(() -> {
+                                showCancelMediaCollectionSaveDialog(mediaFiles);
+                            });
+                        }
                     }
 
                     @Override public void onMediaFilesBlockReplaceSync(ArrayList<Object> mediaFiles, String blockId) {


### PR DESCRIPTION
Fixes a crash in the editor related to the dialog shown as part of the upload process. Specifically, the ones displayed when trying to cancel or retry an upload (p5T066-41d-p2#comment-14730).

**Error displayed in development mode:**
<img src=https://github.com/wordpress-mobile/WordPress-Android/assets/14905380/29c059fa-27a3-4450-b026-03d70db790fc width=300>

After merging https://github.com/wordpress-mobile/WordPress-Android/pull/18364, seems that some of the upgraded dependencies (probably `activity`), require the `Dialog` component to be called from the main thread when showing it. This PR updates the React Native bridge code that handles showing upload dialogs.

### To test

#### Cancel dialog - Upload for media

1. Create/open a post.
2. Add an Image block.
3. Select an image from the device.
4. While the image is uploading, tap on the block.
5. Observe that a dialog is presented with the option to cancel the upload.

#### Retry dialog - Upload for media

1. Create/open a post.
2. Add an Image block.
3. Select an image from the device.
4. While the image is uploading, turn off the internet connection and wait.
5. Observe that a retry message is displayed.
6. Tap on the image.
7. Observe that a dialog is presented with the option to retry the upload.

#### Cancel dialog - Upload for media collection _(only used in Story block)_

1. Create/open a post.
2. Add a Story block.
3. Tap on "ADD MEDIA".
4. Select images from the device.
5. Apply changes to save the story.
6. While images are uploading, tap on the block.
7. Observe that a dialog is presented with the option to cancel the upload.

#### Retry dialog - Upload for media collection _(only used in Story block)_

1. Create/open a post.
2. Add a Story block.
3. Tap on "ADD MEDIA".
4. Select images from the device.
5. Apply changes to save the story.
6. While images are uploading, turn off the internet connection and wait.
7. Observe that a retry message is displayed.
8. Tap on the block.
9. Observe that a dialog is presented with the option to retry the upload.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)