### PR TITLE
UI Modernization: Fix Me related issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -198,6 +198,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         if (BuildConfig.DEBUG) {
             rowDebugSettings.isVisible = true
+            debugSettingsDivider.isVisible = true
             rowDebugSettings.setOnClickListener {
                 requireContext().startActivity(Intent(requireContext(), DebugSettingsActivity::class.java))
             }
@@ -398,6 +399,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             meUsername.visibility = View.VISIBLE
             cardAvatar.visibility = View.VISIBLE
             rowMyProfile.visibility = View.VISIBLE
+            myProfileDivider.visibility = View.VISIBLE
+            accountSettingsDivider.visibility = View.VISIBLE
             loadAvatar(null)
             meUsername.text = getString(R.string.at_username, defaultAccount.userName)
             meLoginLogoutTextView.setText(R.string.me_disconnect_from_wordpress_com)
@@ -408,7 +411,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             cardAvatar.visibility = View.GONE
             avatarProgress.visibility = View.GONE
             rowMyProfile.visibility = View.GONE
+            myProfileDivider.visibility = View.GONE
             rowAccountSettings.visibility = View.GONE
+            accountSettingsDivider.visibility = View.GONE
             meLoginLogoutTextView.setText(R.string.me_connect_to_wordpress_com)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/MySiteListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/MySiteListItemViewHolder.kt
@@ -1,8 +1,13 @@
 package org.wordpress.android.ui.mysite.items.listitem
 
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.core.widget.ImageViewCompat
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.MySiteItemBlockBinding
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.main.utils.MeGravatarLoader
@@ -11,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.extensions.viewBinding
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
 
 class MySiteListItemViewHolder(
@@ -44,7 +50,37 @@ class MySiteListItemViewHolder(
                 null,
                 it,
                 ImageType.USER,
-                null
+                object : ImageManager.RequestListener<android.graphics.drawable.Drawable> {
+                    override fun onLoadFailed(e: Exception?, model: Any?) {
+                        val appLogMessage = "onLoadFailed while loading Gravatar image!"
+                        if (e == null) {
+                            AppLog.e(
+                                AppLog.T.MAIN,
+                                "$appLogMessage e == null"
+                            )
+                        } else {
+                            AppLog.e(
+                                AppLog.T.MAIN,
+                                appLogMessage,
+                                e
+                            )
+                        }
+                        ImageViewCompat.setImageTintList(imgIcon, ColorStateList.valueOf(Color.GRAY))
+                    }
+
+                    override fun onResourceReady(resource: android.graphics.drawable.Drawable, model: Any?) {
+                        ImageViewCompat.setImageTintList(imgIcon, null)
+                        if (resource is BitmapDrawable) {
+                            var bitmap = resource.bitmap
+                            // create a copy since the original bitmap may by automatically recycled
+                            bitmap = bitmap.copy(bitmap.config, true)
+                            WordPress.getBitmapCache().put(
+                                avatarUrl,
+                                bitmap
+                            )
+                        }
+                    }
+                }
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -203,7 +203,8 @@ class SiteListItemBuilder @Inject constructor(
         return if ((!buildConfigWrapper.isJetpackApp &&
                     jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures() &&
                     site.hasCapabilityManageOptions) ||
-            !siteUtilsWrapper.isAccessedViaWPComRest(site)
+            (!buildConfigWrapper.isJetpackApp &&
+                    site.isSelfHostedAdmin)
         ) {
             ListItem(
                 R.drawable.ic_user_primary_white_24,

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -124,7 +124,11 @@
 
             </LinearLayout>
 
-            <View style="@style/MeListSectionDividerView" />
+            <View
+                android:id="@+id/my_profile_divider"
+                android:visibility="gone"
+                style="@style/MeListSectionDividerView"
+                tools:visibility="visible"/>
 
             <LinearLayout
                 android:id="@+id/row_account_settings"
@@ -143,7 +147,11 @@
 
             </LinearLayout>
 
-            <View style="@style/MeListSectionDividerView" />
+            <View
+                android:id="@+id/account_settings_divider"
+                android:visibility="gone"
+                style="@style/MeListSectionDividerView"
+                tools:visibility="visible"/>
 
             <LinearLayout
                 android:id="@+id/row_scan_login_code"
@@ -192,7 +200,8 @@
             <LinearLayout
                 android:id="@+id/row_debug_settings"
                 android:visibility="gone"
-                style="@style/MeListRowLayout">
+                style="@style/MeListRowLayout"
+                tools:visibility="visible">
 
                 <ImageView
                     android:id="@+id/me_debug_settings_icon"
@@ -207,7 +216,11 @@
 
             </LinearLayout>
 
-            <View style="@style/MeListSectionDividerView" />
+            <View
+                android:id="@+id/debug_settings_divider"
+                android:visibility="gone"
+                style="@style/MeListSectionDividerView"
+                tools:visibility="visible"/>
 
             <LinearLayout
                 android:id="@+id/row_support"


### PR DESCRIPTION
Fixes the following issues for Me screen
- Me appearing under Menu, and on bottom nav on JP app for self hosted sites
- Inconsistent dividers
- Me icon not visible on light theme

Fixes #18710, #18764, #18765 

| Before | After | Before | After
|--------|--------|--------|--------|
| ![Screenshot_20230712_094351](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/6a9646bd-8dd1-4959-9ad2-7266017efe72) |![Screenshot_20230712_102007](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/c29e392a-7fa5-4001-bc37-9515f9958887) | ![Screenshot_20230713_100555](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/da55f825-bc0b-4299-97ef-36d333c409fe)| ![Screenshot_20230712_224741](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/7e299b05-8078-4de3-87bd-166481ed4fbd)



To test:

***Me appearing under Menu, and on bottom nav on JP app for self hosted sites***
Before:
- Launch a current version of JP app
- Use a WPCOM site
- `Verify` that `Me` appears only on bottom navigation
- Add a self hosted site
- `Verify` that `Me` appears under `Menu`, and also on bottom navigation

After
- Launch this version of the JP app
- `Verify` that Me doesn't appear under Menu any more, and only on bottom navigation
- Launch WP app
- `check` that `Me` appears under `Menu`, and there's `no bottom navigation` on WP app for both self hosted sites, and WPCOM sites

***Dividers, and icon***
Before:
- Use a ***light theme***
- Launch a current version of JP app
- Add a self hosted site (an account without an avatar)
- `Verify` that `Me` icon doesn't appears on bottom navigation (as in second Before image above)
- Tap on Me in bottom nav
- `Verify` that the dividers are inconsistent (as shown in second Before image above)

After
- Launch this version of the JP app
- `Verify` that Me icon appears on bottom navigation
- Tap on Me in bottom nav
- `Verify` that the dividers are now consistent
- Launch WP app
- `check` that `Me` appears under `Menu`, and icon is visible 
- `Verify` that the dividers are inconsistent 
- For completeness, `Verify` the above in ***dark theme*** as well.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested both JP, and WP app

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
