### PR TITLE
Add a dialog for missing splits case

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -6,12 +6,6 @@ import android.util.TypedValue
 import org.wordpress.android.R
 
 object MissingSplitsUtils {
-    // Dialog texts are hardcoded because we can't be sure if resources will be available when there are missing splits.
-    const val DIALOG_TITLE = "Installation error"
-    const val DIALOG_MESSAGE =
-        "The app Jetpack is missing required components and must be reinstalled from the Google Play Store."
-    const val DIALOG_BUTTON = "CLOSE"
-
     /**
      * R.drawable.splash_icon is the first drawable the app attempts to access. If a NotFoundException occurs while
      * trying to access it, it indicates that there are missing splits, possibly due to sideloading the app.

--- a/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.content.res.Resources
+import android.util.TypedValue
+import org.wordpress.android.R
+
+object MissingSplitsUtils {
+    // Dialog texts are hardcoded because we can't be sure if resources will be available when there are missing splits.
+    const val DIALOG_TITLE = "Installation error"
+    const val DIALOG_MESSAGE =
+        "The app Jetpack is missing required components and must be reinstalled from the Google Play Store."
+    const val DIALOG_BUTTON = "CLOSE"
+
+    /**
+     * R.drawable.splash_icon is the first drawable the app attempts to access. If a NotFoundException occurs while
+     * trying to access it, it indicates that there are missing splits, possibly due to sideloading the app.
+     */
+    fun isMissingSplits(context: Context) = try {
+        context.resources.getValue(R.drawable.bg_jetpack_login_splash, TypedValue(), true)
+        true
+    } catch (e: Resources.NotFoundException) {
+        false
+    }
+}

--- a/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -18,8 +18,8 @@ object MissingSplitsUtils {
      */
     fun isMissingSplits(context: Context) = try {
         context.resources.getValue(R.drawable.bg_jetpack_login_splash, TypedValue(), true)
-        true
-    } catch (e: Resources.NotFoundException) {
         false
+    } catch (e: Resources.NotFoundException) {
+        true
     }
 }

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -45,4 +45,6 @@
 
     <!-- Share button in Me -->
     <string name="me_btn_share">Share Jetpack with a friend</string>
+
+    <string name="missing_splits_dialog_message">The app Jetpack is missing required components and must be reinstalled from the Google Play Store.</string>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -4,9 +4,12 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.main.WPMainActivity;
+import org.wordpress.android.util.MissingSplitsUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -21,8 +24,22 @@ public class WPLaunchActivity extends LocaleAwareActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (MissingSplitsUtils.INSTANCE.isMissingSplits(this)) {
+            // There are missing splits. Display a warning message.
+            showMissingSplitsDialog();
+            return;
+        }
         ProfilingUtils.split("WPLaunchActivity.onCreate");
         launchWPMainActivity();
+    }
+
+    private void showMissingSplitsDialog() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(MissingSplitsUtils.DIALOG_TITLE)
+                .setMessage(MissingSplitsUtils.DIALOG_MESSAGE)
+                .setNegativeButton(MissingSplitsUtils.DIALOG_BUTTON, null)
+                .setOnDismissListener(dialog -> finish())
+                .show();
     }
 
     private void launchWPMainActivity() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -35,9 +35,9 @@ public class WPLaunchActivity extends LocaleAwareActivity {
 
     private void showMissingSplitsDialog() {
         new MaterialAlertDialogBuilder(this)
-                .setTitle(MissingSplitsUtils.DIALOG_TITLE)
-                .setMessage(MissingSplitsUtils.DIALOG_MESSAGE)
-                .setNegativeButton(MissingSplitsUtils.DIALOG_BUTTON, null)
+                .setTitle(R.string.missing_splits_dialog_title)
+                .setMessage(R.string.missing_splits_dialog_message)
+                .setNegativeButton(R.string.missing_splits_dialog_button, null)
                 .setOnDismissListener(dialog -> finish())
                 .show();
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4647,4 +4647,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blaze_promote_error_title" translatable="false">@string/campaign_detail_error_title</string>
     <string name="blaze_promote_error_description" translatable="false">@string/request_failed_message</string>
     <string name="blaze_promote_error_button_text" translatable="false">@string/retry</string>
+
+    <string name="missing_splits_dialog_title">Installation failed</string>
+    <string name="missing_splits_dialog_message">The app WordPress is missing required components and must be reinstalled from the Google Play Store.</string>
+    <string name="missing_splits_dialog_button">CLOSE</string>
 </resources>

--- a/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -18,8 +18,8 @@ object MissingSplitsUtils {
      */
     fun isMissingSplits(context: Context) = try {
         context.resources.getValue(R.drawable.splash_icon, TypedValue(), true)
-        true
-    } catch (e: Resources.NotFoundException) {
         false
+    } catch (e: Resources.NotFoundException) {
+        true
     }
 }

--- a/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -6,12 +6,6 @@ import android.util.TypedValue
 import org.wordpress.android.R
 
 object MissingSplitsUtils {
-    // Dialog texts are hardcoded because we can't be sure if resources will be available when there are missing splits.
-    const val DIALOG_TITLE = "Installation error"
-    const val DIALOG_MESSAGE =
-        "The app WordPress is missing required components and must be reinstalled from the Google Play Store."
-    const val DIALOG_BUTTON = "CLOSE"
-
     /**
      * R.drawable.brush_stroke is the first drawable the app attempts to access. If a NotFoundException occurs while
      * trying to access it, it indicates that there are missing splits, possibly due to sideloading the app.

--- a/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.util
+
+import android.content.Context
+import android.content.res.Resources
+import android.util.TypedValue
+import org.wordpress.android.R
+
+object MissingSplitsUtils {
+    // Dialog texts are hardcoded because we can't be sure if resources will be available when there are missing splits.
+    const val DIALOG_TITLE = "Installation error"
+    const val DIALOG_MESSAGE =
+        "The app WordPress is missing required components and must be reinstalled from the Google Play Store."
+    const val DIALOG_BUTTON = "CLOSE"
+
+    /**
+     * R.drawable.splash_icon is the first drawable the app attempts to access. If a NotFoundException occurs while
+     * trying to access it, it indicates that there are missing splits, possibly due to sideloading the app.
+     */
+    fun isMissingSplits(context: Context) = try {
+        context.resources.getValue(R.drawable.splash_icon, TypedValue(), true)
+        true
+    } catch (e: Resources.NotFoundException) {
+        false
+    }
+}

--- a/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/util/MissingSplitsUtils.kt
@@ -13,11 +13,11 @@ object MissingSplitsUtils {
     const val DIALOG_BUTTON = "CLOSE"
 
     /**
-     * R.drawable.splash_icon is the first drawable the app attempts to access. If a NotFoundException occurs while
+     * R.drawable.brush_stroke is the first drawable the app attempts to access. If a NotFoundException occurs while
      * trying to access it, it indicates that there are missing splits, possibly due to sideloading the app.
      */
     fun isMissingSplits(context: Context) = try {
-        context.resources.getValue(R.drawable.splash_icon, TypedValue(), true)
+        context.resources.getValue(R.drawable.brush_stroke, TypedValue(), true)
         false
     } catch (e: Resources.NotFoundException) {
         true


### PR DESCRIPTION
Fixes #18546

When a user installs apps from a third-party store or an apk that is part of the app bundle, the app sometimes crashes at launch. For example, the user may install the app from `base-master.apk`, but the app also requires `base-master_2.apk`.

To reproduce: https://github.com/wordpress-mobile/WordPress-Android/issues/18546#issuecomment-1660386537

> **Note**
> **For reviewers:** I have added three reviewers. However, the code review and test from one reviewer should suffice. The others can simply provide their feedback on my solution.

### Solution
Google introduced [MissingSplitsManager](https://developer.android.com/reference/com/google/android/play/core/missingsplits/MissingSplitsManager) to prevent app crashes due to missing splits, but it is now deprecated because Play Protect blocks installs with missing splits. However, we are still crash reports on Sentry because some users do not have Play Protect active.

To address this, I implemented a solution that checks the first resource that the app requires for the launch. If the resources cannot be loaded, a warning message is displayed, and the app is closed. I used the same message that Google used in [MissingSplitsManager](https://developer.android.com/reference/com/google/android/play/core/missingsplits/MissingSplitsManager).

**Performance impact:** In the solution, I added an extra check that tries to access a resource. This could have affected the app's startup time. I measured the app startup time ten times.
Before, the average startup time was _1.744sec_.
After the solution, it is _1.684sec_.
Thus, the solution did not affect the app startup time. 

To test: Follow the instructions under "[To reproduce:](https://github.com/wordpress-mobile/WordPress-Android/issues/18546#issuecomment-1660386537)" and ensure that the warning message appears and the app closes as in the video below.

[Screen_recording_20230731_230433.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ef15a40d-ba21-43a2-b27b-944a26260c48)

> **Note**
> [An issue](https://github.com/wordpress-mobile/WordPress-Android/issues/18867) was opened for converting `WPLaunchActivity` to Java.

## Regression Notes
1. Potential unintended areas of impact
App startup time.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Measured app startup times.

3. What automated tests I added (or what prevented me from doing so)
The missing splits case is not suitable for automated testing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
