### PR TITLE
Update FAB shape icon and color

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 22.7
 -----
+* [*] Updates Floating Action Button(FAB) color to black, shape to squircle, and icon to plus [https://github.com/wordpress-mobile/WordPress-Android/pull/18599]
 
 
 22.6

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -92,6 +92,7 @@
             android:contentDescription="@string/create_post_page_fab_tooltip"
             android:src="@drawable/ic_create_white_24dp"
             android:visibility="gone"
+            android:backgroundTint="@color/gray_90"
             app:borderWidth="0dp"
             tools:visibility="visible" />
     </RelativeLayout>

--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -90,9 +90,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/create_post_page_fab_tooltip"
-            android:src="@drawable/ic_create_white_24dp"
+            android:src="@drawable/ic_plus_white_24dp"
             android:visibility="gone"
-            android:backgroundTint="@color/gray_90"
             app:borderWidth="0dp"
             tools:visibility="visible" />
     </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -505,6 +505,7 @@
         android:contentDescription="@string/fab_content_description_preview"
         android:src="@drawable/ic_fullscreen_white_24dp"
         android:visibility="gone"
+        app:backgroundTint="?attr/colorBackgroundFloating"
         app:elevation="8dp"
         app:layout_anchor="@id/app_bar_layout"
         app:layout_anchorGravity="bottom|right|end"

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -81,7 +81,7 @@
         android:layout_marginBottom="@dimen/fab_margin"
         android:layout_marginEnd="@dimen/fab_margin"
         android:contentDescription="@string/fab_create_desc"
-        android:src="@drawable/ic_create_white_24dp"
+        android:src="@drawable/ic_plus_white_24dp"
         android:layout_gravity="end|bottom"
         app:borderWidth="0dp"
         app:layout_behavior="org.wordpress.android.ui.FloatingActionButtonBehavior" />

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -101,7 +101,8 @@
     </style>
 
     <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
-        <item name="android:backgroundTint">?attr/colorSecondaryVariant</item>
+        <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.Material3.FloatingActionButton</item>
+        <item name="android:backgroundTint">?attr/colorBackgroundFloating</item>
         <item name="tint">?attr/colorOnSurface</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -217,7 +217,8 @@
     </style>
 
     <style name="WordPress.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
-        <item name="android:backgroundTint">?attr/colorSecondary</item>
+        <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.Material3.FloatingActionButton</item>
+        <item name="android:backgroundTint">?attr/colorOnSurface</item>
     </style>
 
     <style name="NumberPickerTheme" parent="WordPress">


### PR DESCRIPTION
Updates FAB button on both Jetpack and WordPress apps
- shape from circle to squircle
- icon from create to plus
- colour from green/blue to black/grey

Fixes # See p1686513683293089-slack-C04SFL0RP51

| Light | Dark |
|--------|--------|
|![Screenshot_20230614_115843](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/363cdfd4-b5e3-4213-8c3e-28b64d7004db)|![Screenshot_20230614_115817](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/05e51acc-2b7f-4910-b5de-02d3018f004f)|


To test:
- Launch Jetpack/WordPress app, and login
- Verify that FAB shape is now squircle
- Verify that FAB colour is now black 
- Turn on dark theme, if on light before, and light if it were dark
- Verify that FAB is visible as in the second screen shot above, is squircle, and grey


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested both JP and WP apps in light and dark themes

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)