### PR TITLE
Integrate gutenberg-mobile release 1.99.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.99.0'
+    gutenbergMobileVersion = '5962-9933c99a7a29149cbe43052f2d3f3540e97a8ef9'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.36.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5962-9933c99a7a29149cbe43052f2d3f3540e97a8ef9'
+    gutenbergMobileVersion = 'v1.99.1'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.36.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.99.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5962

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.