### PR TITLE
[Unit Tests] Added tests analytics for Unit Tests.

### DIFF
--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -27,4 +27,7 @@ else
     annotate_test_failures "$results_file"
 fi
 
+echo "--- 🧪 Copying test logs for test collector"
+mkdir buildkite-test-analytics && cp build/instrumented-tests/*/*/*.xml buildkite-test-analytics
+
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -7,10 +7,10 @@ if [ "$1" == "wordpress" ]; then
     test_log_dir="WordPress/build/test-results/*/*.xml"
 elif [ "$1" == "processors" ]; then
     test_suite=":libs:processors:test"
-    test_log_dir="WordPress/libs/processors/build/test-results/*/*.xml"    
+    test_log_dir="libs/processors/build/test-results/test/*.xml"
 elif [ "$1" == "image-editor" ]; then
     test_suite=":libs:image-editor:test"
-    test_log_dir="WordPress/libs/image-editor/build/test-results/*/*.xml"       
+    test_log_dir="libs/image-editor/build/test-results/testReleaseUnitTest/*.xml"
 else
     echo "Invalid Test Suite! Expected 'wordpress', 'processors', or 'image-editor', received '$1' instead"
     exit 1
@@ -43,6 +43,7 @@ for file in "${results_files[@]}"; do
 done
 
 echo "--- 🧪 Copying test logs for test collector"
-mkdir buildkite-test-analytics && cp $test_log_dir buildkite-test-analytics
+mkdir buildkite-test-analytics
+cp $test_log_dir buildkite-test-analytics
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -4,10 +4,13 @@ echo "--- 🧪 Testing"
 set +e
 if [ "$1" == "wordpress" ]; then
     test_suite="testWordpressVanillaRelease"
+    test_log_dir="WordPress/build/test-results/*/*.xml"
 elif [ "$1" == "processors" ]; then
     test_suite=":libs:processors:test"
+    test_log_dir="WordPress/libs/processors/build/test-results/*/*.xml"    
 elif [ "$1" == "image-editor" ]; then
     test_suite=":libs:image-editor:test"
+    test_log_dir="WordPress/libs/image-editor/build/test-results/*/*.xml"       
 else
     echo "Invalid Test Suite! Expected 'wordpress', 'processors', or 'image-editor', received '$1' instead"
     exit 1
@@ -38,5 +41,8 @@ for file in "${results_files[@]}"; do
     annotate_test_failures "$file"
   fi
 done
+
+echo "--- 🧪 Copying test logs for test collector"
+mkdir buildkite-test-analytics && cp $test_log_dir buildkite-test-analytics
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -44,6 +44,6 @@ done
 
 echo "--- 🧪 Copying test logs for test collector"
 mkdir buildkite-test-analytics
-cp $test_log_dir buildkite-test-analytics
+cp "$test_log_dir" buildkite-test-analytics
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -44,6 +44,6 @@ done
 
 echo "--- 🧪 Copying test logs for test collector"
 mkdir buildkite-test-analytics
-cp "$test_log_dir" buildkite-test-analytics
+cp $test_log_dir buildkite-test-analytics
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,19 +61,34 @@ steps:
     steps:
       - label: "🔬 Unit Test WordPress"
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
-        plugins: *common_plugins
+        plugins:
+          - automattic/a8c-ci-toolkit#2.17.0
+          - test-collector#v1.8.0:
+              files: "**/build/test-results/*/*.xml"
+              format: "junit"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"                
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
-        plugins: *common_plugins
+        plugins:
+          - automattic/a8c-ci-toolkit#2.17.0
+          - test-collector#v1.8.0:
+              files: "**/build/test-results/*/*.xml"
+              format: "junit"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"        
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
-        plugins: *common_plugins
+        plugins:
+          - automattic/a8c-ci-toolkit#2.17.0
+          - test-collector#v1.8.0:
+              files: "**/build/test-results/*/*.xml"
+              format: "junit"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"             
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -82,39 +97,27 @@ steps:
   #################
   - group: "🔬 Instrumented tests"
     steps:
-      - label: ":wordpress: 🔬 Instrumented tests"
-        key: "WP_instrumented_tests"      
+      - label: ":wordpress: 🔬 Instrumented tests"   
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
-        plugins: *common_plugins
-        artifact_paths:
-          - "**/build/instrumented-tests/**/*"
-
-      - label: ":wordpress: 🔍 Test Analytics"
-        depends_on:
-          - "WP_instrumented_tests"
-        command: buildkite-agent artifact download '**/test_result_1.xml' . --step "WP_instrumented_tests"
         plugins:
+          - automattic/a8c-ci-toolkit#2.17.0
           - test-collector#v1.8.0:
-              files: "**/test_result_1.xml"
+              files: "build/instrumented-tests/**/test_result_1.xml"
               format: "junit"
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS"          
-
-      - label: ":jetpack: 🔬 Instrumented tests"
-        key: "JP_instrumented_tests"
-        command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
-        plugins: *common_plugins
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
-      - label: ":jetpack: 🔍 Test Analytics"
-        depends_on:
-          - "JP_instrumented_tests"
-        command: buildkite-agent artifact download '**/test_result_1.xml' . --step "JP_instrumented_tests"
+      - label: ":jetpack: 🔬 Instrumented tests"
+        command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
         plugins:
+          - automattic/a8c-ci-toolkit#2.17.0
           - test-collector#v1.8.0:
-              files: "**/test_result_1.xml"
+              files: "build/instrumented-tests/**/test_result_1.xml"
               format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"        
+        artifact_paths:
+          - "**/build/instrumented-tests/**/*"
 
   #################
   # Create Prototype Builds for WP and JP

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,11 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/a8c-ci-toolkit#2.17.0
+  - &common_plugins_with_test_collector
+    - automattic/a8c-ci-toolkit#2.17.0
+    - test-collector#v1.8.0:
+        files: "buildkite-test-analytics/*.xml"
+        format: "junit"
 
 steps:
   #################
@@ -61,34 +66,25 @@ steps:
     steps:
       - label: "🔬 Unit Test WordPress"
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
-        plugins:
-          - automattic/a8c-ci-toolkit#2.17.0
-          - test-collector#v1.8.0:
-              files: "**/build/test-results/*/*.xml"
-              format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"                
+        plugins: *common_plugins_with_test_collector
+        env:
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
-        plugins:
-          - automattic/a8c-ci-toolkit#2.17.0
-          - test-collector#v1.8.0:
-              files: "**/build/test-results/*/*.xml"
-              format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"        
+        plugins: *common_plugins_with_test_collector
+        env:
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
-        plugins:
-          - automattic/a8c-ci-toolkit#2.17.0
-          - test-collector#v1.8.0:
-              files: "**/build/test-results/*/*.xml"
-              format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"             
+        plugins: *common_plugins_with_test_collector
+        env:
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -97,25 +93,19 @@ steps:
   #################
   - group: "🔬 Instrumented tests"
     steps:
-      - label: ":wordpress: 🔬 Instrumented tests"   
+      - label: ":wordpress: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
-        plugins:
-          - automattic/a8c-ci-toolkit#2.17.0
-          - test-collector#v1.8.0:
-              files: "build/instrumented-tests/**/test_result_1.xml"
-              format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS"          
+        plugins: *common_plugins_with_test_collector
+        env:
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
       - label: ":jetpack: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
-        plugins:
-          - automattic/a8c-ci-toolkit#2.17.0
-          - test-collector#v1.8.0:
-              files: "build/instrumented-tests/**/test_result_1.xml"
-              format: "junit"
-              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"        
+        plugins: *common_plugins_with_test_collector
+        env:
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,13 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
-  - &common_plugins_with_test_collector
-    - automattic/a8c-ci-toolkit#2.17.0
-    - test-collector#v1.8.0:
-        files: "buildkite-test-analytics/*.xml"
-        format: "junit"
+  - &ci_toolkit
+    automattic/a8c-ci-toolkit#2.17.0
+  - &test_collector
+    test-collector#v1.8.0
+  - &test_collector_common_params
+      files: "buildkite-test-analytics/*.xml"
+      format: "junit"
 
 steps:
   #################
@@ -16,7 +16,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [*ci_toolkit]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -30,7 +30,7 @@ steps:
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew checkstyle
-        plugins: *common_plugins
+        plugins: [*ci_toolkit]
         artifact_paths:
           - "**/build/reports/checkstyle/checkstyle.*"
 
@@ -38,7 +38,7 @@ steps:
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew detekt
-        plugins: *common_plugins
+        plugins: [*ci_toolkit]
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
 
@@ -57,7 +57,7 @@ steps:
       cp gradle.properties-example gradle.properties
       .buildkite/commands/dependency-tree-diff.sh
     if: build.pull_request.id != null
-    plugins: *common_plugins
+    plugins: [*ci_toolkit]
 
   #################
   # Unit Tests
@@ -66,25 +66,31 @@ steps:
     steps:
       - label: "🔬 Unit Test WordPress"
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
-        plugins: *common_plugins_with_test_collector
-        env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS
+        plugins: 
+          - *ci_toolkit
+          - *test_collector :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
-        plugins: *common_plugins_with_test_collector
-        env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS
+        plugins: 
+          - *ci_toolkit
+          - *test_collector :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
-        plugins: *common_plugins_with_test_collector
-        env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR
+        plugins: 
+          - *ci_toolkit
+          - *test_collector :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -95,17 +101,21 @@ steps:
     steps:
       - label: ":wordpress: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
-        plugins: *common_plugins_with_test_collector
-        env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS
+        plugins: 
+          - *ci_toolkit
+          - *test_collector :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS"
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
       - label: ":jetpack: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
-        plugins: *common_plugins_with_test_collector
-        env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK
+        plugins: 
+          - *ci_toolkit
+          - *test_collector :
+              <<: *test_collector_common_params
+              api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
@@ -117,9 +127,9 @@ steps:
       - label: ":wordpress: :android: Prototype Build"
         command: ".buildkite/commands/prototype-build.sh wordpress"
         if: build.pull_request.id != null
-        plugins: *common_plugins
+        plugins: [*ci_toolkit]
 
       - label: ":jetpack: :android: Prototype Build"
         command: ".buildkite/commands/prototype-build.sh jetpack"
         if: build.pull_request.id != null
-        plugins: *common_plugins
+        plugins: [*ci_toolkit]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &ci_toolkit
-    automattic/a8c-ci-toolkit#2.17.0
+    automattic/a8c-ci-toolkit#2.18.2
   - &test_collector
     test-collector#v1.8.0
   - &test_collector_common_params

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
         plugins: *common_plugins_with_test_collector
         env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -76,7 +76,7 @@ steps:
         command: ".buildkite/commands/run-unit-tests.sh processors"
         plugins: *common_plugins_with_test_collector
         env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -84,7 +84,7 @@ steps:
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
         plugins: *common_plugins_with_test_collector
         env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR
         artifact_paths:
           - "**/build/test-results/*/*.xml"
 
@@ -97,7 +97,7 @@ steps:
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
         plugins: *common_plugins_with_test_collector
         env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 
@@ -105,7 +105,7 @@ steps:
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
         plugins: *common_plugins_with_test_collector
         env:
-          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: $BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK
+          BUILDKITE_PLUGIN_TEST_COLLECTOR_API_TOKEN_ENV_NAME: BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK
         artifact_paths:
           - "**/build/instrumented-tests/**/*"
 


### PR DESCRIPTION
### Description

As a continuation of #18746, and using (approved 😃) DRYing improvements from woocommerce/woocommerce-android/pull/9380, with lots of help from @AliSoftware and @crazytonyli, the PR adds tests analytics for Unit Tests and introduces some refactoring in Instrumented Tests area.

### To Test
- CI is 🟢 
- Unit Tests (WordPress / Processors / Image Editor) and Instrumented Tests analytics are present in Buildkite for the commits in the PR.