### PR TITLE
Blaze: Minor refactoring in promote blaze

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.blaze.OnBlazeWebViewClientListener
 import org.wordpress.android.ui.blaze.blazeoverlay.BlazeViewModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.editor.R as EditorR
 
 @AndroidEntryPoint
@@ -76,7 +77,10 @@ class BlazePromoteWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
 
     private fun handleActionEvents(actionEvent: BlazeActionEvent) {
         when (actionEvent) {
-            is BlazeActionEvent.FinishActivity, is BlazeActionEvent.FinishActivityWithMessage -> {
+            is BlazeActionEvent.FinishActivity -> requireActivity().finish()
+
+            is BlazeActionEvent.FinishActivityWithMessage -> {
+                ToastUtils.showToast(requireContext(), actionEvent.id)
                 requireActivity().finish()
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
@@ -177,7 +177,7 @@ class BlazePromoteWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
         blazePromoteWebViewViewModel.onRedirectToExternalBrowser(url)
     }
 
-    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    @Suppress("DEPRECATION")
     override fun startActivityForFileChooserResult(intent: Intent?, requestCode: Int) {
         startActivityForResult(intent, requestCode)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
@@ -56,15 +57,17 @@ class BlazePromoteWebViewViewModel @Inject constructor(
         blazeFeatureUtils.trackBlazeFlowStarted(source)
         val url = buildUrl(promoteScreen)
         blazeFlowStep = extractCurrentStep(url)
-        validateAndFinishIfNeeded()
+        if (validateAndPostFinishIfNeeded()) return
         postScreenState(model.value.copy(url = url, addressToLoad = prepareUrl(url)))
     }
 
-    private fun validateAndFinishIfNeeded() {
+    private fun validateAndPostFinishIfNeeded(): Boolean {
         if (accountStore.account.userName.isNullOrEmpty() || accountStore.accessToken.isNullOrEmpty()) {
             blazeFeatureUtils.trackFlowError(blazeFlowSource, blazeFlowStep)
-            postActionEvent(BlazeActionEvent.FinishActivity)
+            postActionEvent(BlazeActionEvent.FinishActivityWithMessage(R.string.promote_blaze_flow_error))
+            return false
         }
+        return true
     }
 
     private fun buildUrl(promoteScreen: BlazeUiState.PromoteScreen?): String {
@@ -166,7 +169,7 @@ class BlazePromoteWebViewViewModel @Inject constructor(
 
     fun onWebViewReceivedError() {
         blazeFeatureUtils.trackFlowError(blazeFlowSource, blazeFlowStep)
-        postActionEvent(BlazeActionEvent.FinishActivity)
+        postActionEvent(BlazeActionEvent.FinishActivityWithMessage(R.string.promote_blaze_flow_error))
     }
 
     fun onRedirectToExternalBrowser(url: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
@@ -155,10 +155,10 @@ class BlazePromoteWebViewViewModel @Inject constructor(
     }
 
     fun updateHeaderActionUiState() {
-        val nonDismissableStep = nonDismissableHashConfig.getValue<String>()
+        val nonDismissibleStep = nonDismissableHashConfig.getValue<String>()
         val completedStep = completedStepHashConfig.getValue<String>()
 
-        if (blazeFlowStep.label == nonDismissableStep) {
+        if (blazeFlowStep.label == nonDismissibleStep) {
             postHeaderUiState(DisabledCancelAction())
         } else if (blazeFlowStep.label == completedStep || blazeFlowStep == BlazeFlowStep.CAMPAIGNS_LIST) {
             postHeaderUiState(DoneAction())

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
@@ -221,11 +221,12 @@ class BlazePromoteWebViewViewModel @Inject constructor(
         }?: return false
     }
 
+
     fun handleOnBackPressed() {
-        val nonDismissableStep = nonDismissableHashConfig.getValue<String>()
+        val nonDismissibleStep = nonDismissableHashConfig.getValue<String>()
         val completedStep = completedStepHashConfig.getValue<String>()
 
-        if (blazeFlowStep.label == nonDismissableStep) return
+        if (blazeFlowStep.label == nonDismissibleStep) return
 
         if (blazeFlowStep.label == completedStep || blazeFlowStep == BlazeFlowStep.CAMPAIGNS_LIST) {
             blazeFeatureUtils.trackBlazeFlowCompleted(blazeFlowSource)

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
@@ -183,7 +183,7 @@ class BlazePromoteWebViewViewModel @Inject constructor(
     }
 
     @Suppress("ReturnCount")
-    fun extractCurrentStep(url: String?): BlazeFlowStep {
+    private fun extractCurrentStep(url: String?): BlazeFlowStep {
         url?.let {
             val uri = UriWrapper(url)
             uri.fragment?.let { return BlazeFlowStep.fromString(it) }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4515,6 +4515,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="promote_blaze_card_title">Promote your content with Blaze</string>
     <string name="promote_blaze_card_sub_title">Display your work across millions of sites.</string>
     <string name="promote_blaze_card_menu_hide_this">Hide this</string>
+    <string name="promote_blaze_flow_error">The blaze promote flow couldn\'t be loaded</string>
 
     <string name="gutenberg_native_blocks_menu" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Blocks menu</string>
 


### PR DESCRIPTION
Closes #18532 

This PR applies minor refactoring to the Blaze promote flow

(1) Properly handle `ActionEvent.FinishActivityWithMessage` to show an error message (as a toast) if the webview promote flow encounters an error
(2) Renamed `BlazePromoteWebViewViewModel.validateAndPostFinishIfNeeded` and changed the signature to return true/false. The return value will determine if the model needs to be posted. 
(3) Renamed `dismissable` to `dismissible` because it was bugging the heck out of me

### Merge Instructions
- Verify that PR #18811 and PR #18814 have been merged
- Remove Not Ready For Merge label
- Merge as normal

### To test:
**Setup**
- Install and launch the app
- Navigate to Me -> App Settings -> Privacy Setting
- Enable collection information
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze
- Restart the app

**Test Flow Works as Expected**
- Navigate to My SIte tab
- Tap on the Promote With Blaze card
- Tap on the Blaze a Post Now button within the overlay
- Enter the details and submit the blaze
- ✅ Verify the flow worked as expected

**Test Flow captures invalid account detail and shows toast**
- Download the branch
- In fun `validateAndPostFinishIfNeeded` comment out the if statement and the return true
- Build, install, and run
- Navigate to My SIte tab
- Tap on the Promote With Blaze card
- Tap on the Blaze a Post Now button within the overlay
- ✅ Verify the flow ended and the toast is shown on the tab view

## Regression Notes
1. Potential unintended areas of impact
Blaze promote shows an error when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Ran existing unit tests

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: No UI changes in this PR
