### PR TITLE
Integrate gutenberg-mobile release 1.100.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5981-2868590afad0ea84727da1f9a4793c587f4293f3'
+    gutenbergMobileVersion = 'v1.100.0'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.37.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.100.0-alpha1'
+    gutenbergMobileVersion = '5981-2868590afad0ea84727da1f9a4793c587f4293f3'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.37.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.100.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5981

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.