### PR TITLE
Fixes: WP Android database migration from 14-16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.99.0'
     wordPressAztecVersion = 'v1.6.4'
-    wordPressFluxCVersion = 'trunk-355bb5e8ce03a4ac0a5f859efef24a0bf3b26ab0'
+    wordPressFluxCVersion = '2769-26b0de25ad4193ecd867bb1d70802b59ea7e544f'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
## Fixes
The WP Android database migration from 14-16

## Description
This PR fixes the database migration issue that was introduced with https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2762. Note that there is no crash or any issues, but the the unused table `BlazeStatus` was still present

## Fixes 
The code for migration of the database was left out from the previous PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2762

## To test
There is nothing to test as such since the usage of the dropped table was removed the from the compain WP PR - https://github.com/wordpress-mobile/WordPress-Android/pull/18718. 

- Run the app from a previous version -branch `release/22.7`
- Install the app from this branch
- Check whether the app is working as expected 
- Check `BlazeStatus` table is there in app through database inspector or not

## Merge Instructions 
- Merge https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2769
- Update FluxC Hash
- Remove donot merge label 
- Merge as normal

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
