### PR TITLE
[Compose] Create TrainOfIcons reusable Composable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.ui.compose.components
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -18,11 +19,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 private const val DEFAULT_ICON_SIZE = 32
 private const val DEFAULT_ICON_BORDER_WIDTH = 2
+
 // this proportion is calculated based on the Figma design for Jetpack Social (Th1ahHKq53k5JT1PNDMavY-fi-865_13166)
 private const val ICON_OFFSET_PROPORTION = 29f / 36f
 
@@ -61,14 +62,10 @@ fun TrainOfIcons(
                     placeholder = placeholder,
                     modifier = Modifier
                         .size(iconSizeWithBorder.dp)
-                        .border(
-                            width = iconBorderWidth,
-                            color = AppColor.White,
-                            shape = CircleShape
-                        )
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colors.surface)
                         .padding(iconBorderWidth)
                         .clip(CircleShape)
-                        .background(AppColor.White)
                 )
             }
         }
@@ -93,6 +90,7 @@ fun TrainOfIcons(
 }
 
 @Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun TrainOfIconsPreview() {
     AppTheme {

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -95,9 +95,12 @@ fun TrainOfIcons(
 fun TrainOfIconsPreview() {
     AppTheme {
         TrainOfIcons(
-            iconModels = List(4) {
-                R.drawable.login_prologue_fifth_asset_one
-            }
+            iconModels = listOf(
+                R.drawable.login_prologue_second_asset_three,
+                R.drawable.login_prologue_second_asset_two,
+                R.drawable.login_prologue_third_asset_one,
+                R.mipmap.app_icon
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -43,6 +45,7 @@ private const val ICON_OFFSET_PROPORTION = 29f / 36f
 fun TrainOfIcons(
     iconModels: List<Any>,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     iconSize: Dp = DEFAULT_ICON_SIZE.dp,
     iconBorderWidth: Dp = DEFAULT_ICON_BORDER_WIDTH.dp,
     placeholder: Painter = ColorPainter(colorResource(R.color.placeholder)),
@@ -52,7 +55,11 @@ fun TrainOfIcons(
     val iconSizeWithBorder = (iconSize.value + 2 * iconBorderWidth.value).toInt()
 
     Layout(
-        modifier = modifier,
+        modifier = modifier.then(Modifier.semantics(mergeDescendants = true) {
+            contentDescription?.let {
+                this.contentDescription = it
+            }
+        }),
         content = {
             iconModels.forEach { iconModel ->
                 AsyncImage(
@@ -100,7 +107,8 @@ fun TrainOfIconsPreview() {
                 R.drawable.login_prologue_second_asset_two,
                 R.drawable.login_prologue_third_asset_one,
                 R.mipmap.app_icon
-            )
+            ),
+            contentDescription = "Train of icons",
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -1,0 +1,105 @@
+package org.wordpress.android.ui.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+private const val DEFAULT_ICON_SIZE = 32
+private const val DEFAULT_ICON_BORDER_WIDTH = 2
+// this proportion is calculated based on the Figma design for Jetpack Social (Th1ahHKq53k5JT1PNDMavY-fi-865_13166)
+private const val ICON_OFFSET_PROPORTION = 29f / 36f
+
+/**
+ * This component uses coil's [AsyncImage] internally so it supports any model the regular [AsyncImage] composable can
+ * use. The icons are laid out horizontally, with the first icon being the first element in the list and the last icon
+ * being the last element in the list. The icons are laid out in a way that they overlap each other slightly.
+ *
+ * The space an individual icon occupies is calculated by the sum of the [iconSize] and [iconBorderWidth] parameters.
+ *
+ * @param iconModels a list of models to be used for the icons. The list must have at least 1 element.
+ * @param modifier the modifier to be applied to the layout.
+ * @param iconSize the size of an individual icon.
+ * @param placeholder the placeholder to be used while the icons are loading.
+ */
+@Composable
+fun TrainOfIcons(
+    iconModels: List<Any>,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = DEFAULT_ICON_SIZE.dp,
+    iconBorderWidth: Dp = DEFAULT_ICON_BORDER_WIDTH.dp,
+    placeholder: Painter = ColorPainter(colorResource(R.color.placeholder)),
+) {
+    require(iconModels.isNotEmpty()) { "TrainOfIcons must have at least 1 icon" }
+
+    val iconSizeWithBorder = (iconSize.value + 2 * iconBorderWidth.value).toInt()
+
+    Layout(
+        modifier = modifier,
+        content = {
+            iconModels.forEach { iconModel ->
+                AsyncImage(
+                    model = iconModel,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    placeholder = placeholder,
+                    modifier = Modifier
+                        .size(iconSizeWithBorder.dp)
+                        .border(
+                            width = iconBorderWidth,
+                            color = AppColor.White,
+                            shape = CircleShape
+                        )
+                        .padding(iconBorderWidth)
+                        .clip(CircleShape)
+                        .background(AppColor.White)
+                )
+            }
+        }
+    ) { measurables, constraints ->
+        val placeables = measurables.map { measurable ->
+            measurable.measure(constraints)
+        }
+
+        val measuredIconSize = placeables[0].width
+        val iconOffset = (measuredIconSize * ICON_OFFSET_PROPORTION).toInt()
+        val totalWidth = iconOffset * (placeables.size - 1) + measuredIconSize
+
+        val width = totalWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
+
+        layout(width, measuredIconSize) {
+            placeables.forEachIndexed { index, placeable ->
+                val offsetX = index * iconOffset
+                placeable.placeRelative(offsetX, 0, 0f)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TrainOfIconsPreview() {
+    AppTheme {
+        TrainOfIcons(
+            iconModels = List(4) {
+                R.drawable.login_prologue_fifth_asset_one
+            }
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -38,7 +38,9 @@ private const val ICON_OFFSET_PROPORTION = 29f / 36f
  *
  * @param iconModels a list of models to be used for the icons. The list must have at least 1 element.
  * @param modifier the modifier to be applied to the layout.
+ * @param contentDescription the content description of the container.
  * @param iconSize the size of an individual icon.
+ * @param iconBorderWidth the width of the icon border.
  * @param placeholder the placeholder to be used while the icons are loading.
  */
 @Composable


### PR DESCRIPTION
Fixes #18583

This is similar to the `TrainOfAvatars` Android view but more flexible. It is being created for use in the Jetpack Social improvements, which contain a "train" of social network icons, but we can use it to replace the `TrainOfAvatars` view in other future Compose layouts.

This uses `AsyncImage` to load the icons/avatars/images so it's flexible in terms of the image model / source.

<img width="322" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/e0173306-9261-4591-8d1e-5f754db7d4ad">

_Note: the image content is not properly loaded in the Preview because `AsyncImage` is being used, which doesn't load in Android Studio's preview, but it's possible to run the Preview on a device to see it._

<img width="328" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/44004c94-2dc8-400c-9e43-68e36f732837">

## To test
Nothing to test as this creates the Composable but does not use it at the moment. It's possible to sync the code and check the Compose previews and run the component preview on a device from there.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] RTL
