### PR TITLE
[Jetpack Social] Post settings UI fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -60,7 +60,9 @@ fun TrainOfIcons(
     iconBorderColor: Color = MaterialTheme.colors.surface,
     placeholderPainter: Painter = ColorPainter(colorResource(R.color.placeholder)),
 ) {
-    require(iconModels.isNotEmpty()) { "TrainOfIcons must have at least 1 icon" }
+    if (iconModels.isEmpty()) {
+        return
+    }
 
     val iconSizeWithBorder = (iconSize.value + 2 * iconBorderWidth.value).toInt()
     val semanticsModifier = contentDescription?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapper.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.posts
 
 import org.wordpress.android.R
+import org.wordpress.android.datasets.wrappers.PublicizeTableWrapper
+import org.wordpress.android.models.PublicizeService
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.JetpackSocialUiState.Loaded
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel.JetpackSocialUiState.NoConnections
@@ -14,6 +16,7 @@ import javax.inject.Inject
 class EditPostPublishSettingsJetpackSocialUiStateMapper @Inject constructor(
     private val stringProvider: StringProvider,
     private val localeProvider: LocaleProvider,
+    private val publicizeTableWrapper: PublicizeTableWrapper,
 ) {
     @Suppress("LongParameterList")
     fun mapLoaded(
@@ -53,7 +56,10 @@ class EditPostPublishSettingsJetpackSocialUiStateMapper @Inject constructor(
         onNotNowClick: () -> Unit,
     ): NoConnections =
         NoConnections(
-            trainOfIconsModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
+            trainOfIconsModels = publicizeTableWrapper.getServiceList()
+                .filter { it.status != PublicizeService.Status.UNSUPPORTED }
+                .mapNotNull { PublicizeServiceIcon.fromServiceId(it.id) }
+                .map { TrainOfIconsModel(it.iconResId) },
             message = stringProvider.getString(
                 R.string.post_settings_jetpack_social_connect_social_profiles_message
             ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialSharesContainer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialSharesContainer.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppThemeEditor
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.posts.social.compose.PostSocialSharingItem
+import org.wordpress.android.ui.posts.social.compose.DescriptionText
 import org.wordpress.android.ui.posts.social.compose.PostSocialSharingModel
 import org.wordpress.android.ui.publicize.PublicizeServiceIcon
 
@@ -20,12 +20,13 @@ fun EditPostSettingsJetpackSocialSharesContainer(
     subscribeButtonLabel: String,
     onSubscribeClick: () -> Unit,
 ) {
-    PostSocialSharingItem(
-        model = postSocialSharingModel,
+    DescriptionText(
+        text = postSocialSharingModel.description,
+        isLowOnShares = postSocialSharingModel.isLowOnShares,
         modifier = Modifier.padding(
             vertical = Margin.ExtraLarge.value,
             horizontal = Margin.ExtraLarge.value,
-        ),
+        )
     )
     PrimaryButton(
         text = subscribeButtonLabel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapper.kt
@@ -18,11 +18,7 @@ class PostSocialSharingModelMapper @Inject constructor(
     ): PostSocialSharingModel {
         return if (shareLimit is ShareLimit.Enabled) {
             val title = mapTitle(connections)
-            val description = stringProvider.getString(
-                R.string.jetpack_social_social_shares_remaining,
-                (shareLimit.sharesRemaining - connections.filter { it.isSharingEnabled }.size)
-                    .coerceAtLeast(0)
-            )
+            val description = mapDescription(shareLimit, connections)
             val iconModels = mapIconModels(connections)
             val isLowOnShares = mapIsLowOnShares(shareLimit, connections)
             PostSocialSharingModel(
@@ -38,6 +34,16 @@ class PostSocialSharingModelMapper @Inject constructor(
                 iconModels = emptyList(),
                 isLowOnShares = false,
             )
+        }
+    }
+
+    private fun mapDescription(shareLimit: ShareLimit.Enabled, connections: List<PostSocialConnection>): String {
+        val sharesRemaining =
+            (shareLimit.sharesRemaining - connections.filter { it.isSharingEnabled }.size).coerceAtLeast(0)
+        return if (sharesRemaining == 1) {
+            stringProvider.getString(R.string.jetpack_social_social_shares_remaining_one)
+        } else {
+            stringProvider.getString(R.string.jetpack_social_social_shares_remaining, sharesRemaining)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharingItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharingItem.kt
@@ -108,7 +108,7 @@ private val defaultDescriptionStyle: TextStyle
         .copy(color = AppColor.Gray30)
 
 @Composable
-private fun DescriptionText(
+fun DescriptionText(
     text: String,
     isLowOnShares: Boolean,
     modifier: Modifier = Modifier,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1719,7 +1719,8 @@
     <string name="post_settings_jetpack_social_subscribe_share_more">Subscribe to share more</string>
     <string name="post_settings_jetpack_social_share_message_title">Customize the message</string>
     <string name="post_settings_jetpack_social_share_message_description">Customize the message you want to share. If you don\'t add your own text here, we\'ll use the post\'s title as the message.</string>
-    <string name="jetpack_social_social_shares_remaining">%1$d Social shares remaining</string>
+    <string name="jetpack_social_social_shares_remaining">%1$d social shares remaining</string>
+    <string name="jetpack_social_social_shares_remaining_one">1 social share remaining</string>
     <string name="jetpack_social_social_shares_title_not_sharing">Not sharing to social</string>
     <string name="jetpack_social_social_shares_title_single_account">Sharing to %1$s</string>
     <string name="jetpack_social_social_shares_title_part_of_the_accounts">Sharing to %1$d of %2$d accounts</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapperTest.kt
@@ -114,7 +114,7 @@ class PostSocialSharingModelMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should map description correctly`() {
+    fun `Should map description correctly (multiple shares)`() {
         val connections = listOf(
             postSocialConnection(isSharingEnabled = false),
         )
@@ -125,6 +125,25 @@ class PostSocialSharingModelMapperTest : BaseUnitTest() {
             shareLimit = shareLimitEnabled,
         ).description
         assertThat(actual).isEqualTo(description)
+    }
+
+    @Test
+    fun `Should map description correctly (one share)`() {
+        val descriptionOneShare = "One share remaining"
+        val connections = listOf(
+            postSocialConnection(isSharingEnabled = false),
+        )
+        mockTitleSharingToZeroAccounts("")
+        whenever(stringProvider.getString(R.string.jetpack_social_social_shares_remaining_one))
+            .thenReturn(descriptionOneShare)
+        val shareLimit = shareLimitEnabled.copy(
+            sharesRemaining = 1,
+        )
+        val actual = classToTest.map(
+            connections = connections,
+            shareLimit = shareLimit,
+        ).description
+        assertThat(actual).isEqualTo(descriptionOneShare)
     }
 
     @Test
@@ -207,10 +226,11 @@ class PostSocialSharingModelMapperTest : BaseUnitTest() {
         val connections = listOf(
             postSocialConnection(isSharingEnabled = false),
             postSocialConnection(isSharingEnabled = false),
+            postSocialConnection(isSharingEnabled = false),
         )
         mockTitleSharingToZeroAccounts("")
         val shareLimit = shareLimitEnabled.copy(
-            sharesRemaining = 1,
+            sharesRemaining = 2,
         )
         mockDescription(connections, shareLimit)
         val actual = classToTest.map(


### PR DESCRIPTION
## Fix share limit UI
Unlike pre-publishing screen, we should only be showing the description part of the share limit UI in post settings.

Before:
<img width="362" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/1bc61760-b7b9-4b57-b8b7-a862054cb171">

After:
<img width="362" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/962f67cb-bba0-4f02-84b5-6ed9aaf8718d">

To test:
1 - Enable JetpackSocialFeatureConfig feature flag;
2 - Select a SH site with Jetpack plugin or Jetpack Social plugin installed;
3 - Make sure you have at least one social sharing account connected;
4 - Open post list;
5 - Select a draft or create a new one;
6 - Tap the overflow menu and select "Post settings";
7 - Scroll down to the "Social Sharing" section: you should only see the description part of the share limit UI (e.g. `30 social shares remaining`)
8 - Select a site like step 2 but with more accounts than remaining shares (e.g. 2 social sharing accounts connected and 1 remaining share);
9 - Go back to "Social Sharing" section in post settings: you should see a yellow exclamation point next to the description.

## Fix publicize service icons in no connection UI
We were showing publicize service icons of unsupported services. With this fix we're only showing the icons of supported services.

<img width="362" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/bee5aa4d-8994-4f07-bfa2-2f08b1b46513">


To test:
1 - Enable JetpackSocialFeatureConfig feature flag;
2 - Make sure you have no sharing accounts connected;
3 - Select a SH site with Jetpack plugin or Jetpack Social plugin installed;
4 - Open post list;
5 - Select a draft or create a new one;
6 - Tap the overflow menu and select "Post settings";
7 - Scroll down to the "Social Sharing" section;
8 - The no connections UI should be shown. Observe the icons: you should only see the supported publicize services. Currently they are: Tumblr, Facebook, Instagram Business, LinkedIn, Mastodon.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated `PostSocialSharingModelMapperTest.kt`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
