### PR TITLE
Fixes require statement logic error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModelFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModelFactory.kt
@@ -70,7 +70,7 @@ class StatsViewAllViewModelFactory(
     @StringRes private val titleResource: Int
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        require(!modelClass.isAssignableFrom(StatsViewAllViewModel::class.java)) { "ViewModel Not Found" }
+        require(modelClass.isAssignableFrom(StatsViewAllViewModel::class.java)) { "ViewModel Not Found" }
         @Suppress("UNCHECKED_CAST")
         return StatsViewAllViewModel(
             mainDispatcher,


### PR DESCRIPTION
Fixes #18859

## Description
Fixes require statement logic error introduced in [#18502](https://github.com/wordpress-mobile/WordPress-Android/pull/18502/commits/2be916e3fb18beba5ce1f1f6d17cfc9f21136c4e#diff-0f805cf2fb592eaa9e21bd6dbfadf87b1b9c1eb608770cb853c7044d5abb8c95)

## To test:
1. Open stats
2. Select a period with enough data (e.g. year)
3. Scroll down and tap "View more" were available (e.g. Countries, Clicks etc)
4. **Verify** that the app does not crash

Below you can find a recording of the app crash

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/013cd9d7-d687-451f-8a8d-b1d6ec8da281



## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The type/scope of the fix makes a unit test impractical. I'm open to iterate if there are suggestions on this 🙇 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
