### PR TITLE
Fix the crash on the site deletion

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 22.8
 -----
-
+* [*] Fixes the crash that occurs after deleting the site [https://github.com/wordpress-mobile/WordPress-Android/pull/18736]
 
 22.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -159,8 +159,12 @@ public class BlogPreferencesActivity extends LocaleAwareActivity {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (!event.isError()) {
+        if (!event.isError() && mSite != null) {
             mSite = mSiteStore.getSiteByLocalId(mSite.getId());
+            if (mSite == null) {
+                // The site could be deleted. No need for any further action.
+                return;
+            }
             mActionBar.setTitle(StringEscapeUtils.unescapeHtml4(SiteUtils.getSiteNameOrHomeURL(mSite)));
         }
     }


### PR DESCRIPTION
Fixes #18628 
This fixed the crash that occurs after deleting a site.

To test:
1. Login app.
2. Select a site that you can delete.
3. Navigate to "MENU → Site Settings"
4. Find the "Delete Site" button at the bottom of the list.
5. Follow the instructions to delete the site.
6. After deleting, it must return to the home screen without crashing. To ensure it was crashing in this step, you can test the case on `trunk`.

## Regression Notes
1. Potential unintended areas of impact
None

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
The class is in Java, and uses EventBus. It needs to refactor before covering this case in tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
