### PR TITLE
[Compose] Make Compose and View-based switch visually identical

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
@@ -153,17 +153,11 @@ private fun WPSwitchPreview() {
         Column(modifier = Modifier.fillMaxWidth()) {
             val viewModifier = Modifier
                 .fillMaxWidth()
-                .padding(
-                    horizontal = 8.dp,
-                    vertical = 16.dp,
-                )
+                .padding(8.dp)
 
             val composeModifier = Modifier
                 .fillMaxWidth()
-                .padding(
-                    start = 8.dp,
-                    end = 2.dp,
-                )
+                .padding(horizontal = 8.dp)
 
             // compose enabled checked
             StatefulWPSwitchWithText(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
@@ -1,0 +1,250 @@
+package org.wordpress.android.ui.compose.components.buttons
+
+import android.annotation.SuppressLint
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.appcompat.widget.SwitchCompat
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchColors
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+/**
+ * A switch that by default uses the same colors as the SwitchCompat from the App Compat libraries, so there are no
+ * differences when using this component next to Android View-based switch views.
+ *
+ * The default colors are available through [WPSwitchDefaults.colors], in case you want to use them as a base for
+ * your own custom colors. This [WPSwitch] is just a helper to avoid having to pass the same colors every time.
+ *
+ * @param checked whether or not this component is checked
+ * @param onCheckedChange callback to be invoked when Switch is being clicked,
+ * therefore the change of checked state is requested.  If null, then this is passive
+ * and relies entirely on a higher-level component to control the "checked" state.
+ * @param modifier Modifier to be applied to the switch layout
+ * @param enabled whether the component is enabled or grayed out
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this Switch. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this Switch in different [Interaction]s.
+ * @param colors [SwitchColors] that will be used to determine the color of the thumb and track
+ * in different states. See [WPSwitchDefaults.colors].
+ *
+ * @see [Switch]
+ */
+@Composable
+fun WPSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = WPSwitchDefaults.colors(),
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled,
+        interactionSource = interactionSource,
+        colors = colors,
+    )
+}
+
+object WPSwitchDefaults {
+    @Composable
+    fun colors(): SwitchColors {
+        val disabledAlpha = 0.3f // it seems this the alpha used by the AppCompat
+        // thumb colors
+        val baseThumbColor = Color(0xFFF9F9F9) // color from the 9-patch drawable used for the thumb
+        val thumbDisabledColor = colorResource(
+            if (MaterialTheme.colors.isLight) {
+                R.color.switch_thumb_disabled_material_light
+            } else {
+                R.color.switch_thumb_disabled_material_dark
+            }
+        )
+        val thumbEnabledUncheckedColor = colorResource(
+            if (MaterialTheme.colors.isLight) {
+                R.color.switch_thumb_normal_material_light
+            } else {
+                R.color.switch_thumb_normal_material_dark
+            }
+        )
+        val thumbEnabledCheckedColor = MaterialTheme.colors.primary
+
+        // track colors
+        val baseTrackColor = MaterialTheme.colors.surface
+        val trackDisabledColor = MaterialTheme.colors.onSurface.copy(alpha = disabledAlpha)
+        val trackEnabledUncheckedColor = MaterialTheme.colors.onSurface
+        val trackEnabledCheckedColor = MaterialTheme.colors.primary
+
+        return SwitchDefaults.colors(
+            checkedTrackAlpha = disabledAlpha,
+            uncheckedTrackAlpha = disabledAlpha,
+            checkedThumbColor = thumbEnabledCheckedColor.multiply(baseThumbColor),
+            checkedTrackColor = trackEnabledCheckedColor,
+            uncheckedThumbColor = thumbEnabledUncheckedColor.multiply(baseThumbColor),
+            uncheckedTrackColor = trackEnabledUncheckedColor,
+            disabledCheckedThumbColor = thumbDisabledColor.multiply(baseThumbColor),
+            disabledCheckedTrackColor = trackDisabledColor.compositeOver(baseTrackColor),
+            disabledUncheckedThumbColor = thumbDisabledColor.multiply(baseThumbColor),
+            disabledUncheckedTrackColor = trackDisabledColor.compositeOver(baseTrackColor),
+        )
+    }
+
+    private fun Color.multiply(other: Color): Color {
+        return Color(
+            red = this.red * other.red,
+            green = this.green * other.green,
+            blue = this.blue * other.blue,
+            alpha = this.alpha * other.alpha,
+        )
+    }
+}
+
+@SuppressLint("SetTextI18n")
+@Preview(name = "Light mode")
+@Preview(name = "Dark mode", uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun WPSwitchPreview() {
+    AppTheme {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            val itemModifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+
+            AndroidView(
+                factory = { context ->
+                    SwitchCompat(context).apply {
+                        isChecked = true
+                        isEnabled = true
+                        text = "The first one view gets wrong colors..."
+                    }
+                },
+                modifier = itemModifier
+            )
+
+            Divider()
+
+            // compose enabled checked
+            Row(modifier = itemModifier) {
+                Text(
+                    "Compose enabled checked",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.body2
+                )
+                WPSwitch(checked = true, onCheckedChange = null)
+            }
+
+            Divider()
+
+            // view enabled checked
+            AndroidView(
+                factory = { context ->
+                    SwitchCompat(context).apply {
+                        isChecked = true
+                        isEnabled = true
+                        text = "View enabled checked"
+                    }
+                },
+                modifier = itemModifier
+            )
+
+            Divider()
+
+            // compose enabled unchecked
+            Row(modifier = itemModifier) {
+                Text(
+                    "Compose enabled unchecked",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.body2
+                )
+                WPSwitch(checked = false, onCheckedChange = null)
+            }
+
+            Divider()
+
+            // view enabled unchecked
+            AndroidView(
+                factory = { context ->
+                    SwitchCompat(context).apply {
+                        isChecked = false
+                        isEnabled = true
+                        text = "View enabled unchecked"
+                    }
+                },
+                modifier = itemModifier
+            )
+
+            Divider()
+
+            // compose disabled checked
+            Row(modifier = itemModifier) {
+                Text(
+                    "Compose disabled checked",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.body2
+                )
+                WPSwitch(checked = true, onCheckedChange = null, enabled = false)
+            }
+
+            Divider()
+
+            // view disabled checked
+            AndroidView(
+                factory = { context ->
+                    SwitchCompat(context).apply {
+                        isChecked = true
+                        isEnabled = false
+                        text = "View disabled checked"
+                    }
+                },
+                modifier = itemModifier
+            )
+
+            Divider()
+
+            // compose disabled unchecked
+            Row(modifier = itemModifier) {
+                Text(
+                    "Compose disabled unchecked",
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.body2
+                )
+                WPSwitch(checked = false, onCheckedChange = null, enabled = false)
+            }
+
+            Divider()
+
+            // view disabled unchecked
+            AndroidView(
+                factory = { context ->
+                    SwitchCompat(context).apply {
+                        isChecked = false
+                        isEnabled = false
+                        text = "View disabled unchecked"
+                    }
+                },
+                modifier = itemModifier
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ContentAlpha
@@ -63,9 +62,11 @@ fun WPSwitch(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: SwitchColors = WPSwitchDefaults.colors(),
 ) {
+    // always pass a lambda to `onCheckedChange` to avoid different padding when the callback is null
+    // note: maybe provide `false` to LocalMinimumInteractiveComponentEnforcement for ignoring min 48dp touch target
     Switch(
         checked = checked,
-        onCheckedChange = onCheckedChange,
+        onCheckedChange = { onCheckedChange?.invoke(it) },
         modifier = modifier,
         enabled = enabled,
         interactionSource = interactionSource,
@@ -139,7 +140,6 @@ private fun StatefulWPSwitchWithText(
             checked = checkedState.value,
             onCheckedChange = { checkedState.value = it },
             enabled = enabled,
-            modifier = Modifier.defaultMinSize(1.dp, 1.dp),
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,6 +25,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.posts.social.PostSocialConnection
@@ -62,7 +62,7 @@ fun PostSocialConnectionItem(
                 .copy(alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled),
         )
         Spacer(modifier = Modifier.weight(1f))
-        Switch(
+        WPSwitch(
             enabled = enabled,
             checked = connection.isSharingEnabled,
             onCheckedChange = onSharingChange,
@@ -84,7 +84,7 @@ fun PostSocialConnectionItemPreview() {
         isSharingEnabled = true
     )
     var connectionState by remember { mutableStateOf(connection) }
-    var disabledState by remember { mutableStateOf(connection) }
+    var disabledState by remember { mutableStateOf(connection.copy(isSharingEnabled = false)) }
     AppTheme {
         Column {
             // enabled

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Switch
-import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
@@ -37,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
@@ -88,11 +87,8 @@ fun PrivacyBannerScreen(
                     text = stringResource(R.string.privacy_banner_analytics),
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                Switch(
+                WPSwitch(
                     modifier = Modifier.padding(end = 16.dp),
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = MaterialTheme.colors.primary
-                    ),
                     checked = state.analyticsSwitchEnabled,
                     onCheckedChange = { onSwitchChanged(it) },
                 )

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.widgets
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.widget.SwitchCompat
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.buttons.WPSwitch
+
+/**
+ * SwitchCompat with custom track and thumb drawables and width to match closely the [WPSwitch] composable. This lets
+ * us incrementally adopt Compose and use [WPSwitch] even inside Android View-based layouts without big visual
+ * differences.
+ */
+class WPSwitchCompat(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.switchStyle,
+) : SwitchCompat(context, attrs, defStyleAttr) {
+    init {
+        setEnforceSwitchWidth(false)
+        trackDrawable = AppCompatResources.getDrawable(context, R.drawable.switch_track)
+        thumbDrawable = AppCompatResources.getDrawable(context, R.drawable.switch_thumb)
+        switchMinWidth = resources.getDimensionPixelSize(R.dimen.switch_min_width)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.ui.compose.components.buttons.WPSwitch
  * us incrementally adopt Compose and use [WPSwitch] even inside Android View-based layouts without big visual
  * differences.
  */
-class WPSwitchCompat(
+class WPSwitchCompat @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.switchStyle,

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
@@ -11,6 +11,10 @@ import org.wordpress.android.ui.compose.components.buttons.WPSwitch
  * SwitchCompat with custom track and thumb drawables and width to match closely the [WPSwitch] composable. This lets
  * us incrementally adopt Compose and use [WPSwitch] even inside Android View-based layouts without big visual
  * differences.
+ *
+ * Important: since this view was made to match [WPSwitch], in turn matching [androidx.compose.material.Switch], it is
+ * going to be necessary to double check the appearance of this whenever the Material Compose lib is updated (since that
+ * can lead to visual changes in [androidx.compose.material.Switch]).
  */
 class WPSwitchCompat @JvmOverloads constructor(
     context: Context,

--- a/WordPress/src/main/res/color/switch_track.xml
+++ b/WordPress/src/main/res/color/switch_track.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Based on AOSP's color/switch_track_material.xml -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.38" android:color="?attr/colorOnSurface" android:state_enabled="false" />
+    <item android:color="?attr/colorControlActivated" android:state_checked="true" />
+    <item android:color="?attr/colorOnSurface" />
+</selector>

--- a/WordPress/src/main/res/color/white_disabled.xml
+++ b/WordPress/src/main/res/color/white_disabled.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Based on AOSP's color/white_disabled_material.xml -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white" android:alpha="0.38" />
+</selector>

--- a/WordPress/src/main/res/drawable/switch_thumb.xml
+++ b/WordPress/src/main/res/drawable/switch_thumb.xml
@@ -7,7 +7,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="false">
         <layer-list>
-            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:bottom="@dimen/switch_vertical_padding" android:end="@dimen/switch_horizontal_padding" android:start="@dimen/switch_horizontal_padding" android:top="@dimen/switch_vertical_padding">
                 <shape android:gravity="center" android:shape="oval">
                     <solid android:color="?attr/colorSwitchThumbNormal" />
                 </shape>
@@ -18,7 +18,7 @@
 
     <item android:state_checked="true">
         <layer-list>
-            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:bottom="@dimen/switch_vertical_padding" android:end="@dimen/switch_horizontal_padding" android:start="@dimen/switch_horizontal_padding" android:top="@dimen/switch_vertical_padding">
                 <shape android:gravity="center" android:shape="oval">
                     <solid android:color="?attr/colorControlActivated" />
                 </shape>
@@ -28,7 +28,7 @@
 
     <item>
         <layer-list>
-            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:bottom="@dimen/switch_vertical_padding" android:end="@dimen/switch_horizontal_padding" android:start="@dimen/switch_horizontal_padding" android:top="@dimen/switch_vertical_padding">
                 <shape android:gravity="center" android:shape="oval">
                     <solid android:color="?attr/colorSwitchThumbNormal" />
                 </shape>

--- a/WordPress/src/main/res/drawable/switch_thumb.xml
+++ b/WordPress/src/main/res/drawable/switch_thumb.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Created to be visually similar to the Switch thumb from Compose, using colors from
+     AOSP's drawable/switch_thumb_material_anim.xml
+ -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false">
+        <layer-list>
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+                <shape android:gravity="center" android:shape="oval">
+                    <solid android:color="?attr/colorSwitchThumbNormal" />
+                </shape>
+            </item>
+        </layer-list>
+
+    </item>
+
+    <item android:state_checked="true">
+        <layer-list>
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+                <shape android:gravity="center" android:shape="oval">
+                    <solid android:color="?attr/colorControlActivated" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+
+    <item>
+        <layer-list>
+            <item android:width="@dimen/switch_thumb_size" android:height="@dimen/switch_thumb_size" android:end="@dimen/switch_thumb_padding" android:start="@dimen/switch_thumb_padding">
+                <shape android:gravity="center" android:shape="oval">
+                    <solid android:color="?attr/colorSwitchThumbNormal" />
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+</selector>

--- a/WordPress/src/main/res/drawable/switch_track.xml
+++ b/WordPress/src/main/res/drawable/switch_track.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Based on AOSP's drawable/switch_track_material.xml -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="center_vertical|fill_horizontal"
+        android:start="1dp"
+        android:end="1dp">
+        <shape android:shape="rectangle"
+            android:tint="@color/switch_track">
+            <corners android:radius="7dp" />
+            <solid android:color="@color/white_disabled" />
+            <size android:height="14dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/WordPress/src/main/res/drawable/switch_track.xml
+++ b/WordPress/src/main/res/drawable/switch_track.xml
@@ -4,8 +4,8 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:gravity="center_vertical|fill_horizontal"
-        android:start="1dp"
-        android:end="1dp">
+        android:start="@dimen/switch_horizontal_padding"
+        android:end="@dimen/switch_horizontal_padding">
         <shape android:shape="rectangle"
             android:tint="@color/switch_track">
             <corners android:radius="7dp" />

--- a/WordPress/src/main/res/layout/comment_notifications_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/comment_notifications_bottom_sheet.xml
@@ -32,7 +32,7 @@
             android:textSize="@dimen/text_sz_medium"
             app:layout_constraintTop_toBottomOf="@+id/sheet_handle" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/enable_push_notifications"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -255,7 +255,7 @@
 
             <LinearLayout style="@style/PostSettingsContainer">
 
-                <androidx.appcompat.widget.SwitchCompat
+                <org.wordpress.android.widgets.WPSwitchCompat
                     android:id="@+id/post_settings_sticky_switch"
                     style="@style/PostSettingsSwitch"
                     android:text="@string/post_settings_post_sticky" />

--- a/WordPress/src/main/res/layout/followed_sites_dialog.xml
+++ b/WordPress/src/main/res/layout/followed_sites_dialog.xml
@@ -18,7 +18,7 @@
         android:paddingEnd="@dimen/related_posts_dialog_padding_right"
         android:paddingBottom="@dimen/related_posts_dialog_padding_bottom">
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/notification_new_posts_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
             android:layout_marginBottom="@dimen/margin_large"
             android:background="?android:attr/listDivider" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/email_new_posts_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -116,7 +116,7 @@
             android:layout_marginBottom="@dimen/margin_large"
             android:background="?android:attr/listDivider" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/email_new_comments_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/notifications_settings_switch.xml
+++ b/WordPress/src/main/res/layout/notifications_settings_switch.xml
@@ -43,7 +43,7 @@
                 tools:text="Some example sub text." />
         </LinearLayout>
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/notifications_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/number_picker_dialog.xml
+++ b/WordPress/src/main/res/layout/number_picker_dialog.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.SwitchCompat
+    <org.wordpress.android.widgets.WPSwitchCompat
         android:id="@+id/number_picker_switch"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -223,7 +223,7 @@
                                 style="@style/PluginCardViewPrimaryText"
                                 android:text="@string/plugin_detail_label_state_active" />
 
-                            <androidx.appcompat.widget.SwitchCompat
+                            <org.wordpress.android.widgets.WPSwitchCompat
                                 android:id="@+id/plugin_state_active"
                                 style="@style/PluginCardViewSecondaryElement" />
 
@@ -241,7 +241,7 @@
                             style="@style/PluginCardViewPrimaryText"
                             android:text="@string/plugin_detail_label_state_autoupdates" />
 
-                        <androidx.appcompat.widget.SwitchCompat
+                        <org.wordpress.android.widgets.WPSwitchCompat
                             android:id="@+id/plugin_state_autoupdates"
                             style="@style/PluginCardViewSecondaryElement" />
                     </RelativeLayout>

--- a/WordPress/src/main/res/layout/related_posts_dialog.xml
+++ b/WordPress/src/main/res/layout/related_posts_dialog.xml
@@ -16,7 +16,7 @@
         android:paddingEnd="@dimen/related_posts_dialog_padding_right"
         android:paddingBottom="@dimen/related_posts_dialog_padding_bottom">
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/toggle_related_posts_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/toolbar_switch.xml
+++ b/WordPress/src/main/res/layout/toolbar_switch.xml
@@ -1,4 +1,4 @@
-<androidx.appcompat.widget.SwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wordpress.android.widgets.WPSwitchCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/toolbar_switch"
     android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/wppref_view.xml
+++ b/WordPress/src/main/res/layout/wppref_view.xml
@@ -39,7 +39,7 @@
             android:textAppearance="?attr/textAppearanceSubtitle1"
             tools:text="text_title" />
 
-        <androidx.appcompat.widget.SwitchCompat
+        <org.wordpress.android.widgets.WPSwitchCompat
             android:id="@+id/switch_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -775,7 +775,8 @@
     <dimen name="dashboard_card_plans_done_button_bottom_margin">16dp</dimen>
 
     <!-- WPSwitchCompat min width to closely match the Switch composable -->
-    <dimen name="switch_min_width">36dp</dimen>
+    <dimen name="switch_min_width">48dp</dimen>
     <dimen name="switch_thumb_size">20dp</dimen>
-    <dimen name="switch_thumb_padding">1dp</dimen>
+    <dimen name="switch_horizontal_padding">7dp</dimen>
+    <dimen name="switch_vertical_padding">4dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -773,4 +773,9 @@
     <dimen name="dashboard_card_plans_layout_padding">16dp</dimen>
     <dimen name="dashboard_card_plans_top_margin">48dp</dimen>
     <dimen name="dashboard_card_plans_done_button_bottom_margin">16dp</dimen>
+
+    <!-- WPSwitchCompat min width to closely match the Switch composable -->
+    <dimen name="switch_min_width">36dp</dimen>
+    <dimen name="switch_thumb_size">20dp</dimen>
+    <dimen name="switch_thumb_padding">1dp</dimen>
 </resources>


### PR DESCRIPTION
While working on the Jetpack Social improvements we discovered the Compose `Switch` component does not have the same colors or size when compared to the View-based `SwitchCompat` used throughout the app. 

This problem is not that bad when using a full-Compose screen but it was very noticeable when using a Compose component inside a View-based layout, such as in this PR #18708.

Since we are moving towards using Compose more in our codebase and we want to do it gradually, it would be great if we were able to mix Compose and non-Compose components in the same screen for now.

This PR tries to solve the visual differences by:
- creating a Compose-based `WPSwitch`, which uses the same Switch colors from the View-based counterpart;
- creating a View-based `WPSwitchCompat`, which extends `SwitchCompat` and matches the size and visual design of the Compose-based counterpart (e.g.: thumb and track edge-aligned).

The solution is not 100% perfect but it works for our usage.

Some known drawbacks:
- `WPSwitchPreference` (used in Preference screens) uses `Switch` so it was not changed, but I don't see us using Compose in those screens in the near future and the difference between that Switch and `WPSwitch` is difficult to notice when they are not used beside each other.
- `WPSwitchCompat` drawables and dimensions match the current `Switch` Composable from `androidx.compose.material` so we will need to revisit it every time we update the `compose.material` lib.
- The `WPSwitchCompat` introduces small padding (7dp) on its right side, which is not really that noticeable (especially because the original `SwitchCompat` already had different visual padding when it's on vs off) but it's there to match Compose's `Switch` padding automatically added to make the component touch target have `48dp`.

Here's `WPSwitch` composable preview, which compares against the view-based `WPSwitchCompat` to make sure they closely match visually.

| Light mode | Dark mode |
| --- | --- |
| ![light mode](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/00623680-1a78-4db5-adec-45fae48c59fb) | ![dark mode](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/52483a8a-32f3-4951-bca2-deacfdd8c54f) |

To test:
- Check the `WPSwitch` preview and run it on a few devices to make sure they look the same across Android OS versions
- Go to non-preference screens that used `SwitchCompat` and make sure they work normally:
  - `comment_notifications_bottom_sheet.xml`
  - `edit_post_settings_fragment.xml`
  - `followed_sites_dialog.xml`
  - `notifications_settings_switch.xml`
  - `number_picker_dialog.xml`
  - `plugin_detail_activity.xml`
  - `related_posts_dialog.xml`
  - `toolbar_switch.xml`
  - `wppref_view.xml`

## Regression Notes
1. Potential unintended areas of impact
Breaking existing `Switch` buttons around the app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
