### PR TITLE
[JP Social/Pre-publishing] Open Sharing Settings from "no connection" item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.PostPrepublishingBottomSheetBinding
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPBottomSheetDialogFragment
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.ADD_CATEGORY
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.CATEGORIES
@@ -158,6 +159,10 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
 
         viewModel.dismissKeyboard.observeEvent(this) {
             ActivityUtils.hideKeyboardForced(view)
+        }
+
+        viewModel.navigateToSharingSettings.observeEvent(this) { site ->
+            context?.let { ActivityLauncher.viewBlogSharing(it, site) }
         }
 
         val prepublishingScreenState = savedInstanceState?.getParcelableCompat<PrepublishingScreen>(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModel.kt
@@ -48,6 +48,9 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     private val _triggerOnDeviceBackPressed = MutableLiveData<Event<PrepublishingScreen>>()
     val triggerOnDeviceBackPressed: LiveData<Event<PrepublishingScreen>> = _triggerOnDeviceBackPressed
 
+    private val _navigateToSharingSettings = MutableLiveData<Event<SiteModel>>()
+    val navigateToSharingSettings: LiveData<Event<SiteModel>> = _navigateToSharingSettings
+
     init {
         dispatcher.register(this)
     }
@@ -130,14 +133,24 @@ class PrepublishingViewModel @Inject constructor(private val dispatcher: Dispatc
     }
 
     fun onActionClicked(actionType: ActionType, bundle: Bundle? = null) {
-        val screen = PrepublishingScreen.valueOf(actionType.name)
-        currentScreen = screen
-        navigateToScreen(screen, bundle)
+        when (actionType) {
+            is ActionType.PrepublishingScreenNavigation -> {
+                currentScreen = actionType.prepublishingScreen
+                navigateToScreen(actionType.prepublishingScreen, bundle)
+            }
+            is ActionType.Action -> handleAction(actionType)
+        }
     }
 
     fun onSubmitButtonClicked(publishPost: PublishPost) {
         onCloseClicked()
         _triggerOnSubmitButtonClickedListener.postValue(Event(publishPost))
+    }
+
+    private fun handleAction(action: ActionType.Action) {
+        when (action) {
+            ActionType.Action.NavigateToSharingSettings -> _navigateToSharingSettings.postValue(Event(site))
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
@@ -22,10 +22,10 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingAddCategoryRequest
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.ADD_CATEGORY
-import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingScreenClosedListener
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PrepublishingScreenNavigation
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingActionClickedListener
+import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingScreenClosedListener
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.ToastUtils.Duration.SHORT
@@ -145,7 +145,7 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
         })
 
         viewModel.navigateToAddCategoryScreen.observe(viewLifecycleOwner, { bundle ->
-            actionListener?.onActionClicked(ADD_CATEGORY, bundle)
+            actionListener?.onActionClicked(PrepublishingScreenNavigation.AddCategory, bundle)
         }
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeItemUiState.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts.prepublishing.home
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import org.wordpress.android.R
+import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -11,12 +12,12 @@ typealias PublishPost = Boolean
 
 sealed class PrepublishingHomeItemUiState {
     data class HomeUiState(
-        val actionType: ActionType,
+        val navigationAction: ActionType.PrepublishingScreenNavigation,
         @ColorRes val actionTypeColor: Int = R.color.prepublishing_action_type_enabled_color,
         val actionResult: UiString? = null,
         @ColorRes val actionResultColor: Int = R.color.prepublishing_action_result_enabled_color,
         val actionClickable: Boolean,
-        val onActionClicked: ((actionType: ActionType) -> Unit)?
+        val onNavigationActionClicked: ((navigationAction: ActionType.PrepublishingScreenNavigation) -> Unit)?
     ) : PrepublishingHomeItemUiState()
 
     data class StoryTitleUiState(
@@ -84,10 +85,31 @@ sealed class PrepublishingHomeItemUiState {
         )
     }
 
-    enum class ActionType(val textRes: UiStringRes) {
-        PUBLISH(UiStringRes(R.string.prepublishing_nudges_publish_action)),
-        TAGS(UiStringRes(R.string.prepublishing_nudges_tags_action)),
-        CATEGORIES(UiStringRes(R.string.prepublishing_nudges_categories_action)),
-        ADD_CATEGORY(UiStringRes(R.string.prepublishing_nudges_categories_action))
+    sealed interface ActionType {
+        sealed class PrepublishingScreenNavigation(
+            val textRes: UiStringRes,
+            val prepublishingScreen: PrepublishingScreen,
+        ) : ActionType {
+            object Publish : PrepublishingScreenNavigation(
+                UiStringRes(R.string.prepublishing_nudges_publish_action),
+                PrepublishingScreen.PUBLISH,
+            )
+            object Tags : PrepublishingScreenNavigation(
+                UiStringRes(R.string.prepublishing_nudges_tags_action),
+                PrepublishingScreen.TAGS,
+            )
+            object Categories : PrepublishingScreenNavigation(
+                UiStringRes(R.string.prepublishing_nudges_categories_action),
+                PrepublishingScreen.CATEGORIES,
+            )
+            object AddCategory : PrepublishingScreenNavigation(
+                UiStringRes(R.string.prepublishing_nudges_categories_action),
+                PrepublishingScreen.ADD_CATEGORY,
+            )
+        }
+
+        sealed class Action : ActionType {
+            object NavigateToSharingSettings : Action()
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
@@ -49,14 +49,14 @@ sealed class PrepublishingHomeViewHolder(
         override fun onBind(uiState: PrepublishingHomeItemUiState) {
             uiState as HomeUiState
 
-            actionType.text = uiHelpers.getTextOfUiString(itemView.context, uiState.actionType.textRes)
+            actionType.text = uiHelpers.getTextOfUiString(itemView.context, uiState.navigationAction.textRes)
             uiState.actionResult?.let { resultText ->
                 actionResult.text = uiHelpers.getTextOfUiString(itemView.context, resultText)
             }
 
             actionLayout.isEnabled = uiState.actionClickable
             actionLayout.setOnClickListener {
-                uiState.onActionClicked?.invoke(uiState.actionType)
+                uiState.onNavigationActionClicked?.invoke(uiState.navigationAction)
             }
 
             actionType.setTextColor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
@@ -15,9 +15,8 @@ import org.wordpress.android.ui.posts.GetCategoriesUseCase
 import org.wordpress.android.ui.posts.GetPostTagsUseCase
 import org.wordpress.android.ui.posts.PostSettingsUtils
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.CATEGORIES
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PUBLISH
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.TAGS
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.Action
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PrepublishingScreenNavigation
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.HeaderUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.HomeUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.SocialUiState
@@ -113,14 +112,14 @@ class PrepublishingHomeViewModel @Inject constructor(
             )
 
             add(HomeUiState(
-                actionType = CATEGORIES,
+                navigationAction = PrepublishingScreenNavigation.Categories,
                 actionResult = if (categoriesString.isNotEmpty()) {
                     UiStringText(categoriesString)
                 } else {
                     run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) }
                 },
                 actionClickable = true,
-                onActionClicked = ::onActionClicked
+                onNavigationActionClicked = ::onActionClicked
             ))
 
             if (!editPostRepository.isPage && socialFeatureConfig.isEnabled()) {
@@ -143,12 +142,12 @@ class PrepublishingHomeViewModel @Inject constructor(
     ) {
         add(
             HomeUiState(
-                actionType = TAGS,
+                navigationAction = PrepublishingScreenNavigation.Tags,
                 actionResult = getPostTagsUseCase.getTags(editPostRepository)
                     ?.let { UiStringText(it) }
                     ?: run { UiStringRes(R.string.prepublishing_nudges_home_tags_not_set) },
                 actionClickable = true,
-                onActionClicked = ::onActionClicked
+                onNavigationActionClicked = ::onActionClicked
             )
         )
 
@@ -166,7 +165,7 @@ class PrepublishingHomeViewModel @Inject constructor(
     ) {
         add(
             HomeUiState(
-                actionType = PUBLISH,
+                navigationAction = PrepublishingScreenNavigation.Publish,
                 actionResult = editPostRepository.getEditablePost()
                     ?.let {
                         UiStringText(
@@ -178,7 +177,7 @@ class PrepublishingHomeViewModel @Inject constructor(
                 actionTypeColor = R.color.prepublishing_action_type_disabled_color,
                 actionResultColor = R.color.prepublishing_action_result_disabled_color,
                 actionClickable = false,
-                onActionClicked = null
+                onNavigationActionClicked = null
             )
         )
     }
@@ -188,7 +187,7 @@ class PrepublishingHomeViewModel @Inject constructor(
     ) {
         add(
             HomeUiState(
-                actionType = PUBLISH,
+                navigationAction = PrepublishingScreenNavigation.Publish,
                 actionResult = editPostRepository.getEditablePost()
                     ?.let {
                         UiStringText(
@@ -198,7 +197,7 @@ class PrepublishingHomeViewModel @Inject constructor(
                         )
                     },
                 actionClickable = true,
-                onActionClicked = ::onActionClicked
+                onNavigationActionClicked = ::onActionClicked
             )
         )
     }
@@ -226,7 +225,7 @@ class PrepublishingHomeViewModel @Inject constructor(
                     SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_mastodon),
                     SocialUiState.ConnectionServiceIcon(R.drawable.ic_social_linkedin),
                 ),
-                onConnectClicked = { /* TODO in other PR: open sharing settings */ },
+                onConnectClicked = { onActionClicked(Action.NavigateToSharingSettings) },
                 onDismissClicked = { /* TODO in other PR: hide this item forever */ },
             )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -18,8 +18,7 @@ import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus.PRIVATE
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PUBLISH
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.TAGS
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PrepublishingScreenNavigation
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ButtonUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ButtonUiState.PublishButtonUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.HeaderUiState
@@ -135,7 +134,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         viewModel.start(editPostRepository, site, false)
 
         // assert
-        assertThat(getHomeUiState(TAGS)).isNotNull()
+        assertThat(getHomeUiState(PrepublishingScreenNavigation.Tags)).isNotNull()
     }
 
     @Test
@@ -147,7 +146,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         viewModel.start(editPostRepository, site, false)
 
         // assert
-        assertThat(getHomeUiState(TAGS)).isNull()
+        assertThat(getHomeUiState(PrepublishingScreenNavigation.Tags)).isNull()
     }
 
     @Test
@@ -181,12 +180,12 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Test
     fun `verify that publish action type is propagated to prepublishingActionType`() {
         // arrange
-        val expectedActionType = PUBLISH
+        val expectedActionType = PrepublishingScreenNavigation.Publish
 
         // act
         viewModel.start(mock(), site, false)
         val publishAction = getHomeUiState(expectedActionType)
-        publishAction?.onActionClicked?.invoke(expectedActionType)
+        publishAction?.onNavigationActionClicked?.invoke(expectedActionType)
 
         // assert
         assertThat(requireNotNull(viewModel.onActionClicked.value).peekContent()).isEqualTo(expectedActionType)
@@ -195,12 +194,12 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Test
     fun `verify that tags action type is propagated to prepublishingActionType`() {
         // arrange
-        val expectedActionType = TAGS
+        val expectedActionType = PrepublishingScreenNavigation.Tags
 
         // act
         viewModel.start(mock(), site, false)
         val tagsAction = getHomeUiState(expectedActionType)
-        tagsAction?.onActionClicked?.invoke(expectedActionType)
+        tagsAction?.onNavigationActionClicked?.invoke(expectedActionType)
 
         // assert
         assertThat(requireNotNull(viewModel.onActionClicked.value).peekContent()).isEqualTo(expectedActionType)
@@ -214,7 +213,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         // act
         viewModel.start(editPostRepository, site, false)
-        val publishAction = getHomeUiState(PUBLISH)
+        val publishAction = getHomeUiState(PrepublishingScreenNavigation.Publish)
 
         // assert
         assertThat((publishAction?.actionResult as? UiStringText)?.text).isEqualTo(expectedLabel)
@@ -228,7 +227,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         // act
         viewModel.start(editPostRepository, site, false)
-        val tagsAction = getHomeUiState(TAGS)
+        val tagsAction = getHomeUiState(PrepublishingScreenNavigation.Tags)
 
         // assert
         assertThat((tagsAction?.actionResult as? UiStringText)?.text).isEqualTo(expectedTags)
@@ -241,7 +240,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         // act
         viewModel.start(editPostRepository, site, false)
-        val tagsAction = getHomeUiState(TAGS)
+        val tagsAction = getHomeUiState(PrepublishingScreenNavigation.Tags)
 
         // assert
         assertThat((tagsAction?.actionResult as? UiStringRes)?.stringRes)
@@ -313,7 +312,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         viewModel.start(editPostRepository, site, false)
 
-        val uiState = getHomeUiState(PUBLISH)
+        val uiState = getHomeUiState(PrepublishingScreenNavigation.Publish)
 
         assertThat(uiState?.actionClickable).isFalse()
     }
@@ -324,7 +323,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         viewModel.start(editPostRepository, site, false)
 
-        val uiState = getHomeUiState(TAGS)
+        val uiState = getHomeUiState(PrepublishingScreenNavigation.Tags)
 
         assertThat(uiState?.actionClickable).isTrue()
     }
@@ -465,6 +464,6 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     private fun getHomeUiState(actionType: ActionType): HomeUiState? {
         val actions = viewModel.uiState.value
             ?.filterIsInstance(HomeUiState::class.java)
-        return actions?.find { it.actionType == actionType }
+        return actions?.find { it.navigationAction == actionType }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingViewModelTest.kt
@@ -6,10 +6,14 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.ADD_CATEGORY
+import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.CATEGORIES
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.HOME
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.PUBLISH
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.TAGS
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.Action
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PrepublishingScreenNavigation
 import org.wordpress.android.viewmodel.Event
 
 @ExperimentalCoroutinesApi
@@ -90,7 +94,7 @@ class PrepublishingViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when onActionClicked is called with TAGS, navigate to TAGS screen`() {
+    fun `when onActionClicked is called with Tags, navigate to TAGS screen`() {
         val expectedScreen = TAGS
 
         var event: Event<PrepublishingNavigationTarget>? = null
@@ -99,13 +103,13 @@ class PrepublishingViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start(mock(), mock())
-        viewModel.onActionClicked(ActionType.TAGS)
+        viewModel.onActionClicked(PrepublishingScreenNavigation.Tags)
 
         assertThat(event?.peekContent()?.targetScreen).isEqualTo(expectedScreen)
     }
 
     @Test
-    fun `when onActionClicked is called with PUBLISH, navigate to PUBLISH screen`() {
+    fun `when onActionClicked is called with Publish, navigate to PUBLISH screen`() {
         val expectedScreen = PUBLISH
 
         var event: Event<PrepublishingNavigationTarget>? = null
@@ -114,9 +118,53 @@ class PrepublishingViewModelTest : BaseUnitTest() {
         }
 
         viewModel.start(mock(), mock())
-        viewModel.onActionClicked(ActionType.PUBLISH)
+        viewModel.onActionClicked(PrepublishingScreenNavigation.Publish)
 
         assertThat(event?.peekContent()?.targetScreen).isEqualTo(expectedScreen)
+    }
+
+    @Test
+    fun `when onActionClicked is called with Categories, navigate to CATEGORIES screen`() {
+        val expectedScreen = CATEGORIES
+
+        var event: Event<PrepublishingNavigationTarget>? = null
+        viewModel.navigationTarget.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), mock())
+        viewModel.onActionClicked(PrepublishingScreenNavigation.Categories)
+
+        assertThat(event?.peekContent()?.targetScreen).isEqualTo(expectedScreen)
+    }
+
+    @Test
+    fun `when onActionClicked is called with AddCategory, navigate to ADD_CATEGORY screen`() {
+        val expectedScreen = ADD_CATEGORY
+
+        var event: Event<PrepublishingNavigationTarget>? = null
+        viewModel.navigationTarget.observeForever {
+            event = it
+        }
+
+        viewModel.start(mock(), mock())
+        viewModel.onActionClicked(PrepublishingScreenNavigation.AddCategory)
+
+        assertThat(event?.peekContent()?.targetScreen).isEqualTo(expectedScreen)
+    }
+
+    @Test
+    fun `when onActionClicked is called with NavigateToSharingSettings, navigateToSharingSettings is emitted`() {
+        val mockSite = mock<SiteModel>()
+        var event: Event<SiteModel>? = null
+        viewModel.navigateToSharingSettings.observeForever {
+            event = it
+        }
+
+        viewModel.start(mockSite, mock())
+        viewModel.onActionClicked(Action.NavigateToSharingSettings)
+
+        assertThat(event?.peekContent()).isEqualTo(mockSite)
     }
 
     @Test


### PR DESCRIPTION
Part of #18752 

This integrates the sharing settings navigation from the JP Social item inside the pre-publishing sheet when it's in the "No Connection" state.

To test:
1. Install and open the app
2. Go to Debug settings
3. Enable the `JetpackSocialFeatureConfig` in the "Features in Development" tab
4. Go back to the `My Site` screen
5. Open the Post lists
6. Open a post / Create a new post
7. Tap `Publish`/`Update` button to see the pre-publishing sheet
8. **Verify** the "No connection"/"connection prompt" UI is shown in the list (the buttons don't do anything currently)
9. Tap "Connect your social profiles"
10. **Verify** it opens the Sharing settings for the site

## Regression Notes
1. Potential unintended areas of impact
Back button behavior, wrong site selected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Tests to the ViewModel and new Action types

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A