### PR TITLE
Fixing 18823 unit tests CI issues.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -95,7 +95,7 @@ class EditPostPublishSettingsViewModel @Inject constructor(
                     getJetpackSocialShareLimitStatusUseCase.execute(it)
                 } ?: ShareLimit.Disabled
                 loadConnections()
-                loadJetpackSocial()
+                loadJetpackSocialIfSupported()
             }
         } else {
             _showJetpackSocialContainer.value = false
@@ -109,7 +109,7 @@ class EditPostPublishSettingsViewModel @Inject constructor(
             // make sure we have the latest data.
             viewModelScope.launch {
                 updateConnections()
-                loadJetpackSocial()
+                loadJetpackSocialIfSupported()
             }
         }
     }
@@ -154,7 +154,7 @@ class EditPostPublishSettingsViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadJetpackSocial() {
+    private suspend fun loadJetpackSocialIfSupported() {
         val showJetpackSocial = jetpackSocialFeatureConfig.isEnabled() && siteModel?.supportsPublicize() == true
         if (!showJetpackSocial) {
             _showJetpackSocialContainer.value = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -103,8 +103,7 @@ class EditPostPublishSettingsViewModel @Inject constructor(
     }
 
     fun onScreenShown() {
-        if (!jetpackSocialFeatureConfig.isEnabled()) return
-        if (actionEvents.value is ActionEvent.OpenSocialConnectionsList) {
+        if (jetpackSocialFeatureConfig.isEnabled() && actionEvents.value is ActionEvent.OpenSocialConnectionsList) {
             // When getting back from publicize connections screen, we should update connections to
             // make sure we have the latest data.
             viewModelScope.launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -102,7 +102,7 @@ class EditPostPublishSettingsViewModel @Inject constructor(
         }
     }
 
-    fun onScreenShown() {
+    fun onResume() {
         if (jetpackSocialFeatureConfig.isEnabled() && actionEvents.value is ActionEvent.OpenSocialConnectionsList) {
             // When getting back from publicize connections screen, we should update connections to
             // make sure we have the latest data.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModel.kt
@@ -88,16 +88,22 @@ class EditPostPublishSettingsViewModel @Inject constructor(
             siteStore.getSiteByLocalId(it)
         }
         loadAuthors()
-        viewModelScope.launch {
-            shareLimit = siteModel?.let {
-                getJetpackSocialShareLimitStatusUseCase.execute(it)
-            } ?: ShareLimit.Disabled
-            loadConnections()
-            loadJetpackSocial()
+
+        if (jetpackSocialFeatureConfig.isEnabled()) {
+            viewModelScope.launch {
+                shareLimit = siteModel?.let {
+                    getJetpackSocialShareLimitStatusUseCase.execute(it)
+                } ?: ShareLimit.Disabled
+                loadConnections()
+                loadJetpackSocial()
+            }
+        } else {
+            _showJetpackSocialContainer.value = false
         }
     }
 
     fun onScreenShown() {
+        if (!jetpackSocialFeatureConfig.isEnabled()) return
         if (actionEvents.value is ActionEvent.OpenSocialConnectionsList) {
             // When getting back from publicize connections screen, we should update connections to
             // make sure we have the latest data.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -279,7 +279,7 @@ public class EditPostSettingsFragment extends Fragment {
 
     @Override public void onResume() {
         super.onResume();
-        mPublishedViewModel.onScreenShown();
+        mPublishedViewModel.onResume();
     }
 
     @Override

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -12,17 +12,22 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.datasets.wrappers.PublicizeTableWrapper
+import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.models.PublicizeConnection
+import org.wordpress.android.models.PublicizeService
 import org.wordpress.android.ui.people.utils.PeopleUtilsWrapper
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.ActionEvent
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.JetpackSocialUiState
+import org.wordpress.android.ui.posts.social.PostSocialConnection
 import org.wordpress.android.ui.posts.social.PostSocialSharingModelMapper
 import org.wordpress.android.usecase.social.GetJetpackSocialShareLimitStatusUseCase
 import org.wordpress.android.usecase.social.GetJetpackSocialShareMessageUseCase
 import org.wordpress.android.usecase.social.GetPublicizeConnectionsForUserUseCase
+import org.wordpress.android.usecase.social.ShareLimit
 import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.config.JetpackSocialFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
@@ -67,7 +72,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
     private val actionEventsObserver: Observer<ActionEvent> = mock()
     private val editPostRepository: EditPostRepository = mock()
     private val remoteSiteId = 123L
-//    private val userId = 456L
+    private val userId = 456L
     private val siteModel = SiteModel().apply {
         siteId = 12345
     }
@@ -107,209 +112,224 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should show jetpack social container if FF is enabled`() = test {
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(emptyList())
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        classToTest.start(editPostRepository)
-//        verify(showJetpackSocialContainerObserver).onChanged(true)
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(showJetpackSocialContainerObserver).onChanged(true)
     }
 
     @Test
     fun `Should get publicize connections for user if jetpack social FF is enabled`() = test {
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(emptyList())
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        classToTest.start(editPostRepository)
-//        verify(getPublicizeConnectionsForUserUseCase).execute(remoteSiteId, userId)
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(getPublicizeConnectionsForUserUseCase).execute(remoteSiteId, userId)
     }
 
     @Test
     fun `Should get jetpack social share limit status if jetpack social FF is enabled`() = test {
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(emptyList())
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        classToTest.start(editPostRepository)
-//        verify(getJetpackSocialShareLimitStatusUseCase).execute(siteModel)
+        mockSiteModel()
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(getJetpackSocialShareLimitStatusUseCase).execute(siteModel)
     }
 
     @Test
     fun `Should map no connections UI state if connections list is empty and jetpack social FF is enabled`() = test {
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(emptyList())
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        classToTest.start(editPostRepository)
-//        verify(jetpackUiStateMapper).mapNoConnections(any())
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(publicizeTableWrapper.getServiceList())
+            .thenReturn(listOf(PublicizeService().apply { status = PublicizeService.Status.OK }))
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+
+        classToTest.start(editPostRepository)
+        verify(jetpackUiStateMapper).mapNoConnections(any())
     }
 
     @Test
     fun `Should emit no connections UI state if connections list is empty and jetpack social FF is enabled`() = test {
-//        val noConnections = JetpackSocialUiState.NoConnections(
-//            trainOfIconsModels = listOf(),
-//            message = "message",
-//            connectProfilesButtonLabel = "label",
-//            onConnectProfilesClick = {},
-//        )
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(emptyList())
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        whenever(jetpackUiStateMapper.mapNoConnections(any()))
-//            .thenReturn(noConnections)
-//        classToTest.start(editPostRepository)
-//        verify(jetpackSocialUiStateObserver).onChanged(noConnections)
+        val noConnections = JetpackSocialUiState.NoConnections(
+            trainOfIconsModels = listOf(),
+            message = "message",
+            connectProfilesButtonLabel = "label",
+            onConnectProfilesClick = {},
+        )
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(publicizeTableWrapper.getServiceList())
+            .thenReturn(listOf(PublicizeService().apply { status = PublicizeService.Status.OK }))
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(jetpackUiStateMapper.mapNoConnections(any()))
+            .thenReturn(noConnections)
+        classToTest.start(editPostRepository)
+        verify(jetpackSocialUiStateObserver).onChanged(noConnections)
     }
 
     @Test
     fun `Should map loaded UI state if connections list is NOT empty and jetpack social FF is enabled`() = test {
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(
-//                listOf(
-//                    PublicizeConnection().apply {
-//                        connectionId = 0
-//                        service = "tumblr"
-//                        label = "Tumblr"
-//                        externalId = "myblog.tumblr.com"
-//                        externalName = "My blog"
-//                        externalProfilePictureUrl =
-//                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
-//                    },
-//                )
-//            )
-//        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
-//            .thenReturn("Message")
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        classToTest.start(editPostRepository)
-//        verify(jetpackUiStateMapper).mapLoaded(any(), any(), any(), any(), any())
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        connectionId = 0
+                        service = "tumblr"
+                        label = "Tumblr"
+                        externalId = "myblog.tumblr.com"
+                        externalName = "My blog"
+                        externalProfilePictureUrl =
+                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+                    },
+                )
+            )
+        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
+            .thenReturn("Message")
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        classToTest.start(editPostRepository)
+        verify(jetpackUiStateMapper).mapLoaded(any(), any(), any(), any(), any(), any(), any())
     }
 
     @Test
     fun `Should emit loaded UI state if connections list is NOT empty and jetpack social FF is enabled`() = test {
-//        val loaded = JetpackSocialUiState.Loaded(
-//            postSocialConnectionList = listOf(
-//                PostSocialConnection(
-//                    1,
-//                    "service",
-//                    "label",
-//                    "externalId",
-//                    "externalName",
-//                    "iconUrl",
-//                    true
-//                )
-//            ),
-//            showShareLimitUi = true,
-//            shareMessage = "message",
-//            onShareMessageClick = {},
-//            remainingSharesMessage = "remaining shares",
-//            subscribeButtonLabel = "label",
-//            onSubscribeClick = {},
-//        )
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(
-//                listOf(
-//                    PublicizeConnection().apply {
-//                        connectionId = 0
-//                        service = "tumblr"
-//                        label = "Tumblr"
-//                        externalId = "myblog.tumblr.com"
-//                        externalName = "My blog"
-//                        externalProfilePictureUrl =
-//                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
-//                    },
-//                )
-//            )
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
-//            .thenReturn("Message")
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        whenever(jetpackUiStateMapper.mapLoaded(any(), any(), any(), any(), any()))
-//            .thenReturn(loaded)
-//        classToTest.start(editPostRepository)
-//        verify(jetpackSocialUiStateObserver).onChanged(loaded)
+        val loaded = JetpackSocialUiState.Loaded(
+            jetpackSocialConnectionDataList = listOf(
+                JetpackSocialConnectionData(
+                    postSocialConnection = PostSocialConnection(
+                        connectionId = 1,
+                        service = "service",
+                        label = "label",
+                        externalId = "externalId",
+                        externalName = "externalName",
+                        iconUrl = "iconUrl",
+                        isSharingEnabled = true
+                    ),
+                    onConnectionClick = {},
+                    enabled = false
+                )
+            ),
+            showShareLimitUi = true,
+            isShareMessageEnabled = false,
+            shareMessage = "message",
+            onShareMessageClick = {},
+            subscribeButtonLabel = "label",
+            onSubscribeClick = {}
+        )
+
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        connectionId = 0
+                        service = "tumblr"
+                        label = "Tumblr"
+                        externalId = "myblog.tumblr.com"
+                        externalName = "My blog"
+                        externalProfilePictureUrl =
+                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+                    },
+                )
+            )
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
+            .thenReturn("Message")
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(jetpackUiStateMapper.mapLoaded(any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(loaded)
+        classToTest.start(editPostRepository)
+        verify(jetpackSocialUiStateObserver).onChanged(loaded)
     }
 
     @Test
     fun `Should reload jetpack social on screen shown if last emitted action was OpenSocialConnectionsList`() = test {
-//        val loaded = JetpackSocialUiState.Loaded(
-//            postSocialConnectionList = listOf(
-//                PostSocialConnection(
-//                    1,
-//                    "service",
-//                    "label",
-//                    "externalId",
-//                    "externalName",
-//                    "iconUrl",
-//                    true
-//                )
-//            ),
-//            showShareLimitUi = true,
-//            shareMessage = "message",
-//            onShareMessageClick = {},
-//            remainingSharesMessage = "remaining shares",
-//            subscribeButtonLabel = "label",
-//            onSubscribeClick = {},
-//        )
-//        mockSiteModel()
-//        mockUserId()
-//        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
-//            .thenReturn(
-//                listOf(
-//                    PublicizeConnection().apply {
-//                        connectionId = 0
-//                        service = "tumblr"
-//                        label = "Tumblr"
-//                        externalId = "myblog.tumblr.com"
-//                        externalName = "My blog"
-//                        externalProfilePictureUrl =
-//                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
-//                    },
-//                )
-//            )
-//        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
-//            .thenReturn(ShareLimit.Disabled)
-//        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
-//            .thenReturn("Message")
-//        whenever(jetpackSocialFeatureConfig.isEnabled())
-//            .thenReturn(true)
-//        whenever(jetpackUiStateMapper.mapLoaded(any(), any(), any(), any(), any()))
-//            .thenReturn(loaded)
-//
-//        classToTest.start(editPostRepository)
-//        classToTest.onScreenShown()
-//
-//        verify(jetpackSocialUiStateObserver).onChanged(loaded)
+        val loaded = JetpackSocialUiState.Loaded(
+            jetpackSocialConnectionDataList = listOf(
+                JetpackSocialConnectionData(
+                    postSocialConnection = PostSocialConnection(
+                        connectionId = 1,
+                        service = "service",
+                        label = "label",
+                        externalId = "externalId",
+                        externalName = "externalName",
+                        iconUrl = "iconUrl",
+                        isSharingEnabled = true
+                    ),
+                    onConnectionClick = {},
+                    enabled = false
+                )
+            ),
+            showShareLimitUi = true,
+            isShareMessageEnabled = false,
+            shareMessage = "message",
+            onShareMessageClick = {},
+            subscribeButtonLabel = "label",
+            onSubscribeClick = {}
+        )
+
+        mockSiteModel(true)
+        mockUserId()
+        whenever(getPublicizeConnectionsForUserUseCase.execute(any(), any(), any()))
+            .thenReturn(
+                listOf(
+                    PublicizeConnection().apply {
+                        connectionId = 0
+                        service = "tumblr"
+                        label = "Tumblr"
+                        externalId = "myblog.tumblr.com"
+                        externalName = "My blog"
+                        externalProfilePictureUrl =
+                            "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png"
+                    },
+                )
+            )
+        whenever(getJetpackSocialShareLimitStatusUseCase.execute(any()))
+            .thenReturn(ShareLimit.Disabled)
+        whenever(getJetpackSocialShareMessageUseCase.execute(any()))
+            .thenReturn("Message")
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(jetpackUiStateMapper.mapLoaded(any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(loaded)
+
+        classToTest.start(editPostRepository)
+        classToTest.onScreenShown()
+
+        verify(jetpackSocialUiStateObserver).onChanged(loaded)
     }
 
     @Test
@@ -330,20 +350,28 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
         )
     }
 
-    private fun mockSiteModel() {
+    private fun mockSiteModel(supportsPublicize: Boolean = false) {
         whenever(editPostRepository.localSiteId)
             .thenReturn(1)
         whenever(siteStore.getSiteByLocalId(1))
             .thenReturn(siteModel.apply {
                 siteId = remoteSiteId
+            }.also {
+                if (supportsPublicize) {
+                    it.apply {
+                        origin = SiteModel.ORIGIN_WPCOM_REST
+                        hasCapabilityPublishPosts = true
+                        setIsPublicizePermanentlyDisabled(false)
+                    }
+                }
             })
     }
 
-//    private fun mockUserId() {
-//        val accountModel: AccountModel = mock()
-//        whenever(accountStore.account)
-//            .thenReturn(accountModel)
-//        whenever(accountModel.userId)
-//            .thenReturn(userId)
-//    }
+    private fun mockUserId() {
+        val accountModel: AccountModel = mock()
+        whenever(accountStore.account)
+            .thenReturn(accountModel)
+        whenever(accountModel.userId)
+            .thenReturn(userId)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -327,14 +327,14 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             .thenReturn(loaded)
 
         classToTest.start(editPostRepository)
-        classToTest.onScreenShown()
+        classToTest.onResume()
 
         verify(jetpackSocialUiStateObserver).onChanged(loaded)
     }
 
     @Test
     fun `Should NOT reload jetpack social on screen shown if last emitted action was NOT OpenSocialConnectionsList`() {
-        classToTest.onScreenShown()
+        classToTest.onResume()
         verify(jetpackSocialUiStateObserver, never()).onChanged(any())
     }
 


### PR DESCRIPTION
This PR fixes un underling issue with unit tests CI in #18823. The issue was `kotlinx.coroutines.test.UncaughtExceptionsBeforeTest: There were uncaught exceptions before the test started.` collected in tests running after the `EditPostPublishSettingsViewModelTest`. The reason for it was a not completely mocked variable in loadConnetions call bringing to a silent coroutine NullPointerException.

What this PR does: 

- It guards the JP social specific code in `EditPostPublishSettingsViewModel.kt` more behind the JP social FF
- With the previous point in place, it restores the existent and commented-out unit tests making them work with minor adjustments

More unit tests coverage will be added in a separate PR 

To test:
- Check the guard conditions in EditPostPublishSettingsViewModel are guarding JP social specific code
- Check the CI is green

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Restored non functioning and commented out unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
