### PR TITLE
Upload test results as Buildkite Artifacts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,18 +64,24 @@ steps:
           cp gradle.properties-example gradle.properties
           ./gradlew testWordpressVanillaRelease
         plugins: *common_plugins
+        artifact_paths:
+          - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Test Processors"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:processors:test
         plugins: *common_plugins
+        artifact_paths:
+          - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Test Image Editor"
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew :libs:image-editor:test
         plugins: *common_plugins
+        artifact_paths:
+          - "**/build/test-results/*/*.xml"
 
   #################
   # Instrumented (aka UI) Tests


### PR DESCRIPTION
This PR uploads test results files to Buildkite's Artifacts for further processing:

<img width="1169" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17252150/a81739c1-b14c-4bbf-910e-bbcd971eb7de">

<img width="1168" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17252150/468be50d-a77e-4fbd-b745-d95d477a940e">


This is the same as https://github.com/woocommerce/woocommerce-android/pull/9205 that's done in WCAndroid