### PR TITLE
Fix Campaign status label color - scheduled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/CampaignStatus.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/CampaignStatus.kt
@@ -29,18 +29,18 @@ enum class CampaignStatus(val status: String, @StringRes val stringResource: Int
     fun textColor(isInDarkMode: Boolean): Color {
         return when (this) {
             Active -> if (isInDarkMode) Color(0xFF68DE86) else Color(0xFF00450C)
-            Completed -> if (isInDarkMode) Color(0xFF91CAF2) else Color(0xFF02395C)
+            Completed, Scheduled -> if (isInDarkMode) Color(0xFF91CAF2) else Color(0xFF02395C)
             Rejected, Canceled -> if (isInDarkMode) Color(0xFFFFABAF) else Color(0xFF8A2424)
-            InModeration, Scheduled -> if (isInDarkMode) Color(0xFFF2D76B) else Color(0xFF4F3500)
+            InModeration -> if (isInDarkMode) Color(0xFFF2D76B) else Color(0xFF4F3500)
         }
     }
 
     fun textViewBackgroundColor(isInDarkMode: Boolean): Color {
         return when (this) {
             Active -> if (isInDarkMode) Color(0xFF003008) else Color(0xFFB8E6BF)
-            Completed -> if (isInDarkMode) Color(0xFF01283D) else Color(0xFFBBE0FA)
+            Completed, Scheduled -> if (isInDarkMode) Color(0xFF01283D) else Color(0xFFBBE0FA)
             Rejected, Canceled -> if (isInDarkMode) Color(0xFF451313) else Color(0xFFFACFD2)
-            InModeration, Scheduled -> if (isInDarkMode) Color(0xFF332200) else Color(0xFFF5E6B3)
+            InModeration -> if (isInDarkMode) Color(0xFF332200) else Color(0xFFF5E6B3)
         }
     }
 }


### PR DESCRIPTION
## Fixes 
The color of the status label for scheduled campaign status

## To test:
- Go to app → Campaign Dashboard card 
- Or Click on the Campaign Dashboard card to navigate to Campaign listing page 
- Verify that for the campaign in Scheduled status, the status label background color and text color is same as that of Completed.
 
## Regression Notes
1. Potential unintended areas of impact
Campaign status label color is not correct

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A


PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)