### PR TITLE
Blaze Campaigns: Update campaign detail URL format

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailFragment.kt
@@ -39,12 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.isActive
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
 import androidx.compose.ui.text.style.TextAlign
@@ -188,7 +184,6 @@ class CampaignDetailFragment : Fragment(), CampaignDetailWebViewClient.CampaignD
     @Composable
     private fun CampaignDetailWebView(uiState: CampaignDetailUiState) {
         var webView: WebView? by remember { mutableStateOf(null) }
-        val delayScope = CoroutineScope(Dispatchers.Default)
 
         if (uiState is CampaignDetailUiState.Prepared) {
             val model = uiState.model
@@ -215,7 +210,6 @@ class CampaignDetailFragment : Fragment(), CampaignDetailWebViewClient.CampaignD
             if (uiState is CampaignDetailUiState.Prepared) {
                 LoadingState()
             } else {
-                if (delayScope.isActive) delayScope.cancel()
                 webView?.let { theWebView ->
                     AndroidView(
                         factory = { theWebView },

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailViewModel.kt
@@ -75,9 +75,9 @@ class CampaignDetailViewModel @Inject constructor(
         val url = createURL(
             pathComponents = arrayOf(
                 ADVERTISING_PATH,
-                extractAndSanitizeSiteUrl(),
                 CAMPAIGNS_PATH,
-                campaignId.toString()
+                campaignId.toString(),
+                extractAndSanitizeSiteUrl()
             ),
             source = pageSource.trackingName
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailWebViewNavigationDelegate.kt
@@ -7,7 +7,7 @@ object CampaignDetailWebViewNavigationDelegate {
         UrlMatcher(
             "wordpress.com".toRegex(),
             listOf(
-                "/advertising/[a-zA-Z0-9.-]+/campaigns/\\d+\$".toRegex()
+                "/advertising/campaigns/\\d+/[a-zA-Z0-9.-]+\$".toRegex()
             )
         )
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
@@ -40,12 +40,8 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.isActive
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebChromeClientWithFileChooser
 import org.wordpress.android.ui.WPWebViewActivity.WPCOM_LOGIN_URL
@@ -204,7 +200,6 @@ class BlazePromoteWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
     @Composable
     private fun BlazeWebViewContent(uiState: BlazePromoteUiState) {
         var webView: WebView? by remember { mutableStateOf(null) }
-        val delayScope = CoroutineScope(Dispatchers.Default)
 
         if (uiState is BlazePromoteUiState.Loading) {
             val model = uiState.model
@@ -238,7 +233,6 @@ class BlazePromoteWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
             if (uiState is BlazePromoteUiState.Loading) {
                 LoadingState()
             } else {
-                if (delayScope.isActive) delayScope.cancel()
                 webView?.let { theWebView ->
                     AndroidView(
                         factory = { theWebView },

--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignDetailWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignDetailWebViewNavigationDelegateTest.kt
@@ -15,7 +15,7 @@ class CampaignDetailWebViewNavigationDelegateTest : BaseUnitTest() {
     fun `when advertising campaign url, then web view can navigate`() {
         assertThat(
             buildUrls(
-                "/advertising/dummywpcomsite.wordpress.com/campaigns/12345"
+                "/advertising/campaigns/12345/dummywpcomsite.wordpress.com"
             )
         ).allMatch {
             navigationDelegate.canNavigateTo(it)
@@ -28,7 +28,8 @@ class CampaignDetailWebViewNavigationDelegateTest : BaseUnitTest() {
             buildUrls(
                 "/dummywpcomsite.wordpress.com",
                 "/advertising/dummywpcomsite.wordpress.com/campaigns",
-                "/advertising/dummywpcomsite.wordpress.com"
+                "/advertising/dummywpcomsite.wordpress.com",
+                "/advertising/dummywpcomsite.wordpress.com/campaigns/12345"
             )
         ).noneMatch {
             navigationDelegate.canNavigateTo(it)


### PR DESCRIPTION
This PR changes the campaign detail URL format to match the change on Calypso

The previous route was `/:site/campaigns/:campaignId` and the new route style is `campaigns/:campaignId/:site` 

Also removed to unneeded delay scope references for blaze

### To test:
**Setup**
- Install and launch the app
- Navigate to Me -> App Settings -> Privacy Setting
- Enable collection information
- Navigate to Me -> App Settings -> Debug Setting
- Enable Blaze
- Restart the app

**Viewing Campaign Details**
- Navigate to a site that has blaze campaigns (use the test creds or create a blaze campaign first)
- Navigate to My Site tab
- Tap on the Campaign Detail section within the Blaze Card to launch the Campaign Detail View
- ✅ Verify the Campaign Detail view is loaded


## Regression Notes
1. Potential unintended areas of impact
Campaign detail view is not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A - have to actually load the webview

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A

