### PR TITLE
[Jetpack Social] Post settings endpoint integration (unit tests)

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapperTest.kt
@@ -1,0 +1,142 @@
+package org.wordpress.android.ui.posts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.R
+import org.wordpress.android.models.PublicizeConnection
+import org.wordpress.android.ui.compose.components.TrainOfIconsModel
+import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.JetpackSocialUiState
+import org.wordpress.android.ui.posts.social.PostSocialConnection
+import org.wordpress.android.ui.publicize.PublicizeServiceIcon
+import org.wordpress.android.usecase.social.ShareLimit
+import org.wordpress.android.util.LocaleProvider
+import org.wordpress.android.util.StringProvider
+import java.util.Locale
+
+class EditPostPublishSettingsJetpackSocialUiStateMapperTest {
+    private val stringProvider: StringProvider = mock()
+    private val localProvider: LocaleProvider = mock()
+    private val classToTest = EditPostPublishSettingsJetpackSocialUiStateMapper(
+        stringProvider = stringProvider,
+        localeProvider = localProvider,
+    )
+
+    @Test
+    fun `Should map loaded UI state with share limit enabled`() {
+        val shareLimit = ShareLimit.Enabled(
+            shareLimit = 10,
+            publicizedCount = 11,
+            sharedPostsCount = 12,
+            sharesRemaining = 13,
+        )
+        val sharesRemaining = "13 remaining shares"
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_subscribe_share_more))
+            .thenReturn("Share more")
+        whenever(stringProvider.getString(R.string.jetpack_social_social_shares_remaining, shareLimit.sharesRemaining))
+            .thenReturn(sharesRemaining)
+        whenever(localProvider.getAppLocale())
+            .thenReturn(Locale.US)
+        val connections = listOf(
+            PublicizeConnection().apply {
+                connectionId = 0
+                service = "tumblr"
+                label = "Tumblr"
+                externalId = "myblog.tumblr.com"
+                externalName = "My blog"
+                externalProfilePictureUrl =
+                    "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+            },
+            PublicizeConnection().apply {
+                connectionId = 1
+                service = "linkedin"
+                label = "LinkedIn"
+                externalId = "linkedin.com"
+                externalName = "My Profile"
+                externalProfilePictureUrl =
+                    "https://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-linkedin-2x.png"
+            },
+        )
+        val onConnectProfilesClick: () -> Unit = mock()
+        val actual = classToTest.mapLoaded(
+            connections = connections,
+            shareLimit = shareLimit,
+            onSubscribeClick = onConnectProfilesClick,
+        )
+        val expected = JetpackSocialUiState.Loaded(
+            postSocialConnectionList = PostSocialConnection.fromPublicizeConnectionList(connections),
+            showShareLimitUi = true,
+            shareMessage = "Message",
+            remainingSharesMessage = sharesRemaining,
+            subscribeButtonLabel = "SHARE MORE",
+            onSubscribeClick = onConnectProfilesClick,
+        )
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Should map loaded UI state with share limit disabled`() {
+        val shareLimit = ShareLimit.Disabled
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_subscribe_share_more))
+            .thenReturn("Share more")
+        whenever(localProvider.getAppLocale())
+            .thenReturn(Locale.US)
+        val connections = listOf(
+            PublicizeConnection().apply {
+                connectionId = 0
+                service = "tumblr"
+                label = "Tumblr"
+                externalId = "myblog.tumblr.com"
+                externalName = "My blog"
+                externalProfilePictureUrl =
+                    "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+            },
+            PublicizeConnection().apply {
+                connectionId = 1
+                service = "linkedin"
+                label = "LinkedIn"
+                externalId = "linkedin.com"
+                externalName = "My Profile"
+                externalProfilePictureUrl =
+                    "https://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-linkedin-2x.png"
+            },
+        )
+        val onConnectProfilesClick: () -> Unit = mock()
+        val actual = classToTest.mapLoaded(
+            connections = connections,
+            shareLimit = shareLimit,
+            onSubscribeClick = onConnectProfilesClick,
+        )
+        val expected = JetpackSocialUiState.Loaded(
+            postSocialConnectionList = PostSocialConnection.fromPublicizeConnectionList(connections),
+            showShareLimitUi = false,
+            shareMessage = "Message",
+            remainingSharesMessage = "",
+            subscribeButtonLabel = "SHARE MORE",
+            onSubscribeClick = onConnectProfilesClick,
+        )
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Should map no connections UI state`() {
+        val connectProfilesButtonLabel = "Connect profiles button"
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_connect_social_profiles_button))
+            .thenReturn(connectProfilesButtonLabel)
+        whenever(localProvider.getAppLocale())
+            .thenReturn(Locale.US)
+        val connectProfilesMessage = "Connect profiles message"
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_connect_social_profiles_message))
+            .thenReturn(connectProfilesMessage)
+        val onConnectProfilesClick: () -> Unit = mock()
+        val actual = classToTest.mapNoConnections(onConnectProfilesClick)
+        val expected = JetpackSocialUiState.NoConnections(
+            trainOfIconsModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
+            message = connectProfilesMessage,
+            connectProfilesButtonLabel = "CONNECT PROFILES BUTTON",
+            onConnectProfilesClick = onConnectProfilesClick,
+        )
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -1,0 +1,256 @@
+package org.wordpress.android.ui.posts
+
+import androidx.lifecycle.Observer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.models.PublicizeConnection
+import org.wordpress.android.ui.people.utils.PeopleUtilsWrapper
+import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.JetpackSocialUiState
+import org.wordpress.android.ui.posts.social.PostSocialConnection
+import org.wordpress.android.usecase.social.GetJetpackSocialShareLimitStatusUseCase
+import org.wordpress.android.usecase.social.GetPublicizeConnectionsForUserUseCase
+import org.wordpress.android.usecase.social.ShareLimit
+import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.config.JetpackSocialFeatureConfig
+import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Calendar
+
+@ExperimentalCoroutinesApi
+class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
+    private val resourceProvider: ResourceProvider = mock()
+    private val postSettingsUtils: PostSettingsUtils = mock()
+    private val peopleUtilsWrapper: PeopleUtilsWrapper = mock()
+    private val localeManagerWrapper: LocaleManagerWrapper = mock()
+    private val postSchedulingNotificationStore: PostSchedulingNotificationStore = mock()
+    private val siteStore: SiteStore = mock()
+    private val jetpackSocialFeatureConfig: JetpackSocialFeatureConfig = mock()
+    private val accountStore: AccountStore = mock()
+    private val getPublicizeConnectionsForUserUseCase: GetPublicizeConnectionsForUserUseCase = mock()
+    private val getJetpackSocialShareLimitStatusUseCase: GetJetpackSocialShareLimitStatusUseCase = mock()
+    private val jetpackUiStateMapper: EditPostPublishSettingsJetpackSocialUiStateMapper = mock()
+
+    private val classToTest = EditPostPublishSettingsViewModel(
+        resourceProvider = resourceProvider,
+        postSettingsUtils = postSettingsUtils,
+        peopleUtilsWrapper = peopleUtilsWrapper,
+        localeManagerWrapper = localeManagerWrapper,
+        postSchedulingNotificationStore = postSchedulingNotificationStore,
+        siteStore = siteStore,
+        jetpackSocialFeatureConfig = jetpackSocialFeatureConfig,
+        accountStore = accountStore,
+        getPublicizeConnectionsForUserUseCase = getPublicizeConnectionsForUserUseCase,
+        getJetpackSocialShareLimitStatusUseCase = getJetpackSocialShareLimitStatusUseCase,
+        jetpackUiStateMapper = jetpackUiStateMapper,
+    )
+
+    private val showJetpackSocialContainerObserver: Observer<Boolean> = mock()
+    private val jetpackSocialUiStateObserver: Observer<JetpackSocialUiState> = mock()
+    private val editPostRepository: EditPostRepository = mock()
+    private val remoteSiteId = 123L
+    private val userId = 456L
+    private val siteModel = SiteModel()
+
+    @Before
+    fun setup() {
+        classToTest.showJetpackSocialContainer.observeForever(showJetpackSocialContainerObserver)
+        classToTest.jetpackSocialUiState.observeForever(jetpackSocialUiStateObserver)
+        whenever(localeManagerWrapper.getCurrentCalendar()).thenReturn(Calendar.getInstance())
+        whenever(resourceProvider.getString(R.string.immediately)).thenReturn("Immediately")
+    }
+
+    @Test
+    fun `Should NOT load jetpack social if FF is disabled`() = test {
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(false)
+        classToTest.start(null)
+        verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any())
+    }
+
+    @Test
+    fun `Should hide jetpack social container if FF is disabled`() = test {
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(false)
+        classToTest.start(null)
+        verify(showJetpackSocialContainerObserver).onChanged(false)
+    }
+
+    @Test
+    fun `Should show jetpack social container if FF is enabled`() = test {
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(showJetpackSocialContainerObserver).onChanged(true)
+    }
+
+    @Test
+    fun `Should get publicize connections for user if jetpack social FF is enabled`() = test {
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(getPublicizeConnectionsForUserUseCase).execute(remoteSiteId, userId)
+    }
+
+    @Test
+    fun `Should get jetpack social share limit status if jetpack social FF is enabled`() = test {
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(getJetpackSocialShareLimitStatusUseCase).execute(siteModel)
+    }
+
+    @Test
+    fun `Should map no connections UI state if connections list is empty and jetpack social FF is enabled`() = test {
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(jetpackUiStateMapper).mapNoConnections(any())
+    }
+
+    @Test
+    fun `Should emit no connections UI state if connections list is empty and jetpack social FF is enabled`() = test {
+        val noConnections = JetpackSocialUiState.NoConnections(
+            trainOfIconsModels = listOf(),
+            message = "message",
+            connectProfilesButtonLabel = "label",
+            onConnectProfilesClick = {},
+        )
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(jetpackUiStateMapper.mapNoConnections(any()))
+            .thenReturn(noConnections)
+        classToTest.start(editPostRepository)
+        verify(jetpackSocialUiStateObserver).onChanged(noConnections)
+    }
+
+    @Test
+    fun `Should map loaded UI state if connections list is NOT empty and jetpack social FF is enabled`() = test {
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        connectionId = 0
+                        service = "tumblr"
+                        label = "Tumblr"
+                        externalId = "myblog.tumblr.com"
+                        externalName = "My blog"
+                        externalProfilePictureUrl =
+                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+                    },
+                )
+            )
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(jetpackUiStateMapper).mapLoaded(any(), any(), any())
+    }
+
+    @Test
+    fun `Should emit loaded UI state if connections list is NOT empty and jetpack social FF is enabled`() = test {
+        val loaded = JetpackSocialUiState.Loaded(
+            postSocialConnectionList = listOf(
+                PostSocialConnection(
+                    1,
+                    "service",
+                    "label",
+                    "externalId",
+                    "externalName",
+                    "iconUrl",
+                    true
+                )
+            ),
+            showShareLimitUi = true,
+            shareMessage = "message",
+            remainingSharesMessage = "remaining shares",
+            subscribeButtonLabel = "label",
+            onSubscribeClick = {}
+        )
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any()))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        connectionId = 0
+                        service = "tumblr"
+                        label = "Tumblr"
+                        externalId = "myblog.tumblr.com"
+                        externalName = "My blog"
+                        externalProfilePictureUrl =
+                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+                    },
+                )
+            )
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(jetpackUiStateMapper.mapLoaded(any(), any(), any()))
+            .thenReturn(loaded)
+        classToTest.start(editPostRepository)
+        verify(jetpackSocialUiStateObserver).onChanged(loaded)
+    }
+
+    private fun mockSiteModel() {
+        whenever(editPostRepository.localSiteId)
+            .thenReturn(1)
+        whenever(siteStore.getSiteByLocalId(1))
+            .thenReturn(siteModel.apply {
+                siteId = remoteSiteId
+            })
+    }
+
+    private fun mockUserId() {
+        val accountModel: AccountModel = mock()
+        whenever(accountStore.account)
+            .thenReturn(accountModel)
+        whenever(accountModel.userId)
+            .thenReturn(userId)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -88,6 +88,14 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `Should hide jetpack social container if FF is enabled but SiteModel is null`() = test {
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(null)
+        verify(showJetpackSocialContainerObserver).onChanged(false)
+    }
+
+    @Test
     fun `Should show jetpack social container if FF is enabled`() = test {
         mockSiteModel()
         mockUserId()

--- a/WordPress/src/test/java/org/wordpress/android/usecase/social/GetPublicizeConnectionsForUserUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/usecase/social/GetPublicizeConnectionsForUserUseCaseTest.kt
@@ -1,0 +1,136 @@
+package org.wordpress.android.usecase.social
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.datasets.wrappers.PublicizeTableWrapper
+import org.wordpress.android.models.PublicizeConnection
+import org.wordpress.android.models.PublicizeService
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class GetPublicizeConnectionsForUserUseCaseTest : BaseUnitTest() {
+    private val publicizeTableWrapper: PublicizeTableWrapper = mock()
+
+    private val classToTest = GetPublicizeConnectionsForUserUseCase(
+        ioDispatcher = testDispatcher(),
+        publicizeTableWrapper = publicizeTableWrapper,
+    )
+
+    @Test
+    fun `Should return publicize connection if connection user ID matches parameter user ID`() = test {
+        val serviceId = "service"
+        val siteId = 123L
+        val currentUserId = 456L
+        val publicizeConnection = PublicizeConnection().apply {
+            userId = currentUserId.toInt()
+            connectionId = 123
+            service = serviceId
+            label = "label"
+            isShared = false
+        }
+        whenever(publicizeTableWrapper.getServiceList())
+            .thenReturn(listOf(
+                PublicizeService().apply {
+                    id = "1"
+                    status = PublicizeService.Status.UNSUPPORTED
+                },
+                PublicizeService().apply {
+                    id = "2"
+                    status = PublicizeService.Status.UNSUPPORTED
+                },
+                PublicizeService().apply {
+                    id = serviceId
+                    status = PublicizeService.Status.OK
+                }
+            ))
+        whenever(publicizeTableWrapper.getConnectionsForSite(siteId))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        userId = 123
+                        connectionId = 123
+                        service = "123"
+                        label = "label"
+                        isShared = false
+                    },
+                    publicizeConnection,
+                )
+            )
+        val expected = listOf(
+            publicizeConnection,
+        )
+        val actual = classToTest.execute(siteId, currentUserId)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return zero connections if all publicize services are UNSUPPORTED`() = test {
+        val serviceId = "service"
+        val siteId = 123L
+        val currentUserId = 456L
+        val publicizeConnection1 = PublicizeConnection().apply {
+            userId = currentUserId.toInt()
+            connectionId = 123
+            service = serviceId
+            label = "label"
+            isShared = false
+        }
+        val publicizeConnection2 = PublicizeConnection().apply {
+            userId = currentUserId.toInt()
+            connectionId = 123
+            service = serviceId
+            label = "label"
+            isShared = true
+        }
+        whenever(publicizeTableWrapper.getServiceList())
+            .thenReturn(listOf(
+                PublicizeService().apply {
+                    id = serviceId
+                    status = PublicizeService.Status.UNSUPPORTED
+                }
+            ))
+        whenever(publicizeTableWrapper.getConnectionsForSite(siteId))
+            .thenReturn(
+                listOf(
+                    publicizeConnection1,
+                    publicizeConnection2
+                )
+            )
+        val expected = emptyList<PublicizeConnection>()
+        val actual = classToTest.execute(siteId, currentUserId)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return connection if isShared is true`() = test {
+        val serviceId = "service"
+        val siteId = 123L
+        val currentUserId = 456L
+        val publicizeConnection = PublicizeConnection().apply {
+            userId = 1
+            connectionId = 2
+            service = serviceId
+            label = "label"
+            isShared = true
+        }
+        whenever(publicizeTableWrapper.getServiceList())
+            .thenReturn(listOf(
+                PublicizeService().apply {
+                    id = serviceId
+                    status = PublicizeService.Status.OK
+                }
+            ))
+        whenever(publicizeTableWrapper.getConnectionsForSite(siteId))
+            .thenReturn(
+                listOf(
+                    publicizeConnection,
+                )
+            )
+        val expected = listOf(publicizeConnection)
+        val actual = classToTest.execute(siteId, currentUserId)
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
**Should be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/18782**

Implements the unit tests related to PR #18782.

Part of #18571 

To test:
Make sure unit tests are green.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
