### PR TITLE
[JP Social/Pre-publishing] Create Social Connect item UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
@@ -42,8 +42,10 @@ fun PrimaryButton(
         end = dimensionResource(R.dimen.jp_migration_buttons_padding_horizontal),
         bottom = 10.dp
     ),
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     textStyle: TextStyle = LocalTextStyle.current,
     buttonSize: ButtonSize = ButtonSize.NORMAL,
+    fillMaxWidth: Boolean = true,
 ) {
     Button(
         onClick = onClick,
@@ -56,7 +58,8 @@ fun PrimaryButton(
         modifier = modifier
             .padding(padding)
             .defaultMinSize(minHeight = buttonSize.height)
-            .fillMaxWidth(),
+            .then(if (fillMaxWidth) Modifier.fillMaxWidth() else Modifier),
+        contentPadding = contentPadding,
     ) {
         if (isInProgress) {
             CircularProgressIndicator(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButton.kt
@@ -38,8 +38,10 @@ fun SecondaryButton(
         end = dimensionResource(R.dimen.jp_migration_buttons_padding_horizontal),
         bottom = 10.dp,
     ),
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     textStyle: TextStyle = LocalTextStyle.current,
     buttonSize: ButtonSize = ButtonSize.NORMAL,
+    fillMaxWidth: Boolean = true,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {
     Button(
@@ -53,7 +55,8 @@ fun SecondaryButton(
         modifier = modifier
             .padding(padding)
             .defaultMinSize(minHeight = buttonSize.height)
-            .fillMaxWidth()
+            .then(if (fillMaxWidth) Modifier.fillMaxWidth() else Modifier),
+        contentPadding = contentPadding,
     ) {
         Text(text, style = textStyle)
         trailingContent?.invoke()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
@@ -50,7 +50,7 @@ fun PrepublishingHomeSocialConnectItem(
         Spacer(Modifier.height(Margin.ExtraLarge.value))
 
         Text(
-            text = "Increase your traffic by auto-sharing your posts with your friends on social media.",
+            text = stringResource(R.string.prepublishing_nudges_social_new_connection_text),
             style = MaterialTheme.typography.body1.copy(color = AppColor.Gray30),
             modifier = Modifier.fillMaxWidth(),
         )
@@ -63,7 +63,7 @@ fun PrepublishingHomeSocialConnectItem(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SecondaryButton(
-                text = "Connect your social profiles",
+                text = stringResource(R.string.prepublishing_nudges_social_new_connection_cta),
                 onClick = onConnectClick,
                 padding = PaddingValues(0.dp),
                 contentPadding = PaddingValues(0.dp),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
@@ -1,0 +1,98 @@
+package org.wordpress.android.ui.posts.prepublishing.home.compose
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.TrainOfIcons
+import org.wordpress.android.ui.compose.components.TrainOfIconsModel
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.publicize.PublicizeServiceIcon
+
+@Composable
+fun PrepublishingHomeSocialConnectItem(
+    connectionIconModels: List<TrainOfIconsModel>,
+    onConnectClick: () -> Unit,
+    onHideClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.colors.surface
+) {
+    Column(
+        modifier = Modifier
+            .background(backgroundColor)
+            .then(modifier),
+    ) {
+        TrainOfIcons(
+            iconModels = connectionIconModels,
+            iconBorderColor = backgroundColor,
+        )
+
+        Spacer(Modifier.height(Margin.ExtraLarge.value))
+
+        Text(
+            text = "Increase your traffic by auto-sharing your posts with your friends on social media.",
+            style = MaterialTheme.typography.body1.copy(color = AppColor.Gray30),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(Margin.Medium.value))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SecondaryButton(
+                text = "Connect your social profiles",
+                onClick = onConnectClick,
+                padding = PaddingValues(0.dp),
+                contentPadding = PaddingValues(0.dp),
+                fillMaxWidth = false,
+            )
+
+            SecondaryButton(
+                text = stringResource(R.string.button_not_now),
+                onClick = onHideClick,
+                padding = PaddingValues(0.dp),
+                contentPadding = PaddingValues(0.dp),
+                fillMaxWidth = false,
+            )
+        }
+    }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PrepublishingHomeSocialConnectItemPreview() {
+    AppTheme {
+        PrepublishingHomeSocialConnectItem(
+            connectionIconModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
+            onConnectClick = { /*TODO*/ },
+            onHideClick = { /*TODO*/ },
+            modifier = Modifier.padding(
+                horizontal = 16.dp,
+                vertical = 24.dp,
+            ),
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.publicize.PublicizeServiceIcon
 fun PrepublishingHomeSocialConnectItem(
     connectionIconModels: List<TrainOfIconsModel>,
     onConnectClick: () -> Unit,
-    onHideClick: () -> Unit,
+    onDismissClick: () -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colors.surface
 ) {
@@ -76,7 +76,7 @@ fun PrepublishingHomeSocialConnectItem(
 
             SecondaryButton(
                 text = stringResource(R.string.button_not_now),
-                onClick = onHideClick,
+                onClick = onDismissClick,
                 padding = PaddingValues(0.dp),
                 contentPadding = PaddingValues(0.dp),
                 fillMaxWidth = false,
@@ -93,7 +93,7 @@ private fun PrepublishingHomeSocialConnectItemPreview() {
         PrepublishingHomeSocialConnectItem(
             connectionIconModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
             onConnectClick = { /*TODO*/ },
-            onHideClick = { /*TODO*/ },
+            onDismissClick = { /*TODO*/ },
             modifier = Modifier.padding(
                 horizontal = 16.dp,
                 vertical = 24.dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialConnectItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -67,7 +68,11 @@ fun PrepublishingHomeSocialConnectItem(
                 padding = PaddingValues(0.dp),
                 contentPadding = PaddingValues(0.dp),
                 fillMaxWidth = false,
+                modifier = Modifier.weight(1f, fill = false)
             )
+
+            // min spacing between buttons
+            Spacer(Modifier.width(Margin.Medium.value))
 
             SecondaryButton(
                 text = stringResource(R.string.button_not_now),

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3482,6 +3482,8 @@
     <string name="prepublishing_nudges_toolbar_title_categories">Categories</string>
     <string name="prepublishing_nudges_toolbar_title_add_categories">Add New Category</string>
     <string name="prepublishing_nudges_add_category_button">Add Category</string>
+    <string name="prepublishing_nudges_social_new_connection_text">Increase your traffic by auto-sharing your posts with your friends on social media.</string>
+    <string name="prepublishing_nudges_social_new_connection_cta">Connect your social profiles</string>
 
     <!-- Modal Layout Picker -->
     <string name="mlp_choose_layout_title">Choose a layout</string>


### PR DESCRIPTION
Part of #18752

Create Compose component for the JP Social Connect item to be used in the pre-publishing bottom sheet.

This also adds some parameters to the Primary and Secondary Compose buttons to provide more customization:
- `contentPadding` to be able to customize the button internal padding
- `fillMaxWidth` to be able to disable full max width buttons

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/8a302f45-fb2a-4333-9d20-a4e41d3d81d0)

To test:
This is only the Compose UI so there's no way to test other than going to `PrepublishingHomeSocialConnectItem.kt` and looking at the Preview and making sure it runs properly on a device.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
