### PR TITLE
[TEST] Force crash when rendering an unsupported block

### DIFF
--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -34,6 +34,8 @@
         <activity
             android:name=".ui.debug.previews.PreviewFragmentActivity"
             android:theme="@style/WordPress.NoActionBar" />
+
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = 'v1.101.0'
+    gutenbergMobileVersion = '6031-5300fc29c154328a9a0d57f5fd1a282de1784599'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = 'trunk-544130cbf7535c5cbcbcced125fc49f22befe3bb'
     wordPressLoginVersion = '1.4.0'


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
