### PR TITLE
[Unit Tests] Run `image-editor` Unit Tests only for Release

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -9,7 +9,7 @@ elif [ "$1" == "processors" ]; then
     test_suite=":libs:processors:test"
     test_log_dir="libs/processors/build/test-results/test/*.xml"
 elif [ "$1" == "image-editor" ]; then
-    test_suite=":libs:image-editor:test"
+    test_suite=":libs:image-editor:testReleaseUnitTest"
     test_log_dir="libs/image-editor/build/test-results/testReleaseUnitTest/*.xml"
 else
     echo "Invalid Test Suite! Expected 'wordpress', 'processors', or 'image-editor', received '$1' instead"


### PR DESCRIPTION
### Description
Currently, the `image-editor` Unit Tests from `libs` are executed on CI for both `Release` and `Debug`:

![SCR-20230720-hrd](https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/6ffbadb7-6973-43d1-b71f-193090a6f506)

After noticing this point while working on a [different PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18748#discussion_r1268439848), and then discussing it in Slack, it was agreed that running them for `Release` only is justified.

### To Tests
- CI is 🟢
- `Unit Tests Image Editor` contains the log for `Release` only:

<img width="1152" alt="Screenshot 2023-07-20 at 13 12 08" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/87ad46eb-ff7c-4f66-9d50-823c6ce521b7">