### PR TITLE
Implements: Campaign listing page navigation and tracking 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -2,11 +2,14 @@ package org.wordpress.android.ui
 
 import android.content.Context
 import android.content.Intent
+import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.blaze.blazecampaigns.ARG_EXTRA_BLAZE_CAMPAIGN_PAGE
 import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignPage
 import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
+import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_FLOW_SOURCE
+import org.wordpress.android.ui.blaze.blazepromote.BlazeParentActivity
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -36,5 +39,14 @@ class ActivityNavigator @Inject constructor() {
                 )
             }
         )
+    }
+
+    fun openPromoteWithBlaze(
+        context: Context,
+        source: BlazeFlowSource
+    ) {
+        val intent = Intent(context, BlazeParentActivity::class.java)
+        intent.putExtra(ARG_BLAZE_FLOW_SOURCE, source)
+        context.startActivity(intent)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeUiState.kt
@@ -21,7 +21,8 @@ enum class BlazeFlowSource(val trackingName: String) {
     MENU_ITEM("menu_item"),
     POSTS_LIST("posts_list"),
     STATS_POST("stats_post"),
-    PAGES_LIST("pages_list")
+    PAGES_LIST("pages_list"),
+    CAMPAIGN_LISTING_PAGE("campaign_listing_page")
 }
 sealed interface BlazeUIModel: Parcelable {
     val title: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
@@ -54,7 +54,6 @@ private const val CAMPAIGN_LISTING_PAGE_SOURCE = "campaign_listing_page_source"
 
 @AndroidEntryPoint
 class CampaignListingFragment : Fragment() {
-
     @Inject
     lateinit var activityNavigator: ActivityNavigator
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -17,6 +18,10 @@ import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -36,6 +41,7 @@ import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.blaze.blazecampaigns.CampaignViewModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
@@ -84,7 +90,7 @@ class CampaignListingFragment : Fragment() {
 
     private fun initObservers() {
         viewModel.navigation.observeEvent(viewLifecycleOwner) { navigation ->
-            when(navigation){
+            when (navigation) {
                 is CampaignListingNavigation.CampaignDetailPage -> {
                     activityNavigator.navigateToCampaignDetailPage(
                         requireContext(),
@@ -92,6 +98,7 @@ class CampaignListingFragment : Fragment() {
                         navigation.campaignDetailPageSource
                     )
                 }
+
                 is CampaignListingNavigation.CampaignCreatePage -> {
                     activityNavigator.openPromoteWithBlaze(
                         requireContext(),
@@ -119,7 +126,14 @@ class CampaignListingFragment : Fragment() {
                         campaignViewModel.onNavigationUp()
                     }
                 )
-            }
+            },
+            floatingActionButton = {
+                if (uiState is CampaignListingUiState.Success) {
+                    CreateCampaignFloatingActionButton(
+                        onClick = uiState.createCampaignClick
+                    )
+                }
+            },
         ) { CampaignListingContent(uiState) }
     }
 
@@ -138,6 +152,7 @@ class CampaignListingFragment : Fragment() {
     fun CampaignListingSuccess(uiState: CampaignListingUiState.Success) {
         LazyColumn(
             modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(bottom = 72.dp),
         ) {
             items(uiState.campaigns) { campaign ->
                 CampaignListRow(
@@ -191,6 +206,25 @@ fun CampaignListingErrorPreview() {
                 click = { }
             )
         ))
+    }
+}
+
+@Composable
+private fun CreateCampaignFloatingActionButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    val isInDarkMode = !MaterialTheme.colors.isLight
+    FloatingActionButton(
+        modifier = modifier,
+        onClick = onClick,
+        containerColor = if (isInDarkMode)
+            AppColor.Gray30
+        else MaterialTheme.colors.onSurface
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Add,
+            contentDescription = stringResource(id = R.string.campaign_listing_page_create_campaign_fab_description),
+            tint = if (isInDarkMode) MaterialTheme.colors.onSurface
+            else MaterialTheme.colors.surface
+        )
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUiState.kt
@@ -19,7 +19,8 @@ sealed class CampaignListingUiState {
 
     data class Success(
         val campaigns: List<CampaignModel>,
-        val itemClick: (CampaignModel) -> Unit
+        val itemClick: (CampaignModel) -> Unit,
+        val createCampaignClick: () -> Unit
     ) : CampaignListingUiState()
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
@@ -89,7 +89,13 @@ class CampaignListingViewModel @Inject constructor(
     }
 
     private fun showCampaigns(campaigns: List<CampaignModel>) {
-        _uiState.postValue(CampaignListingUiState.Success(campaigns, this::onCampaignClicked))
+        _uiState.postValue(
+            CampaignListingUiState.Success(
+                campaigns,
+                this::onCampaignClicked,
+                this::createCampaignClick
+            )
+        )
     }
 
     private fun onCampaignClicked(campaignModel: CampaignModel) {
@@ -97,14 +103,16 @@ class CampaignListingViewModel @Inject constructor(
     }
 
     private fun showNoCampaigns() {
-        _uiState.postValue(CampaignListingUiState.Error(
-            title = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_title),
-            description = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_description),
-            button = CampaignListingUiState.Error.ErrorButton(
-                text = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_button_text),
-                click = this::createCampaignClick
+        _uiState.postValue(
+            CampaignListingUiState.Error(
+                title = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_title),
+                description = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_description),
+                button = CampaignListingUiState.Error.ErrorButton(
+                    text = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_button_text),
+                    click = this::createCampaignClick
+                )
             )
-        ))
+        )
     }
 
     private fun createCampaignClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
@@ -33,6 +33,9 @@ class CampaignListingViewModel @Inject constructor(
     private val _uiState = MutableLiveData<CampaignListingUiState>()
     val uiState: LiveData<CampaignListingUiState> = _uiState
 
+    private val _navigation = MutableLiveData<Event<CampaignListingNavigation>>()
+    val navigation = _navigation
+
     fun start(campaignListingPageSource: CampaignListingPageSource) {
         blazeFeatureUtils.trackCampaignListingPageShown(campaignListingPageSource)
         _uiState.postValue(CampaignListingUiState.Loading)
@@ -86,9 +89,8 @@ class CampaignListingViewModel @Inject constructor(
         _uiState.postValue(CampaignListingUiState.Success(campaigns, this::onCampaignClicked))
     }
 
-    @Suppress("UNUSED_PARAMETER")
     private fun onCampaignClicked(campaignModel: CampaignModel) {
-        // todo navigate to campaign detail page
+        _navigation.postValue(Event(CampaignListingNavigation.CampaignDetailPage(campaignModel.id.toInt())))
     }
 
     private fun showNoCampaigns() {
@@ -108,4 +110,16 @@ enum class CampaignListingPageSource(val trackingName: String) {
     MENU_ITEM("menu_item"),
     UNKNOWN("unknown")
 }
+
+sealed class CampaignListingNavigation {
+    data class CampaignDetailPage(
+        val campaignId: Int,
+        val campaignDetailPageSource: CampaignDetailPageSource = CampaignDetailPageSource.CAMPAIGN_LISTING_PAGE
+    ) : CampaignListingNavigation()
+
+    data class CampaignCreatePage(
+        val blazeFlowSource: BlazeFlowSource = BlazeFlowSource.CAMPAIGN_LISTING_PAGE
+    ) : CampaignListingNavigation()
+}
+
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
@@ -102,9 +102,13 @@ class CampaignListingViewModel @Inject constructor(
             description = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_description),
             button = CampaignListingUiState.Error.ErrorButton(
                 text = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_button_text),
-                click = { }
+                click = this::createCampaignClick
             )
         ))
+    }
+
+    private fun createCampaignClick() {
+        _navigation.postValue(Event(CampaignListingNavigation.CampaignCreatePage()))
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingViewModel.kt
@@ -9,12 +9,15 @@ import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
+import org.wordpress.android.ui.blaze.BlazeFlowSource
+import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.blaze.CampaignStatus
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -43,7 +46,7 @@ class CampaignListingViewModel @Inject constructor(
     }
 
     private fun loadCampaigns() {
-        if(!networkUtilsWrapper.isNetworkAvailable()) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
             // showNoInternet() error, skipping for now so that loading state can be design reviewed
             return
         }
@@ -82,7 +85,7 @@ class CampaignListingViewModel @Inject constructor(
     }
 
     private fun convertToDollars(budgetCents: Long): UiString {
-        return UiString.UiStringText("$"+ (budgetCents/CENTS_IN_DOLLARS).toString())
+        return UiString.UiStringText("$" + (budgetCents / CENTS_IN_DOLLARS).toString())
     }
 
     private fun showCampaigns(campaigns: List<CampaignModel>) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4625,6 +4625,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="campaign_listing_page_no_campaigns_message_description">You have not created any campaigns yet. Click create to get started.</string>
     <string name="campaign_listing_page_no_campaigns_button_text">Create</string>
     <string name="blaze_campaign_detail_error">Campaign Details couldn\'t be loaded</string>
+    <string name="campaign_listing_page_create_campaign_fab_description" translatable="false"> @string/blaze_campaigns_card_footer_label</string>
+
     <string name="gutenberg_native_insert_audio_block" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Insert Audio Block</string>
     <string name="gutenberg_native_insert_gallery_block" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Insert Gallery Block</string>
     <string name="gutenberg_native_insert_image_block" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Insert Image Block</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
@@ -1,0 +1,206 @@
+package org.wordpress.android.ui.blaze.blazecampaigns
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
+import org.wordpress.android.fluxc.model.blaze.BlazeCampaignsModel
+import org.wordpress.android.fluxc.store.blaze.BlazeCampaignsStore
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
+import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingNavigation
+import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
+import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingUiState
+import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingViewModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.blaze.CampaignStatus
+import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.util.NetworkUtilsWrapper
+import java.util.Date
+
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class CampaignListingViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: CampaignListingViewModel
+
+    @Mock
+    lateinit var blazeFeatureUtils: BlazeFeatureUtils
+
+    @Mock
+    lateinit var blazeCampaignsStore: BlazeCampaignsStore
+
+    @Mock
+    lateinit var statsUtils: StatsUtils
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    private val uiStates = mutableListOf<CampaignListingUiState>()
+
+    private val navigationEvents = mutableListOf<CampaignListingNavigation>()
+
+    lateinit var campaignModel: BlazeCampaignsModel
+
+    @Before
+    fun setUp() {
+        viewModel = CampaignListingViewModel(
+            testDispatcher(),
+            blazeFeatureUtils,
+            blazeCampaignsStore,
+            statsUtils,
+            selectedSiteRepository,
+            networkUtilsWrapper
+        )
+        observeUIState()
+        observeNavigationEvents()
+        setupCampaignModels()
+    }
+
+    private fun observeUIState() {
+        viewModel.uiState.observeForever {
+            it?.let { uiStates.add(it) }
+        }
+    }
+
+    private fun observeNavigationEvents() {
+        viewModel.navigation.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                navigationEvents.add(it)
+            }
+        }
+    }
+
+    @Test
+    fun `when viewmodel start, then should track campaign listing page shown`() {
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+
+        assertThat(uiStates.first() is CampaignListingUiState.Loading).isTrue
+        verify(blazeFeatureUtils).trackCampaignListingPageShown(CampaignListingPageSource.DASHBOARD_CARD)
+    }
+
+    @Test
+    fun `given internet available, when viewmodel start, then should fetch campaigns`() = runTest {
+        val siteModel = mock<SiteModel>()
+        setupCampaignModels()
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeCampaignsStore.getBlazeCampaigns(siteModel)).thenReturn(campaignModel)
+        whenever(statsUtils.toFormattedString(1000L, ONE_THOUSAND)).thenReturn("1000")
+
+
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+        advanceUntilIdle()
+
+        assertThat(uiStates.last() is CampaignListingUiState.Success).isTrue
+        assertThat((uiStates.last() as CampaignListingUiState.Success).campaigns.size).isEqualTo(10)
+    }
+
+    @Test
+    fun `given no campaigns, when viewmodel start, then should show no campaigns error`() = runTest {
+        val siteModel = mock<SiteModel>()
+        val noCampaigns = BlazeCampaignsModel(emptyList(), 1, 1, 0)
+
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeCampaignsStore.getBlazeCampaigns(siteModel)).thenReturn(noCampaigns)
+
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+        advanceUntilIdle()
+
+        assertThat(uiStates.last() is CampaignListingUiState.Error).isTrue
+    }
+
+
+    @Test
+    fun `given no campaigns, when click is invoked on create, then navigate to blaze flow`() = runTest {
+        val siteModel = mock<SiteModel>()
+        val noCampaigns = BlazeCampaignsModel(emptyList(), 1, 1, 0)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeCampaignsStore.getBlazeCampaigns(siteModel)).thenReturn(noCampaigns)
+
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+        val noCampaignsState = uiStates.last() as CampaignListingUiState.Error
+        noCampaignsState.button!!.click.invoke()
+
+        assertThat(navigationEvents.last() is CampaignListingNavigation.CampaignCreatePage).isTrue
+    }
+
+    @Test
+    fun `given campaigns available, when clicked on campaign, then navigate to detail`() = runTest {
+        val siteModel = mock<SiteModel>()
+        setupCampaignModels()
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeCampaignsStore.getBlazeCampaigns(siteModel)).thenReturn(campaignModel)
+        whenever(statsUtils.toFormattedString(1000L, ONE_THOUSAND)).thenReturn("1000")
+
+
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+        val success = uiStates.last() as CampaignListingUiState.Success
+        success.itemClick.invoke(success.campaigns.first())
+
+        assertThat(navigationEvents.last() is CampaignListingNavigation.CampaignDetailPage).isTrue
+    }
+
+    @Test
+    fun `given campaigns available, when clicked on create campaign fab, then navigate to blaze flow`() = runTest {
+        val siteModel = mock<SiteModel>()
+        setupCampaignModels()
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        whenever(blazeCampaignsStore.getBlazeCampaigns(siteModel)).thenReturn(campaignModel)
+        whenever(statsUtils.toFormattedString(1000L, ONE_THOUSAND)).thenReturn("1000")
+
+
+        viewModel.start(CampaignListingPageSource.DASHBOARD_CARD)
+        val success = uiStates.last() as CampaignListingUiState.Success
+        success.createCampaignClick.invoke()
+
+        assertThat(navigationEvents.last() is CampaignListingNavigation.CampaignCreatePage).isTrue
+    }
+
+    private fun setupCampaignModels() {
+        campaignModel = BlazeCampaignsModel(
+            campaigns = getCampaigns(10),
+            page = 1,
+            totalPages = 1,
+            totalItems = 10
+        )
+    }
+
+    private fun getCampaigns(numbers: Int): List<BlazeCampaignModel> {
+        val listOfCampaigns = mutableListOf<BlazeCampaignModel>()
+        for (i in 0 until numbers) {
+            listOfCampaigns.add(
+                BlazeCampaignModel(
+                    campaignId = i.toLong(),
+                    title = "Campaign $i",
+                    imageUrl = "https://picsum.photos/200/300",
+                    startDate = Date(),
+                    endDate = Date(),
+                    uiStatus = CampaignStatus.Active.status,
+                    budgetCents = 1000L,
+                    impressions = 1000L,
+                    clicks = 1000L,
+                )
+            )
+        }
+        return listOfCampaigns
+    }
+
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
@@ -187,7 +187,7 @@ class CampaignListingViewModelTest : BaseUnitTest() {
         for (i in 0 until numbers) {
             listOfCampaigns.add(
                 BlazeCampaignModel(
-                    campaignId = i.toLong(),
+                    campaignId = i,
                     title = "Campaign $i",
                     imageUrl = "https://picsum.photos/200/300",
                     startDate = Date(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignListingViewModelTest.kt
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.NetworkUtilsWrapper
 import java.util.Date
 
-
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class CampaignListingViewModelTest : BaseUnitTest() {
@@ -202,5 +201,4 @@ class CampaignListingViewModelTest : BaseUnitTest() {
         }
         return listOfCampaigns
     }
-
 }


### PR DESCRIPTION
Part of
#18800
#18533
#18528

## Description 
This PR implements the following in the Campaign listing page
1. The Floating action button 
    1. Clicking will navigate to the blaze creation flow 
    2. Tracking events on click 
2. Clicking on the Campaign item navigates to the campaign detail page
3. Clicking on the Create button in no Campaigns view navigates to the campaign detail page  
4. Adds test in [CampaignListingViewModelTest](https://github.com/wordpress-mobile/WordPress-Android/pull/18833/commits/aa58588b06660173eee6dffcb60b6d828e591f7a)

## Testing instruction 

### Click on FAB 
1. Log in to an account having campaigns 
2. Click on the campaigns card 
3. Verify that the campaign listing page is shown 
5. Click on the + Fab button 
6. Verify that the blaze promote overlay is shown 
7. Verify tracking event 🔵  `Tracked: blaze_overlay_displayed, Properties: {"source":"campaign_listing_page”}`

### Campaign item click 
1. Log in to an account having campaigns 
2. Click on the campaigns card 
3. Verify that the campaign listing page is shown 
4. Click on any campaign 
5. Verify that the campaign detail page is shown 
6. Verify the tracking event 🔵 `Tracked: blaze_campaign_details_opened, Properties: {"source":"campaign_listing_page"}`

### No campaigns button click & FAB 
1. Log in to an account having no campaigns 
2. Click on menu → blaze 
3. Verify that no campaigns page is shown 
4. Verify that the FAB is not shown 
5. Click on Create button in no Campaigns view 
6. Verify that the blaze flow is triggered 
8. Verify tracking event is triggered 🔵 `Tracked: blaze_overlay_displayed, Properties: {"source":"campaign_listing_page"}`

Note: The FAB implemented in this Page is a Jetpack compose replica of the current XML FAB implemented in the app with the PR - https://github.com/wordpress-mobile/WordPress-Android/pull/18599, This FAB color is different to the one provided in the design. The one provided in the design was given before the FAB shape and color was changed across the Android PR, so I am guessing the one I have done is right. I am cc ing @osullivanchris so that he can review this when he comes back from AFK. Once he gives a design review of the FAB, I will take up the change if necessary. Lets go with the merge so that we can progress with the rest of the implementation

## Regression Notes
1. Potential unintended areas of impact
Nothing as this is a new screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
