### PR TITLE
Fixes: crash on site creation in jetpack

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.cancel
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityLauncherWrapper
@@ -162,6 +163,9 @@ class SiteCreationActivity : LocaleAwareActivity(),
     }
 
     private fun observeOverlayEvents(savedInstanceState: Bundle?) {
+        if(BuildConfig.IS_JETPACK_APP)
+            return
+
         val fragment =  if (savedInstanceState == null) {
             JetpackFeatureFullScreenOverlayFragment
                 .newInstance(


### PR DESCRIPTION
## Fixes
#18726 

This PR fixes a crash in Jetpack app on site creation activity. THis PR was introduced due to the change in the PR https://github.com/wordpress-mobile/WordPress-Android/pull/18597 where the Jetpack overlay fragment was created/retrieved on orientation change. Since on Jetpack App, the jetpack feature overlay is not shown, the overlay events should not be subscribed. 

## test

### Verify no crashes - JP app 
1. Login to the Jetpack app 
2. tap add a new site button → create wordpress.com site
3. when the jetpack overlay opens, change the orientation to the portrait/landscapre.
4. tap the x button.
5. verify that there are no crashes.

### Regression testing - WP app 
#### verify that there is no crash

1. launch wp app in the horizontal orientation.
3. sign up.
4. tap add a new site button → create wordpress.com site
5. when the jetpack overlay opens, change the orientation to the portrait.
6. tap the x button.
7. verify that there are no crashes.

#### verify that there is no crash and close button on horizontal direction works
1. launch wp app in the horizontal orientation.
2. sign up.
3. tap add a new site button → create wordpress.com site
4. tap the x button.
5. verify that there are no crashes and the previous screen is shown as intended

## Regression Notes
1. Potential unintended areas of impact
WP app site creation overlay is not shown 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)