### PR TITLE
Contact support add feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -152,6 +152,7 @@ android {
         buildConfigField "boolean", "DASHBOARD_CARD_FREE_TO_PAID_PLANS", "false"
         buildConfigField "boolean", "SITE_EDITOR_MVP", "false"
         buildConfigField "boolean", "JETPACK_SOCIAL", "false"
+        buildConfigField "boolean", "CONTACT_SUPPORT", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ContactSupportFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ContactSupportFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val CONTACT_SUPPORT_REMOTE_FIELD = "contact_support"
+
+@Feature(CONTACT_SUPPORT_REMOTE_FIELD, false)
+class ContactSupportFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.CONTACT_SUPPORT,
+    CONTACT_SUPPORT_REMOTE_FIELD
+)


### PR DESCRIPTION
Adds feature config for the new Contact Support project on JP app

Fixes #18817 

<img width=320 alt="Screenshot_20230725_140406" src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/4184b6b9-9414-4fef-a963-028a008c7ade" />

1. Launch Jetpack app
2. Go to `Me` (Tap on Avatar in the bottom nav)
3. Tap `Debug Settings`
4. Find `contact_support` under `Remote features` tab as shown in the image above

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.