### PR TITLE
[JP Social] Create improvements feature config and enable it by default

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 * [*] Block editor: Remove visual gap in mobile toolbar when a Gallery block is selected [https://github.com/WordPress/gutenberg/pull/52966]
 * [*] Block editor: Remove Gallery caption button on mobile [https://github.com/WordPress/gutenberg/pull/53010]
 * [*] Block editor: Fix Gallery block selection when adding media [https://github.com/WordPress/gutenberg/pull/53127]
-* [***] Jetpack Social: Control your post's social sharing settings from the post editor [https://github.com/wordpress-mobile/WordPress-Android/pull/18897]
+* [***] [Jetpack-only] Jetpack Social: Control your post's social sharing settings from the post editor [https://github.com/wordpress-mobile/WordPress-Android/pull/18897]
 
 22.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Block editor: Remove visual gap in mobile toolbar when a Gallery block is selected [https://github.com/WordPress/gutenberg/pull/52966]
 * [*] Block editor: Remove Gallery caption button on mobile [https://github.com/WordPress/gutenberg/pull/53010]
 * [*] Block editor: Fix Gallery block selection when adding media [https://github.com/WordPress/gutenberg/pull/53127]
+* [***] Jetpack Social: Control your post's social sharing settings from the post editor [https://github.com/wordpress-mobile/WordPress-Android/pull/18897]
 
 22.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackSocialFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackSocialFeatureConfig.kt
@@ -1,13 +1,16 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val JETPACK_SOCIAL_REMOTE_FIELD = "jetpack_social_improvements_v1"
+
+@Feature(JETPACK_SOCIAL_REMOTE_FIELD, defaultValue = true)
 class JetpackSocialFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
     appConfig,
     BuildConfig.JETPACK_SOCIAL,
+    JETPACK_SOCIAL_REMOTE_FIELD,
 )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackSocialFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackSocialFeatureConfig.kt
@@ -13,4 +13,8 @@ class JetpackSocialFeatureConfig @Inject constructor(
     appConfig,
     BuildConfig.JETPACK_SOCIAL,
     JETPACK_SOCIAL_REMOTE_FIELD,
-)
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}


### PR DESCRIPTION
Should be merged only after #18895

Sets the remote field `jetpack_social_improvements_v1`  to the `JetpackSocialFeatureConfig` and enables it by default.

To test:
1. Open the app
2. Go to Debug Settings
3. **Verify** the `jetpack_social_improvements_v1` FeatureConfig is enabled by default
4. Go to Posts
5. Open a Draft post / create a new post
6. Open the Post Settings
7. **Verify** the JP Social section is available
8. Hit `Publish`
9. **Verify** the JP Social item is available in the pre-publish sheet

## Regression Notes
1. Potential unintended areas of impact
N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

11. What automated tests I added (or what prevented me from doing so)
N/A, just feature flag work.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.