### PR TITLE
[UI Tests] Added Buildkite test analytics support.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,16 +83,38 @@ steps:
   - group: "🔬 Instrumented tests"
     steps:
       - label: ":wordpress: 🔬 Instrumented tests"
+        key: "WP_instrumented_tests"      
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
         plugins: *common_plugins
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
+      - label: ":wordpress: 🔍 Test Analytics"
+        depends_on:
+          - "WP_instrumented_tests"
+        command: buildkite-agent artifact download '**/test_result_1.xml' . --step "WP_instrumented_tests"
+        plugins:
+          - test-collector#v1.8.0:
+              files: "**/test_result_1.xml"
+              format: "junit"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS"          
+
       - label: ":jetpack: 🔬 Instrumented tests"
+        key: "JP_instrumented_tests"
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
         plugins: *common_plugins
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
+
+      - label: ":jetpack: 🔍 Test Analytics"
+        depends_on:
+          - "JP_instrumented_tests"
+        command: buildkite-agent artifact download '**/test_result_1.xml' . --step "JP_instrumented_tests"
+        plugins:
+          - test-collector#v1.8.0:
+              files: "**/test_result_1.xml"
+              format: "junit"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"
 
   #################
   # Create Prototype Builds for WP and JP


### PR DESCRIPTION
### Description
Adds `Test Analytics` steps to `pipeline.yml` for both WP and JP Instrumented Tests.

In this step, a corresponding test report `test_result_1.xml` created during `Instrumented tests` step (stored in `Artifacts`) is passed to Test Analytics plugin together with a unique token, which is used to locate a corresponding test suite.

### Testing instructions
- The `Test Analytics` step is 🟢 
- Test data is available at `JP Android - Instrumented Tests` and `WP Android - Instrumented Tests` test suites in Buildkite Test Analytics:

------------------

<img width="1147" alt="Screenshot 2023-07-05 at 15 51 29" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/904af994-3d53-4d26-b72e-b56060663a47">

------------------

<img width="1161" alt="Screenshot 2023-07-05 at 15 51 20" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/f6b977b2-eda8-4dbb-b14d-52cb55109c6a">

------------------