### PR TITLE
Fixes: the jetpack migration issues 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -44,8 +44,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         return if (buildConfigWrapper.isJetpackApp) null
         else if (jetpackFeatureRemovalSelfHostedUsersConfig.isEnabled()) PhaseSelfHostedUsers
         else if (jetpackFeatureRemovalNewUsersConfig.isEnabled()) PhaseNewUsers
-        else if (jetpackFeatureRemovalStaticPostersConfig.isEnabled()) PhaseStaticPosters
         else if (jetpackFeatureRemovalPhaseFourConfig.isEnabled()) PhaseFour
+        else if (jetpackFeatureRemovalStaticPostersConfig.isEnabled()) PhaseStaticPosters
         else if (jetpackFeatureRemovalPhaseThreeConfig.isEnabled()) PhaseThree
         else if (jetpackFeatureRemovalPhaseTwoConfig.isEnabled()) PhaseTwo
         else if (jetpackFeatureRemovalPhaseOneConfig.isEnabled()) PhaseOne

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilder.kt
@@ -74,6 +74,9 @@ class SiteItemsBuilder @Inject constructor(
     private fun getTrafficSiteItems(
         params: SiteItemsBuilderParams
     ): List<MySiteCardAndItem> {
+        if(jetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures())
+            return emptyList()
+
         val checkStatsTask = quickStartRepository.quickStartType
             .getTaskFromString(QuickStartStore.QUICK_START_CHECK_STATS_LABEL)
         val showStatsFocusPoint = params.activeTask == checkStatsTask && params.enableStatsFocusPoint
@@ -93,10 +96,7 @@ class SiteItemsBuilder @Inject constructor(
     private fun getManageSiteItems(
         params: SiteItemsBuilderParams
     ): List<MySiteCardAndItem> {
-        val header = CategoryHeaderItem(UiStringRes(string.my_site_header_manage))
-        val activityLog = siteListItemBuilder.buildActivityLogItemIfAvailable(params.site, params.onClick)
-        val backup = siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable)
-        val scan = siteListItemBuilder.buildScanItemIfAvailable(params.onClick, params.scanAvailable)
+        val manageSiteItems = buildManageSiteItems(params)
 
         val emptyHeaderItem1 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
         val jetpackConfiguration = buildJetpackDependantConfigurationItemsIfNeeded(params)
@@ -105,10 +105,7 @@ class SiteItemsBuilder @Inject constructor(
 
         val emptyHeaderItem2 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
         val admin = siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
-        return listOfNotNull(header) +
-                listOfNotNull(activityLog) +
-                listOfNotNull(backup) +
-                listOfNotNull(scan) +
+        return manageSiteItems +
                 emptyHeaderItem1 +
                 jetpackConfiguration +
                 lookAndFeel +
@@ -129,6 +126,17 @@ class SiteItemsBuilder @Inject constructor(
         return listOfNotNull(
                 siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick)
+        )
+    }
+
+    private fun buildManageSiteItems(params: SiteItemsBuilderParams): List<MySiteCardAndItem>{
+        if(jetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures())
+            return emptyList()
+        val header = CategoryHeaderItem(UiStringRes(string.my_site_header_manage))
+        return listOf(header) + listOfNotNull(
+            siteListItemBuilder.buildActivityLogItemIfAvailable(params.site, params.onClick),
+            siteListItemBuilder.buildBackupItemIfAvailable(params.onClick, params.backupAvailable),
+            siteListItemBuilder.buildScanItemIfAvailable(params.onClick, params.scanAvailable),
         )
     }
 


### PR DESCRIPTION
## Fixes 
- The incorrect precendence of static posters phase over phase 4 
- Incorrectly building stats, activitiy log and back up on phase 4

## Phase dashboard
<img src="https://github.com/wordpress-mobile/wordpress-android/assets/17463767/44e49348-54dd-47a6-aadd-cd636d51018c" width="250" height="480">

## To test:
### Phase 4 takes precedence over static posters phase 
- Login to wordpress app
- navigate to debug settings 
- make sure the remote feature flag `jp_removal_static_posters_phase` is on 
- toggle the jp_removal_four
- verify that the UI is as per the requirements
    - Activity log, back up and scan item is not shown 
    - the reader/notifications tab is not shown 

## Regression Notes
1. Potential unintended areas of impact
Phase 4 ui is not shown correctly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/a

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
