### PR TITLE
Fix: Blaze "400" error on image retrieval  

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeWebClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeWebClient.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.blaze
 import android.graphics.Bitmap
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import org.wordpress.android.util.UriWrapper
@@ -37,16 +36,6 @@ class BlazeWebViewClient(
             errorReceived = true
             blazeWebViewClientListener.onWebViewReceivedError(request.url.toString())
         }
-    }
-
-    override fun onReceivedHttpError(
-        view: WebView?,
-        request: WebResourceRequest?,
-        errorResponse: WebResourceResponse?
-    ) {
-        super.onReceivedHttpError(view, request, errorResponse)
-        errorReceived = true
-        blazeWebViewClientListener.onWebViewReceivedError(request?.url.toString())
     }
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {


### PR DESCRIPTION
This PR addresses an issue affecting some pressable sites, preventing them from completing the promote blaze flow due to an error in image retrieval, resulting in an HTTP 400 status. To enhance the solution, we have decided to streamline error handling by removing the `onReceivedHttpError` handler. Instead, we will rely on the `onReceivedError` handler to manage webview errors, providing a more effective and efficient resolution. This approach ensures that we can improve the overall performance of the flow. 

Note: This issue only affects pressable sites with images that are broken and only if they are attempting to blaze. It is advisable to add this to the beta, as to avoid affecting the least amount of users are possible.

**To test:**
- Install and login to app using blaze test credentials
- Navigate to dashboard
- Tap on the "create campaign" link within the Blaze Card
- Tap on the "Blaze a post now" button within the overlay
- ✅ Verify the blaze promote dashboard is opened in a webview 

## Regression Notes
1. Potential unintended areas of impact
Blaze promote flow does not load the promote dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing - this logic takes place in a webview

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
