### PR TITLE
Contact support launch chat widget

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -352,6 +352,7 @@ kapt {
 }
 
 dependencies {
+    implementation 'androidx.webkit:webkit:1.7.0'
     compileOnly project(path: ':libs:annotations')
     kapt project(':libs:processors')
     implementation (project(path:':libs:networking')) {
@@ -423,6 +424,7 @@ dependencies {
     implementation "androidx.preference:preference:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
+    implementation "androidx.webkit:webkit:$androidxWebkitVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"

--- a/WordPress/src/jetpack/assets/support_chat_widget.html
+++ b/WordPress/src/jetpack/assets/support_chat_widget.html
@@ -1,0 +1,53 @@
+<html>
+<head>
+    <script type="text/javascript">
+  ;(window.DocsBotAI = window.DocsBotAI || {}),
+    (DocsBotAI.init = function (c) {
+      return new Promise(function (e, o) {
+        var t = document.createElement('script')
+        ;(t.type = 'text/javascript'), (t.async = !0), (t.src = 'https://widget.docsbot.ai/chat.js')
+        var n = document.getElementsByTagName('script')[0]
+        n.parentNode.insertBefore(t, n),
+          t.addEventListener('load', function () {
+            window.DocsBotAI.mount({
+              id: c.id,
+              supportCallback: c.supportCallback,
+              identify: c.identify,
+              options: c.options,
+            })
+            var t
+            ;(t = function (n) {
+              return new Promise(function (e) {
+                if (document.querySelector(n)) return e(document.querySelector(n))
+                var o = new MutationObserver(function (t) {
+                  document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
+                })
+                o.observe(document.body, { childList: !0, subtree: !0 })
+              })
+            }),
+              t && t('#docsbotai-root').then(e).catch(o)
+          }),
+          t.addEventListener('error', function (t) {
+            o(t.message)
+          })
+      })
+    })
+    </script>
+</head>
+<body>
+<script type="text/javascript">
+        DocsBotAI.init({
+            id: 'TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH',
+            options: {
+                horizontalMargin: 40,
+                verticalMargin: 60,
+            },
+        }).then(() => {
+            // Safely do stuff here after the widget is loaded.
+        })
+        setTimeout(() => {
+           DocsBotAI.open()
+        }, 300);
+    </script>
+</body>
+</html>

--- a/WordPress/src/jetpack/assets/support_chat_widget.html
+++ b/WordPress/src/jetpack/assets/support_chat_widget.html
@@ -1,42 +1,10 @@
 <html>
 <head>
-    <script type="text/javascript">
-  ;(window.DocsBotAI = window.DocsBotAI || {}),
-    (DocsBotAI.init = function (c) {
-      return new Promise(function (e, o) {
-        var t = document.createElement('script')
-        ;(t.type = 'text/javascript'), (t.async = !0), (t.src = 'https://widget.docsbot.ai/chat.js')
-        var n = document.getElementsByTagName('script')[0]
-        n.parentNode.insertBefore(t, n),
-          t.addEventListener('load', function () {
-            window.DocsBotAI.mount({
-              id: c.id,
-              supportCallback: c.supportCallback,
-              identify: c.identify,
-              options: c.options,
-            })
-            var t
-            ;(t = function (n) {
-              return new Promise(function (e) {
-                if (document.querySelector(n)) return e(document.querySelector(n))
-                var o = new MutationObserver(function (t) {
-                  document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
-                })
-                o.observe(document.body, { childList: !0, subtree: !0 })
-              })
-            }),
-              t && t('#docsbotai-root').then(e).catch(o)
-          }),
-          t.addEventListener('error', function (t) {
-            o(t.message)
-          })
-      })
-    })
-    </script>
+    <script type="text/javascript" src="/assets/support_chat_widget.js"></script>
 </head>
 <body>
 <script type="text/javascript">
-        DocsBotAI.init({
+    DocsBotAI.init({
             id: 'TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH',
             options: {
                 horizontalMargin: 40,
@@ -47,7 +15,7 @@
         })
         setTimeout(() => {
            DocsBotAI.open()
-        }, 300);
+        }, 200);
     </script>
 </body>
 </html>

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -1,0 +1,31 @@
+;(window.DocsBotAI = window.DocsBotAI || {}),
+    (DocsBotAI.init = function (c) {
+      return new Promise(function (e, o) {
+        var t = document.createElement('script')
+        ;(t.type = 'text/javascript'), (t.async = !0), (t.src = 'https://widget.docsbot.ai/chat.js')
+        var n = document.getElementsByTagName('script')[0]
+        n.parentNode.insertBefore(t, n),
+          t.addEventListener('load', function () {
+            window.DocsBotAI.mount({
+              id: c.id,
+              supportCallback: c.supportCallback,
+              identify: c.identify,
+              options: c.options,
+            })
+            var t
+            ;(t = function (n) {
+              return new Promise(function (e) {
+                if (document.querySelector(n)) return e(document.querySelector(n))
+                var o = new MutationObserver(function (t) {
+                  document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
+                })
+                o.observe(document.body, { childList: !0, subtree: !0 })
+              })
+            }),
+              t && t('#docsbotai-root').then(e).catch(o)
+          }),
+          t.addEventListener('error', function (t) {
+            o(t.message)
+          })
+      })
+    })

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -740,6 +740,10 @@
             android:label="@string/my_profile"
             android:theme="@style/WordPress.NoActionBar" />
 
+        <activity
+            android:name=".support.SupportWebViewActivity"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Lib activities-->
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -1,0 +1,75 @@
+package org.wordpress.android.support
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.Menu
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
+import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
+import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.ChatDetails
+import org.wordpress.android.ui.WPWebViewActivity
+
+class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        toggleNavbarVisibility(false)
+
+        val assetLoader = WebViewAssetLoader.Builder()
+            .addPathHandler("/assets/", AssetsPathHandler(this))
+            .addPathHandler("/res/", ResourcesPathHandler(this))
+            .build()
+
+        configureWebView()
+        mWebView.webViewClient = SupportWebViewClient(this, assetLoader)
+        mWebView.loadUrl("https://$DEFAULT_DOMAIN/assets/support_chat_widget.html")
+    }
+
+    override fun configureWebView() {
+        super.configureWebView()
+        supportActionBar?.hide()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        // We don't want any menu items
+        return true
+    }
+
+    override fun onChatSessionClosed() {
+        setResult(RESULT_OK, intent)
+        finish()
+    }
+
+    class OpenChatWidget : ActivityResultContract<ChatDetails, ChatCompletionEvent?>() {
+        override fun createIntent(context: Context, input: ChatDetails) =
+            Intent(context, SupportWebViewActivity::class.java).apply {
+                putExtra(USE_GLOBAL_WPCOM_USER, true)
+                putExtra(AUTHENTICATION_URL, WPCOM_LOGIN_URL)
+                putExtra(URL_TO_LOAD, input.url)
+//                putExtra(CHAT_TEXT, input.chatText)
+                putExtra(CHAT_EMAIL, input.site?.email)
+            }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): ChatCompletionEvent? {
+            val data = intent?.takeIf { it.hasExtra(CHAT_TEXT) && it.hasExtra(CHAT_EMAIL) }
+            if (resultCode == RESULT_OK && data != null) {
+                val chatText = data.getStringExtra(CHAT_TEXT).orEmpty()
+                val email = data.getStringExtra(CHAT_EMAIL).orEmpty()
+                return ChatCompletionEvent(chatText, email)
+            }
+            return null
+        }
+
+        data class ChatDetails(val site: SiteModel?, val url: String)
+
+        companion object {
+            const val CHAT_TEXT = "CHAT_TEXT"
+            const val CHAT_EMAIL = "CHAT_EMAIL"
+        }
+    }
+
+    data class ChatCompletionEvent(val chatText: String, val email: String)
+}

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.support
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.webkit.WebViewAssetLoader
+import org.wordpress.android.util.ErrorManagedWebViewClient
+
+class SupportWebViewClient(
+    private val listener: SupportWebViewClientListener,
+    private val assetLoader: WebViewAssetLoader
+) : ErrorManagedWebViewClient(listener) {
+    interface SupportWebViewClientListener : ErrorManagedWebViewClientListener {
+        fun onChatSessionClosed()
+    }
+
+    override fun shouldInterceptRequest(
+        view: WebView,
+        request: WebResourceRequest
+    ): WebResourceResponse? {
+        return assetLoader.shouldInterceptRequest(request.url)
+    }
+
+    // to support API < 21
+    override fun shouldInterceptRequest(
+        view: WebView,
+        url: String
+    ): WebResourceResponse? {
+        return assetLoader.shouldInterceptRequest(Uri.parse(url))
+    }
+}
+
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -42,6 +42,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.config.ContactSupportFeatureConfig
 import org.wordpress.android.util.image.ImageType.AVATAR_WITHOUT_BACKGROUND
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -69,6 +70,9 @@ class HelpActivity : LocaleAwareActivity() {
 
     @Inject
     lateinit var mDispatcher: Dispatcher
+
+    @Inject
+    lateinit var contactSupportFeatureConfig: ContactSupportFeatureConfig
 
     private lateinit var binding: HelpActivityBinding
 
@@ -163,6 +167,10 @@ class HelpActivity : LocaleAwareActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    private fun launchSupportWidget() {
+        // TODO
+    }
+
     private fun createNewZendeskTicket() {
         zendeskHelper.createNewTicket(
             this,
@@ -205,7 +213,13 @@ class HelpActivity : LocaleAwareActivity() {
             AnalyticsTracker.track(Stat.SUPPORT_MIGRATION_FAQ_VIEWED)
             JpFaqContainer.setOnClickListener { showMigrationFaq() }
         }
-        contactUsButton.setOnClickListener { createNewZendeskTicket() }
+        contactUsButton.setOnClickListener {
+            if (contactSupportFeatureConfig.isEnabled()) {
+                launchSupportWidget()
+            } else {
+                createNewZendeskTicket()
+            }
+        }
         ticketsButton.setOnClickListener { showZendeskTickets() }
 
         contactEmailContainer.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -29,6 +29,9 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
+import org.wordpress.android.support.SupportWebViewActivity
+import org.wordpress.android.support.SupportWebViewActivity.ChatCompletionEvent
+import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.ChatDetails
 import org.wordpress.android.support.ZendeskExtraTags
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
@@ -89,6 +92,12 @@ class HelpActivity : LocaleAwareActivity() {
     }
     private val selectedSiteFromExtras by lazy {
         intent.extras?.get(WordPress.SITE) as SiteModel?
+    }
+
+    private val openChatWidget = registerForActivityResult(SupportWebViewActivity.OpenChatWidget()) {
+        it?.let {
+            viewModel.finishSupportChat(it)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -168,7 +177,12 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun launchSupportWidget() {
-        // TODO
+        openChatWidget.launch(
+            ChatDetails(
+                selectedSiteFromExtras,
+                "https://appassets.androidplatform.net/assets/support_chat_widget.html"
+            )
+        )
     }
 
     private fun createNewZendeskTicket() {
@@ -321,6 +335,15 @@ class HelpActivity : LocaleAwareActivity() {
             // Load Main Activity once signed out, which launches the login flow
             ActivityLauncher.showMainActivity(this@HelpActivity, true)
         }
+
+        viewModel.onSupportChatCompleted.observe(this@HelpActivity) {
+            finishSupportChat(it)
+        }
+    }
+
+    private fun finishSupportChat(event: ChatCompletionEvent) {
+        setResult(RESULT_OK, Intent().putExtra(SupportWebViewActivity.OpenChatWidget.CHAT_EMAIL, event.email))
+        finish()
     }
 
     private fun HelpActivityBinding.loadAvatar(avatarUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
@@ -12,11 +12,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.support.SupportWebViewActivity
 import org.wordpress.android.support.SupportWebViewActivity.ChatCompletionEvent
-import org.wordpress.android.ui.domains.DomainRegistrationActivity
-import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
-import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
@@ -12,6 +12,11 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.support.SupportWebViewActivity
+import org.wordpress.android.support.SupportWebViewActivity.ChatCompletionEvent
+import org.wordpress.android.ui.domains.DomainRegistrationActivity
+import org.wordpress.android.ui.domains.DomainRegistrationCompletedEvent
+import org.wordpress.android.ui.domains.DomainRegistrationNavigationAction
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -32,6 +37,9 @@ class HelpViewModel @Inject constructor(
     private val _onSignOutCompleted = SingleLiveEvent<Unit?>()
     val onSignOutCompleted: LiveData<Unit?> = _onSignOutCompleted
 
+    private val _onSupportChatCompleted = SingleLiveEvent<ChatCompletionEvent>()
+    val onSupportChatCompleted: LiveData<ChatCompletionEvent> = _onSupportChatCompleted
+
     fun signOutWordPress(application: WordPress) {
         launch {
             _showSigningOutDialog.value = Event(true)
@@ -48,5 +56,13 @@ class HelpViewModel @Inject constructor(
         if (!accountStore.hasAccessToken() && siteStore.hasSiteAccessedViaXMLRPC()) {
             dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
         }
+    }
+
+    fun finishSupportChat(event: ChatCompletionEvent) {
+        endChatSession(event)
+    }
+
+    private fun endChatSession(event: ChatCompletionEvent) {
+        _onSupportChatCompleted.value = event
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ ext {
     androidxSwipeToRefreshVersion = '1.1.0'
     androidxViewpager2Version = '1.0.0'
     androidxWorkManagerVersion = "2.8.1"
+    androidxWebkitVersion =  '1.7.0'
     androidxComposeMaterial3Version = '1.1.1'
     apacheCommonsTextVersion = '1.10.0'
     coilComposeVersion = '2.3.0'


### PR DESCRIPTION
Adds contact support widget, and launch in a webview

Fixes #18827 


<img width=320 alt="Screenshot_20230725_140406" src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/366ed2a6-8ce4-4311-acb6-baf7675cfb94" />


1. Launch Jetpack app
2. Go to `Me` (Tap on Avatar in the bottom nav)
3. Tap `Debug Settings`
4. Find `contact_support` under `Remote features` tab as shown in the image above
5. Tap on Help -> Contact Support
6. `Verify` it launches Support Bot as shown above

>**Note**
> This PR only aimed at launching the bot in a WebView.  Bot itself would be tweaked in the next one 

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
