### PR TITLE
[Nullability Annotations to Java Classes] Replace `org.jetbrains` with `androidx` annotations

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/ImeTestRule.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/ImeTestRule.java
@@ -5,10 +5,10 @@ import android.content.Context;
 import android.provider.Settings;
 import android.view.inputmethod.InputMethodManager;
 
+import androidx.annotation.NonNull;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -33,13 +33,13 @@ public class ImeTestRule implements TestRule {
         this(LATIN_IME);
     }
 
-    public ImeTestRule(@NotNull String allowedIme) {
+    public ImeTestRule(@NonNull String allowedIme) {
         Objects.requireNonNull(allowedIme);
         this.mAllowedIme = allowedIme;
     }
 
     @Override
-    public Statement apply(@NotNull final Statement base, @NotNull Description description) {
+    public Statement apply(@NonNull final Statement base, @NonNull Description description) {
         Statement statement = new Statement() {
             @Override
             public void evaluate() throws Throwable {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -18,7 +18,6 @@ import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
 import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener;
 import com.google.android.material.snackbar.Snackbar;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -900,7 +899,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     }
 
     @Override
-    public void onPositiveClicked(@NotNull String instanceTag) {
+    public void onPositiveClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
             case GOOGLE_ERROR_DIALOG_TAG:
                 // just dismiss the dialog

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
@@ -296,7 +297,7 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
-    public void trackConnectedSiteInfoSucceeded(@NotNull Map<String, ?> properties) {
+    public void trackConnectedSiteInfoSucceeded(@NonNull Map<String, ?> properties) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_CONNECTED_SITE_INFO_SUCCEEDED, properties);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/BaseUsernameChangerFullScreenDialogFragment.java
@@ -27,7 +27,6 @@ import com.google.android.material.textfield.TextInputEditText;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -266,7 +265,7 @@ public abstract class BaseUsernameChangerFullScreenDialogFragment extends Fragme
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(KEY_IS_SHOWING_DISMISS_DIALOG, mIsShowingDismissDialog);
         outState.putBoolean(KEY_SHOULD_WATCH_TEXT, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -37,7 +37,6 @@ import com.yalantis.ucrop.UCropActivity;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -70,13 +69,13 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
+import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageManager.RequestListener;
 import org.wordpress.android.util.image.ImageType;
@@ -632,7 +631,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                         }
 
                         @Override
-                        public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
+                        public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                             if (newAvatarUploaded && resource instanceof BitmapDrawable) {
                                 Bitmap bitmap = ((BitmapDrawable) resource).getBitmap();
                                 // create a copy since the original bitmap may by automatically recycled

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -39,7 +39,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -257,7 +256,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         if (mComment != null) {
             outState.putLong(KEY_COMMENT_ID, mComment.getRemoteCommentId());
@@ -592,7 +591,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     @SuppressWarnings("deprecation") // TODO: Remove when minSdkVersion >= 23
-    public void onAttach(@NotNull Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
         if (activity instanceof OnPostClickListener) {
             mOnPostClickListener = (OnPostClickListener) activity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -14,6 +14,7 @@ import android.widget.EditText;
 import android.widget.ProgressBar;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -22,7 +23,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.NotificationsTable;
@@ -114,7 +114,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
 
         if (mCancelEditCommentDialog != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -42,7 +42,6 @@ import com.google.android.material.tabs.TabLayout;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -446,7 +445,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
 
         outState.putString(SAVED_QUERY, mQuery);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -57,7 +57,6 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.editor.EditorImageMetaData;
@@ -445,7 +444,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(ARG_MEDIA_LOCAL_ID, mMedia.getId());
         outState.putParcelable(ARG_EDITOR_IMAGE_METADATA, mEditorImageMetaData);
@@ -768,7 +767,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         mImageManager.loadWithResultListener(mImageView, ImageType.IMAGE, imageUrl, ScaleType.CENTER, null,
                 new RequestListener<Drawable>() {
                     @Override
-                    public void onResourceReady(@NotNull Drawable resource, @Nullable Object model) {
+                    public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                         if (!isFinishing()) {
                             showProgress(false);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -24,7 +24,6 @@ import com.google.android.material.appbar.AppBarLayout;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -262,7 +261,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         mViewPager.addOnPageChangeListener(mOnPageChangeListener);
     }
 
-    private void trackCommentNote(@NotNull Note note) {
+    private void trackCommentNote(@NonNull Note note) {
         if (note.isCommentType()) {
             SiteModel site = mSiteStore.getSiteBySiteId(note.getSiteId());
             AnalyticsUtils.trackCommentActionWithSiteDetails(
@@ -587,7 +586,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
     }
 
     @Override
-    public void onPositiveClicked(@NotNull String instanceTag) {
+    public void onPositiveClicked(@NonNull String instanceTag) {
         Fragment fragment = mAdapter.getItem(mViewPager.getCurrentItem());
         if (fragment instanceof BasicFragmentDialog.BasicDialogPositiveClickInterface) {
             ((BasicDialogPositiveClickInterface) fragment).onPositiveClicked(instanceTag);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
@@ -5,7 +5,8 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.tools.FormattableContent;
 import org.wordpress.android.fluxc.tools.FormattableRange;
@@ -81,7 +82,7 @@ public class FooterNoteBlock extends NoteBlock {
         return view;
     }
 
-    @NotNull
+    @NonNull
     private String getNoticonGlyph() {
         return FormattableContentUtilsKt.getRangeValueOrEmpty(getNoteData(), 0);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -31,7 +31,6 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.android.material.textview.MaterialTextView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -330,11 +329,11 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         }
 
         mUsernamesEmails.setItemsManager(new ItemsManagerInterface() {
-            @Override public void onRemoveItem(@NotNull String item) {
+            @Override public void onRemoveItem(@NonNull String item) {
                 removeUsername(item);
             }
 
-            @Override public void onAddItem(@NotNull String item) {
+            @Override public void onAddItem(@NonNull String item) {
                 addUsername(item, null);
             }
         });
@@ -412,7 +411,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         }
     }
 
-    private void addUsername(@NotNull String username, ValidationEndListener validationEndListener) {
+    private void addUsername(@NonNull String username, ValidationEndListener validationEndListener) {
         if (username.isEmpty() || mUsernamesEmails.containsChip(username)) {
             if (validationEndListener != null) {
                 validationEndListener.onValidationEnd();

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -11,19 +11,20 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 
 import org.apache.commons.text.StringEscapeUtils;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PeopleTable;
 import org.wordpress.android.fluxc.model.RoleModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.models.JetpackPoweredScreen;
 import org.wordpress.android.models.Person;
 import org.wordpress.android.models.RoleUtils;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
@@ -31,7 +32,6 @@ import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.JetpackBrandingUtils;
-import org.wordpress.android.models.JetpackPoweredScreen;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -101,7 +101,7 @@ public class PersonDetailFragment extends Fragment {
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putLong(ARG_CURRENT_USER_ID, mCurrentUserId);
         outState.putLong(ARG_PERSON_ID, mPersonId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
@@ -16,7 +16,6 @@ import androidx.fragment.app.DialogFragment;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.greenrobot.eventbus.EventBus;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.RoleModel;
@@ -42,7 +41,7 @@ public class RoleChangeDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         String role = mRoleListAdapter.getSelectedRole();
         outState.putSerializable(ROLE_TAG, role);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -30,7 +30,6 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 
 import com.google.android.material.appbar.AppBarLayout;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -151,7 +150,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         mViewModel.writeToBundle(outState);
     }
@@ -373,15 +372,15 @@ public class PluginBrowserActivity extends LocaleAwareActivity
             return mItems.getItemId(position);
         }
 
-        @NotNull
+        @NonNull
         @Override
-        public ViewHolder onCreateViewHolder(@NotNull ViewGroup parent, int viewType) {
+        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
             View view = mLayoutInflater.inflate(R.layout.plugin_browser_row, parent, false);
             return new PluginBrowserViewHolder(view);
         }
 
         @Override
-        public void onBindViewHolder(@NotNull ViewHolder viewHolder, int position) {
+        public void onBindViewHolder(@NonNull ViewHolder viewHolder, int position) {
             PluginBrowserViewHolder holder = (PluginBrowserViewHolder) viewHolder;
             ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
             if (plugin == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -40,7 +40,6 @@ import com.google.android.material.snackbar.Snackbar;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -346,7 +345,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     }
 
     @Override
-    public void onPositiveClicked(@NotNull String instanceTag) {
+    public void onPositiveClicked(@NonNull String instanceTag) {
         // do nothing
     }
 
@@ -426,7 +425,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putString(KEY_PLUGIN_SLUG, mSlug);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -24,7 +24,6 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -32,10 +31,10 @@ import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.models.networkresource.ListState;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.ColorUtils;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -155,7 +154,7 @@ public class PluginListFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, @NotNull MenuInflater inflater) {
+    public void onCreateOptionsMenu(Menu menu, @NonNull MenuInflater inflater) {
         menu.clear();
         super.onCreateOptionsMenu(menu, inflater);
     }
@@ -226,15 +225,15 @@ public class PluginListFragment extends Fragment {
             return mItems.size();
         }
 
-        @NotNull
+        @NonNull
         @Override
-        public RecyclerView.ViewHolder onCreateViewHolder(@NotNull ViewGroup parent, int viewType) {
+        public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
             View view = mLayoutInflater.inflate(R.layout.plugin_list_row, parent, false);
             return new PluginViewHolder(view);
         }
 
         @Override
-        public void onBindViewHolder(@NotNull RecyclerView.ViewHolder viewHolder, int position) {
+        public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
             ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
             if (plugin == null) {
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -51,7 +51,6 @@ import com.google.android.material.snackbar.Snackbar;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -174,8 +173,8 @@ import org.wordpress.android.ui.posts.editor.media.AddExistingMediaSource;
 import org.wordpress.android.ui.posts.editor.media.EditorMedia;
 import org.wordpress.android.ui.posts.editor.media.EditorMediaListener;
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment;
-import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingBottomSheetListener;
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.PublishPostImmediatelyUseCase;
+import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingBottomSheetListener;
 import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.AztecVideoLoader;
@@ -1295,7 +1294,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
      * called by PhotoPickerFragment when media is selected - may be a single item or a list of items
      */
     @Override
-    public void onPhotoPickerMediaChosen(@NotNull final List<? extends Uri> uriList) {
+    public void onPhotoPickerMediaChosen(@NonNull final List<? extends Uri> uriList) {
         mEditorPhotoPicker.hidePhotoPicker();
         mEditorMedia.onPhotoPickerMediaChosen(uriList);
     }
@@ -1536,7 +1535,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     private RemotePreviewLogicHelper.RemotePreviewHelperFunctions getEditPostActivityStrategyFunctions() {
         return new RemotePreviewLogicHelper.RemotePreviewHelperFunctions() {
             @Override
-            public boolean notifyUploadInProgress(@NotNull PostImmutableModel post) {
+            public boolean notifyUploadInProgress(@NonNull PostImmutableModel post) {
                 if (UploadService.hasInProgressMediaUploadsForPost(post)) {
                     ToastUtils.showToast(EditPostActivity.this,
                             getString(R.string.editor_toast_uploading_please_wait), Duration.SHORT);
@@ -1995,7 +1994,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 // This method handles the custom Exception thrown by Aztec to notify the parent app of the error #8828
                 // We don't need to log the error, since it was already logged by Aztec, instead we need to write the
                 // prefs to disable HW acceleration for it.
-                private boolean isError8828(@NotNull Throwable throwable) {
+                private boolean isError8828(@NonNull Throwable throwable) {
                     if (!(throwable instanceof DynamicLayoutGetBlockIndexOutOfBoundsException)) {
                         return false;
                     }
@@ -2008,12 +2007,12 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 }
 
                 @Override
-                public void log(@NotNull String s) {
+                public void log(@NonNull String s) {
                     AppLog.e(T.EDITOR, s);
                 }
 
                 @Override
-                public void logException(@NotNull Throwable throwable) {
+                public void logException(@NonNull Throwable throwable) {
                     if (isError8828(throwable)) {
                         return;
                     }
@@ -2021,7 +2020,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 }
 
                 @Override
-                public void logException(@NotNull Throwable throwable, String s) {
+                public void logException(@NonNull Throwable throwable, String s) {
                     if (isError8828(throwable)) {
                         return;
                     }
@@ -2407,7 +2406,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         }
 
         @Override
-        public @NotNull Object instantiateItem(@NotNull ViewGroup container, int position) {
+        public @NonNull Object instantiateItem(@NonNull ViewGroup container, int position) {
             Fragment fragment = (Fragment) super.instantiateItem(container, position);
             switch (position) {
                 case PAGE_CONTENT:
@@ -3881,11 +3880,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     // EditorMediaListener
     @Override
-    public void appendMediaFiles(@NotNull Map<String, ? extends MediaFile> mediaFiles) {
+    public void appendMediaFiles(@NonNull Map<String, ? extends MediaFile> mediaFiles) {
         mEditorFragment.appendMediaFiles((Map<String, MediaFile>) mediaFiles);
     }
 
-    @NotNull @Override
+    @NonNull @Override
     public PostImmutableModel getImmutablePost() {
         return Objects.requireNonNull(mEditPostRepository.getPost());
     }
@@ -3895,12 +3894,12 @@ public class EditPostActivity extends LocaleAwareActivity implements
         updateAndSavePostAsync(listener);
     }
 
-    @Override public void advertiseImageOptimization(@NotNull Function0<Unit> listener) {
+    @Override public void advertiseImageOptimization(@NonNull Function0<Unit> listener) {
         WPMediaUtils.advertiseImageOptimization(this, listener::invoke);
     }
 
     @Override
-    public void onMediaModelsCreatedFromOptimizedUris(@NotNull Map<Uri, ? extends MediaModel> oldUriToMediaModels) {
+    public void onMediaModelsCreatedFromOptimizedUris(@NonNull Map<Uri, ? extends MediaModel> oldUriToMediaModels) {
         // no op - we're not doing any special handling on MediaModels in EditPostActivity
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -20,13 +20,13 @@ import android.view.ViewGroup;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -251,7 +251,7 @@ public class AppSettingsFragment extends PreferenceFragment
         }
     }
 
-    private void openPreference(@NotNull String key, @NotNull Stat event) {
+    private void openPreference(@NonNull String key, @NonNull Stat event) {
         final PreferenceScreen preferenceScreen = getPreferenceScreen();
         final ListAdapter listAdapter = preferenceScreen.getRootAdapter();
 
@@ -706,7 +706,7 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     @Override
-    public void onLocaleSelected(@NotNull String languageCode) {
+    public void onLocaleSelected(@NonNull String languageCode) {
         onPreferenceChange(mLanguagePreference, languageCode);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.ArrayUtils;
@@ -293,9 +292,9 @@ public class DetailListPreference extends ListPreference
             super(context, resource, new ArrayList<>(Arrays.asList(objects)));
         }
 
-        @NotNull
+        @NonNull
         @Override
-        public View getView(final int position, View convertView, @NotNull ViewGroup parent) {
+        public View getView(final int position, View convertView, @NonNull ViewGroup parent) {
             if (convertView == null) {
                 convertView = View.inflate(getContext(), R.layout.detail_list_preference, null);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MultiSelectRecyclerViewAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MultiSelectRecyclerViewAdapter.java
@@ -6,9 +6,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public class MultiSelectRecyclerViewAdapter extends RecyclerView.Adapter<MultiSe
         holder.mContainer.setSelected(isItemSelected(position));
     }
 
-    @NotNull @Override
+    @NonNull @Override
     public ItemHolder onCreateViewHolder(ViewGroup parent, int type) {
         return new ItemHolder(
                 LayoutInflater.from(parent.getContext()).inflate(R.layout.wp_simple_list_item_1, parent, false));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -53,7 +53,6 @@ import com.google.android.material.snackbar.Snackbar;
 import org.apache.commons.text.StringEscapeUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -2175,7 +2174,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     // Using an interface callback, cause this SiteSettingsFragment is a extending deprecated PreferenceFragment.  So,
     // can't use neither setTargetFragment nor onActivityResult before re-writing this!
     @Override
-    public void onSelectTimezone(@NotNull String timezone) {
+    public void onSelectTimezone(@NonNull String timezone) {
         mSiteSettings.setTimezone(timezone);
         onPreferenceChange(mTimezonePref, timezone);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -32,7 +32,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.apache.commons.text.StringEscapeUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -200,7 +199,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putBoolean(KEY_IS_SEARCHING, mIsSearching);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserListAdapter.java
@@ -8,9 +8,9 @@ import android.widget.ImageView;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.PublicizeConnection;
@@ -40,7 +40,7 @@ public class PublicizeAccountChooserListAdapter
     }
 
     @Override
-    public @NotNull ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public @NonNull ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext())
                                   .inflate(R.layout.publicize_connection_list_item, parent, false);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -9,7 +9,6 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -109,7 +108,7 @@ public class PublicizeButtonPrefsFragment extends PublicizeBaseFragment implemen
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -9,7 +9,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
@@ -81,7 +80,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putString(PublicizeConstants.ARG_SERVICE_ID, mServiceId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.MenuItem;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -19,7 +20,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -104,7 +104,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -20,7 +20,6 @@ import com.google.android.material.snackbar.Snackbar;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -304,13 +303,13 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
     }
 
     @Override
-    public void onAttach(@NotNull Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
 
         if (activity instanceof PublicizeButtonPrefsListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -7,9 +7,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
@@ -94,7 +94,7 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
         return mConnections.get(position).connectionId;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public ConnectionViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -13,7 +13,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
@@ -56,7 +55,7 @@ public class ReaderActivityLauncher {
         context.startActivity(intent);
     }
 
-    @NotNull
+    @NonNull
     public static Intent buildReaderPostDetailIntent(Context context, boolean isFeed, long blogId, long postId,
                                                       DirectOperation directOperation, int commentId,
                                                       boolean isRelatedPost, String interceptedUri) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -1,9 +1,10 @@
 package org.wordpress.android.ui.reader.actions;
 
+import androidx.annotation.NonNull;
+
 import com.wordpress.rest.RestRequest;
 
 import org.greenrobot.eventbus.EventBus;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
@@ -87,7 +88,7 @@ public class ReaderTagActions {
         return true;
     }
 
-    public static boolean addTag(@NotNull final ReaderTag tag,
+    public static boolean addTag(@NonNull final ReaderTag tag,
                                  final ReaderActions.ActionListener actionListener,
                                  final boolean isLoggedIn) {
         ReaderTagList tags = new ReaderTagList();
@@ -95,12 +96,12 @@ public class ReaderTagActions {
         return addTags(tags, actionListener, isLoggedIn);
     }
 
-    public static boolean addTags(@NotNull final List<ReaderTag> tags,
+    public static boolean addTags(@NonNull final List<ReaderTag> tags,
                                   final boolean isLoggedIn) {
         return addTags(tags, null, isLoggedIn);
     }
 
-    public static boolean addTags(@NotNull final List<ReaderTag> tags,
+    public static boolean addTags(@NonNull final List<ReaderTag> tags,
                                   final ReaderActions.ActionListener actionListener,
                                   final boolean isLoggedIn) {
         ReaderTagList newTags = new ReaderTagList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -57,12 +56,12 @@ import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ColorUtils;
-import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.extensions.ContextExtensionsKt;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
@@ -314,7 +313,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void toggleFollowButton(
             Context context,
-            @NotNull ReaderTag currentTag,
+            @NonNull ReaderTag currentTag,
             TagHeaderViewHolder tagHolder
     ) {
         if (!NetworkUtils.checkConnection(context)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionRecyclerAdapter.java
@@ -8,9 +8,9 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderSearchTable;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionRecyclerAdapter.SearchSuggestionHolder;
@@ -33,7 +33,7 @@ public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<
     }
 
     @Override
-    @NotNull
+    @NonNull
     public SearchSuggestionHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         final Context context = parent.getContext();
         final View view =
@@ -42,7 +42,7 @@ public class ReaderSearchSuggestionRecyclerAdapter extends RecyclerView.Adapter<
     }
 
     @Override
-    public void onBindViewHolder(@NotNull SearchSuggestionHolder holder, int position) {
+    public void onBindViewHolder(@NonNull SearchSuggestionHolder holder, int position) {
         if (isLast(position)) {
             onBindClearAllViewHolder(holder);
         } else if (!mCursor.moveToPosition(position)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -8,7 +8,6 @@ import android.view.View;
 import androidx.annotation.NonNull;
 
 import org.apache.commons.text.StringEscapeUtils;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
@@ -523,7 +522,7 @@ public class ReaderUtils {
         return slugs.toString();
     }
 
-    public static ReaderTagList getTagsFromCommaSeparatedSlugs(@NotNull String commaSeparatedTagSlugs) {
+    public static ReaderTagList getTagsFromCommaSeparatedSlugs(@NonNull String commaSeparatedTagSlugs) {
         ReaderTagList tags = new ReaderTagList();
         if (!commaSeparatedTagSlugs.trim().equals("")) {
             for (String slug : commaSeparatedTagSlugs.split(",", -1)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -19,7 +19,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -135,7 +134,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     }
 
     @Override
-    protected void onSaveInstanceState(@NotNull Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -17,12 +17,12 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.elevation.ElevationOverlayProvider;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -197,7 +197,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public void onSaveInstanceState(@NotNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         if (mSearchMenuItem != null && mSearchMenuItem.isActionViewExpanded()) {
             outState.putString(KEY_LAST_SEARCH, mSearchView.getQuery().toString());
@@ -206,7 +206,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public void onCreateOptionsMenu(@NotNull Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.search, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/Mp4ComposerVideoOptimizer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/Mp4ComposerVideoOptimizer.java
@@ -5,7 +5,6 @@ import androidx.annotation.NonNull;
 import com.daasuu.mp4compose.composer.ComposerInterface;
 import com.daasuu.mp4compose.composer.Listener;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -50,7 +49,7 @@ public class Mp4ComposerVideoOptimizer extends VideoOptimizerBase implements Lis
     }
 
     @Override
-    public void onFailed(@NotNull Exception exception) {
+    public void onFailed(@NonNull Exception exception) {
         AppLog.e(AppLog.T.MEDIA, "VideoOptimizer > Can't optimize the video", exception);
         trackVideoProcessingEvents(true, exception);
         mListener.onVideoOptimizationCompleted(mMedia);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -15,7 +15,6 @@ import androidx.annotation.NonNull;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -619,7 +618,7 @@ public class PostUploadHandler implements UploadHandler<PostModel>, OnAutoSavePo
     }
 
     @Override
-    public void handleAutoSavePostIfNotDraftResult(@NotNull AutoSavePostIfNotDraftResult result) {
+    public void handleAutoSavePostIfNotDraftResult(@NonNull AutoSavePostIfNotDraftResult result) {
         PostModel post = result.getPost();
         if (result instanceof FetchPostStatusFailed
             || result instanceof PostAutoSaveFailed

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -5,7 +5,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -283,7 +282,7 @@ public class SiteUtils {
         return type;
     }
 
-    public static SiteAccessibilityInfo getAccessibilityInfoFromSite(@NotNull SiteModel site) {
+    public static SiteAccessibilityInfo getAccessibilityInfoFromSite(@NonNull SiteModel site) {
         SiteVisibility siteVisibility;
 
         if (site.isPrivateWPComAtomic()) {

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -3,9 +3,8 @@ package org.wordpress.android.analytics;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
-
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarAction.java
@@ -1,7 +1,8 @@
 package org.wordpress.android.editor;
 
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.ITextFormat;
 import org.wordpress.aztec.toolbar.IToolbarAction;
@@ -44,13 +45,13 @@ public enum MediaToolbarAction implements IToolbarAction {
         return mButtonId;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public ToolbarActionType getActionType() {
         return mActionType;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public Set<ITextFormat> getTextFormats() {
         return mTextFormats;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarCameraButton.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarCameraButton.java
@@ -6,7 +6,8 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.aztec.plugins.IMediaToolbarButton;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IToolbarAction;
@@ -28,13 +29,13 @@ public class MediaToolbarCameraButton implements IMediaToolbarButton {
         mClickListener = mediaToolbarClickListener;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public IToolbarAction getAction() {
         return mAction;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public Context getContext() {
         return mContext;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarGalleryButton.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarGalleryButton.java
@@ -6,7 +6,8 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.aztec.plugins.IMediaToolbarButton;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IToolbarAction;
@@ -28,13 +29,13 @@ public class MediaToolbarGalleryButton implements IMediaToolbarButton {
         mClickListener = mediaToolbarClickListener;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public IToolbarAction getAction() {
         return mAction;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public Context getContext() {
         return mContext;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarLibraryButton.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/MediaToolbarLibraryButton.java
@@ -6,7 +6,8 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.wordpress.aztec.plugins.IMediaToolbarButton;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IToolbarAction;
@@ -28,13 +29,13 @@ public class MediaToolbarLibraryButton implements IMediaToolbarButton {
         mClickListener = mediaToolbarClickListener;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public IToolbarAction getAction() {
         return mAction;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public Context getContext() {
         return mContext;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -38,7 +38,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.gson.Gson;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.editor.BuildConfig;
 import org.wordpress.android.editor.EditorEditMediaListener;
 import org.wordpress.android.editor.EditorFragmentAbstract;
@@ -49,8 +48,8 @@ import org.wordpress.android.editor.EditorThemeUpdateListener;
 import org.wordpress.android.editor.LiveTextWatcher;
 import org.wordpress.android.editor.R;
 import org.wordpress.android.editor.WPGutenbergWebViewActivity;
-import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogPositiveClickInterface;
 import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogNegativeClickInterface;
+import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogPositiveClickInterface;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -1539,7 +1538,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onGutenbergDialogPositiveClicked(@NotNull String instanceTag, int mediaId) {
+    public void onGutenbergDialogPositiveClicked(@NonNull String instanceTag, int mediaId) {
         switch (instanceTag) {
             case TAG_REPLACE_FEATURED_DIALOG:
                 setFeaturedImage(mediaId);
@@ -1548,7 +1547,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onGutenbergDialogNegativeClicked(@NotNull String instanceTag) {
+    public void onGutenbergDialogNegativeClicked(@NonNull String instanceTag) {
         switch (instanceTag) {
             case TAG_REPLACE_FEATURED_DIALOG:
                 // Dismiss dialog with no action.


### PR DESCRIPTION
Parent #18904
Closes #18924

This PR replaces:
- All occurrences of `org.jetbrains.annotations.Nullable` with the `androidx.annotation.Nullable` annotation, and
- All occurrences of `org.jetbrains.annotations.NotNull` with the `androidx.annotation.NonNull` annotation.

-----

## To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you really want to be thorough, quickly smoke test both, the WordPress and Jetpack apps, and see if they work as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

4. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
