### PR TITLE
[JP Social/Pre-publishing] Add connection prompt UI to View Holder

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
@@ -61,13 +61,23 @@ sealed class PrepublishingHomeItemUiState {
         )
     }
 
-    data class SocialUiState(
-        val title: UiString,
-        val description: UiString,
-        val isLowOnShares: Boolean,
-        val serviceIcons: List<ConnectionServiceIcon>,
-        val onItemClicked: (() -> Unit)?
-    ) : PrepublishingHomeItemUiState() {
+    sealed class SocialUiState : PrepublishingHomeItemUiState() {
+        abstract val serviceIcons: List<ConnectionServiceIcon>
+
+        data class SocialSharingUiState(
+            override val serviceIcons: List<ConnectionServiceIcon>,
+            val title: UiString,
+            val description: UiString,
+            val isLowOnShares: Boolean,
+            val onItemClicked: (() -> Unit),
+        ) : SocialUiState()
+
+        data class SocialConnectPromptUiState(
+            override val serviceIcons: List<ConnectionServiceIcon>,
+            val onConnectClicked: (() -> Unit),
+            val onDismissClicked: (() -> Unit),
+        ) : SocialUiState()
+
         data class ConnectionServiceIcon(
             @DrawableRes val iconRes: Int,
             val isEnabled: Boolean = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
@@ -65,10 +65,10 @@ sealed class PrepublishingHomeItemUiState {
         val title: UiString,
         val description: UiString,
         val isLowOnShares: Boolean,
-        val connectionIcons: List<ConnectionIcon>,
+        val serviceIcons: List<ConnectionServiceIcon>,
         val onItemClicked: (() -> Unit)?
     ) : PrepublishingHomeItemUiState() {
-        data class ConnectionIcon(
+        data class ConnectionServiceIcon(
             @DrawableRes val iconRes: Int,
             val isEnabled: Boolean = true
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
@@ -117,7 +117,7 @@ sealed class PrepublishingHomeViewHolder(
                     mutableStateOf(uiState as SocialUiState)
                 }
 
-                val avatarModels = state.connectionIcons.map { icon ->
+                val serviceIconModels = state.serviceIcons.map { icon ->
                     TrainOfIconsModel(
                         data = icon.iconRes,
                         alpha = if (icon.isEnabled) 1f else ContentAlpha.disabled,
@@ -128,7 +128,7 @@ sealed class PrepublishingHomeViewHolder(
                     PrepublishingHomeSocialItem(
                         title = state.title.asString(),
                         description = state.description.asString(),
-                        avatarModels = avatarModels,
+                        iconModels = serviceIconModels,
                         isLowOnShares = state.isLowOnShares,
                         backgroundColor = MaterialTheme.colors.surface.withBottomSheetElevation(),
                         modifier = Modifier.fillMaxWidth(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
@@ -7,6 +7,8 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.LayoutRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
@@ -26,6 +28,7 @@ import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUi
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.HeaderUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.HomeUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.SocialUiState
+import org.wordpress.android.ui.posts.prepublishing.home.compose.PrepublishingHomeSocialConnectItem
 import org.wordpress.android.ui.posts.prepublishing.home.compose.PrepublishingHomeSocialItem
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
@@ -112,9 +115,13 @@ sealed class PrepublishingHomeViewHolder(
         private val composeView: ComposeView = itemView.findViewById(R.id.prepublishing_compose_view)
 
         override fun onBind(uiState: PrepublishingHomeItemUiState) {
+            require(uiState is SocialUiState) {
+                "PrepublishingSocialItemViewHolder can only bind SocialUiState"
+            }
+
             composeView.setContent {
                 val state: SocialUiState by remember(uiState) {
-                    mutableStateOf(uiState as SocialUiState)
+                    mutableStateOf(uiState)
                 }
 
                 val serviceIconModels = state.serviceIcons.map { icon ->
@@ -125,14 +132,32 @@ sealed class PrepublishingHomeViewHolder(
                 }
 
                 AppTheme {
-                    PrepublishingHomeSocialItem(
-                        title = state.title.asString(),
-                        description = state.description.asString(),
-                        iconModels = serviceIconModels,
-                        isLowOnShares = state.isLowOnShares,
-                        backgroundColor = MaterialTheme.colors.surface.withBottomSheetElevation(),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    (state as? SocialUiState.SocialSharingUiState)?.let { sharingState ->
+                        PrepublishingHomeSocialItem(
+                            title = sharingState.title.asString(),
+                            description = sharingState.description.asString(),
+                            iconModels = serviceIconModels,
+                            isLowOnShares = sharingState.isLowOnShares,
+                            backgroundColor = MaterialTheme.colors.surface.withBottomSheetElevation(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null, // no ripple
+                                    onClick = sharingState.onItemClicked,
+                                ),
+                        )
+                    }
+
+                    (state as? SocialUiState.SocialConnectPromptUiState)?.let { promptState ->
+                        PrepublishingHomeSocialConnectItem(
+                            connectionIconModels = serviceIconModels,
+                            onConnectClick = promptState.onConnectClicked,
+                            onDismissClick = promptState.onDismissClicked,
+                            backgroundColor = MaterialTheme.colors.surface.withBottomSheetElevation(),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
@@ -205,16 +205,29 @@ class PrepublishingHomeViewModel @Inject constructor(
 
     private fun MutableList<PrepublishingHomeItemUiState>.showSocialItem() {
         // TODO in other PR: use actual data, for now just using fake data
+//        add(
+//            SocialUiState.SocialSharingUiState(
+//                serviceIcons = listOf(
+//                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_facebook, isEnabled = false),
+//                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_tumblr)
+//                ),
+//                title = UiStringText("Sharing to 2 of 3 accounts"),
+//                description = UiStringText("27/30 social shares remaining"),
+//                isLowOnShares = false,
+//                onItemClicked = { Log.d("thomashorta", "hey there!") },
+//            )
+//        )
         add(
-            SocialUiState(
-                title = UiStringText("Sharing to 2 of 3 accounts"),
-                description = UiStringText("27/30 social shares remaining"),
-                isLowOnShares = false,
+            SocialUiState.SocialConnectPromptUiState(
                 serviceIcons = listOf(
-                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_facebook, isEnabled = false),
-                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_tumblr)
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_tumblr),
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_facebook),
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_instagram),
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_mastodon),
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_linkedin),
                 ),
-                onItemClicked = { /* TODO in other PR: open social section in bottom sheet */ },
+                onConnectClicked = { /* TODO in other PR: open sharing settings */ },
+                onDismissClicked = { /* TODO in other PR: hide this item forever */ },
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
@@ -210,9 +210,9 @@ class PrepublishingHomeViewModel @Inject constructor(
                 title = UiStringText("Sharing to 2 of 3 accounts"),
                 description = UiStringText("27/30 social shares remaining"),
                 isLowOnShares = false,
-                connectionIcons = listOf(
-                    SocialUiState.ConnectionIcon(R.drawable.ic_social_facebook, isEnabled = false),
-                    SocialUiState.ConnectionIcon(R.drawable.ic_social_tumblr)
+                serviceIcons = listOf(
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_facebook, isEnabled = false),
+                    SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_tumblr)
                 ),
                 onItemClicked = { /* TODO in other PR: open social section in bottom sheet */ },
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialItem.kt
@@ -36,13 +36,13 @@ import org.wordpress.android.ui.compose.unit.Margin
 fun PrepublishingHomeSocialItem(
     title: String,
     description: String,
-    avatarModels: List<TrainOfIconsModel>,
+    iconModels: List<TrainOfIconsModel>,
     modifier: Modifier = Modifier,
     isLowOnShares: Boolean = false,
     backgroundColor: Color = MaterialTheme.colors.surface
 ) {
     SocialContainer(
-        avatarCount = avatarModels.size,
+        iconCount = iconModels.size,
         modifier = Modifier
             .background(backgroundColor)
             .then(modifier),
@@ -63,21 +63,21 @@ fun PrepublishingHomeSocialItem(
             )
         }
 
-        if (avatarModels.isNotEmpty()) {
+        if (iconModels.isNotEmpty()) {
             Spacer(modifier = Modifier.size(Margin.Medium.value))
 
-            TrainOfIcons(iconModels = avatarModels, iconBorderColor = backgroundColor)
+            TrainOfIcons(iconModels = iconModels, iconBorderColor = backgroundColor)
         }
     }
 }
 
 @Composable
 private fun SocialContainer(
-    avatarCount: Int,
+    iconCount: Int,
     modifier: Modifier = Modifier,
     content: @Composable (textColumnModifier: Modifier) -> Unit,
 ) {
-    if (avatarCount > 2) {
+    if (iconCount > 2) {
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
             modifier = modifier,
@@ -153,7 +153,7 @@ private fun PrepublishingHomeSocialItemPreview() {
             PrepublishingHomeSocialItem(
                 title = "Sharing to 2 of 3 accounts",
                 description = "27/30 social shares remaining",
-                avatarModels = listOf(
+                iconModels = listOf(
                     TrainOfIconsModel(R.drawable.ic_social_tumblr, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_facebook),
                 ),
@@ -163,7 +163,7 @@ private fun PrepublishingHomeSocialItemPreview() {
             PrepublishingHomeSocialItem(
                 title = "Sharing to 2 of 3 accounts",
                 description = "27/30 social shares remaining with a very long text that should be truncated",
-                avatarModels = listOf(
+                iconModels = listOf(
                     TrainOfIconsModel(R.drawable.ic_social_tumblr, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_facebook),
                 ),
@@ -175,7 +175,7 @@ private fun PrepublishingHomeSocialItemPreview() {
             PrepublishingHomeSocialItem(
                 title = "Sharing to 3 of 5 accounts",
                 description = "27/30 social shares remaining",
-                avatarModels = listOf(
+                iconModels = listOf(
                     TrainOfIconsModel(R.drawable.ic_social_facebook, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_mastodon, ContentAlpha.disabled),
                     TrainOfIconsModel(R.drawable.ic_social_twitter),
@@ -192,7 +192,7 @@ private fun PrepublishingHomeSocialItemPreview() {
                 title = "Not sharing to social",
                 description = "0/30 social shares remaining",
                 isLowOnShares = true,
-                avatarModels = listOf(
+                iconModels = listOf(
                     TrainOfIconsModel(R.drawable.ic_social_tumblr, ContentAlpha.disabled),
                 ),
                 modifier = Modifier.fillMaxWidth().padding(16.dp)


### PR DESCRIPTION
Part of #18752 

Add the "no connections"/connection prompt UI to the JP Social item View Holder in the pre-publishing sheet, creating an appropriate state sent by the `ViewModel`. 

This still contains only fake data at the `ViewModel` level, simply setting the connection prompt state without fetching any real data, for testing purposes, when the `JetpackSocialFeatureConfig` flag is **on**.

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/1e32488e-8df0-494f-b50a-d52f65b1a212)

To test:
1. Install and open the app
2. Go to Debug settings
3. Enable the `JetpackSocialFeatureConfig` in the "Features in Development" tab
4. Go back to the `My Site` screen
5. Open the Post lists
6. Open a post / Create a new post
7. Hit `Publish`/`Update` button to see the pre-publishing sheet
8. **Verify** the "No connection"/"connection prompt" UI is shown in the list (the buttons don't do anything currently)
9. Go to Debug settings
3. Disable the `JetpackSocialFeatureConfig` in the "Features in Development" tab
4. Go back to the `My Site` screen
5. Open the Post lists
6. Open a post / Create a new post
7. Hit `Publish`/`Update` button to see the pre-publishing sheet
8. **Verify** the "No connection"/"connection prompt" UI is NOT shown in the list

## Regression Notes
1. Potential unintended areas of impact
Other items in the pre-publishing sheet not working.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
