### PR TITLE
Integrate gutenberg-mobile release 1.97.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5873-ad39cc0f9322ee37257db920370a28c6cde6bbd2'
+    gutenbergMobileVersion = '5873-af66ca3baede9653ff52cfa19dae328f1675305e'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5873-af66ca3baede9653ff52cfa19dae328f1675305e'
+    gutenbergMobileVersion = 'v1.97.1'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.97.0'
+    gutenbergMobileVersion = '5873-ad39cc0f9322ee37257db920370a28c6cde6bbd2'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.30.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.97.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5873

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.