### PR TITLE
[Bottom Navigation] Remove default content description from navbar item layout

### DIFF
--- a/WordPress/src/main/res/layout/navbar_item.xml
+++ b/WordPress/src/main/res/layout/navbar_item.xml
@@ -18,7 +18,7 @@
             android:layout_width="@dimen/bottom_nav_bar_icon_size"
             android:layout_height="@dimen/bottom_nav_bar_icon_size"
             android:layout_gravity="center"
-            android:contentDescription="@string/tabbar_accessibility_label_my_site"
+            android:importantForAccessibility="no"
             app:tint="@drawable/nav_bar_button_selector"
             tools:src="@drawable/ic_create_white_24dp" />
 


### PR DESCRIPTION
Fixes #18698

That icon content description was not being changed nor properly used since the parent layout had a content description set via code. 

This caused issues when selecting items for which the screen doesn't announce something else, like `My Site` and `Me`, causing that default content description (which was set to the `My Site` description) to be read again.

This didn't happen for `Reader` and `Notifications` because when selecting those items, the selected Tab of the Pager inside the screen was being read by Talkback, skipping that default icon content description.

To test:
1. Activate TalkBack
2. Open the Jetpack app.
3. Tap on `Me` tab to see the `Me` screen
4. **Verify**  Talkback reads that the `Me` tab was selected

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None. This interaction is not easily tested.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
