### PR TITLE
Avoid work manager job service id collisions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -378,6 +378,7 @@ class AppInitializer @Inject constructor(
         if (BuildConfig.DEBUG) {
             configBuilder.setMinimumLoggingLevel(Log.DEBUG)
         }
+        configBuilder.setJobSchedulerJobIdRange(WORK_MANAGER_ID_RANGE_MIN, WORK_MANAGER_ID_RANGE_MAX)
         WorkManager.initialize(application, configBuilder.build())
     }
 
@@ -960,6 +961,11 @@ class AppInitializer @Inject constructor(
         private const val KILOBYTES_IN_BYTES = 1024
         private const val MEMORY_CACHE_RATIO = 0.25 // Use 1/4th of the available memory for memory cache.
         private const val DEFAULT_TIMEOUT = 2 * 60 // 2 minutes
+
+        // Use service ids near the int max to avoid collisions with existing JobService ids
+        // The minimum range size is 1000, but we can easily give 10000.
+        private const val WORK_MANAGER_ID_RANGE_MAX = Int.MAX_VALUE
+        private const val WORK_MANAGER_ID_RANGE_MIN = WORK_MANAGER_ID_RANGE_MAX - 10000
 
         @SuppressLint("StaticFieldLeak")
         var context: Context? = null

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -26,7 +26,8 @@ public class JobServiceId {
     public static final int JOB_READER_DISCOVER_SERVICE_ID = 10000;
 
     // Note: Until these JobServices are refactored as WorkManager requests, we should avoid using id values for these
-    // services that may collide w/ the WorkManager id range (currently 1000 ids with range ending in Integer.MAX_VALUE)
+    // services that may collide w/ the WorkManager id range (currently 10000 ids with range ending in
+    // Integer.MAX_VALUE)
 
     /*
      * This method checks that a bundle for a given JobService matches perfectly (all extras and all of its

--- a/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
+++ b/WordPress/src/main/java/org/wordpress/android/JobServiceId.java
@@ -13,14 +13,20 @@ import java.util.List;
 import java.util.Set;
 
 public class JobServiceId {
-    public static final int JOB_INSTALL_REFERRER_SERVICE_ID = 9000;
-    public static final int JOB_STATS_SERVICE_ID = 8000;
-    public static final int JOB_NOTIFICATIONS_UPDATE_SERVICE_ID = 7000;
-    public static final int JOB_READER_SEARCH_SERVICE_ID = 5000;
-    public static final int JOB_PUBLICIZE_UPDATE_SERVICE_ID = 3000;
-    public static final int JOB_READER_UPDATE_SERVICE_ID = 2000;
-    public static final int JOB_READER_DISCOVER_SERVICE_ID = 10000;
     public static final int JOB_GCM_REG_SERVICE_ID = 1000;
+    public static final int JOB_READER_UPDATE_SERVICE_ID = 2000;
+    public static final int JOB_PUBLICIZE_UPDATE_SERVICE_ID = 3000;
+    public static final int JOB_READER_POST_SERVICE_ID_TAG = 4001;
+    public static final int JOB_READER_POST_SERVICE_ID_BLOG = 4002;
+    public static final int JOB_READER_POST_SERVICE_ID_FEED = 4003;
+    public static final int JOB_READER_SEARCH_SERVICE_ID = 5000;
+    public static final int JOB_NOTIFICATIONS_UPDATE_SERVICE_ID = 7000;
+    public static final int JOB_STATS_SERVICE_ID = 8000;
+    public static final int JOB_INSTALL_REFERRER_SERVICE_ID = 9000;
+    public static final int JOB_READER_DISCOVER_SERVICE_ID = 10000;
+
+    // Note: Until these JobServices are refactored as WorkManager requests, we should avoid using id values for these
+    // services that may collide w/ the WorkManager id range (currently 1000 ids with range ending in Integer.MAX_VALUE)
 
     /*
      * This method checks that a bundle for a given JobService matches perfectly (all extras and all of its

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -11,10 +11,11 @@ import android.os.PersistableBundle;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.util.AppLog;
 
+import static org.wordpress.android.JobServiceId.JOB_READER_POST_SERVICE_ID_BLOG;
+import static org.wordpress.android.JobServiceId.JOB_READER_POST_SERVICE_ID_FEED;
+import static org.wordpress.android.JobServiceId.JOB_READER_POST_SERVICE_ID_TAG;
+
 public class ReaderPostServiceStarter {
-    private static final int JOB_READER_POST_SERVICE_ID_TAG = 4001;
-    private static final int JOB_READER_POST_SERVICE_ID_BLOG = 4002;
-    private static final int JOB_READER_POST_SERVICE_ID_FEED = 4003;
     public static final String ARG_TAG = "tag";
     public static final String ARG_ACTION = "action";
     public static final String ARG_BLOG_ID = "blog_id";


### PR DESCRIPTION
Fixes #18632

### Description

This PR specifies an id range for the `WorkManager` configuration to avoid collisions with our "manually" created JobServices. It is not yet clear whether this will reduce the incidence rate of the crash in the related issue, but it is worth trying, imo, since this should be done anyway to avoid id collisions (as jobs will be stopped unintentionally, and probably unpredictably by the underlying implementation).

To test:
Since the underlying crash is difficult to reproduce, the best way to check the impact of this is to monitor the underlying crash metrics. That is listed as a subtask in the associated issue.

## Regression Notes
1. Potential unintended areas of impact
This should not affect any user-facing aspect of the app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
