### PR TITLE
[JP Social/Pre-publish] Load JP Social item for pre-publish sheet on PostsListActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
@@ -59,10 +59,15 @@ class EditorJetpackSocialViewModel @Inject constructor(
     private lateinit var shareLimit: ShareLimit
     private val connections = mutableListOf<PostSocialConnection>()
 
+    var isStarted: Boolean = false
+
     private val currentPost: PostImmutableModel?
         get() = editPostRepository.getPost()
 
     fun start(siteModel: SiteModel, editPostRepository: EditPostRepository) {
+        if (isStarted) return
+
+        isStarted = true
         this.siteModel = siteModel
         this.editPostRepository = editPostRepository
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
@@ -1,13 +1,17 @@
 package org.wordpress.android.ui.posts.prepublishing
 
+import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -19,8 +23,12 @@ import org.wordpress.android.databinding.PostPrepublishingBottomSheetBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPBottomSheetDialogFragment
+import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
+import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenEditShareMessage
+import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenSocialConnectionsList
+import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenSubscribeJetpackSocial
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.ADD_CATEGORY
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.CATEGORIES
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingScreen.HOME
@@ -39,6 +47,8 @@ import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingSocia
 import org.wordpress.android.ui.posts.prepublishing.publishsettings.PrepublishingPublishSettingsFragment
 import org.wordpress.android.ui.posts.prepublishing.social.PrepublishingSocialFragment
 import org.wordpress.android.ui.posts.prepublishing.tags.PrepublishingTagsFragment
+import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
+import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity.Companion.createIntent
 import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.KeyboardResizeViewUtil
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -60,6 +70,9 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
 
     private var prepublishingBottomSheetListener: PrepublishingBottomSheetListener? = null
 
+    private var jetpackSocialViewModel: EditorJetpackSocialViewModel? = null
+    private lateinit var editShareMessageActivityResultLauncher: ActivityResultLauncher<Intent>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireNotNull(activity).application as WordPress).component().inject(this)
@@ -71,6 +84,19 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             context
         } else {
             throw RuntimeException("$context must implement PrepublishingBottomSheetListener")
+        }
+
+        editShareMessageActivityResultLauncher = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.let {
+                    val shareMessage = it.getStringExtra(
+                        EditJetpackSocialShareMessageActivity.RESULT_UPDATED_SHARE_MESSAGE
+                    )
+                    getEditorJetpackSocialViewModel().onJetpackSocialShareMessageChanged(shareMessage)
+                }
+            }
         }
     }
 
@@ -279,17 +305,48 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     override fun getEditorJetpackSocialViewModel(): EditorJetpackSocialViewModel {
-        return ViewModelProvider(
-            requireActivity(), // try using the activity-scoped ViewModel, but only if it's started
-            viewModelFactory
-        )[EditorJetpackSocialViewModel::class.java].takeIf {
-            it.isStarted
-        } ?: ViewModelProvider(
-            this, // if not, let's use our own scope to create the ViewModel and start it
-            viewModelFactory
-        )[EditorJetpackSocialViewModel::class.java].also {
-            val hook = getEditorHook()
-            it.start(hook.site, hook.editPostRepository)
+        jetpackSocialViewModel?.let {
+            return it
+        } ?: run {
+            val viewModel = ViewModelProvider(
+                requireActivity(), // try using the activity-scoped ViewModel, but only if it's started
+                viewModelFactory
+            )[EditorJetpackSocialViewModel::class.java].takeIf {
+                it.isStarted
+            } ?: run {
+                ViewModelProvider(
+                    this, // if not, let's use our own scope to create the ViewModel and start it
+                    viewModelFactory
+                )[EditorJetpackSocialViewModel::class.java].also {
+                    val hook = getEditorHook()
+                    it.start(hook.site, hook.editPostRepository)
+                    // let's also handle the action events
+                    it.actionEvents.observe(viewLifecycleOwner) { actionEvent ->
+                        when (actionEvent) {
+                            is OpenEditShareMessage -> {
+                                val intent = createIntent(
+                                    requireActivity(),
+                                    actionEvent.shareMessage
+                                )
+                                editShareMessageActivityResultLauncher.launch(intent)
+                            }
+
+                            is OpenSocialConnectionsList -> {
+                                ActivityLauncher.viewBlogSharing(requireActivity(), actionEvent.siteModel)
+                            }
+
+                            is OpenSubscribeJetpackSocial -> {
+                                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(
+                                    requireActivity(),
+                                    actionEvent.url
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            return viewModel.also { jetpackSocialViewModel = it }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostSettingsFragment
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingActionClickedListener
+import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingSocialViewModelProvider
 import org.wordpress.android.ui.stats.refresh.utils.WrappingLinearLayoutManager
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
@@ -124,10 +125,8 @@ class PrepublishingHomeFragment : Fragment(R.layout.post_prepublishing_home_frag
     }
 
     private fun setupJetpackSocialViewModel() {
-        jetpackSocialViewModel = ViewModelProvider(
-            requireActivity(),
-            viewModelFactory
-        )[EditorJetpackSocialViewModel::class.java]
+        jetpackSocialViewModel = (parentFragment as PrepublishingSocialViewModelProvider)
+            .getEditorJetpackSocialViewModel()
 
         merge(
             jetpackSocialViewModel.jetpackSocialUiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/listeners/PrepublishingSocialViewModelProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/listeners/PrepublishingSocialViewModelProvider.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.posts.prepublishing.listeners
+
+import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
+
+interface PrepublishingSocialViewModelProvider {
+    fun getEditorJetpackSocialViewModel(): EditorJetpackSocialViewModel
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.compose.utils.withBottomSheetElevation
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel
+import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingSocialViewModelProvider
 import org.wordpress.android.ui.posts.prepublishing.social.compose.PrepublishingSocialScreen
 import javax.inject.Inject
 
@@ -59,10 +60,7 @@ class PrepublishingSocialFragment : Fragment(R.layout.prepublishing_social_fragm
             viewModelFactory
         )[PrepublishingViewModel::class.java]
 
-        socialViewModel = ViewModelProvider(
-            requireActivity(),
-            viewModelFactory
-        )[EditorJetpackSocialViewModel::class.java]
+        socialViewModel = (parentFragment as PrepublishingSocialViewModelProvider).getEditorJetpackSocialViewModel()
     }
 
     private fun setupObservers() {


### PR DESCRIPTION
This can only be merged after PR #18892

On the PostsListActivity, if the user selects `Publish` on a Draft post, it shows the pre-publish bottom sheet, and that was not properly loading the JP Social item.

This PRs fixes this by loading the JP Social data and showing the item with the correct information for the selected post, letting the user choose the social settings for the post.

One downside here is that since the fetching only starts after the bottom sheet is already visible, the load time for the item is pretty noticeable, so we might want to look into implementing some loading state or something, in the future. Wdyt, @osullivanchris ?

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/a808b111-7df9-4188-88d4-0acefb6e5552

To test:
1. Open the app
2. Enable the FeatureInDevelopment for JP Social in Debug Settings
3. Go to the Posts list
4. Go to Drafts (create a draft if there's none available)
5. Tap the `Publish` action for the draft post
6. **Verify** the social item appears
7. **Verify** the social item can be interacted with and works as expected

## Regression Notes
1. Potential unintended areas of impact
N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

9. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
