### PR TITLE
[App Settings] Fix system dark theme not applied properly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -122,8 +122,6 @@ public class AppSettingsFragment extends PreferenceFragment
         ((WordPress) getActivity().getApplication()).component().inject(this);
         mDispatcher.register(this);
 
-        setRetainInstance(true);
-
         addPreferencesFromResource(R.xml.app_settings);
 
         findPreference(getString(R.string.pref_key_send_usage)).setOnPreferenceChangeListener(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -196,8 +196,8 @@ public class DetailListPreference extends ListPreference
             if (mDetails == null) {
                 mListAdapter.clear();
                 mListAdapter.notifyDataSetChanged();
-            } else if (mDetails.length != mListAdapter.getCount() ||
-                       !Arrays.equals(mDetails, mListAdapter.getItems())) {
+            } else if (mDetails.length != mListAdapter.getCount()
+                       || !Arrays.equals(mDetails, mListAdapter.getItems())) {
                 mListAdapter.clear();
                 mListAdapter.addAll(mDetails);
                 mListAdapter.notifyDataSetChanged();
@@ -266,16 +266,16 @@ public class DetailListPreference extends ListPreference
                         return new SavedState[size];
                     }
                 };
-        boolean isDialogShowing;
-        Bundle dialogBundle;
+        public boolean isDialogShowing;
+        public Bundle dialogBundle;
 
-        public SavedState(Parcel source) {
+        SavedState(Parcel source) {
             super(source);
             isDialogShowing = source.readInt() == 1;
             dialogBundle = source.readBundle(getClass().getClassLoader());
         }
 
-        public SavedState(Parcelable superState) {
+        SavedState(Parcelable superState) {
             super(superState);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditTextPreferenceWithValidation.java
@@ -73,12 +73,15 @@ public class EditTextPreferenceWithValidation extends SummaryEditTextPreference 
             });
         }
 
-        CharSequence summary = getSummary();
-        if (summary == null || summary.equals(mStringToIgnoreForPrefilling)) {
-            getEditText().setText("");
-        } else {
-            getEditText().setText(summary);
-            getEditText().setSelection(0, summary.length());
+        // if the bundle is not null, there's no need to set the text again as it will be restored from the bundle
+        if (state == null) {
+            CharSequence summary = getSummary();
+            if (summary == null || summary.equals(mStringToIgnoreForPrefilling)) {
+                getEditText().setText("");
+            } else {
+                getEditText().setText(summary);
+                getEditText().setSelection(0, summary.length());
+            }
         }
 
         // Use "hidden" input type for passwords so characters are replaced with dots for added security.

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -345,7 +345,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         // initialize the appropriate settings interface (WP.com or WP.org)
         mSiteSettings = SiteSettingsInterface.getInterface(activity, mSite, this);
 
-        setRetainInstance(true);
         addPreferencesFromResource();
 
         // toggle which preferences are shown and set references

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -276,16 +276,16 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
                         return new SavedState[size];
                     }
                 };
-        boolean isDialogShowing;
-        Bundle dialogBundle;
+        public boolean isDialogShowing;
+        public Bundle dialogBundle;
 
-        public SavedState(Parcel source) {
+        SavedState(Parcel source) {
             super(source);
             isDialogShowing = source.readInt() == 1;
             dialogBundle = source.readBundle(getClass().getClassLoader());
         }
 
-        public SavedState(Parcelable superState) {
+        SavedState(Parcelable superState) {
             super(superState);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -6,6 +6,8 @@ import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.preference.EditTextPreference;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -42,6 +44,7 @@ import java.util.Locale;
  */
 
 public class SummaryEditTextPreference extends EditTextPreference implements PreferenceHint {
+    private static final String STATE_TEXT = "SummaryEditTextPreference_STATE_TEXT";
     private int mLines;
     private int mMaxLines;
     private String mHint;
@@ -134,6 +137,12 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
 
         if (state != null) {
             mDialog.onRestoreInstanceState(state);
+
+            EditText editText = getEditText();
+            if (editText != null && state.containsKey(STATE_TEXT)) {
+                editText.setText(state.getString(STATE_TEXT));
+                editText.setSelection(editText.getText().length());
+            }
         }
         mDialog.setOnDismissListener(this);
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
@@ -206,4 +215,86 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
     public void setHint(String hint) {
         mHint = hint;
     }
+
+    // region adapted from DialogPreference and EditTextPreference to make sure dialog state behaves correctly,
+    // specially in system initiated death/recreation scenarios, such as changing system dark mode.
+    private void dismissDialog() {
+        if (mDialog == null || !mDialog.isShowing()) {
+            return;
+        }
+
+        mDialog.dismiss();
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+        if (mDialog == null || !mDialog.isShowing()) {
+            return superState;
+        }
+
+        final SavedState myState = new SavedState(superState);
+        myState.isDialogShowing = true;
+        myState.dialogBundle = mDialog.onSaveInstanceState();
+
+        // Save the text from the EditText
+        CharSequence text = getEditText().getText();
+        String stateText = text == null ? "" : text.toString();
+        myState.dialogBundle.putString(STATE_TEXT, stateText);
+
+        // Since dialog is showing, let's dismiss it so it doesn't leak. This is not the best place to do it, but
+        // since the android.preference is deprecated we are not able to register the proper lifecycle listeners, and
+        // we should migrate to androidx.preference or something similar in the future.
+        dismissDialog();
+
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+        if (myState.isDialogShowing) {
+            showDialog(myState.dialogBundle);
+        }
+    }
+
+    private static class SavedState extends BaseSavedState {
+        public static final @NonNull Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
+        boolean isDialogShowing;
+        Bundle dialogBundle;
+
+        public SavedState(Parcel source) {
+            super(source);
+            isDialogShowing = source.readInt() == 1;
+            dialogBundle = source.readBundle(getClass().getClassLoader());
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(isDialogShowing ? 1 : 0);
+            dest.writeBundle(dialogBundle);
+        }
+    }
+    // endregion
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -97,7 +97,6 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (activity.application as WordPress).component().inject(this)
-        retainInstance = true
         addPreferencesFromResource(R.xml.account_settings)
         bindPreferences()
         setUpListeners()
@@ -263,7 +262,6 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
                 entryValues = state.siteIds
                 canShowDialog = state.canShowChoosePrimarySiteDialog
                 setDetails(state.homeURLOrHostNames)
-                refreshAdapter()
                  // Add click listener to show toast
                 setOnPreferenceClickListener {
                     if (state.sites?.size == 1) {


### PR DESCRIPTION
Fixes #17780 

I did some investigation and found out the issue happens because these screens are using `PreferenceFragment` with `setRetainInstance(true)`. It seems other types of Fragments have better support even when they are retained, so this could indeed be an issue with the `android.preference` version of `PreferenceFragment`. At the same time, looking at the project history, it seems those fragments were retained simply to survive configuration changes and other system-initiated process deaths and re-creations because our custom preferences did not handle that instance state save/restore properly.

With that in mind, I made some changes to remove the `setRetainInstance` call in those fragments and implemented `onSaveInstanceState`/`onRestoreInstanceState` for the custom preferences we have to address this specific bug of changing the Dark mode system settings while we don't tackle the bigger task of updating these screens to use `androidx.preference` or Compose.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/ea9a465f-7777-4783-b2a0-73d4ffa52259

To test:
### Steps to reproduce the behavior
1. Build & install the WordPress/Jetpack app
2. Login, go to `Me` → `App Settings`
3. Drag down from the top of the screen to show the system notifications drawer
4. Enable `Dark theme`
5. Dismiss the system notifications drawer
6. 🔎  **Verify** the `App Settings` applies the dark theme properly
7. Do the same for `Account Settings` and `Site Settings`

Extra checks: also **verify** that state is properly saved on those screens when the theme changes, even if there are preference dialogs opened. 

**Note: I noticed that some `PreferenceScreens` were not saving state properly, but this wasn't something introduced by this fix. Some of them close or lose some state if they are opened while the dark theme is set, but this was already happening without the fix.**

## Regression Notes
1. Potential unintended areas of impact
Preference behavior changes, state loss in preferences screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller, and bold text.
- [x] High contrast.
- [x] Talkback.
- **N/A** Languages with large words or with letters/accents not frequently used in English.
- **N/A** Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- **N/A** Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
