### PR TITLE
Add Kotlin conversion doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Using Android Resources](using-android-resources.md) - describes how to add or use Android resources like strings and drawables
 - [Localization](localization.md)
 - [Pull Request Guidelines](pull-request-guidelines.md) - branch naming and how to write good pull requests
+- [Converting to Kotlin](converting-to-kotlin.md)
 - [UI Tests](../WordPress/src/androidTest/java/org/wordpress/android/e2e/)
 
 ## Accessibility
@@ -23,7 +24,7 @@
 
 - [Handbook: Git Branching Guidelines](https://make.wordpress.org/mobile/handbook/general-guides/git-branching/)
 
-## External Resources 
+## External Resources
 
 - [WordPress Mobile Blog](http://make.wordpress.org/mobile)
 - [WordPress Mobile Handbook](http://make.wordpress.org/mobile/handbook/)

--- a/docs/converting-to-kotlin.md
+++ b/docs/converting-to-kotlin.md
@@ -1,0 +1,7 @@
+# Converting to Kotlin
+
+The conversion of our Java code to Kotlin is still in progress. To facilitate this process, please
+follow these tips:
+- If you are making changes to a Java class for your feature/fix PR, consider migrating that class to Kotlin in the same PR as a separate commit.
+- If the class is too large for converting in the feature/fix PR, you can open a separate PR for the conversion the class. This will help prevent breaking the focus of the feature/fix PR.
+- Consider adding or updating unit tests, which could help to avoid accidentally breaking anything while migrating to Kotlin.

--- a/docs/converting-to-kotlin.md
+++ b/docs/converting-to-kotlin.md
@@ -1,7 +1,24 @@
 # Converting to Kotlin
 
-The conversion of our Java code to Kotlin is still in progress. To facilitate this process, please
+The conversion of Java code to Kotlin is in progress. To contribute, please
 follow these tips:
 - If you are making changes to a Java class for your feature/fix PR, consider migrating that class to Kotlin in the same PR as a separate commit.
-- If the class is too large for converting in the feature/fix PR, you can open a separate PR for the conversion the class. This will help prevent breaking the focus of the feature/fix PR.
-- Consider adding or updating unit tests, which could help to avoid accidentally breaking anything while migrating to Kotlin.
+- If the class is too large for converting in the feature/fix PR, you can open a separate PR for that matter. This will help prevent breaking the focus of the feature/fix PR.
+- Consider adding or updating unit tests. They can help avoid accidentally breaking anything while migrating to Kotlin.
+
+## Commit Tips to Help in Review
+
+### Check the "Extra commit for .java > .kt renames" option in Android Studio:
+
+When converting a file from Java to Kotlin, ensure you enable this option in Android Studio. It allows the conversion to be a two-step process:
+1. The first commit will involve a simple rename from `.java` to `.kt`.
+2. The second commit will rename the `.kt` extension back to .java, followed by the actual commit.
+
+**Reason**: Enabling this option helps the reviewer perform a diff on the second commit, showing precisely what changes occurred between the Java and Kotlin files. Otherwise, the PR will display a file deletion (`.java` file) and a file addition (`.kt` file), making it challenging for the reviewer to diff effectively.
+
+### Depend on automatic conversion and commit immediately:
+
+When performing the conversion, rely on the automatic conversion tools and commit the changes promptly, even if the resulting Kotlin code doesn't compile. Subsequently, on another commit, you can refine the Kotlin code, making it more idiomatic or addressing any compilation issues, such as adding nullable checks (`!!` or `let`).
+
+**Reason**: This approach informs the reviewer and other readers that the first commit involved an automated conversion without manual intervention. It helps establish that any code refinements occurred separately, providing clarity on the development process.
+


### PR DESCRIPTION
This introduces a new documentation page titled "Converting to Kotlin." This page's purpose is to guide contributors working on the Kotlin conversion process.
_Internal initiative post: paqN3M-YC-p2#comment-1151_

**Note for reviewers:** Please feel free to reject this new page or suggest any updates to the text.