### PR TITLE
[JP Social/Post Editing] Show social service icon in connections list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialConnection.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/PostSocialConnection.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts.social
 
 import org.wordpress.android.models.PublicizeConnection
+import org.wordpress.android.ui.publicize.PublicizeServiceIcon
 
 @Suppress("LongParameterList", "DataClassShouldBeImmutable")
 data class PostSocialConnection(
@@ -9,7 +10,7 @@ data class PostSocialConnection(
     val label: String,
     val externalId: String,
     val externalName: String,
-    val iconUrl: String,
+    val iconResId: Int?,
     var isSharingEnabled: Boolean,
 ) {
     companion object {
@@ -20,7 +21,7 @@ data class PostSocialConnection(
                 label = connection.label,
                 externalId = connection.externalId,
                 externalName = connection.externalDisplayName,
-                iconUrl = connection.externalProfilePictureUrl,
+                iconResId = PublicizeServiceIcon.fromServiceId(connection.service)?.iconResId,
                 isSharingEnabled = isSharingEnabled,
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
@@ -47,7 +48,7 @@ fun PostSocialConnectionItem(
             setToSaturation(if (enabled) 1f else 0f)
         }
         AsyncImage(
-            model = connection.iconUrl,
+            model = connection.iconResId,
             contentDescription = null,
             contentScale = ContentScale.FillBounds,
             colorFilter = ColorFilter.colorMatrix(saturationMatrix),
@@ -80,7 +81,7 @@ fun PostSocialConnectionItemPreview() {
         label = "Tumblr",
         externalId = "myblog.tumblr.com",
         externalName = "My blog",
-        iconUrl = "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png",
+        iconResId = R.drawable.ic_social_tumblr,
         isSharingEnabled = true
     )
     var connectionState by remember { mutableStateOf(connection) }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsJetpackSocialUiStateMapperTest.kt
@@ -42,7 +42,7 @@ class EditPostPublishSettingsJetpackSocialUiStateMapperTest {
             label = "Tumblr",
             externalId = "myblog.tumblr.com",
             externalName = "My blog",
-            iconUrl = "http://i.wordpress.com/wp-content/publicize/assets/publicize-tumblr-2x.png",
+            iconResId = R.drawable.ic_social_tumblr,
             isSharingEnabled = true,
         )
 
@@ -52,7 +52,7 @@ class EditPostPublishSettingsJetpackSocialUiStateMapperTest {
             label = "LinkedIn",
             externalId = "linkedin.com",
             externalName = "My Profile",
-            iconUrl = "https://i.wordpress.com/wp-content/publicize/assets/publicize-linkedin-2x.png",
+            iconResId = R.drawable.ic_social_linkedin,
             isSharingEnabled = true,
         )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.datasets.wrappers.PublicizeTableWrapper
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.AccountModel
@@ -562,7 +563,7 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
             label = "label",
             externalId = "externalId",
             externalName = "externalName",
-            iconUrl = "iconUrl",
+            iconResId = R.drawable.ic_social_tumblr,
             isSharingEnabled = true
         )
         private val FAKE_SOCIAL_SHARING_MODEL = PostSocialSharingModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/social/PostSocialSharingModelMapperTest.kt
@@ -273,7 +273,7 @@ class PostSocialSharingModelMapperTest : BaseUnitTest() {
         label = "label",
         externalId = "externalId",
         externalName = "externalName",
-        iconUrl = "iconUrl",
+        iconResId = R.drawable.ic_social_tumblr,
         isSharingEnabled = isSharingEnabled,
     )
 }


### PR DESCRIPTION
Fixes #18926 

Instead of showing the profile pic we should show the service (tumblr, facebook, etc) icon so the connection is easily recognizable.

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/db6bec58-ae68-4ba9-8fc2-d1b8aa86421f)


To test:
Pre-req: site with JP Social active and social networks connected for sharing.

1. Open Jetpack App
2. Go to `Posts`
3. Create a new Post
4. Go to the `Post Settings`
5. **Verify** the Social sharing section shows the social network icons for each connection, and not the profile picture
6. Tap `Publish`
7. In the pre-publishing sheet, tap on the Social sharing item
8. **Verify** the connection list shows the social network icons for each connection, and not the profile picture

## Regression Notes
1. Potential unintended areas of impact
N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

10. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
