### PR TITLE
[WebView] fix Blob URLs opening externally in Site Editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/URLFilteredWebViewClient.java
@@ -22,6 +22,7 @@ public class URLFilteredWebViewClient extends ErrorManagedWebViewClient {
 
     private static final String WP_LOGIN_URL_SUFFIX = "wp-login.php";
     private static final String REMOTE_LOGIN_URL_SUFFIX = "remote-login.php";
+    private static final String BLOB_URL_PREFIX = "blob:";
 
     public URLFilteredWebViewClient(String url, ErrorManagedWebViewClientListener listener) {
         super(listener);
@@ -66,6 +67,7 @@ public class URLFilteredWebViewClient extends ErrorManagedWebViewClient {
 
             boolean isRemoteLoginUrl = url.endsWith(REMOTE_LOGIN_URL_SUFFIX);
             boolean isLoginUrl = url.endsWith(WP_LOGIN_URL_SUFFIX);
+            boolean isBlobUrl = url.startsWith(BLOB_URL_PREFIX);
 
             Uri currentUri = Uri.parse((view.getUrl()));
             Uri incomingUri = Uri.parse(url);
@@ -73,8 +75,8 @@ public class URLFilteredWebViewClient extends ErrorManagedWebViewClient {
             boolean newUrlIsOnTheSameHost =
                     currentUri.getHost() != null && currentUri.getHost().equals(incomingUri.getHost());
 
-            boolean openInExternalBrowser =
-                    !isRemoteLoginUrl && !isLoginUrl && !isComingFromLoginUrl && !newUrlIsOnTheSameHost;
+            boolean openInExternalBrowser = !isRemoteLoginUrl && !isLoginUrl && !isComingFromLoginUrl
+                                            && !newUrlIsOnTheSameHost && !isBlobUrl;
 
             if (openInExternalBrowser) {
                 ReaderActivityLauncher.openUrl(view.getContext(), url, ReaderActivityLauncher.OpenUrlType.EXTERNAL);


### PR DESCRIPTION
This issue was found by @geriux here: pctCYC-P7-p2#comment-897

It looks like there were updates to the Site Editor page, which we open in our WebView, that introduced the usage of Blob URLs, but our client is intercepting them and trying to open them externally instead of just loading the resources, causing the page to not load properly.

Blob URLs (starting with "blob:") are browser-generated URLs for blob objects: https://developer.mozilla.org/en-US/docs/Web/API/Blob. Those URLs are specific to the browser instance that generates them so they can't and should not be opened externally.

This fixes the issue by making sure we let this type of URL load in the WebView properly.

To test:
The easiest way to test it currently is by going to the Site Editor, using a blog that has a block-based theme.

1. Install the Jetpack app OR the WordPress app
2. Login to your account
3. Select a blog using a block-based theme
4. Navigate to the Pages List screen by tapping Pages in the menu or shortcuts
5. 🔍 Verify there is a Homepage item talking about theme templates
6. Tap the item
7. (self-hosted only) you should see a login screen inside a WebView, enter the credentials
8. 🔍 Verify the Site Editor WebView opens to edit the template for the homepage

More testing steps here: pctCYC-P7-p2

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist
_No UI changes made here._