### PR TITLE
Integrate gutenberg-mobile release 1.96.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5821-93e472e086d8dee4f8e8b7395a5331e1637e3da7'
+    gutenbergMobileVersion = '5821-c7251b9f532b297b8f58add1baa756a79406125c'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.96.0'
+    gutenbergMobileVersion = '5821-93e472e086d8dee4f8e8b7395a5331e1637e3da7'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5821-c7251b9f532b297b8f58add1baa756a79406125c'
+    gutenbergMobileVersion = 'v1.96.1'
     wordPressAztecVersion = 'v1.6.3'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.96.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5821

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.