### PR TITLE
Add a condition to prevent double adding a fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1885,7 +1885,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (privacyBannerFragment == null) {
             privacyBannerFragment = new PrivacyBannerFragment();
         }
-        privacyBannerFragment.show(getSupportFragmentManager(), PrivacyBannerFragment.TAG);
+        if (!privacyBannerFragment.isAdded()) {
+            privacyBannerFragment.show(getSupportFragmentManager(), PrivacyBannerFragment.TAG);
+        }
     }
 
     private void showPrivacySettingsScreen(@Nullable Boolean requestedAnalyticsValue) {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -757,6 +757,35 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
             verify(analyticsTrackerWrapper).track(Stat.BLOGGING_PROMPTS_CREATE_SHEET_CARD_VIEWED)
         }
 
+    @Test
+    fun `it asks for privacy consent at the start when it should`() = test {
+        // Given
+        whenever(shouldAskPrivacyConsent()).thenReturn(true)
+        val observer: Observer<Unit> = mock()
+        viewModel.askForPrivacyConsent.observeForever(observer)
+
+        // When
+        startViewModelWithDefaultParameters()
+
+        // Then
+        verify(observer).onChanged(anyOrNull())
+    }
+
+    @Test
+    fun `it asks for privacy consent only once, even when viewmodel is started more than once`() = test {
+        // Given
+        whenever(shouldAskPrivacyConsent()).thenReturn(true)
+        val observer: Observer<Unit> = mock()
+        viewModel.askForPrivacyConsent.observeForever(observer)
+
+        // When
+        startViewModelWithDefaultParameters()
+        startViewModelWithDefaultParameters()
+
+        // Then
+        verify(observer, times(1)).onChanged(anyOrNull())
+    }
+
     private fun startViewModelWithDefaultParameters(
         isWhatsNewFeatureEnabled: Boolean = true,
         isCreateFabEnabled: Boolean = true,


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/18766

### Description

This PR adds a guard condition to prevent adding the privacy banner fragment twice. It isn't expected that we'd need this, based on the documentation of `SingleLiveEvent`, however, it seems that somehow this event is being triggered multiple times. While this should fix the crash, it may also be worth tracking down whether there is an issue with `SingleLiveEvent` that could be a cause for other similar problems.

To test:

Perform the testing steps from this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18696

## Regression Notes
1. Potential unintended areas of impact
Privacy banner

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
I've added some unit tests in this PR. It is worth noting, though, that these tests do not seem to cover the original issue, since they pass even without the guard. It is worth adding these, though, since they help rule out one of the possible causes of duplicate event emissions.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
