### PR TITLE
[JP Social] Create PublicizeServiceIcon enum

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeServiceIcon.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeServiceIcon.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.publicize
+
+import androidx.annotation.DrawableRes
+import org.wordpress.android.R
+import org.wordpress.android.models.PublicizeService
+
+/**
+ * Enum mapping the service id to the local icon resource id, so we can use custom icons for the Publicize Services.
+ *
+ * @param serviceId The id of the service, as returned by the Publicize API.
+ * @param iconResId The local resource id of the icon to use for this service.
+ *
+ * @see PublicizeService
+ */
+enum class PublicizeServiceIcon(
+    val serviceId: String,
+    @DrawableRes val iconResId: Int,
+) {
+    FACEBOOK("facebook", R.drawable.ic_social_facebook),
+    INSTAGRAM("instagram-business", R.drawable.ic_social_instagram),
+    LINKEDIN("linkedin", R.drawable.ic_social_linkedin),
+    MASTODON("mastodon", R.drawable.ic_social_mastodon),
+    TUMBLR("tumblr", R.drawable.ic_social_tumblr),
+    TWITTER("twitter", R.drawable.ic_social_twitter);
+
+    companion object {
+        /**
+         * Returns the [PublicizeServiceIcon] for the given service name, or null if not found.
+         *
+         * @param serviceId The name of the service, as returned by the Publicize API.
+         */
+        fun fromServiceId(serviceId: String): PublicizeServiceIcon? {
+            return values().find { it.serviceId == serviceId }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeServiceIconTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/publicize/PublicizeServiceIconTest.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.publicize
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PublicizeServiceIconTest {
+    @Test
+    fun `given supported social service ID when calling fromServiceId then return expected value`() {
+        // iterate and test all existing services supported by this enum
+        PublicizeServiceIcon.values().forEach { expectedServiceIcon ->
+            val icon = PublicizeServiceIcon.fromServiceId(expectedServiceIcon.serviceId)
+            assertThat(icon).isEqualTo(expectedServiceIcon)
+        }
+    }
+
+    @Test
+    fun `given unsupported social service ID when calling fromServiceId then return null`() {
+        val icon = PublicizeServiceIcon.fromServiceId("unsupported")
+        assertThat(icon).isNull()
+    }
+}


### PR DESCRIPTION
Part of #18752 

Create an `enum` to store the local icon resource for each Publicize/JP Social service, based on the ID returned by the API.

This will later be used to map the service to the corresponding icon whenever we need it, such as in the JP Social improvements.

To test:
N/A

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the new class.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A
