### PR TITLE
Integrate gutenberg-mobile release 1.101.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,9 @@
 23.0
 -----
 * [**] [internal] Upgrade React Native to 0.71.11 [https://github.com/wordpress-mobile/WordPress-Android/pull/18613]
+* [*] Block editor: Remove visual gap in mobile toolbar when a Gallery block is selected [https://github.com/WordPress/gutenberg/pull/52966]
+* [*] Block editor: Remove Gallery caption button on mobile [https://github.com/WordPress/gutenberg/pull/53010]
+* [*] Block editor: Fix Gallery block selection when adding media [https://github.com/WordPress/gutenberg/pull/53127]
 
 22.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = '6024-12a85bbf321238c108656233ab60e27705ad84c4'
+    gutenbergMobileVersion = 'v1.101.0'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = 'trunk-628b0b4def5df5a3d9e33c64a136cdcd0423a8a3'
     wordPressLoginVersion = '1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = 'v1.101.0-alpha2'
+    gutenbergMobileVersion = '6024-12a85bbf321238c108656233ab60e27705ad84c4'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = 'trunk-628b0b4def5df5a3d9e33c64a136cdcd0423a8a3'
     wordPressLoginVersion = '1.4.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.101.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6024

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.