### PR TITLE
[JP Social/Pre-publishing] Hide Social Connect Prompt item

### DIFF
--- a/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
+++ b/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/actions_recycler_view"
@@ -21,6 +21,8 @@
         android:layout_width="0dp"
         android:visibility="gone"
         android:layout_height="wrap_content"
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintVertical_bias="1"
         app:layout_constraintBottom_toTopOf="@id/actions_recycler_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUi
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeViewModel
 import org.wordpress.android.ui.posts.prepublishing.home.PublishPost
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.GetButtonUiStateUseCase
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stories.StoryRepositoryWrapper
 import org.wordpress.android.ui.stories.usecase.UpdateStoryPostTitleUseCase
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -63,6 +64,9 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     lateinit var socialFeatureConfig: JetpackSocialFeatureConfig
 
     @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Mock
     lateinit var site: SiteModel
 
     @Before
@@ -77,6 +81,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
             updateStoryTitleUseCase,
             getCategoriesUseCase,
             socialFeatureConfig,
+            appPrefsWrapper,
             testDispatcher()
         )
         whenever(
@@ -94,6 +99,9 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
         whenever(site.name).thenReturn("")
         whenever(storyRepositoryWrapper.getCurrentStoryThumbnailUrl()).thenReturn("")
         whenever(getCategoriesUseCase.getPostCategoriesString(any(), any())).thenReturn("")
+
+        // right now we have hardcoded fake data so better to just test this way for now
+        whenever(appPrefsWrapper.getShouldShowJetpackSocialNoConnections(any(), any())).thenReturn(true)
     }
 
     @Test


### PR DESCRIPTION
Part of #18752

This is a very small PR adding some logic that will be changed, just as a guide for how to use it in the future. The logic for showing it is still WIP as it is not using real data, but this should give a direction when the actual fetching logic is in place.

To test:
1. Install and open the app
2. Go to Debug settings
3. Enable the `JetpackSocialFeatureConfig` in the "Features in Development" tab
4. Go back to the `My Site` screen
5. Open the Post lists
6. Open a post / Create a new post
7. Tap `Publish`/`Update` button to see the pre-publishing sheet
8. **Verify** the "No connection"/"connection prompt" UI is shown in the list
9. Tap "Not now"
10. **Verify** it hides the item
11. Close the bottom sheet
12. Tap `Publish`/`Update` button to see the pre-publishing sheet again
13. **Verify** the "No connection"/"connection prompt" UI is not shown anymore

The app data needs to be cleared to see the item again.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
