### PR TITLE
Fixes: the unit test failures after coroutine version update

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
@@ -578,8 +579,8 @@ class ActivityLogViewModel @Inject constructor(
     private fun queryRestoreStatus(restoreId: Long? = null) {
         restoreStatusJob?.cancel()
         restoreStatusJob = viewModelScope.launch {
-            getRestoreStatusUseCase.getRestoreStatus(site, restoreId)
-                .collect { handleRestoreStatus(it) }
+            val flow = getRestoreStatusUseCase.getRestoreStatus(site, restoreId) as? Flow<RestoreRequestState?>
+            flow?.collect { it?.run { handleRestoreStatus(it) } }
         }
     }
 
@@ -651,8 +652,9 @@ class ActivityLogViewModel @Inject constructor(
     private fun queryBackupDownloadStatus(downloadId: Long? = null) {
         backupDownloadStatusJob?.cancel()
         backupDownloadStatusJob = viewModelScope.launch {
-            getBackupDownloadStatusUseCase.getBackupDownloadStatus(site, downloadId)
-                .collect { state -> handleBackupDownloadStatus(state) }
+            val flow = getBackupDownloadStatusUseCase.getBackupDownloadStatus(site, downloadId)
+                    as? Flow<BackupDownloadRequestState?>
+            flow?.collect { it?.run { handleBackupDownloadStatus(it) } }
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/onboarding/BloggingPromptsOnboardingViewModelTest.kt
@@ -130,6 +130,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
         val siteModel = SiteModel().apply { id = 123 }
         whenever(siteStore.sitesCount).thenReturn(1)
         whenever(siteStore.sites).thenReturn(listOf(siteModel))
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
 
         val startState = viewStates[0]
         (startState as Ready).onPrimaryButtonClick()
@@ -142,6 +143,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
         val siteModel = SiteModel().apply { id = 123 }
         whenever(siteStore.sitesCount).thenReturn(1)
         whenever(siteStore.sites).thenReturn(listOf(siteModel))
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
         whenever(getIsFirstBloggingPromptsOnboardingUseCase.execute()).thenReturn(false)
         classToTest.start(ONBOARDING)
         val startState = viewStates[0]
@@ -206,6 +208,7 @@ class BloggingPromptsOnboardingViewModelTest : BaseUnitTest() {
     fun `Should track try it now clicked when onPrimaryButtonClick is called with ONBOARDING`() = test {
         classToTest.start(ONBOARDING)
         val startState = viewStates[0]
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(SiteModel())
         (startState as Ready).onPrimaryButtonClick()
         verify(analyticsTracker).trackTryItNowClicked()
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/viewmodels/UnifiedCommentsEditViewModelTest.kt
@@ -311,6 +311,8 @@ class UnifiedCommentsEditViewModelTest : BaseUnitTest() {
             .thenReturn(listOf(COMMENT_ENTITY))
         whenever(commentsStore.updateEditComment(eq(site), any()))
             .thenReturn(CommentsActionPayload(CommentsActionData(emptyList(), 0)))
+        whenever(notificationActionsWrapper.downloadNoteAndUpdateDB(noteId))
+            .thenReturn(true)
         viewModel.start(site, notificationCommentIdentifier)
         viewModel.onActionMenuClicked()
         verify(notificationActionsWrapper).downloadNoteAndUpdateDB(noteId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -128,7 +128,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         whenever(productsStore.fetchProducts(any())).thenReturn(mock())
 
         viewModel.start(site, domainRegistrationPurpose)
-        viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
 
         verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))
@@ -136,13 +135,14 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `site on blogger plan is requesting only dot blog domain suggestions`() = test {
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
         site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
 
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val lastAction = captor.value
 
@@ -161,12 +161,14 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `site on non blogger plan is requesting all possible domain suggestions`() = test {
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
+
         site.planId = PlansConstants.PREMIUM_PLAN_ID
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
         val captor = ArgumentCaptor.forClass(Action::class.java)
-        verify(dispatcher, times(1)).dispatch(captor.capture())
+        verify(dispatcher, times(2)).dispatch(captor.capture())
 
         val lastAction = captor.value
 
@@ -184,6 +186,8 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `clicking select domain button for credit redemption emits selected domain`() = test {
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
+
         viewModel.start(site, CTA_DOMAIN_CREDIT_REDEMPTION)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
         viewModel.onSelectDomainButtonClicked()
@@ -197,6 +201,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     fun `clicking select domain button for purchase calls cart creation use case and emits selected domain`() = test {
         whenever(createCartUseCase.execute(site, DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME, true, false))
             .thenReturn(dummySuccessfulOnShoppingCartCreated)
+        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
 
         viewModel.start(site, DOMAIN_PURCHASE)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -128,6 +128,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
         whenever(productsStore.fetchProducts(any())).thenReturn(mock())
 
         viewModel.start(site, domainRegistrationPurpose)
+        viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
 
         verify(productsStore).fetchProducts(eq(TYPE_DOMAINS_PRODUCT))

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModelTest.kt
@@ -8,9 +8,10 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -50,9 +51,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var createCartUseCase: CreateCartUseCase
 
-    @Mock
-    lateinit var productsStore: ProductsStore
-
+    private val productsStore = mock<ProductsStore> { onBlocking { fetchProducts(any()) } doReturn mock() }
     private lateinit var site: SiteModel
     private lateinit var domainRegistrationPurpose: DomainRegistrationPurpose
     private lateinit var viewModel: DomainSuggestionsViewModel
@@ -71,7 +70,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
             createCartUseCase,
             testDispatcher()
         )
-
         whenever(debouncer.debounce(any(), any(), any(), any())).thenAnswer { invocation ->
             val delayedRunnable = invocation.arguments[1] as Runnable
             delayedRunnable.run()
@@ -125,8 +123,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `domain products are fetched only at first start`() = test {
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
-
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.start(site, domainRegistrationPurpose)
         advanceUntilIdle()
@@ -136,9 +132,7 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `site on blogger plan is requesting only dot blog domain suggestions`() = test {
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
         site.planId = PlansConstants.BLOGGER_PLAN_ONE_YEAR_ID
-
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
 
@@ -162,8 +156,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `site on non blogger plan is requesting all possible domain suggestions`() = test {
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
-
         site.planId = PlansConstants.PREMIUM_PLAN_ID
         viewModel.start(site, domainRegistrationPurpose)
         viewModel.updateSearchQuery("test")
@@ -187,8 +179,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `clicking select domain button for credit redemption emits selected domain`() = test {
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
-
         viewModel.start(site, CTA_DOMAIN_CREDIT_REDEMPTION)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)
         viewModel.onSelectDomainButtonClicked()
@@ -202,7 +192,6 @@ class DomainSuggestionsViewModelTest : BaseUnitTest() {
     fun `clicking select domain button for purchase calls cart creation use case and emits selected domain`() = test {
         whenever(createCartUseCase.execute(site, DUMMY_PRODUCT_ID, DUMMY_DOMAIN_NAME, true, false))
             .thenReturn(dummySuccessfulOnShoppingCartCreated)
-        whenever(productsStore.fetchProducts(any())).thenReturn(mock())
 
         viewModel.start(site, DOMAIN_PURCHASE)
         viewModel.onDomainSuggestionSelected(dummySelectedDomainSuggestionItem)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -190,7 +190,8 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given details step, when request create download success, then state reflects progress`() = test {
-        whenever(percentFormatter.format(0)).thenReturn("30%")
+        whenever(percentFormatter.format(0)).thenReturn("0%")
+        whenever(percentFormatter.format(30)).thenReturn("30%")
         whenever(postBackupDownloadUseCase.postBackupDownloadRequest(anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn(postBackupDownloadSuccess)
 
@@ -312,9 +313,11 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given progress step, when started, then the progress is set to zero`() = test {
-        whenever(percentFormatter.format(0)).thenReturn("30%")
+        whenever(percentFormatter.format(0)).thenReturn("0%")
         whenever(postBackupDownloadUseCase.postBackupDownloadRequest(anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn(postBackupDownloadSuccess)
+        whenever(backupDownloadStatusUseCase.getBackupDownloadStatus(anyOrNull(), anyOrNull()))
+            .thenReturn(flow { emit(getInitialStatusProgress) })
 
         val uiStates = initObservers().uiStates
 
@@ -503,6 +506,11 @@ class BackupDownloadViewModelTest : BaseUnitTest() {
     private val getStatusProgress = BackupDownloadRequestState.Progress(
         rewindId = "rewindId",
         progress = 30
+    )
+
+    private val getInitialStatusProgress = BackupDownloadRequestState.Progress(
+        rewindId = "rewindId",
+        progress = null
     )
 
     private val postBackupDownloadNetworkError = BackupDownloadRequestState.Failure.NetworkUnavailable

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -73,6 +73,8 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
         whenever(gravatarUtilsWrapper.fixGravatarUrlWithResource(any(), any())).thenReturn("")
         whenever(localeManagerWrapper.getLanguage()).thenReturn("")
         classToTest = JetpackMigrationViewModel(
+            mainDispatcher = testDispatcher(),
+            dispatcher = dispatcher,
             siteUtilsWrapper = siteUtilsWrapper,
             gravatarUtilsWrapper = gravatarUtilsWrapper,
             contextProvider = contextProvider,
@@ -85,7 +87,6 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
             siteStore = siteStore,
             localeManagerWrapper = localeManagerWrapper,
             jetpackMigrationLanguageUtil = jetpackMigrationLanguageUtil,
-            dispatcher = dispatcher,
         )
         classToTest.refreshAppTheme.observeForever(refreshAppThemeObserver)
         classToTest.refreshAppLanguage.observeForever(refreshAppLanguageObserver)
@@ -176,6 +177,7 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
         verifyNoInteractions(dispatcher)
     }
 
+    @Test
     fun `Should dispatch fetch account action when finish button is tapped on success screen if needed`() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(accountStore.account).thenReturn(mock())

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -136,12 +136,17 @@ class QRCodeAuthViewModelTest : BaseUnitTest() {
     fun `given validate state, when primary action is clicked, then state is authenticating`() {
         val uiStates = mutableListOf<QRCodeAuthUiState>()
         testWithData(uiStates) {
+            initAuthenticate()
             initAndStartVMForState(VALIDATED)
 
             (uiStates.last() as Validated).primaryActionButton.clickAction()
 
-            assertThat(uiStates.last().type).isEqualTo(AUTHENTICATING)
+            assertThat(getTheSecondLastItem(uiStates).type).isEqualTo(AUTHENTICATING)
         }
+    }
+
+    private fun getTheSecondLastItem(uiStates: MutableList<QRCodeAuthUiState>): QRCodeAuthUiState {
+        return uiStates[uiStates.size - 2]
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -367,7 +367,7 @@ class ReaderViewModelTest : BaseUnitTest() {
         // Assert
         assertThat(uiStates.size).isEqualTo(1)
         assertThat(uiStates[0]).isInstanceOf(ContentUiState::class.java)
-        assertThat((uiStates[0] as ContentUiState).appBarExpanded).isTrue()
+        assertThat((uiStates[0] as ContentUiState).appBarExpanded).isTrue
     }
 
     @Test
@@ -494,7 +494,7 @@ class ReaderViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wp app, when jp bottom sheet feature is false, then bottom sheet is not shown`() = testWithEmptyTags {
-        val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>(Event(false))
+        val showJetpackPoweredBottomSheetEvent = mutableListOf(Event(false))
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)
         }
@@ -507,7 +507,7 @@ class ReaderViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wp app, when jetpack overlay feature is false, then jp fullscreen overlay is not shown`() {
-        val showJetpackOverlayEvent = mutableListOf<Event<Boolean>>(Event(false))
+        val showJetpackOverlayEvent = mutableListOf(Event(false))
         viewModel.showJetpackOverlay.observeForever {
             showJetpackOverlayEvent.add(it)
         }
@@ -520,7 +520,7 @@ class ReaderViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given wp app, when jetpack overlay feature is true, then jp fullscreen overlay is shown`() {
-        val showJetpackOverlayEvent = mutableListOf<Event<Boolean>>(Event(false))
+        val showJetpackOverlayEvent = mutableListOf(Event(false))
         viewModel.showJetpackOverlay.observeForever {
             showJetpackOverlayEvent.add(it)
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -31,7 +31,6 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartType
-import org.wordpress.android.ui.reader.repository.usecases.tags.GetFollowedTagsUseCase
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.LoadReaderTabsUseCase
 import org.wordpress.android.ui.reader.utils.DateProvider
@@ -64,9 +63,6 @@ class ReaderViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var accountStore: AccountStore
-
-    @Mock
-    lateinit var getFollowedTagsUseCase: GetFollowedTagsUseCase
 
     @Mock
     lateinit var quickStartRepository: QuickStartRepository

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -497,7 +497,7 @@ class ReaderViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given wp app, when jp powered bottom sheet feature is false, then jp powered bottom sheet is not shown`() {
+    fun `given wp app, when jp bottom sheet feature is false, then bottom sheet is not shown`() = testWithEmptyTags {
         val showJetpackPoweredBottomSheetEvent = mutableListOf<Event<Boolean>>(Event(false))
         viewModel.showJetpackPoweredBottomSheet.observeForever {
             showJetpackPoweredBottomSheetEvent.add(it)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -293,7 +293,7 @@ class ReaderViewModelTest : BaseUnitTest() {
         triggerReaderTabContentDisplay()
 
         // Assert
-        assertThat(state!!.searchMenuItemUiState.isVisible).isTrue()
+        assertThat(state!!.searchMenuItemUiState.isVisible).isTrue
     }
 
     @Test
@@ -352,7 +352,7 @@ class ReaderViewModelTest : BaseUnitTest() {
         // Assert
         assertThat(uiStates.size).isEqualTo(1)
         assertThat(uiStates[0]).isInstanceOf(ContentUiState::class.java)
-        assertThat((uiStates[0] as ContentUiState).tabLayoutVisible).isTrue()
+        assertThat((uiStates[0] as ContentUiState).tabLayoutVisible).isTrue
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -382,7 +382,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
     private val uiDomains get() = assertIs<List<New.DomainUiState>>(viewModel.uiState.value?.contentState?.items)
 
     @Test
-    fun verifyFetchFreeAndPaidDomainsWhenPurchasingFeatureConfigIsEnabled() = testNewUi {
+    fun verifyFetchFreeAndPaidDomainsWhenPurchasingFeatureConfigIsEnabled() = testWithSuccessResultNewUi {
         val (query, size) = MULTI_RESULT_DOMAIN_FETCH_QUERY
         viewModel.start()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModelTest.kt
@@ -196,7 +196,7 @@ class SiteCreationProgressViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on service success for paid domain creates cart`() = test {
+    fun `on service success for paid domain creates cart`() = testWith(CART_SUCCESS)  {
         startViewModel(SITE_CREATION_STATE.copy(domain = PAID_DOMAIN))
         viewModel.onSiteCreationServiceStateUpdated(SERVICE_SUCCESS)
         verify(createCartUseCase).execute(

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/accounts/PostSignupInterstitialViewModelTest.kt
@@ -47,7 +47,9 @@ class PostSignupInterstitialViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when interstitial is shown should update preference value`() {
+    fun `when interstitial is shown should update preference value`() = test {
+        whenever(wpJetpackIndividualPluginHelper.shouldShowJetpackIndividualPluginOverlay()).thenReturn(false)
+
         viewModel.onInterstitialShown()
 
         verify(analyticsTracker).track(WELCOME_NO_SITES_INTERSTITIAL_SHOWN)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -174,6 +174,11 @@ class ActivityLogViewModelTest : BaseUnitTest() {
         whenever(site.siteId).thenReturn(SITE_ID)
         whenever(jetpackCapabilitiesUseCase.getCachedJetpackPurchasedProducts(anyLong()))
             .thenReturn(JetpackPurchasedProducts(scan = false, backup = false))
+        val progress = BackupDownloadRequestState.Progress(REWIND_ID, 50)
+        whenever(getBackupDownloadStatusUseCase.getBackupDownloadStatus(site, DOWNLOAD_ID))
+            .thenReturn(flow { emit(progress) })
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
+            .thenReturn(flow { emit(RestoreRequestState.Multisite) })
     }
 
     @Test
@@ -1334,6 +1339,9 @@ class ActivityLogViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when query backup status, then trigger get backup download status`() = test {
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
+            .thenReturn(flow { emit(RestoreRequestState.Multisite) })
+
         viewModel.onQueryBackupDownloadStatus(REWIND_ID, DOWNLOAD_ID, JetpackBackupDownloadActionState.PROGRESS.id)
 
         verify(getBackupDownloadStatusUseCase).getBackupDownloadStatus(site, DOWNLOAD_ID)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/activitylog/ActivityLogViewModelTest.kt
@@ -174,9 +174,10 @@ class ActivityLogViewModelTest : BaseUnitTest() {
         whenever(site.siteId).thenReturn(SITE_ID)
         whenever(jetpackCapabilitiesUseCase.getCachedJetpackPurchasedProducts(anyLong()))
             .thenReturn(JetpackPurchasedProducts(scan = false, backup = false))
-        val progress = BackupDownloadRequestState.Progress(REWIND_ID, 50)
-        whenever(getBackupDownloadStatusUseCase.getBackupDownloadStatus(site, DOWNLOAD_ID))
-            .thenReturn(flow { emit(progress) })
+        val progress = RestoreRequestState.Progress(REWIND_ID, 50)
+        val complete = RestoreRequestState.Complete(REWIND_ID, RESTORE_ID)
+        whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
+            .thenReturn(flow { emit(progress); emit(complete) })
         whenever(getRestoreStatusUseCase.getRestoreStatus(site, RESTORE_ID))
             .thenReturn(flow { emit(RestoreRequestState.Multisite) })
     }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -542,6 +542,7 @@ class PagesViewModelTest : BaseUnitTest() {
         // Arrange
         val wpcomSite = SiteModel()
         wpcomSite.setIsWPCom(false)
+        setUpPageStoreWithEmptyPages()
 
         // Act
         viewModel.start(wpcomSite)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -542,7 +542,7 @@ class PagesViewModelTest : BaseUnitTest() {
         // Arrange
         val wpcomSite = SiteModel()
         wpcomSite.setIsWPCom(false)
-        setUpPageStoreWithEmptyPages()
+        setUpPageStoreWithASinglePage(wpcomSite)
 
         // Act
         viewModel.start(wpcomSite)


### PR DESCRIPTION
## Fixes 
Fixes the failure of the unit tests after the coroutines library update. PR - https://github.com/wordpress-mobile/WordPress-Android/pull/18500

#### On **Kotlin coroutines library version 1.6.4**
If the coroutine inside a function throws an exception, the test passes, and the exception is thrown silently to the console. In some cases, if the test is asserting a return value and there is a side effect function that throws an exception, then the test still passes. 

#### On  **Kotlin coroutines library version 1.7.1**
The exceptions inside the production code will be thrown, regardless of whether the test is passing, making the unit tests fail. 

More details in this thread - https://github.com/Kotlin/kotlinx.coroutines/issues/1205

### To test:
1. Run the unit tests changed in this PR on another branch with coroutines version 1.6.4 
2. Verify tests are failing 
3. Run the unit tests in this PR  
4. Verify tests are passing 

## Regression Notes
1. Potential unintended areas of impact
Incorrect unit test logic 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)