### PR TITLE
Show plans card for all free domains

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.BuildConfigWrapper
-import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.DashboardCardFreeToPaidPlansFeatureConfig
 import java.util.concurrent.atomic.AtomicBoolean
@@ -43,7 +42,6 @@ class PlansCardUtils @Inject constructor(
                 !isCardHiddenByUser(siteModel.siteId) &&
                 siteModel.hasFreePlan &&
                 siteModel.isAdmin &&
-                !SiteUtils.hasMappedDomains(siteModel) &&
                 !siteModel.isWpForTeamsSite
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -387,8 +387,4 @@ public class SiteUtils {
         ArrayList<SiteFilter> siteFilters = new ArrayList<>();
         return new FetchSitesPayload(siteFilters, !BuildConfig.IS_JETPACK_APP);
     }
-
-    public static boolean hasMappedDomains(@Nullable SiteModel site) {
-        return site != null && site.isWPCom() && !site.getUnmappedUrl().equals(site.getUrl());
-    }
 }


### PR DESCRIPTION
This removes a condition for the visibility of the "Free domain with annual plan" card.

Removed `SiteUtils.hasMappedDomains(siteModel)`. mappedDomains means having a domain like ***.art.blog instead of ***.wordpress.com. By removing this condition, the "Free domain with annual plan" will be visible for all free domains.
_More context: p1688567770256069/1688563802.683149-slack-C0560PCK2AD_

To test:
1. Launch JP app.
2. Select a site with these conditions:
- The site is on a free WP.com plan
- The user is an admin
- The site is not P2
- The dashboard card for this site wasn't hidden by the user
3. Verify "Free domain with annual plan" card is visible on HOME.

**Bonus optional step:**
4. Tap on the card and make a purchase.

## Regression Notes
1. Potential unintended areas of impact
None

5. What I did to test those areas of impact (or what existing automated tests I relied on)
None

6. What automated tests I added (or what prevented me from doing so)
None. This just updates a condition in a utils class.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.