### PR TITLE
Fix nested preference screens crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -278,6 +278,11 @@ public class AppSettingsFragment extends PreferenceFragment
         return view;
     }
 
+    @Override public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        addPrivacyToolbar();
+    }
+
     private void addJetpackBadgeAsFooterIfEnabled(LayoutInflater inflater, ListView listView) {
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             final JetpackPoweredScreen screen = JetpackPoweredScreen.WithStaticText.APP_SETTINGS;
@@ -351,11 +356,6 @@ public class AppSettingsFragment extends PreferenceFragment
         if (mAccountStore.hasAccessToken() && NetworkUtils.isNetworkAvailable(getActivity())) {
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         }
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
     }
 
     @Override
@@ -644,6 +644,17 @@ public class AppSettingsFragment extends PreferenceFragment
     private boolean handlePrivacyClick() {
         AnalyticsTracker.track(Stat.APP_SETTINGS_PRIVACY_SETTINGS_TAPPED);
 
+        boolean isToolbarAdded = addPrivacyToolbar();
+
+        if (!isToolbarAdded) {
+            return false;
+        }
+
+        AnalyticsTracker.track(Stat.PRIVACY_SETTINGS_OPENED);
+        return true;
+    }
+
+    private boolean addPrivacyToolbar() {
         if (mPrivacySettings == null || !isAdded()) {
             return false;
         }
@@ -653,8 +664,6 @@ public class AppSettingsFragment extends PreferenceFragment
         if (dialog != null) {
             WPActivityUtils.addToolbarToDialog(this, dialog, title);
         }
-
-        AnalyticsTracker.track(Stat.PRIVACY_SETTINGS_OPENED);
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -261,6 +261,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     // Advanced settings
     private Preference mStartOverPref;
+    private PreferenceScreen mStartOverSettingsScreen;
     private Preference mExportSitePref;
     private Preference mDeleteSitePref;
 
@@ -502,6 +503,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         super.onViewStateRestored(savedInstanceState);
         addToolbarToSiteAcceleratorSettings();
         addToolbarToJpSecuritySettings();
+        addToolbarToStartOverSettings();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -565,8 +567,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(getActivity(), WORDPRESS_EMPTY_SITE_SUPPORT_URL);
             } else {
                 setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-                String title = getString(R.string.start_over);
-                WPActivityUtils.addToolbarToDialog(this, dialog, title);
+                addToolbarToStartOverSettings();
             }
         } else if (preference == mDateFormatPref) {
             showDateOrTimeFormatDialog(FormatType.DATE_FORMAT);
@@ -601,6 +602,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void addToolbarToJpSecuritySettings() {
         addToolbarToNestedPreference(mJpSecuritySettings, R.string.jetpack_security_setting_title);
+    }
+
+    private void addToolbarToStartOverSettings() {
+        addToolbarToNestedPreference(mStartOverSettingsScreen, R.string.start_over);
     }
 
     @Override
@@ -981,6 +986,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mModerationHoldPref = getClickPref(R.string.pref_key_site_moderation_hold);
         mDenylistPref = getClickPref(R.string.pref_key_site_denylist);
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
+        mStartOverSettingsScreen = (PreferenceScreen) getClickPref(R.string.pref_key_site_start_over_screen);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
         mJpSecuritySettings = (PreferenceScreen) getClickPref(R.string.pref_key_jetpack_security_screen);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -507,6 +507,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         addToolbarToStartOverSettings();
         addToolbarToJetpackMoreSettings();
         addToolbarToSiteAcceleratorSettingsNested();
+        addToolbarToMorePreference();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -518,15 +519,12 @@ public class SiteSettingsFragment extends PreferenceFragment
         removeJetpackSecurityScreenToolbar();
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
-        setupMorePreferenceScreen();
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
-            setupMorePreferenceScreen();
-
             SiteSettingsTimezoneBottomSheet bottomSheet =
                     (SiteSettingsTimezoneBottomSheet) (getAppCompatActivity())
                             .getSupportFragmentManager().findFragmentByTag(TIMEZONE_BOTTOM_SHEET_TAG);
@@ -617,6 +615,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void addToolbarToSiteAcceleratorSettingsNested() {
         addToolbarToNestedPreference(mSiteAcceleratorSettingsNested, R.string.site_settings_site_accelerator);
+    }
+
+    private void addToolbarToMorePreference() {
+        addToolbarToNestedPreference(mMorePreference, R.string.site_settings_discussion_title);
     }
 
     @Override
@@ -1972,12 +1974,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mMorePreference == null || !isAdded()) {
             return false;
         }
-        String title = getString(R.string.site_settings_discussion_title);
         Dialog dialog = mMorePreference.getDialog();
         if (dialog != null) {
-            dialog.setTitle(title);
             setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            addToolbarToMorePreference();
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -409,6 +409,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSiteSettings != null) {
             mSiteSettings.clear();
         }
+        if (mDialog != null) {
+            mDialog.dismiss();
+        }
         super.onDestroy();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -506,6 +506,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         addToolbarToJpSecuritySettings();
         addToolbarToStartOverSettings();
         addToolbarToJetpackMoreSettings();
+        addToolbarToSiteAcceleratorSettingsNested();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -612,6 +613,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void addToolbarToJetpackMoreSettings() {
         addToolbarToNestedPreference(mJetpackPerformanceMoreSettings, R.string.site_settings_performance);
+    }
+
+    private void addToolbarToSiteAcceleratorSettingsNested() {
+        addToolbarToNestedPreference(mSiteAcceleratorSettingsNested, R.string.site_settings_site_accelerator);
     }
 
     @Override
@@ -1956,11 +1961,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSiteAcceleratorSettingsNested == null || !isAdded()) {
             return;
         }
-        String title = getString(R.string.site_settings_site_accelerator);
         Dialog dialog = mSiteAcceleratorSettingsNested.getDialog();
         if (dialog != null) {
             setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            addToolbarToSiteAcceleratorSettingsNested();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -499,11 +499,13 @@ public class SiteSettingsFragment extends PreferenceFragment
         return view;
     }
 
-    @Override public void onViewStateRestored(Bundle savedInstanceState) {
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
         addToolbarToSiteAcceleratorSettings();
         addToolbarToJpSecuritySettings();
         addToolbarToStartOverSettings();
+        addToolbarToJetpackMoreSettings();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -606,6 +608,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void addToolbarToStartOverSettings() {
         addToolbarToNestedPreference(mStartOverSettingsScreen, R.string.start_over);
+    }
+
+    private void addToolbarToJetpackMoreSettings() {
+        addToolbarToNestedPreference(mJetpackPerformanceMoreSettings, R.string.site_settings_performance);
     }
 
     @Override
@@ -1939,11 +1945,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mJetpackPerformanceMoreSettings == null || !isAdded()) {
             return;
         }
-        String title = getString(R.string.site_settings_performance);
         Dialog dialog = mJetpackPerformanceMoreSettings.getDialog();
         if (dialog != null) {
             setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            addToolbarToJetpackMoreSettings();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -501,6 +501,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Override public void onViewStateRestored(Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
         addToolbarToSiteAcceleratorSettings();
+        addToolbarToJpSecuritySettings();
     }
 
     private AppCompatActivity getAppCompatActivity() {
@@ -513,7 +514,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         setupMorePreferenceScreen();
-        setupJetpackSecurityScreen();
     }
 
     @Override
@@ -521,7 +521,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         super.onActivityCreated(savedInstanceState);
         if (savedInstanceState != null) {
             setupMorePreferenceScreen();
-            setupJetpackSecurityScreen();
 
             SiteSettingsTimezoneBottomSheet bottomSheet =
                     (SiteSettingsTimezoneBottomSheet) (getAppCompatActivity())
@@ -598,6 +597,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void addToolbarToSiteAcceleratorSettings() {
         addToolbarToNestedPreference(mSiteAcceleratorSettings, R.string.site_settings_site_accelerator);
+    }
+
+    private void addToolbarToJpSecuritySettings() {
+        addToolbarToNestedPreference(mJpSecuritySettings, R.string.jetpack_security_setting_title);
     }
 
     @Override
@@ -1908,11 +1911,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mJpSecuritySettings == null || !isAdded()) {
             return;
         }
-        String title = getString(R.string.jetpack_security_setting_title);
         Dialog dialog = mJpSecuritySettings.getDialog();
         if (dialog != null) {
             setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            addToolbarToJpSecuritySettings();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -498,6 +498,11 @@ public class SiteSettingsFragment extends PreferenceFragment
         return view;
     }
 
+    @Override public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        addToolbarToSiteAcceleratorSettings();
+    }
+
     private AppCompatActivity getAppCompatActivity() {
         return (AppCompatActivity) getActivity();
     }
@@ -579,6 +584,20 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         return false;
+    }
+
+    private void addToolbarToNestedPreference(PreferenceScreen preferenceScreen, int titleRes) {
+        if (preferenceScreen != null && isAdded()) {
+            Dialog dialog = preferenceScreen.getDialog();
+            if (dialog != null) {
+                String title = getString(titleRes);
+                WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            }
+        }
+    }
+
+    private void addToolbarToSiteAcceleratorSettings() {
+        addToolbarToNestedPreference(mSiteAcceleratorSettings, R.string.site_settings_site_accelerator);
     }
 
     @Override
@@ -1901,11 +1920,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSiteAcceleratorSettings == null || !isAdded()) {
             return;
         }
-        String title = getString(R.string.site_settings_site_accelerator);
         Dialog dialog = mSiteAcceleratorSettings.getDialog();
         if (dialog != null) {
             setupPreferenceList(dialog.findViewById(android.R.id.list), getResources());
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            addToolbarToSiteAcceleratorSettings();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -400,7 +400,6 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     @Override
     public void onDestroyView() {
-        removeJetpackSecurityScreenToolbar();
         mDispatcher.unregister(this);
         super.onDestroyView();
     }
@@ -516,7 +515,6 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        removeJetpackSecurityScreenToolbar();
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
     }
@@ -1981,14 +1979,6 @@ public class SiteSettingsFragment extends PreferenceFragment
             return true;
         }
         return false;
-    }
-
-    private void removeJetpackSecurityScreenToolbar() {
-        if (mJpSecuritySettings == null || !isAdded()) {
-            return;
-        }
-        Dialog securityDialog = mJpSecuritySettings.getDialog();
-        WPActivityUtils.removeToolbarFromDialog(this, securityDialog);
     }
 
     private void hideAdminRequiredPreferences() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -225,6 +225,13 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         initBloggingReminders();
     }
 
+    @Override public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        PreferenceScreen otherBlogsScreen = (PreferenceScreen) findPreference(
+                getString(R.string.pref_notification_other_blogs));
+        addToolbarToDialog(otherBlogsScreen);
+    }
+
     private void addJetpackBadgeAsFooterIfEnabled(ListView listView) {
         if (mJetpackBrandingUtils.shouldShowJetpackBranding()) {
             final JetpackPoweredScreen screen = JetpackPoweredScreen.WithDynamicText.NOTIFICATIONS_SETTINGS;
@@ -940,17 +947,21 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         super.onPreferenceTreeClick(preferenceScreen, preference);
 
         if (preference instanceof PreferenceScreen) {
-            Dialog prefDialog = ((PreferenceScreen) preference).getDialog();
-            if (prefDialog != null) {
-                String title = String.valueOf(preference.getTitle());
-                WPActivityUtils.addToolbarToDialog(this, prefDialog, title);
-            }
+            addToolbarToDialog(preference);
             AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_SETTINGS_STREAMS_OPENED);
         } else {
             AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_SETTINGS_DETAILS_OPENED);
         }
 
         return false;
+    }
+
+    private void addToolbarToDialog(Preference preference) {
+        Dialog prefDialog = ((PreferenceScreen) preference).getDialog();
+        if (prefDialog != null) {
+            String title = String.valueOf(preference.getTitle());
+            WPActivityUtils.addToolbarToDialog(this, prefDialog, title);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -17,7 +17,6 @@ import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.ViewCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
@@ -96,37 +95,6 @@ public class WPActivityUtils {
         toolbar.setTitle(title);
         toolbar.setNavigationOnClickListener(v -> dialog.dismiss());
         toolbar.setNavigationContentDescription(R.string.navigate_up_desc);
-    }
-
-    /**
-     * Checks for a {@link Toolbar} at the first child element of a given {@link Dialog} and
-     * removes it if it exists.
-     * <p>
-     * Originally added to prevent a crash that occurs with nested PreferenceScreens that added
-     * a toolbar via {@link WPActivityUtils#addToolbarToDialog(android.app.Fragment, Dialog, String)}. The
-     * crash can be reproduced by turning 'Don't keep activities' on from Developer options.
-     */
-
-    // TODO: android.app.Fragment  is deprecated since Android P.
-    // Needs to be replaced with android.support.v4.app.Fragment
-    // See https://developer.android.com/reference/android/app/Fragment
-    public static void removeToolbarFromDialog(final android.app.Fragment context, final Dialog dialog) {
-        if (dialog == null || !context.isAdded()) {
-            return;
-        }
-
-        View dialogContainerView = DialogExtensionsKt.getPreferenceDialogContainerView(dialog);
-
-        if (dialogContainerView == null) {
-            AppLog.e(T.SETTINGS, "Preference Dialog View was null when removing Toolbar");
-            return;
-        }
-
-        ViewGroup root = (ViewGroup) dialogContainerView.getParent().getParent();
-
-        if (root.getChildAt(0) instanceof Toolbar) {
-            root.removeViewAt(0);
-        }
     }
 
     public static Context getThemedContext(Context context) {

--- a/WordPress/src/main/res/layout/preference_screen_wrapper.xml
+++ b/WordPress/src/main/res/layout/preference_screen_wrapper.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/coordinator_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical">
+    android:saveEnabled="false">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
@@ -18,6 +17,7 @@
             android:layout_width="match_parent"
             app:navigationIcon="@drawable/ic_arrow_left_white_24dp"
             android:layout_height="wrap_content"
+            android:saveEnabled="false"
             app:theme="@style/WordPress.ActionBar" />
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
Fixes #18755

This fixes the crashes that occur on nested preference screens.

### History of the crash
- We use deprecated [PreferenceFragment](https://developer.android.com/reference/android/preference/PreferenceFragment) in our settings screens.
- These screens do not support toolbars in nested settings screens, so we [manually added toolbars](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java#L37-L99). 
- However, preference screens cannot handle saving the state of the toolbar. This is a `won't fix` [bug in the framework](https://issuetracker.google.com/issues/37133281).
- To resolve the issue, we [removed the toolbar](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java#L101-L130) before saving the state.
- Then we [added](https://github.com/wordpress-mobile/WordPress-Android/pull/12631) a `CoordinatorLayout` to the dialog layout (`preference_screen_wrapper.xml`).
- 💥 `PreferenceFragment` cannot handle saving the state of the `CoordinatorLayout` either.

### PR solution
- I removed the previous solution that removes the toolbar.
- I disabled saving the state of the `CoordinatorLayout` and `Toolbar` by adding `android:saveEnabled="false"`.
- However, this caused the toolbar to be lost when the view is restored from the background.
- To address this, I manually added the toolbar in `onViewStateRestored()`.

To test:
> **Note**
> The crash occurs when the device is low on memory and can't keep activities. To reproduce the issue, you should enable the `Don't keep activities` setting in the device's developer settings. All the cases below should be tested with `Don't keep activities` both **enabled** and **disabled**.

> **Note**
> To be able to access all settings options, test with a self-hosted site that has all Jetpack features and with Business (Professional) plan.

**Privacy settings:**
1. Log in to the app.
2. Navigate to "Me → App Settings → Privacy Settings".
3. Tap one of the buttons that open a web link, such as LEARN MORE.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Comments on other sites**
1. Log in to the app.
2. Navigate to "Notifications → Notification Settings → Comments on other sites".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Site Accelerator**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → Site Accelerator".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Security**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → Security".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Start Over**
1. Log in to the app.
2. Select a site that was created on WordPress.
3. Navigate to "My Site → MENU → Site Settings → Start Over".
4. Send the app to the background by opening the device's home screen.
5. Return to the app.
6. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Performance More**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → More (in the Performance section)".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Nested Site Accelerator**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → More (in the Performance section) → Site Accelerator".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Discussion More**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → More (in the Discussion section)".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the toolbar is still displayed, it's not duplicated, and the app doesn't crash.

**Hold for Moderation + Disallowed comments**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → More (in the Discussion section)".
3. Tap the "Hold for Moderation" button.
4. Send the app to the background by opening the device's home screen.
5. Return to the app.
6. Ensure the app doesn't crash and navigate back.
7. Tap the "Disallowed comments" button.
8. Repeat 4-5-6.

**Security**
1. Log in to the app.
2. Navigate to "My Site → MENU → Site Settings → Security" → "Always allowed IP adresses".
3. Send the app to the background by opening the device's home screen.
4. Return to the app.
5. Ensure the app doesn't crash and navigate back.

## Regression Notes
1. Potential unintended areas of impact
None. I have already updated all the affected screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Since the settings screen uses the deprecated [PreferenceFragment](https://developer.android.com/reference/android/preference/PreferenceFragment), there is no need to put effort into improving testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
