### PR TITLE
Blaze: Show the blaze overlay once

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1069,7 +1069,7 @@
             android:name="com.google.mlkit.vision.DEPENDENCIES"
             android:value="barcode_ui"/>
 
-        <activity android:name=".ui.blaze.blazepromote.BlazeParentActivity"
+        <activity android:name=".ui.blaze.blazepromote.BlazePromoteParentActivity"
             android:exported="false"
             android:label="@string/blaze_activity_title"
             android:screenOrientation="portrait"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.blaze.BlazeFlowSource;
-import org.wordpress.android.ui.blaze.blazepromote.BlazeParentActivity;
+import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity;
 import org.wordpress.android.ui.blaze.PageUIModel;
 import org.wordpress.android.ui.blaze.PostUIModel;
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListActivity;
@@ -1872,7 +1872,7 @@ public class ActivityLauncher {
     public static void openPromoteWithBlaze(@NonNull Context context,
                                             @Nullable PostModel postModel,
                                             @NonNull BlazeFlowSource source) {
-        Intent intent = new Intent(context, BlazeParentActivity.class);
+        Intent intent = new Intent(context, BlazePromoteParentActivity.class);
         if (postModel != null) {
             PostUIModel postUIModel = new PostUIModel(
                     postModel.getRemotePostId(),
@@ -1889,7 +1889,7 @@ public class ActivityLauncher {
     public static void openPromoteWithBlaze(@NonNull Context context,
                                             @NonNull PageModel page,
                                             @NonNull BlazeFlowSource source) {
-        Intent intent = new Intent(context, BlazeParentActivity.class);
+        Intent intent = new Intent(context, BlazePromoteParentActivity.class);
         PageUIModel pageUIModel = new PageUIModel(
                 page.getPost().getRemotePostId(),
                 page.getPost().getTitle(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
 import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_FLOW_SOURCE
-import org.wordpress.android.ui.blaze.blazepromote.BlazeParentActivity
+import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -45,7 +45,7 @@ class ActivityNavigator @Inject constructor() {
         context: Context,
         source: BlazeFlowSource
     ) {
-        val intent = Intent(context, BlazeParentActivity::class.java)
+        val intent = Intent(context, BlazePromoteParentActivity::class.java)
         intent.putExtra(ARG_BLAZE_FLOW_SOURCE, source)
         context.startActivity(intent)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -62,6 +62,10 @@ class BlazeFeatureUtils @Inject constructor(
 
     fun shouldShowBlazeCampaigns() = blazeManageCampaignFeatureConfig.isEnabled()
 
+    fun shouldHideBlazeOverlay() = appPrefsWrapper.getShouldHideBlazeOverlay()
+
+    fun setShouldHideBlazeOverlay() = appPrefsWrapper.setShouldHideBlazeOverlay(true)
+
     fun track(stat: AnalyticsTracker.Stat, source: BlazeFlowSource) {
         analyticsTrackerWrapper.track(
             stat,

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeViewModel.kt
@@ -41,7 +41,6 @@ class BlazeViewModel @Inject constructor(
     }
 
     private fun initializePromoteContentUIState(blazeUIModel: BlazeUIModel) {
-        blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)
         when(blazeUIModel) {
             is PostUIModel -> initializePromotePostUIState(blazeUIModel)
             is PageUIModel -> initializePromotePageUIState(blazeUIModel)
@@ -57,8 +56,13 @@ class BlazeViewModel @Inject constructor(
                     postModel.featuredImageId)
             }
         )
-        _uiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
+
         _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
+        _uiState.value = if (shouldShowOverlayAndTrack()) {
+            BlazeUiState.PromoteScreen.PromotePost(updatedPostModel)
+        } else {
+            BlazeUiState.WebViewScreen
+        }
     }
 
     private fun initializePromotePageUIState(pageModel: PageUIModel) {
@@ -69,14 +73,31 @@ class BlazeViewModel @Inject constructor(
                 pageModel.featuredImageId
             )
         )
-        _uiState.value = BlazeUiState.PromoteScreen.PromotePage(updatedPageModel)
+
         _promoteUiState.value = BlazeUiState.PromoteScreen.PromotePage(updatedPageModel)
+        _uiState.value = if (shouldShowOverlayAndTrack()) {
+            BlazeUiState.PromoteScreen.PromotePage(updatedPageModel)
+        } else {
+            BlazeUiState.WebViewScreen
+        }
     }
 
     private fun initializePromoteSiteUIState() {
-        blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)
-        _uiState.value = BlazeUiState.PromoteScreen.Site
         _promoteUiState.value = BlazeUiState.PromoteScreen.Site
+        _uiState.value = if (shouldShowOverlayAndTrack()) {
+            BlazeUiState.PromoteScreen.Site
+        } else {
+            BlazeUiState.WebViewScreen
+        }
+    }
+
+    private fun shouldShowOverlayAndTrack() : Boolean  {
+        val shouldShowOverlay = !blazeFeatureUtils.shouldHideBlazeOverlay()
+        if (shouldShowOverlay) {
+            blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)
+            blazeFeatureUtils.setShouldHideBlazeOverlay()
+        }
+        return shouldShowOverlay
     }
 
     // to do: tracking logic and logic for done state - this might not be where we want to track

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
@@ -17,7 +17,7 @@ const val ARG_EXTRA_BLAZE_UI_MODEL = "blaze_ui_model"
 const val ARG_BLAZE_FLOW_SOURCE = "blaze_flow_source"
 
 @AndroidEntryPoint
-class BlazeParentActivity : AppCompatActivity() {
+class BlazePromoteParentActivity : AppCompatActivity() {
     private val viewModel: BlazeViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -193,6 +193,7 @@ public class AppPrefs {
         WP_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY_LAST_SHOWN_TIMESTAMP,
         NOTIFICATIONS_PERMISSION_WARNING_DISMISSED,
         HAS_SAVED_PRIVACY_SETTINGS,
+        SHOULD_HIDE_BLAZE_OVERLAY,
     }
 
     /**
@@ -1673,5 +1674,13 @@ public class AppPrefs {
 
     public static void setNotificationsPermissionWarningDismissed(boolean dismissed) {
         setBoolean(DeletablePrefKey.NOTIFICATIONS_PERMISSION_WARNING_DISMISSED, dismissed);
+    }
+
+    public static Boolean getShouldHideBlazeOverlay() {
+        return getBoolean(DeletablePrefKey.SHOULD_HIDE_BLAZE_OVERLAY, false);
+    }
+
+    public static void setShouldHideBlazeOverlay(final boolean isHidden) {
+        setBoolean(DeletablePrefKey.SHOULD_HIDE_BLAZE_OVERLAY, isHidden);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -351,6 +351,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun incrementWPJetpackIndividualPluginOverlayShownCount() =
         AppPrefs.incrementWPJetpackIndividualPluginOverlayShownCount()
 
+    fun getShouldHideBlazeOverlay(): Boolean =
+        AppPrefs.getShouldHideBlazeOverlay()
+
+    fun setShouldHideBlazeOverlay(isHidden: Boolean) =
+        AppPrefs.setShouldHideBlazeOverlay(isHidden)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
@@ -7,12 +7,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
+import org.wordpress.android.ui.blaze.BlazeUiState
+import org.wordpress.android.ui.blaze.PageUIModel
 import org.wordpress.android.ui.blaze.PostUIModel
 import org.wordpress.android.ui.blaze.blazeoverlay.BlazeViewModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -34,6 +37,8 @@ class BlazeViewModelTest : BaseUnitTest() {
 
     private lateinit var blazeViewModel: BlazeViewModel
 
+    private lateinit var uiStates: MutableList<BlazeUiState>
+    private lateinit var promoteUiState: MutableList<BlazeUiState>
     @Before
     fun setUp() {
         blazeViewModel = BlazeViewModel(
@@ -42,6 +47,14 @@ class BlazeViewModelTest : BaseUnitTest() {
             mediaStore,
             selectedSiteRepository
         )
+        uiStates = mutableListOf()
+        promoteUiState = mutableListOf()
+        blazeViewModel.promoteUiState.observeForever {
+            promoteUiState.add(it)
+        }
+        blazeViewModel.uiState.observeForever {
+            uiStates.add(it)
+        }
     }
 
     @Test
@@ -54,5 +67,93 @@ class BlazeViewModelTest : BaseUnitTest() {
 
 
         Assertions.assertThat(result).isNotNull
+    }
+
+    @Test
+    fun `given blaze overlay shown is false, when started from post list, then uiState is set to promote post`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
+
+        val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
+            url = "url", featuredImageUrl = "featuredImageUrl"
+        )
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePost::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is true, when started from post list, then uiState is set to webview screen`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
+
+        val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
+            url = "url", featuredImageUrl = "featuredImageUrl"
+        )
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is false, when started from page list, then uiState is set to promote post`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
+
+        val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
+            url = "url", featuredImageUrl = "featuredImageUrl"
+        )
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePage::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is true, when started from page list, then uiState is set to webview screen`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
+
+        val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
+            url = "url", featuredImageUrl = "featuredImageUrl"
+        )
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is false, when started from dashboard card, then uiState is set to site`() {
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
+
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is true, when started from dashboard card, then uiState is set to webview screen`() {
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
+
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is false, when started from no campaigns list, then uiState is set to site`() {
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
+
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is true, when started from no campaigns list, then uiState is set to webview`() {
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
+
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
 }


### PR DESCRIPTION
Parent #18787 

This PR support showing the Blaze overlay 1X per session. The value resets on logout.
- Add new app pref `SHOULD_HIDE_BLAZE_OVERLAY` to persist the true/false value. The value will be deleted upon logout.
- Refactored `BlazeWebViewModel` to check for overlay has been shown
- Add tests to `BlazeWebViewModelTest`

Note: This PR does NOT include:
- Adding a more menu to the campaign card
- Adding Learn More to the blaze card (and the aforementioned campaign card) menu
This may or may not be taken up separately; as it was a last minute additions and is out of scope.

### To test:
**Setup**
- Install, launch the app, and login
- Navigate to Me -> App Settings -> Privacy Setting
- Enable collection information
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze
- Restart the app

**Blaze overlay is visible**
- Navigate to a site that has no blaze campaigns 
- Navigate to My Site tab
- Tap on the blaze card
- ✅ Verify the Blaze Overlay has been shown
- ✅ Verify logs contain: 🔵 Tracked: blaze_overlay_displayed, Properties: {"source":"dashboard_card"}
- Close out of the overlay
- ✅ Verify logs contain: 🔵 Tracked: blaze_overlay_dismissed, Properties: {"source":"campaign_listing_page"}
- Tap on the blaze card again
- ✅ Verify the Blaze Overlay has not been shown
- Logout of the app to reset the `SHOULD_HIDE_BLAZE_OVERLAY` key
- Repeat the above steps for each entry point: Campaign Card, Posts List, Pages List, Campaigns List, No Campaigns View

## Regression Notes
1. Potential unintended areas of impact
The blaze overlay shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
Add tests to `BlazeViewModelTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A

