### PR TITLE
[Compile Warnings] Resolve `Xopt-in` Deprecated Warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ allprojects {
             jvmTarget = JavaVersion.VERSION_1_8
             allWarningsAsErrors = true
             freeCompilerArgs += [
-                    "-Xopt-in=kotlin.RequiresOptIn",
+                    "-opt-in=kotlin.RequiresOptIn",
                     "-Xjvm-default=all"
             ]
         }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -194,6 +194,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return mRetainedGutenbergContainerFragment;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -610,6 +611,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return StringUtils.getMd5Hash(gson.toJson(mediaFiles));
     }
 
+    @SuppressWarnings("unchecked")
     private void normalizeMediaFilesIds(ArrayList<Object> mediaFiles) {
         // iterate through all of mediaFiles objects    and convert ids to String
         for (Object mediaFile : mediaFiles) {
@@ -948,6 +950,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         builder.setTitle(getString(R.string.stop_upload_dialog_title));
         builder.setPositiveButton(R.string.stop_upload_dialog_button_yes,
                 new DialogInterface.OnClickListener() {
+                    @SuppressWarnings("unchecked")
                     public void onClick(DialogInterface dialog, int id) {
                         mEditorFragmentListener.onCancelUploadForMediaCollection(mediaFiles);
                         // now signal Gutenberg upload failed, and remove the mediaIds from our tracking map

--- a/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -354,6 +354,7 @@ public class RestClientUtils {
     /**
      * Returns locale parameter used in REST calls which require the response to be localized
      */
+    @SuppressWarnings("deprecation")
     public static HashMap<String, String> getRestLocaleParams(Context context) {
         HashMap<String, String> params = new HashMap<>();
         String deviceLanguageCode = LanguageUtils.getCurrentDeviceLanguageCode(context);


### PR DESCRIPTION
This PR mainly resolves this one `Xopt-in` deprecated warning, simply by replacing its usage with `opt-in`.

-----

In addition to that, this PR suppressed the following `deprecated` and `unchecked` warnings in order to avoid having such build related notes during builds and thus achieve a cleaner and less involved build output. This is done in order to only output was is important so as to notice any important build related changes easier.

1. [Suppress get current device language code deprecated warning](https://github.com/wordpress-mobile/WordPress-Android/pull/18691/commits/c54947e7ed27aaa1b34be053b941e0adfef050c9)
2. [Suppress unchecked warnings for gutenberg editor fragment](https://github.com/wordpress-mobile/WordPress-Android/pull/18691/commits/79345814fa6f0ba4ddef448bbef71841ad41e440)

-----

## To test:

- There is nothing much to test here.
- Verifying that all the CI checks are successful should be enough.
- However, if you want to be thorough about reviewing this change, you could quickly smoke test both, the WordPress and Jetpack apps, and see if they are both working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

4. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
