### PR TITLE
Fixes: Crash on Landscape mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -110,6 +110,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.preloadThumbnails(this)
 
         observeVMState()
+        observeOverlayEvents(savedInstanceState)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -158,15 +159,19 @@ class SiteCreationActivity : LocaleAwareActivity(),
         progressViewModel.onFreeSiteCreated.observe(this, mainViewModel::onFreeSiteCreated)
         progressViewModel.onCartCreated.observe(this, mainViewModel::onCartCreated)
         previewViewModel.onOkButtonClicked.observe(this, mainViewModel::onWizardFinished)
-        observeOverlayEvents()
     }
 
-    private fun observeOverlayEvents() {
-        val fragment = JetpackFeatureFullScreenOverlayFragment
-            .newInstance(
-                isSiteCreationOverlay = true,
-                siteCreationSource = getSiteCreationSource()
-            )
+    private fun observeOverlayEvents(savedInstanceState: Bundle?) {
+        val fragment =  if (savedInstanceState == null) {
+            JetpackFeatureFullScreenOverlayFragment
+                .newInstance(
+                    isSiteCreationOverlay = true,
+                    siteCreationSource = getSiteCreationSource()
+                )
+        }else {
+            supportFragmentManager.findFragmentByTag(JetpackFeatureFullScreenOverlayFragment.TAG)
+                    as JetpackFeatureFullScreenOverlayFragment
+        }
 
         jetpackFullScreenViewModel.action.observe(this) { action ->
             if (mainViewModel.siteCreationDisabled) finish()

--- a/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
+++ b/WordPress/src/main/res/layout-land/jetpack_feature_removal_overlay.xml
@@ -21,10 +21,11 @@
         tools:ignore="ContentDescription" />
 
     <ScrollView
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         android:fillViewport="true"
-        android:layout_weight="1">
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/close_button">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -741,7 +741,7 @@
     <dimen name="jetpack_bottom_sheet_button_height">52dp</dimen>
 
     <!-- Jetpack full screen overlay -->
-    <dimen name="jp_migration_full_screen_overlay_padding_horizontal">90dp</dimen>
+    <dimen name="jp_migration_full_screen_overlay_padding_horizontal">32dp</dimen>
     <dimen name="jetpack_full_screen_overlay_margin_close_button">20dp</dimen>
     <dimen name="jetpack_full_screen_overlay_new_users_content_margin">32dp</dimen>
     <dimen name="jetpack_full_screen_overlay_new_users_content_margin_land">16dp</dimen>


### PR DESCRIPTION
## Related Issue 
#18572 

## Description 
This PR 

<details>
<summary>
⊜ Fixes the crash on rotating the device from landscape to portrait on Jetpack poster in Site creation screen 
</summary>

Commit [* Fixes: the crash on landscape](https://github.com/wordpress-mobile/WordPress-Android/commit/5059294fa75b1e77094c1b189bec6244a9466898)

On landscape, when the event is handled, the fragment would not have
been initiated and hence would crash. This is fixed by getting the
already created fragment variable if the savedInstanceState
is not null.
</details>

<details>
<summary>
⊜ Fixes the non-responsive close button on jetpack poster in Site creation screen 
</summary>

Commit: [Fixes: the close button not working on landscape mode](https://github.com/wordpress-mobile/WordPress-Android/commit/d772623d7a9af5de4510fe60fe166bd6c0d95c60)

The scroll view was overlaping the close button on landscape mode and
hence the scroll view was getting the click events instead of close
button. The scroll view has been shifted in landscape mode to be after
close button so that the click is registered
</details>

## To test:

### Verify that there is no crash 
1. Launch WP app in the horizontal orientation.
2. Sign up.
3. Tap Add a new site button → Create WordPress.com site
4. When the Jetpack overlay opens, change the orientation to the portrait.
5. Tap the x button.
6. Verify that there are no crashes.


### Verify that there is no crash and close button on horizontal direction works
1. Launch WP app in the horizontal orientation.
2. Sign up.
3. Tap Add a new site button → Create WordPress.com site
4. Tap the x button.
5. Verify that there are no crashes and the previous screen is shown as intended

cc: @zwarm, no need to review. Just letting you know about this change as you had worked on it. 

## Regression Notes
1. Potential unintended areas of impact
Close button is not working properly on jetpack poster

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
