### PR TITLE
[Build] Fix Non-Transitive Resources

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
@@ -27,9 +27,9 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.widgets.WPSwitchCompat
+import com.google.android.material.R as MaterialR
 
 /**
  * A switch that by default uses the same colors as the SwitchCompat from the App Compat libraries, so there are no
@@ -80,16 +80,16 @@ object WPSwitchDefaults {
         // thumb colors
         val thumbDisabledColor = colorResource(
             if (MaterialTheme.colors.isLight) {
-                R.color.switch_thumb_disabled_material_light
+                MaterialR.color.switch_thumb_disabled_material_light
             } else {
-                R.color.switch_thumb_disabled_material_dark
+                MaterialR.color.switch_thumb_disabled_material_dark
             }
         )
         val thumbEnabledUncheckedColor = colorResource(
             if (MaterialTheme.colors.isLight) {
-                R.color.switch_thumb_normal_material_light
+                MaterialR.color.switch_thumb_normal_material_light
             } else {
-                R.color.switch_thumb_normal_material_dark
+                MaterialR.color.switch_thumb_normal_material_dark
             }
         )
         val thumbEnabledCheckedColor = MaterialTheme.colors.primary

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwitchCompat.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.SwitchCompat
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
+import com.google.android.material.R as MaterialR
 
 /**
  * SwitchCompat with custom track and thumb drawables and width to match closely the [WPSwitch] composable. This lets
@@ -19,7 +20,7 @@ import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 class WPSwitchCompat @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = R.attr.switchStyle,
+    defStyleAttr: Int = MaterialR.attr.switchStyle,
 ) : SwitchCompat(context, attrs, defStyleAttr) {
     init {
         setEnforceSwitchWidth(false)


### PR DESCRIPTION
This PR fixes some non-transitive resources related build errors for `Material` R classes on `WPSwitch` and `WPSwitchCompat` classes.

FYI: This issue relates to this #18721 compose switch PR (cc @thomashorta), which got merged before this #18707 main non-transitive resources PR, and thus was still using transitive resources for `Material` related R classes.

-----

## To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you use the test instructions with this #18721 to verify that both, the `WPSwitch` and `WPSwitchCompat` classes, are still working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Potential breakage or misbehaviour of screens that use these two classes (`WPSwitch` and `WPSwitchCompat`).

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

4. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
