### PR TITLE
Adds Facebook's VisibleForTesting to proguard dontwarn

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -84,6 +84,8 @@
   **[] $VALUES;
   public *;
 }
+
+-dontwarn com.facebook.common.internal.VisibleForTesting
 ###### React Native - end
 
 ###### Encrypted Logs - begin


### PR DESCRIPTION
Due to Android Gradle Plugin `8.1.0` update, there is a missing class error for `com.facebook.common.internal.VisibleForTesting` in release builds. This PR adds the class to Proguard as a `dontwarn` rule as suggested by Android Gradle Plugin.

We had to make similar changes to WCAndroid, PCAndroid & DOAndroid.

**To test:**
Verify `./gradlew bundleWordPressVanillaRelease` is successful
