### PR TITLE
Adds: feature flag with false value for blaze campaigns

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -163,6 +163,7 @@ android {
         buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
         buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
         buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
+        buildConfigField "boolean", "BLAZE_MANAGE_CAMPAIGNS", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/BlazeManageCampaignFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/BlazeManageCampaignFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+const val BLAZE_MANAGE_CAMPAIGNS_REMOTE_FIELD = "blaze_manage_campaigns"
+
+@Feature(BLAZE_MANAGE_CAMPAIGNS_REMOTE_FIELD, true)
+class BlazeManageCampaignFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.BLAZE_MANAGE_CAMPAIGNS,
+    BLAZE_MANAGE_CAMPAIGNS_REMOTE_FIELD
+)


### PR DESCRIPTION
## Related Issue
Closes #18534 

## Description 
This PR adds a feature flag - `blaze_manage_campaigns` for enabling/disabling the features 


## To test:
1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Remote Features` section
3. Verify that `blaze_manage_campaigns` is visible and is set to false. 

<img width="501" alt="Screenshot 2023-04-27 at 10 59 09 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/d219ce2b-2cf2-4641-9f8c-546a45c5e182.png">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
