### PR TITLE
[Jetpack Social] Connection item for post menus

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialConnection.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialConnection.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.posts.social
+
+import org.wordpress.android.models.PublicizeConnection
+
+data class PostSocialConnection(
+    val connectionId: Int,
+    val service: String,
+    val label: String,
+    val externalId: String,
+    val externalName: String,
+    val iconUrl: String,
+    val isSharingEnabled: Boolean,
+) {
+    companion object {
+        fun fromPublicizeConnection(connection: PublicizeConnection): PostSocialConnection {
+            return PostSocialConnection(
+                connectionId = connection.connectionId,
+                service = connection.service,
+                label = connection.label,
+                externalId = connection.externalId,
+                externalName = connection.externalName,
+                iconUrl = connection.externalProfilePictureUrl,
+                isSharingEnabled = true, // default to true
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
@@ -1,0 +1,105 @@
+package org.wordpress.android.ui.posts.social.compose
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.posts.social.PostSocialConnection
+
+@Composable
+fun PostSocialConnectionItem(
+    connection: PostSocialConnection,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onSharingChange: (Boolean) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .clickable(enabled) { onSharingChange(!connection.isSharingEnabled) }
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
+        val saturationMatrix = ColorMatrix().apply {
+            setToSaturation(if (enabled) 1f else 0f)
+        }
+        AsyncImage(
+            model = connection.iconUrl,
+            contentDescription = null,
+            contentScale = ContentScale.FillBounds,
+            colorFilter = ColorFilter.colorMatrix(saturationMatrix),
+            alpha = if (enabled) 1f else ContentAlpha.disabled,
+            modifier = Modifier.size(28.dp),
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = connection.externalName,
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface
+                .copy(alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled),
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Switch(
+            enabled = enabled,
+            checked = connection.isSharingEnabled,
+            onCheckedChange = onSharingChange,
+        )
+    }
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun PostSocialConnectionItemPreview() {
+    val connection = PostSocialConnection(
+        connectionId = 0,
+        service = "tumblr",
+        label = "Tumblr",
+        externalId = "myblog.tumblr.com",
+        externalName = "My blog",
+        iconUrl = "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png",
+        isSharingEnabled = true
+    )
+    var connectionState by remember { mutableStateOf(connection) }
+    var disabledState by remember { mutableStateOf(connection) }
+    AppTheme {
+        Column {
+            // enabled
+            PostSocialConnectionItem(
+                connection = connectionState,
+                onSharingChange = { connectionState = connectionState.copy(isSharingEnabled = it) },
+            )
+
+            Divider()
+
+            // disabled
+            PostSocialConnectionItem(
+                connection = disabledState,
+                enabled = false,
+                onSharingChange = { disabledState = disabledState.copy(isSharingEnabled = it) },
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.posts.social.PostSocialConnection
 
 @Composable
@@ -40,7 +41,7 @@ fun PostSocialConnectionItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .clickable(enabled) { onSharingChange(!connection.isSharingEnabled) }
-            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .padding(horizontal = Margin.ExtraLarge.value, vertical = Margin.MediumLarge.value)
     ) {
         val saturationMatrix = ColorMatrix().apply {
             setToSaturation(if (enabled) 1f else 0f)
@@ -53,7 +54,7 @@ fun PostSocialConnectionItem(
             alpha = if (enabled) 1f else ContentAlpha.disabled,
             modifier = Modifier.size(28.dp),
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(Margin.ExtraLarge.value))
         Text(
             text = connection.externalName,
             style = MaterialTheme.typography.subtitle1,


### PR DESCRIPTION
Part of #18560 

Add item UI for Social Connection items that will be used in pre-publishing and post-settings menus.

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/fa4d468d-596b-484b-9258-4383f7bda05c)

To test:
It's not possible to test changes in the app as these changes are not integrated with anything. However, it's possible to pull the code, go to `PostSocialConnectionItem.kt` file, and check/run the Compose Previews there.

_Note: the icon is not shown in Compose Preview because the `AsyncImage` composable doesn't work with that._

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A: changes are in code only at this moment and can't be tested in the various scenarios yet.