### PR TITLE
Blaze Manage Campaign: update search campaign response

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -338,7 +338,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val onClick: ListItemInteraction
                         ) : BlazeCard(dashboardCardType = DashboardCardType.BLAZE_CAMPAIGNS_CARD) {
                         data class BlazeCampaignsCardItem(
-                            val id: Long,
+                            val id: Int,
                             val title: UiString,
                             val status: CampaignStatus?,
                             val featuredImageUrl: String?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
@@ -54,7 +54,7 @@ fun BlazeCampaignsCard(
                     modifier = Modifier
                         .padding(start = 16.dp, end = 16.dp, bottom = 8.dp)
                         .clickable {
-                            blazeCampaignCardModel.campaign.onClick(blazeCampaignCardModel.campaign.id.toInt())
+                            blazeCampaignCardModel.campaign.onClick(blazeCampaignCardModel.campaign.id)
                                    },
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
@@ -37,7 +37,7 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
 
     private lateinit var refreshActions: MutableList<Boolean>
 
-    private val campaignId = 1L
+    private val campaignId = 1
 
     @Before
     fun setup() {
@@ -155,13 +155,13 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
         // When
         val result =
             blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as CampaignWithBlazeCardBuilderParams
-        result.onCampaignClick(campaignId.toInt())
+        result.onCampaignClick(campaignId)
 
         // Then
         assertThat(navigationActions)
             .containsOnly(
                 SiteNavigationAction.OpenCampaignDetailPage(
-                    campaignId.toInt(),
+                    campaignId,
                     CampaignDetailPageSource.DASHBOARD_CARD
                 )
             )

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.100.1'
     wordPressAztecVersion = 'v1.6.4'
-    wordPressFluxCVersion = '2.37.0'
+    wordPressFluxCVersion = '2784-57eeefd15cd2e38d8feb8e084658b63c4a1ec9b6'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.0.0'
     gutenbergMobileVersion = 'v1.100.1'
     wordPressAztecVersion = 'v1.6.4'
-    wordPressFluxCVersion = '2784-57eeefd15cd2e38d8feb8e084658b63c4a1ec9b6'
+    wordPressFluxCVersion = 'trunk-3ffb52e49574a0e7041debb67d5331c7717f1614'
     wordPressLoginVersion = '1.3.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.6.1'


### PR DESCRIPTION
Parent #18532 

This PR is the companion to [FluxC [JPAndroid] Update the Blaze Campaigns Response ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2784). It supports the addition of campaign_stats in the search campaigns response. In addition, campaignId has been refactored from a Long to an Int.

## Merge Instructions
- Merge FluxC [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2784) to trunk
- Wait for CI to finish building
- Grab the build hash and update `build.gradle`
- Commit and push `build.gradle` to this branch
- Wait for CI to complete
- Remove the `Not ready for merge` label
- Merge as normal

## To test:

Scenario 1: Upgrade
- Install an older version of jetpack app (Use a closed PR from the repo and install the JP build. Go back 3 days or so)
- Verify the app opens and you can login
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze Campaigns & Blaze if they are not enabled and restart the app
- Install the JP app from the PR over the app you installed earlier
- ✅ Verify the app opens and you can login
- Select a site that has blaze campaigns
- Tap on the My Site Tab > blaze campaign section of the blaze card
- ✅ Verify the campaign detail view is shown

## Regression Notes
1. Potential unintended areas of impact
The app crashes on start because DM migration failure

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test

3. What automated tests I added (or what prevented me from doing so)
Updated existing unit tests

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
