### PR TITLE
[Jetpack Social] Implement customize share message screen (unit tests)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.sharemessage
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -46,7 +47,8 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
         updatedShareMessage = shareMessage
     }
 
-    private fun onBackClick() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun onBackClick() {
         viewModelScope.launch {
             _actionEvents.send(
                 ActionEvent.FinishActivity(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModelTest.kt
@@ -1,0 +1,135 @@
+package org.wordpress.android.ui.posts.sharemessage
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageViewModel.ActionEvent
+import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageViewModel.UiState
+import org.wordpress.android.util.StringProvider
+
+@ExperimentalCoroutinesApi
+class EditJetpackSocialShareMessageViewModelTest : BaseUnitTest() {
+    private val stringProvider: StringProvider = mock()
+    private val classToTest = EditJetpackSocialShareMessageViewModel(
+        stringProvider = stringProvider,
+    )
+    private val shareMessageMaxLength = 255
+    private val title = "Title"
+    val description = "Description"
+
+    @Test
+    fun `Should emit Loaded with starting share message when start is called`() {
+        mockLoadedTitle()
+        mockLoadedDescription()
+
+        val shareMessage = "Share"
+        classToTest.start(shareMessage)
+
+        val actual = classToTest.uiState.value
+        val expected = UiState.Loaded(
+            appBarLabel = title,
+            currentShareMessage = shareMessage,
+            shareMessageMaxLength = shareMessageMaxLength,
+            customizeMessageDescription = description,
+            onBackClick = classToTest::onBackClick,
+        )
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Should emit Loaded with updated share message when start is called and share message was changed`() {
+        mockLoadedTitle()
+        mockLoadedDescription()
+
+        val updatedShareMessage = "Updated share message"
+        classToTest.updateShareMessage(updatedShareMessage)
+        classToTest.start("Share")
+
+        val actual = classToTest.uiState.value
+        val expected = UiState.Loaded(
+            appBarLabel = title,
+            currentShareMessage = updatedShareMessage,
+            shareMessageMaxLength = shareMessageMaxLength,
+            customizeMessageDescription = description,
+            onBackClick = classToTest::onBackClick,
+        )
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Should emit FinishActivity with starting share message when onBackClick is called`() = test {
+        mockLoadedTitle()
+        mockLoadedDescription()
+
+        val startingShareMessage = "Starting share message"
+        classToTest.start(startingShareMessage)
+        classToTest.onBackClick()
+
+        val result = ArrayList<ActionEvent>()
+        val job = launch {
+            classToTest.actionEvents.collectLatest {
+                result.add(it)
+            }
+        }
+        val actual = result.first()
+        val expected = ActionEvent.FinishActivity(startingShareMessage)
+        assertThat(actual).isEqualTo(expected)
+        job.cancel()
+    }
+
+    @Test
+    fun `Should emit FinishActivity with updated share message when onBackClick is called`() = test {
+        val updatedShareMessage = "Updated share message"
+        classToTest.updateShareMessage(updatedShareMessage)
+
+        classToTest.onBackClick()
+
+        val result = ArrayList<ActionEvent>()
+        val job = launch {
+            classToTest.actionEvents.collectLatest {
+                result.add(it)
+            }
+        }
+        val actual = result.first()
+        val expected = ActionEvent.FinishActivity(updatedShareMessage)
+        assertThat(actual).isEqualTo(expected)
+        job.cancel()
+    }
+
+    @Test
+    fun `Should get string post_settings_jetpack_social_share_message_title when start is called`() {
+        mockLoadedTitle()
+        mockLoadedDescription()
+
+        classToTest.start("Message")
+
+        verify(stringProvider).getString(R.string.post_settings_jetpack_social_share_message_title)
+    }
+
+    @Test
+    fun `Should get string post_settings_jetpack_social_share_message_description when start is called`() {
+        mockLoadedTitle()
+        mockLoadedDescription()
+
+        classToTest.start("Message")
+
+        verify(stringProvider).getString(R.string.post_settings_jetpack_social_share_message_description)
+    }
+
+    private fun mockLoadedDescription() {
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_share_message_description))
+            .thenReturn(description)
+    }
+
+    private fun mockLoadedTitle() {
+        whenever(stringProvider.getString(R.string.post_settings_jetpack_social_share_message_title))
+            .thenReturn(title)
+    }
+}


### PR DESCRIPTION
Should be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/18790

Part of #18571

To test:
Make sure unit tests are green.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
`EditJetpackSocialShareMessageViewModelTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
