### PR TITLE
[Jetpack Social] Message item for post menus

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
@@ -15,8 +15,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
@@ -33,7 +35,7 @@ fun PostSocialMessageItem(
             .padding(horizontal = Margin.ExtraLarge.value, vertical = Margin.MediumLarge.value)
     ) {
         Text(
-            text = "Message",
+            text = stringResource(R.string.social_item_message_title),
             style = MaterialTheme.typography.subtitle1,
             color = MaterialTheme.colors.onSurface
                 .copy(alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
@@ -1,0 +1,86 @@
+package org.wordpress.android.ui.posts.social.compose
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+
+@Composable
+fun PostSocialMessageItem(
+    message: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .clickable(enabled, onClick = onClick)
+            .padding(horizontal = Margin.ExtraLarge.value, vertical = Margin.MediumLarge.value)
+    ) {
+        Text(
+            text = "Message",
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface
+                .copy(alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled),
+        )
+        Text(
+            text = message,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface
+                .copy(alpha = if (enabled) ContentAlpha.medium else ContentAlpha.disabled),
+        )
+    }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PostSocialMessageItemPreview() {
+    val messages = listOf(
+        "5 Chicken Recipes that you have to try on the grill this summer",
+        "Small message sample",
+        "Message to be shared to the social network when I publish this post"
+    )
+    var messageId by remember { mutableStateOf(0) }
+
+    val updateMessage = {
+        messageId = (messageId + 1) % messages.size
+    }
+
+    AppTheme {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            PostSocialMessageItem(
+                message = messages[messageId],
+                onClick = updateMessage,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Divider()
+
+            PostSocialMessageItem(
+                message = messages[0],
+                modifier = Modifier.fillMaxWidth(),
+                enabled = false,
+            )
+        }
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2473,6 +2473,7 @@
     <string name="sharing_twitter_deprecation_notice_title">Twitter auto-sharing is no longer available</string>
     <string name="sharing_twitter_deprecation_notice_description">Twitter auto-sharing is no longer available due to Twitter\'s changes in terms and pricing.</string>
     <string name="sharing_twitter_deprecation_notice_find_out_more">Find out more</string>
+    <string name="social_item_message_title">Message</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>


### PR DESCRIPTION
Part of #18560 

Add item UI for Message item that will be used in pre-publishing and post-settings menus of Jetpack Social sharing.

<img width="393" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/89194137-9585-4c47-ad8f-aa2062c5bae9">

To test:
It's not possible to test changes in the app as these changes are not integrated with anything. However, it's possible to pull the code, go to `PostSocialMessageItem.kt` file, and check/run the Compose Previews there.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A: changes are in code only at this moment and can't be tested in the various scenarios yet.