### PR TITLE
Integrate gutenberg-mobile release 1.100.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 22.9
 -----
 * [**] Block editor: Move undo/redo buttons to the navigation bar [https://github.com/wordpress-mobile/WordPress-Android/pull/18705]
+* [***] Block editor: Editor UX improvements with new icons, colors and additional design enhancements. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985]
 
 22.8
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = '5985-81395d4b566105923b560c9d47aff2a9d7441060'
+    gutenbergMobileVersion = 'v1.100.1'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.37.0'
     wordPressLoginVersion = '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.1.0'
     automatticTracksVersion = '3.0.0'
-    gutenbergMobileVersion = 'v1.100.0-alpha1'
+    gutenbergMobileVersion = '5985-81395d4b566105923b560c9d47aff2a9d7441060'
     wordPressAztecVersion = 'v1.6.4'
     wordPressFluxCVersion = '2.37.0'
     wordPressLoginVersion = '1.3.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.100.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.