### PR TITLE
Contact support configure chat widget

### DIFF
--- a/WordPress/src/jetpack/assets/bot_widget.js
+++ b/WordPress/src/jetpack/assets/bot_widget.js
@@ -1,0 +1,32 @@
+;
+window.DocsBotAI = window.DocsBotAI || {}, DocsBotAI.init = function(c) {
+    return new Promise(function(e, o) {
+        var t = document.createElement("script");
+        t.type = "text/javascript", t.async = !0, t.src = "https://widget.docsbot.ai/chat.js";
+        var n = document.getElementsByTagName("script")[0];
+        n.parentNode.insertBefore(t, n), t.addEventListener("load", function() {
+            window.DocsBotAI.mount({
+                id: c.id,
+                supportCallback: c.supportCallback,
+                identify: c.identify,
+                options: c.options,
+                signature: c.signature
+            });
+            var t;
+            t = function(n) {
+                return new Promise(function(e) {
+                    if (document.querySelector(n)) return e(document.querySelector(n));
+                    var o = new MutationObserver(function(t) {
+                        document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
+                    });
+                    o.observe(document.body, {
+                        childList: !0,
+                        subtree: !0
+                    })
+                })
+            }, t && t("#docsbotai-root").then(e).catch(o)
+        }), t.addEventListener("error", function(t) {
+            o(t.message)
+        })
+    })
+};

--- a/WordPress/src/jetpack/assets/support_chat_widget.html
+++ b/WordPress/src/jetpack/assets/support_chat_widget.html
@@ -4,14 +4,36 @@
 </head>
 <body>
 <script type="text/javascript">
-    DocsBotAI.init({
+    window.DocsBotAI.init({
             id: 'TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH',
             options: {
+                botName: "Jetpack Mobile",
+                description: "Ask me anything about using Jetpack mobile app.",
                 horizontalMargin: 40,
                 verticalMargin: 60,
+                color: "#9dd977",
+                alignment: "left", // may need to update this for RTL.
+                supportLink: "https://wordpress.com/contact-form?mode=CHAT",
+                labels: {
+                    inputPlaceholder: "Send a message...",
+                    firstMessage: "What can I help you with?",
+                    sources: "Sources",
+                    helpful: "Rate as helpful",
+                    unhelpful: "Rate as unhelpful",
+                    getSupport: "Contact support",
+                    floatingButton: "Help",
+                    suggestions: "Not sure what to ask?",
+                    thinking: "Thinking..."
+              }, // Override all the default labels for your own language.
+              questions: [
+                "How do I change home page?",
+                "Account or billing issues?",
+                "Need to report an error or crash?"
+              ] // Array of example questions to show in the widget. Three are picked at random.
             },
         }).then(() => {
             // Safely do stuff here after the widget is loaded.
+            DocsBotAI.open()
         })
         setTimeout(() => {
            DocsBotAI.open()
@@ -19,3 +41,4 @@
     </script>
 </body>
 </html>
+

--- a/WordPress/src/jetpack/assets/support_chat_widget.html
+++ b/WordPress/src/jetpack/assets/support_chat_widget.html
@@ -1,60 +1,9 @@
 <html>
-<head>
-    <script type="text/javascript" src="/assets/support_chat_widget.js"></script>
-</head>
-<body>
-<script type="text/javascript">
-    const queryString = window.location.search;
-    console.log(queryString);
-    //const urlParams = new URLSearchParams(queryString);
-    const urlParams = getQueryParams(window.location)
-    const inputPlaceholder = urlParams.inputPlaceholder; //urlParams.get('inputPlaceholder');
-    console.log(inputPlaceholder);
-    const firstMessage = urlParams.firstMessage; //urlParams.get('firstMessage');
-
-    window.DocsBotAI.init({
-            id: 'TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH',
-            supportCallback: function (event, history) {
-               event.preventDefault() // Optionally prevent default behavior opening the url.
-               console.log(history) // Safely access the chat history.
-               sendAndroidMessage(history)
-               DocsBotAI.close() // Close the widget.
-            },
-            options: {
-                botName: "Jetpack Mobile",
-                description: "Ask me anything about using Jetpack mobile app.",
-                color: "#9dd977",
-                supportLink: "https://wordpress.com/contact-form?mode=CHAT",
-                labels: {
-                    inputPlaceholder: inputPlaceholder,
-                    firstMessage: firstMessage, //"What can I help you with?",
-                    sources: "Sources",
-                    helpful: "Rate as helpful",
-                    unhelpful: "Rate as unhelpful",
-                    getSupport: "Contact support",
-                    floatingButton: "Help",
-                    suggestions: "Not sure what to ask?",
-                    thinking: "Thinking..."
-              }, // Override all the default labels for your own language.
-              questions: [
-                "How do I change home page?",
-                "Account or billing issues?",
-                "Need to report an error or crash?"
-              ] // Array of example questions to show in the widget. Three are picked at random.
-            },
-        }).then(() => {
-            // Safely do stuff here after the widget is loaded.
-            DocsBotAI.toggle();
-        })
-        setTimeout(() => {
-           DocsBotAI.open();
-        }, 200);
-
-        setTimeout(() => {
-           hideTopCloseButton();
-           hideTopHeader();
-        }, 300);
-    </script>
-</body>
+    <head>
+        <script type="text/javascript" src="/assets/bot_widget.js"></script>
+    </head>
+    <body>
+        <script type="text/javascript" src="/assets/support_chat_widget.js"></script>
+    </body>
 </html>
 

--- a/WordPress/src/jetpack/assets/support_chat_widget.html
+++ b/WordPress/src/jetpack/assets/support_chat_widget.html
@@ -4,19 +4,30 @@
 </head>
 <body>
 <script type="text/javascript">
+    const queryString = window.location.search;
+    console.log(queryString);
+    //const urlParams = new URLSearchParams(queryString);
+    const urlParams = getQueryParams(window.location)
+    const inputPlaceholder = urlParams.inputPlaceholder; //urlParams.get('inputPlaceholder');
+    console.log(inputPlaceholder);
+    const firstMessage = urlParams.firstMessage; //urlParams.get('firstMessage');
+
     window.DocsBotAI.init({
             id: 'TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH',
+            supportCallback: function (event, history) {
+               event.preventDefault() // Optionally prevent default behavior opening the url.
+               console.log(history) // Safely access the chat history.
+               sendAndroidMessage(history)
+               DocsBotAI.close() // Close the widget.
+            },
             options: {
                 botName: "Jetpack Mobile",
                 description: "Ask me anything about using Jetpack mobile app.",
-                horizontalMargin: 40,
-                verticalMargin: 60,
                 color: "#9dd977",
-                alignment: "left", // may need to update this for RTL.
                 supportLink: "https://wordpress.com/contact-form?mode=CHAT",
                 labels: {
-                    inputPlaceholder: "Send a message...",
-                    firstMessage: "What can I help you with?",
+                    inputPlaceholder: inputPlaceholder,
+                    firstMessage: firstMessage, //"What can I help you with?",
                     sources: "Sources",
                     helpful: "Rate as helpful",
                     unhelpful: "Rate as unhelpful",
@@ -33,11 +44,16 @@
             },
         }).then(() => {
             // Safely do stuff here after the widget is loaded.
-            DocsBotAI.open()
+            DocsBotAI.toggle();
         })
         setTimeout(() => {
-           DocsBotAI.open()
+           DocsBotAI.open();
         }, 200);
+
+        setTimeout(() => {
+           hideTopCloseButton();
+           hideTopHeader();
+        }, 300);
     </script>
 </body>
 </html>

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -1,92 +1,109 @@
-//const queryString = window.location.search;
-//console.log(queryString);
-const urlParams = getQueryParams(window.location);
+( function () {
 
-window.DocsBotAI.init({
-    id: urlParams.id,
-    supportCallback: function(event, history) {
-        event.preventDefault() // Optionally prevent default behavior opening the url.
-        console.log(history) // Safely access the chat history.
-        DocsBotAI.close() // Close the widget.
-        sendAndroidMessage(history)
-    },
-    options: {
-        botName: "Jetpack Mobile",
-        description: "Ask me anything about using Jetpack mobile app.",
-        color: "#9dd977",
-        supportLink: "#",
-        labels: {
-            inputPlaceholder: decodeURIComponent(urlParams.inputPlaceholder),
-            firstMessage: decodeURIComponent(urlParams.firstMessage),
-            sources: "Sources",
-            helpful: "Rate as helpful",
-            unhelpful: "Rate as unhelpful",
-            getSupport: decodeURIComponent(urlParams.getSupport),
-            floatingButton: "Help",
-            suggestions: decodeURIComponent(urlParams.suggestions),
-            thinking: "Thinking..."
-        }, // Override all the default labels for your own language.
-        questions: [
-            decodeURIComponent(urlParams.questionOne),
-            decodeURIComponent(urlParams.questionTwo),
-            decodeURIComponent(urlParams.questionThree)
-        ] // Array of example questions to show in the widget. Three are picked at random.
-    },
-}).then(() => {
-    // Safely do stuff here after the widget is loaded.
-    setTimeout(() => {
-        openDocsBot(); // wait for init
-    }, 200);
-
-    setTimeout(() => {
-        hideTopCloseButton(); // hide after init
-        hideTopHeader();
-        resetConversation();
-    }, 300);
-});
-
-function sendAndroidMessage(history) {
-    /* In this implementation, only the single-arg version of postMessage is supported. As noted
-     * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
-     * Also note that onmessage, addEventListener and removeEventListener are not supported.
-     */
-    console.log(history.toString());
-    jsObject.postMessage(history.toString());
-}
-
-function getQueryParams(location) {
-    return location.search ?
-        location.search.substr(1).split`&`.reduce((qd, item) => {
-            let [k, v] = item.split`=`;
-            v = v && decodeURIComponent(v);
-            (qd[k] = qd[k] || []).push(v);
-            return qd
-        }, {}) :
-        {}
-}
-
-function openDocsBot() {
-    const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
-    if (widget && widget !== null && typeof widget !== 'undefined') {
-        widget.click()
+    function init() {
+        loadDocsBotAI()
     }
-    DocsBotAI.open()
-}
 
-function hideTopCloseButton() {
-    const closeButton = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > a");
-    if (closeButton && closeButton !== null && closeButton !== 'undefined') {
-        closeButton.style.display = 'none';
+    function loadDocsBotAI() {
+        const urlParams = getQueryParams(window.location);
+
+        window.DocsBotAI.init({
+            id: urlParams.id,
+            supportCallback: function(event, history) {
+                event.preventDefault() // Optionally prevent default behavior opening the url.
+                console.log(history) // Safely access the chat history.
+                DocsBotAI.close() // Close the widget.
+                sendAndroidMessage(history)
+            },
+            options: {
+                botName: "Jetpack Mobile",
+                description: "Ask me anything about using Jetpack mobile app.",
+                color: "#9dd977",
+                supportLink: "#",
+                labels: {
+                    inputPlaceholder: decodeURIComponent(urlParams.inputPlaceholder),
+                    firstMessage: decodeURIComponent(urlParams.firstMessage),
+                    sources: "Sources",
+                    helpful: "Rate as helpful",
+                    unhelpful: "Rate as unhelpful",
+                    getSupport: decodeURIComponent(urlParams.getSupport),
+                    floatingButton: "Help",
+                    suggestions: decodeURIComponent(urlParams.suggestions),
+                    thinking: "Thinking..."
+                }, // Override all the default labels for your own language.
+                questions: [
+                    decodeURIComponent(urlParams.questionOne),
+                    decodeURIComponent(urlParams.questionTwo),
+                    decodeURIComponent(urlParams.questionThree)
+                ] // Array of example questions to show in the widget. Three are picked at random.
+            },
+        }).then(() => {
+            // Safely do stuff here after the widget is loaded.
+            let timerId = setInterval(() => {
+                openDocsBot(); // wait for init
+            }, 200);
+
+            setTimeout(() => {
+                clearInterval(timerId)
+
+                hideTopCloseButton(); // hide after init
+                hideTopHeader();
+                resetConversation();
+            }, 300);
+        });
     }
-}
 
-function hideTopHeader() {
-    const header = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > div.docsbot-chat-header");
-    if (header && header !== null && header !== 'undefined') {
-        header.style.display = 'none';
+    function sendAndroidMessage(history) {
+        /* In this implementation, only the single-arg version of postMessage is supported. As noted
+         * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
+         * Also note that onmessage, addEventListener and removeEventListener are not supported.
+         */
+        console.log(history.toString());
+        jsObject.postMessage(history.toString());
     }
-}
 
-function resetConversation() {
-    localStorage.removeItem("docsbot_chat_history");
-}
+    function getQueryParams(location) {
+        return location.search ?
+            location.search.substr(1).split`&`.reduce((qd, item) => {
+                let [k, v] = item.split`=`;
+                v = v && decodeURIComponent(v);
+                (qd[k] = qd[k] || []).push(v);
+                return qd
+            }, {}) :
+            {}
+    }
+
+    function openDocsBot() {
+        const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
+        if (widget && widget !== null && typeof widget !== 'undefined') {
+            widget.click();
+        }
+
+        if ( 'function' === typeof window.DocsBotAI ) {
+            DocsBotAI.open();
+        }
+    }
+
+    function hideTopCloseButton() {
+        const closeButton = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > a");
+        if (closeButton && closeButton !== null && closeButton !== 'undefined') {
+            closeButton.style.display = 'none';
+        }
+    }
+
+    function hideTopHeader() {
+        const header = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > div.docsbot-chat-header");
+        if (header && header !== null && header !== 'undefined') {
+            header.style.display = 'none';
+        }
+    }
+
+    function resetConversation() {
+        // reset button was in top header
+        localStorage.removeItem("docsbot_chat_history");
+    }
+
+
+    document.addEventListener( 'DOMContentLoaded', init );
+} ) ();
+

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -1,5 +1,5 @@
-const queryString = window.location.search;
-console.log(queryString);
+//const queryString = window.location.search;
+//console.log(queryString);
 const urlParams = getQueryParams(window.location);
 
 window.DocsBotAI.init({
@@ -16,20 +16,20 @@ window.DocsBotAI.init({
         color: "#9dd977",
         supportLink: "#",
         labels: {
-            inputPlaceholder: urlParams.inputPlaceholder,
-            firstMessage: urlParams.firstMessage,
+            inputPlaceholder: decodeURIComponent(urlParams.inputPlaceholder),
+            firstMessage: decodeURIComponent(urlParams.firstMessage),
             sources: "Sources",
             helpful: "Rate as helpful",
             unhelpful: "Rate as unhelpful",
-            getSupport: urlParams.getSupport,
+            getSupport: decodeURIComponent(urlParams.getSupport),
             floatingButton: "Help",
-            suggestions: urlParams.suggestions,
+            suggestions: decodeURIComponent(urlParams.suggestions),
             thinking: "Thinking..."
         }, // Override all the default labels for your own language.
         questions: [
-            urlParams.questionOne,
-            urlParams.questionTwo,
-            urlParams.questionThree
+            decodeURIComponent(urlParams.questionOne),
+            decodeURIComponent(urlParams.questionTwo),
+            decodeURIComponent(urlParams.questionThree)
         ] // Array of example questions to show in the widget. Three are picked at random.
     },
 }).then(() => {

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -29,3 +29,33 @@
           })
       })
     })
+
+    function sendAndroidMessage(history) {
+        /* In this implementation, only the single-arg version of postMessage is supported. As noted
+         * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
+         * Also note that onmessage, addEventListener and removeEventListener are not supported.
+         */
+        jsObject.postMessage(history);
+    }
+
+    function getQueryParams(location) {
+      return location.search
+        ? location.search.substr(1).split`&`.reduce((qd, item) => {let [k,v] = item.split`=`; v = v && decodeURIComponent(v); (qd[k] = qd[k] || []).push(v); return qd}, {})
+        : {}
+    }
+
+    function hideTopCloseButton() {
+        document
+            .querySelector("#docsbotai-root")
+            .shadowRoot.querySelector("div > div > div > a")
+            .style.visibility = 'hidden';
+//            .style.display = 'none';
+    }
+
+    function hideTopHeader() {
+        document
+            .querySelector("#docsbotai-root")
+            .shadowRoot.querySelector("div > div > div > div.docsbot-chat-header")
+            .style.visibility = 'hidden';
+//            .style.display = 'none';
+    }

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -1,61 +1,88 @@
-;(window.DocsBotAI = window.DocsBotAI || {}),
-    (DocsBotAI.init = function (c) {
-      return new Promise(function (e, o) {
-        var t = document.createElement('script')
-        ;(t.type = 'text/javascript'), (t.async = !0), (t.src = 'https://widget.docsbot.ai/chat.js')
-        var n = document.getElementsByTagName('script')[0]
-        n.parentNode.insertBefore(t, n),
-          t.addEventListener('load', function () {
-            window.DocsBotAI.mount({
-              id: c.id,
-              supportCallback: c.supportCallback,
-              identify: c.identify,
-              options: c.options,
-            })
-            var t
-            ;(t = function (n) {
-              return new Promise(function (e) {
-                if (document.querySelector(n)) return e(document.querySelector(n))
-                var o = new MutationObserver(function (t) {
-                  document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
-                })
-                o.observe(document.body, { childList: !0, subtree: !0 })
-              })
-            }),
-              t && t('#docsbotai-root').then(e).catch(o)
-          }),
-          t.addEventListener('error', function (t) {
-            o(t.message)
-          })
-      })
-    })
+const queryString = window.location.search;
+console.log(queryString);
+const urlParams = getQueryParams(window.location);
 
-    function sendAndroidMessage(history) {
-        /* In this implementation, only the single-arg version of postMessage is supported. As noted
-         * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
-         * Also note that onmessage, addEventListener and removeEventListener are not supported.
-         */
-        jsObject.postMessage(history);
-    }
+window.DocsBotAI.init({
+    id: urlParams.id,
+    supportCallback: function(event, history) {
+        event.preventDefault() // Optionally prevent default behavior opening the url.
+        console.log(history) // Safely access the chat history.
+        DocsBotAI.close() // Close the widget.
+        sendAndroidMessage(history)
+    },
+    options: {
+        botName: "Jetpack Mobile",
+        description: "Ask me anything about using Jetpack mobile app.",
+        color: "#9dd977",
+        supportLink: "#",
+        labels: {
+            inputPlaceholder: urlParams.inputPlaceholder,
+            firstMessage: urlParams.firstMessage,
+            sources: "Sources",
+            helpful: "Rate as helpful",
+            unhelpful: "Rate as unhelpful",
+            getSupport: urlParams.getSupport,
+            floatingButton: "Help",
+            suggestions: "Not sure what to ask?",
+            thinking: "Thinking..."
+        }, // Override all the default labels for your own language.
+        questions: [
+            "How do I change home page?",
+            "Account or billing issues?",
+            "Need to report an error or crash?"
+        ] // Array of example questions to show in the widget. Three are picked at random.
+    },
+}).then(() => {
+    // Safely do stuff here after the widget is loaded.
+    setTimeout(() => {
+        openDocsBot(); // wait for init
+    }, 200);
 
-    function getQueryParams(location) {
-      return location.search
-        ? location.search.substr(1).split`&`.reduce((qd, item) => {let [k,v] = item.split`=`; v = v && decodeURIComponent(v); (qd[k] = qd[k] || []).push(v); return qd}, {})
-        : {}
-    }
+    setTimeout(() => {
+        hideTopCloseButton(); // hide after init
+        hideTopHeader();
+    }, 300);
+});
 
-    function hideTopCloseButton() {
-        document
-            .querySelector("#docsbotai-root")
-            .shadowRoot.querySelector("div > div > div > a")
-            .style.visibility = 'hidden';
-//            .style.display = 'none';
-    }
+function sendAndroidMessage(history) {
+    /* In this implementation, only the single-arg version of postMessage is supported. As noted
+     * in the WebViewCompat reference doc, the second parameter, MessagePorts, is optional.
+     * Also note that onmessage, addEventListener and removeEventListener are not supported.
+     */
+    console.log(history.toString());
+    jsObject.postMessage(history.toString());
+}
 
-    function hideTopHeader() {
-        document
-            .querySelector("#docsbotai-root")
-            .shadowRoot.querySelector("div > div > div > div.docsbot-chat-header")
-            .style.visibility = 'hidden';
-//            .style.display = 'none';
+function getQueryParams(location) {
+    return location.search ?
+        location.search.substr(1).split`&`.reduce((qd, item) => {
+            let [k, v] = item.split`=`;
+            v = v && decodeURIComponent(v);
+            (qd[k] = qd[k] || []).push(v);
+            return qd
+        }, {}) :
+        {}
+}
+
+function openDocsBot() {
+    const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
+    if (widget && typeof widget !== 'undefined') {
+        widget.click()
+    } else {
+        DocsBotAI.open()
     }
+}
+
+function hideTopCloseButton() {
+    const closeButton = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > a");
+    if (closeButton && closeButton !== null && closeButton !== 'undefined') {
+        closeButton.style.display = 'none';
+    }
+}
+
+function hideTopHeader() {
+    const header = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > div.docsbot-chat-header");
+    if (header && header !== null && header !== 'undefined') {
+        header.style.display = 'none';
+    }
+}

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -41,6 +41,7 @@ window.DocsBotAI.init({
     setTimeout(() => {
         hideTopCloseButton(); // hide after init
         hideTopHeader();
+        resetConversation();
     }, 300);
 });
 
@@ -66,7 +67,7 @@ function getQueryParams(location) {
 
 function openDocsBot() {
     const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
-    if (widget && typeof widget !== 'undefined') {
+    if (widget && widget !== null && typeof widget !== 'undefined') {
         widget.click()
     }
     DocsBotAI.open()
@@ -84,4 +85,8 @@ function hideTopHeader() {
     if (header && header !== null && header !== 'undefined') {
         header.style.display = 'none';
     }
+}
+
+function resetConversation() {
+    localStorage.removeItem("docsbot_chat_history");
 }

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -23,13 +23,13 @@ window.DocsBotAI.init({
             unhelpful: "Rate as unhelpful",
             getSupport: urlParams.getSupport,
             floatingButton: "Help",
-            suggestions: "Not sure what to ask?",
+            suggestions: urlParams.suggestions,
             thinking: "Thinking..."
         }, // Override all the default labels for your own language.
         questions: [
-            "How do I change home page?",
-            "Account or billing issues?",
-            "Need to report an error or crash?"
+            urlParams.questionOne,
+            urlParams.questionTwo,
+            urlParams.questionThree
         ] // Array of example questions to show in the widget. Three are picked at random.
     },
 }).then(() => {
@@ -68,9 +68,8 @@ function openDocsBot() {
     const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
     if (widget && typeof widget !== 'undefined') {
         widget.click()
-    } else {
-        DocsBotAI.open()
     }
+    DocsBotAI.open()
 }
 
 function hideTopCloseButton() {

--- a/WordPress/src/main/java/org/wordpress/android/support/JsObject.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/JsObject.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.support
+
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+
+// Create a handler that runs on the UI thread
+private val handler: Handler = Handler(Looper.getMainLooper())
+
+/**
+ * Injects a JavaScript object which supports a {@code postMessage()} method.
+ * A feature check is used to determine if the preferred API, WebMessageListener, is supported.
+ * If it is, then WebMessageListener will be used to create a JavaScript object. The object will be
+ * injected into all of the frames that have an origin matching those in {@code allowedOriginRules}.
+ * <p>
+ * If WebMessageListener is not supported then the method will defer to using JavascriptInterface
+ * to create the JavaScript object.
+ * <p>
+ * The {@code postMessage()} methods in the Javascript objects created by WebMessageListener and
+ * JavascriptInterface both make calls to the same callback, {@code onMessageReceived()}.
+ * In this case, the callback invokes native Android sharing.
+ * <p>
+ * The WebMessageListener invokes callbacks on the UI thread by default. However,
+ * JavascriptInterface invokes callbacks on a background thread by default. In order to
+ * guarantee thread safety and that the caller always gets consistent behavior the the callback
+ * should always be called on the UI thread. To change the default behavior of JavascriptInterface,
+ * the callback is wrapped in a handler which will tell it to run on the UI thread instead of the default
+ * background thread it would otherwise be invoked on.
+ * <p>
+ * @param webview the component that WebMessageListener or JavascriptInterface will be added to
+ * @param jsObjName the name that will be given to the Javascript objects created by either
+ *        WebMessageListener or JavascriptInterface
+ * @param allowedOriginRules a set of origins used only by WebMessageListener, if a frame matches an
+ * origin in this set then it will have the JS object injected into it
+ * @param onMessageReceived invoked on UI thread with message passed in from JavaScript postMessage() call
+ */
+fun createJsObject(
+    webview: WebView,
+    jsObjName: String,
+    allowedOriginRules: Set<String>,
+    onMessageReceived: (message: String) -> Unit
+) {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+        WebViewCompat.addWebMessageListener(
+            webview, jsObjName, allowedOriginRules
+        ) { _, message, _, _, _ -> onMessageReceived(message.data!!) }
+    } else {
+        webview.addJavascriptInterface(object {
+            @JavascriptInterface
+            fun postMessage(message: String) {
+                // Use the handler to invoke method on UI thread
+                handler.post { onMessageReceived(message) }
+            }
+        }, jsObjName)
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -128,6 +128,10 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         val id: String,
         val inputPlaceholder: String,
         val firstMessage: String,
-        val getSupport: String
+        val getSupport: String,
+        val suggestions: String,
+        val questionOne: String,
+        val questionTwo: String,
+        val questionThree: String
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -1,16 +1,24 @@
 package org.wordpress.android.support
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
 import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
-import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.ChatDetails
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.network.utils.toMap
+import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.Companion.CHAT_HISTORY
 import org.wordpress.android.ui.WPWebViewActivity
 
 class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
@@ -18,19 +26,16 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
 
-        val assetLoader = WebViewAssetLoader.Builder()
-            .addPathHandler("/assets/", AssetsPathHandler(this))
-            .addPathHandler("/res/", ResourcesPathHandler(this))
-            .build()
+        // set send message box to appear above system navigation bar
+        val previewContainer = findViewById<View>(R.id.preview_container)
+        val params = previewContainer.layoutParams as ViewGroup.MarginLayoutParams
+        params.bottomMargin = resources.getDimensionPixelSize(R.dimen.margin_64dp)
+        previewContainer.layoutParams = params
 
-        configureWebView()
-        mWebView.webViewClient = SupportWebViewClient(this, assetLoader)
-        mWebView.loadUrl("https://$DEFAULT_DOMAIN/assets/support_chat_widget.html")
-    }
+        supportActionBar?.title = getString(R.string.help)
+        supportActionBar?.subtitle = ""
 
-    override fun configureWebView() {
-        super.configureWebView()
-        supportActionBar?.hide()
+        setupWebView()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -38,38 +43,90 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         return true
     }
 
-    override fun onChatSessionClosed() {
+    override fun onChatSessionClosed(chatHistory: String) {
+        intent.putExtra(CHAT_HISTORY, chatHistory)
         setResult(RESULT_OK, intent)
         finish()
     }
 
-    class OpenChatWidget : ActivityResultContract<ChatDetails, ChatCompletionEvent?>() {
-        override fun createIntent(context: Context, input: ChatDetails) =
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun setupWebView() {
+        val jsObjName = "jsObject"
+        val allowedOriginRules = setOf("https://$DEFAULT_DOMAIN")
+
+        val assetLoader = WebViewAssetLoader.Builder()
+            .addPathHandler("/assets/", AssetsPathHandler(this))
+            .addPathHandler("/res/", ResourcesPathHandler(this))
+            .build()
+        mWebView.webViewClient = SupportWebViewClient(this, assetLoader)
+
+        // Setup debugging; See https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews
+        if ( 0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
+
+        // Create a JS object to be injected into frames; Determines if WebMessageListener
+        // or WebAppInterface should be used
+        createJsObject(
+            mWebView,
+            jsObjName,
+            allowedOriginRules
+        ) { message ->
+            Log.d("Chat history", message)
+            onChatSessionClosed(message)
+        }
+
+        intent.getStringExtra(URL_TO_LOAD)?.let { mWebView.loadUrl(it) }
+    }
+
+
+    class OpenChatWidget : ActivityResultContract<BotOptions, ChatCompletionEvent?>() {
+        override fun createIntent(context: Context, input: BotOptions) =
             Intent(context, SupportWebViewActivity::class.java).apply {
                 putExtra(USE_GLOBAL_WPCOM_USER, true)
                 putExtra(AUTHENTICATION_URL, WPCOM_LOGIN_URL)
-                putExtra(URL_TO_LOAD, input.url)
-//                putExtra(CHAT_TEXT, input.chatText)
-                putExtra(CHAT_EMAIL, input.site?.email)
+                putExtra(URL_TO_LOAD, buildURI(input))
             }
 
         override fun parseResult(resultCode: Int, intent: Intent?): ChatCompletionEvent? {
-            val data = intent?.takeIf { it.hasExtra(CHAT_TEXT) && it.hasExtra(CHAT_EMAIL) }
+            val data = intent?.takeIf { it.hasExtra(CHAT_HISTORY) }
             if (resultCode == RESULT_OK && data != null) {
-                val chatText = data.getStringExtra(CHAT_TEXT).orEmpty()
-                val email = data.getStringExtra(CHAT_EMAIL).orEmpty()
-                return ChatCompletionEvent(chatText, email)
+                val chatHistory = data.getStringExtra(CHAT_HISTORY).orEmpty()
+                return ChatCompletionEvent(chatHistory)
             }
             return null
         }
 
-        data class ChatDetails(val site: SiteModel?, val url: String)
+        private fun buildURI(options: BotOptions): String {
+            // build url with parameters.
+            val botOptions = options.toMap()
+
+            Log.d("BotOptions Map", botOptions.toString())
+
+            val builder = Uri.Builder()
+            builder.scheme("https")
+                .authority(DEFAULT_DOMAIN)
+                .appendPath("assets")
+                .appendPath("support_chat_widget.html")
+
+            botOptions.forEach { (key, value) ->
+                builder.appendQueryParameter(key, value.toString())
+            }
+
+            return builder.build().toString()
+        }
 
         companion object {
-            const val CHAT_TEXT = "CHAT_TEXT"
-            const val CHAT_EMAIL = "CHAT_EMAIL"
+            const val CHAT_HISTORY = "CHAT_HISTORY"
         }
     }
 
-    data class ChatCompletionEvent(val chatText: String, val email: String)
+    data class ChatCompletionEvent(val chatHistory: String)
+
+    data class BotOptions(
+        val id: String,
+        val inputPlaceHolder: String,
+        val firstMessage: String,
+        val getSupport: String
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.support
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
@@ -36,6 +35,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         supportActionBar?.subtitle = ""
 
         setupWebView()
+        setupJsInterfaceForWebView()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -49,11 +49,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         finish()
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
     private fun setupWebView() {
-        val jsObjName = "jsObject"
-        val allowedOriginRules = setOf("https://$DEFAULT_DOMAIN")
-
         val assetLoader = WebViewAssetLoader.Builder()
             .addPathHandler("/assets/", AssetsPathHandler(this))
             .addPathHandler("/res/", ResourcesPathHandler(this))
@@ -65,6 +61,13 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             WebView.setWebContentsDebuggingEnabled(true)
         }
 
+        intent.getStringExtra(URL_TO_LOAD)?.let { mWebView.loadUrl(it) }
+    }
+
+    private fun setupJsInterfaceForWebView() {
+        val jsObjName = "jsObject"
+        val allowedOriginRules = setOf("https://$DEFAULT_DOMAIN")
+
         // Create a JS object to be injected into frames; Determines if WebMessageListener
         // or WebAppInterface should be used
         createJsObject(
@@ -75,8 +78,6 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             Log.d("Chat history", message)
             onChatSessionClosed(message)
         }
-
-        intent.getStringExtra(URL_TO_LOAD)?.let { mWebView.loadUrl(it) }
     }
 
 
@@ -125,7 +126,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
 
     data class BotOptions(
         val id: String,
-        val inputPlaceHolder: String,
+        val inputPlaceholder: String,
         val firstMessage: String,
         val getSupport: String
     )

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
@@ -12,7 +12,7 @@ class SupportWebViewClient(
     private val assetLoader: WebViewAssetLoader
 ) : ErrorManagedWebViewClient(listener) {
     interface SupportWebViewClientListener : ErrorManagedWebViewClientListener {
-        fun onChatSessionClosed()
+        fun onChatSessionClosed(chatHistory: String)
     }
 
     override fun shouldInterceptRequest(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -179,9 +179,13 @@ class HelpActivity : LocaleAwareActivity() {
         openChatWidget.launch(
             BotOptions(
                 id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
-                inputPlaceholder = "Send a message...",
-                firstMessage = "What can we help you with?",
-                getSupport = "Contact support"
+                inputPlaceholder = getString(R.string.contact_support_input_placeholder),
+                firstMessage = getString(R.string.contact_support_first_message),
+                getSupport = getString(R.string.contact_support_get_support),
+                suggestions = getString(R.string.contact_support_suggestions),
+                questionOne = getString(R.string.contact_support_question_one),
+                questionTwo = getString(R.string.contact_support_question_two),
+                questionThree = getString(R.string.contact_support_question_three)
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -30,8 +30,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
 import org.wordpress.android.support.SupportWebViewActivity
-import org.wordpress.android.support.SupportWebViewActivity.ChatCompletionEvent
-import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.ChatDetails
+import org.wordpress.android.support.SupportWebViewActivity.BotOptions
 import org.wordpress.android.support.ZendeskExtraTags
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
@@ -96,7 +95,7 @@ class HelpActivity : LocaleAwareActivity() {
 
     private val openChatWidget = registerForActivityResult(SupportWebViewActivity.OpenChatWidget()) {
         it?.let {
-            viewModel.finishSupportChat(it)
+            viewModel.sendChatHistory(it)
         }
     }
 
@@ -178,9 +177,11 @@ class HelpActivity : LocaleAwareActivity() {
 
     private fun launchSupportWidget() {
         openChatWidget.launch(
-            ChatDetails(
-                selectedSiteFromExtras,
-                "https://appassets.androidplatform.net/assets/support_chat_widget.html"
+            BotOptions(
+                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH",
+                inputPlaceHolder = "Send a message...",
+                firstMessage = "What can we help you with?",
+                getSupport = "Contact support"
             )
         )
     }
@@ -335,15 +336,6 @@ class HelpActivity : LocaleAwareActivity() {
             // Load Main Activity once signed out, which launches the login flow
             ActivityLauncher.showMainActivity(this@HelpActivity, true)
         }
-
-        viewModel.onSupportChatCompleted.observe(this@HelpActivity) {
-            finishSupportChat(it)
-        }
-    }
-
-    private fun finishSupportChat(event: ChatCompletionEvent) {
-        setResult(RESULT_OK, Intent().putExtra(SupportWebViewActivity.OpenChatWidget.CHAT_EMAIL, event.email))
-        finish()
     }
 
     private fun HelpActivityBinding.loadAvatar(avatarUrl: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -178,8 +178,8 @@ class HelpActivity : LocaleAwareActivity() {
     private fun launchSupportWidget() {
         openChatWidget.launch(
             BotOptions(
-                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH",
-                inputPlaceHolder = "Send a message...",
+                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
+                inputPlaceholder = "Send a message...",
                 firstMessage = "What can we help you with?",
                 getSupport = "Contact support"
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,9 +34,6 @@ class HelpViewModel @Inject constructor(
     private val _onSignOutCompleted = SingleLiveEvent<Unit?>()
     val onSignOutCompleted: LiveData<Unit?> = _onSignOutCompleted
 
-    private val _onSupportChatCompleted = SingleLiveEvent<ChatCompletionEvent>()
-    val onSupportChatCompleted: LiveData<ChatCompletionEvent> = _onSupportChatCompleted
-
     fun signOutWordPress(application: WordPress) {
         launch {
             _showSigningOutDialog.value = Event(true)
@@ -54,11 +52,8 @@ class HelpViewModel @Inject constructor(
         }
     }
 
-    fun finishSupportChat(event: ChatCompletionEvent) {
-        endChatSession(event)
-    }
-
-    private fun endChatSession(event: ChatCompletionEvent) {
-        _onSupportChatCompleted.value = event
+    fun sendChatHistory(event: ChatCompletionEvent) {
+        // Submit to Zendesk
+        Log.d("Chat History: ", event.chatHistory)
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2279,6 +2279,14 @@
     <!-- Contact us -->
     <string name="support_ticket_subject">WordPress for Android Support</string>
 
+    <string name="contact_support_input_placeholder">Send a message…</string>
+    <string name="contact_support_first_message">What can we help you with?</string>
+    <string name="contact_support_get_support">Contact support</string>
+    <string name="contact_support_suggestions">Not sure what to ask?</string>
+    <string name="contact_support_question_one">How do I change home page?</string>
+    <string name="contact_support_question_two">Account or billing issues?</string>
+    <string name="contact_support_question_three">Need to report an error or crash?</string>
+
     <!--My Site-->
     <string name="my_site_header_content">Content</string>
     <string name="my_site_header_traffic">Traffic</string>


### PR DESCRIPTION
Configures chat interface to match the designs as much as possible
- Provides essential options to bot like id, firstMessage, color etc....
- Removes top `X Close` button
- Removes top `Reset` button
- Removes top Header
- Adds `Contact support` button

Fixes #18900 
This also fixes part of #18828 

| Start | Conversation |
|--------|--------|
|![Screenshot_20230811_034120](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/2291d512-3767-451c-8e5d-d88bc9d7b91f) | ![Screenshot_20230811_034138](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/0ac8ef09-c2fc-4e76-828d-f4eab56dfbc9)| 


1. Launch Jetpack app
2. Go to `Me` (Tap on Avatar in the bottom nav)
3. Tap `Debug Settings`
4. Find `contact_support` under `Remote features` tab, and enable it, return to Help screen
5. Tap on Help -> Contact Support
6. `Verify` it launches Support Bot as shown above
7. `Send a message...` in the text field
8. `Verify` bot responds with an answer
9. `Verify` there's a `Contact support` button below response
10. `Tap` on the `Contact support`
11. `Verify` the chat windows is closed, and returns to Help screen
12. `Observe` in AS Logcat Chat history is logged
13. `Tap` on `Contact support` again on `Help` screen
14. `Tap` on back arrow in the header, and ensure it returns to previous `Help` screen

>**Note**
> Further enhancements could be done in the next PRs

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
