### PR TITLE
Close button on Jetpack overlay not working in horizontal orientation…

### DIFF
--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -6,19 +6,7 @@
     android:layout_height="match_parent"
     android:background="@color/jetpack_powered_bottom_sheet_background">
 
-    <ImageButton
-        android:id="@+id/close_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:background="?attr/selectableItemBackground"
-        android:padding="@dimen/margin_medium"
-        android:src="@drawable/ic_close_white_24dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="?attr/wpColorOnSurfaceMedium"
-        tools:ignore="ContentDescription" />
+
 
     <ScrollView
         android:layout_width="match_parent"
@@ -29,6 +17,19 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+            <ImageButton
+                android:id="@+id/close_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:background="?attr/selectableItemBackground"
+                android:padding="@dimen/margin_medium"
+                android:src="@drawable/ic_close_white_24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="?attr/wpColorOnSurfaceMedium"
+                tools:ignore="ContentDescription" />
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/illustration_view"


### PR DESCRIPTION
Title : Close button on Jetpack Overlay not working fix 
Issue: https://github.com/wordpress-mobile/WordPress-Android/issues/18584

Description:The close button on the Jetpack Overlay was not functioning properly in landscape mode. The issue was caused by the overlapping of two views, specifically the ImageButton and ScrollView, in the land/jetpack_feature_removal_overlay.xml file. To resolve this issue, I restructured the layout by placing the close button inside the constraint layout of the scroll view. This modification ensured that the close button was responsive in both portrait and landscape modes.

