### PR TITLE
Plans on JP: Fix for display size and text

### DIFF
--- a/WordPress/src/main/res/layout/dashboard_card_plans.xml
+++ b/WordPress/src/main/res/layout/dashboard_card_plans.xml
@@ -40,6 +40,7 @@
                 android:paddingTop="@dimen/margin_extra_small_large"
                 android:importantForAccessibility="no"
                 android:scaleType="centerCrop"
+                android:adjustViewBounds="true"
                 android:src="@drawable/browser_address_bar"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fix browser image scaling when display size and text are set to max

Fixes #18590 

| Before | After |
|--------|--------|
|![Screenshot_20230621_123338](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/d6be872d-37d9-4659-90b1-d9a6b79e03e0)|![Screenshot_20230621_124602](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/9e9160ef-73e2-4fad-9169-03343161d9b9)|


To test:

- Launch Jetpack app
- Verify **plans card** appears as shown above on dashboard (Choose a site that is on free plan)
- Open device settings, navigate to Display -> Display size and text
- Set the Font size and Display size to max 
- Verify that the browser image is visible entirely on the card as in the after image above

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested at different display size and text settings

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
