### PR TITLE
[JP Social/Pre-publishing] Social item UI low on shares style

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppColor.kt
@@ -50,4 +50,8 @@ object AppColor {
 
     @Stable
     val JetpackGreen50 = Color(0xFF008710)
+
+    // Yellows
+    @Stable
+    val Yellow50 = Color(0xFF9D6E00)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
@@ -134,8 +134,9 @@ private fun DescriptionText(
     }
 }
 
-@Preview
-@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Preview(name = "Light Mode")
+@Preview(name = "Dark Mode", uiMode = UI_MODE_NIGHT_YES)
+@Preview(name = "RTL", locale = "ar")
 @Composable
 fun PrepublishingHomeSocialItemPreview() {
     AppTheme {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
@@ -12,16 +12,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.TrainOfIcons
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
+import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
@@ -30,7 +35,8 @@ fun PrepublishingHomeSocialItem(
     title: String,
     description: String,
     avatarModels: List<TrainOfIconsModel>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isLowOnShares: Boolean = false
 ) {
     SocialContainer(
         avatarCount = avatarModels.size,
@@ -42,19 +48,16 @@ fun PrepublishingHomeSocialItem(
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.body1,
+                style = MaterialTheme.typography.subtitle1,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
 
             Spacer(Modifier.height(Margin.ExtraSmall.value))
 
-            Text(
+            DescriptionText(
                 text = description,
-                style = MaterialTheme.typography.body1,
-                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                isLowOnShares = isLowOnShares,
             )
         }
 
@@ -90,10 +93,51 @@ private fun SocialContainer(
     }
 }
 
+private val lowOnSharesDescriptionStyle: TextStyle
+    @Composable
+    get() = MaterialTheme.typography.body2.copy(
+        color = AppColor.Yellow50,
+    )
+
+private val defaultDescriptionStyle: TextStyle
+    @Composable
+    get() = MaterialTheme.typography.body2.copy(
+        color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+    )
+
+@Composable
+private fun DescriptionText(
+    text: String,
+    isLowOnShares: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Margin.Small.value)
+    ) {
+        if (isLowOnShares) {
+            Icon(
+                painterResource(R.drawable.ic_notice_white_24dp),
+                contentDescription = null,
+                tint = AppColor.Yellow50,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        Text(
+            text = text,
+            style = if (isLowOnShares) lowOnSharesDescriptionStyle else defaultDescriptionStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 @Preview
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
-fun PrepublishingHomeSocialItemPreviewHorizontal() {
+fun PrepublishingHomeSocialItemPreview() {
     AppTheme {
         Column(
             modifier = Modifier
@@ -104,7 +148,7 @@ fun PrepublishingHomeSocialItemPreviewHorizontal() {
                 title = "Sharing to 2 of 3 accounts",
                 description = "27/30 social shares remaining",
                 avatarModels = listOf(
-                    TrainOfIconsModel(R.drawable.ic_social_tumblr, 0.36f),
+                    TrainOfIconsModel(R.drawable.ic_social_tumblr, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_facebook),
                 ),
                 modifier = Modifier.fillMaxWidth()
@@ -116,12 +160,24 @@ fun PrepublishingHomeSocialItemPreviewHorizontal() {
                 title = "Sharing to 3 of 5 accounts",
                 description = "27/30 social shares remaining",
                 avatarModels = listOf(
-                    TrainOfIconsModel(R.drawable.ic_social_facebook, 0.36f),
-                    TrainOfIconsModel(R.drawable.ic_social_mastodon, 0.36f),
+                    TrainOfIconsModel(R.drawable.ic_social_facebook, ContentAlpha.disabled),
+                    TrainOfIconsModel(R.drawable.ic_social_mastodon, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_twitter),
                     TrainOfIconsModel(R.drawable.ic_social_linkedin),
                     TrainOfIconsModel(R.drawable.ic_social_instagram),
                     TrainOfIconsModel(R.drawable.ic_social_tumblr),
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Divider()
+
+            PrepublishingHomeSocialItem(
+                title = "Not sharing to social",
+                description = "0/30 social shares remaining",
+                isLowOnShares = true,
+                avatarModels = listOf(
+                    TrainOfIconsModel(R.drawable.ic_social_tumblr, ContentAlpha.disabled),
                 ),
                 modifier = Modifier.fillMaxWidth()
             )


### PR DESCRIPTION
Part of #18694 

The item was missing a different style for the "low on shares" situation, which displays a warning icon and changes the description color.

This PR also fixes the text styles, which were not matching the specs.

| Light Mode | Dark Mode |
| --- | --- |
| ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/bdbe16c1-bf15-4c92-81a8-a4e1ada925f7) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/80700500-1133-479b-a96c-46fdc44e4ae7) |

To test:
Just Compose UI.

- Open repo
- Checkout this branch
- Go to `PrepublishingHomeSocialItem` file
- **Verify** preview shows up correctly
- Run the preview on a device
- **Verify** preview runs correctly on device

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
