### PR TITLE
Jetpack feature removal: Adds the logic to show phase 4 overlay with frequency

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureOverlayShownTracker.kt
@@ -5,7 +5,9 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.NO
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.READER
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.STATS
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPrefs: SharedPreferences) {
     fun getTheLastShownOverlayTimeStamp(phase: JetpackFeatureRemovalOverlayPhase): Long? {
         val overlayShownTimeStampList: ArrayList<Long> = arrayListOf()
@@ -37,6 +39,9 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
 
     fun setFeatureCollectionOverlayShown(phase: JetpackFeatureRemovalPhase) {
         sharedPrefs.edit().putBoolean(buildFeatureCollectionOverlayShownKey(phase), true).apply()
+        if(phase == JetpackFeatureRemovalPhase.PhaseFour) {
+            setPhaseFourOverlayShownTimeStamp(System.currentTimeMillis())
+        }
     }
 
     fun getFeatureCollectionOverlayShown(phase: JetpackFeatureRemovalPhase) =
@@ -45,8 +50,19 @@ class JetpackFeatureOverlayShownTracker @Inject constructor(private val sharedPr
     private fun buildFeatureCollectionOverlayShownKey(phase: JetpackFeatureRemovalPhase) =
         KEY_FEATURE_COLLECTION_OVERLAY_SHOWN.plus(phase.trackingName)
 
+    fun getPhaseFourOverlayShownTimeStamp(): Long? {
+        val overlayShownTime = sharedPrefs.getLong(KEY_PHASE_FOUR_OVERLAY_SHOWN_TIME_STAMP, 0L)
+        if (overlayShownTime == 0L) return null
+        return overlayShownTime
+    }
+
+    private fun setPhaseFourOverlayShownTimeStamp(timeStamp: Long) {
+        sharedPrefs.edit().putLong(KEY_PHASE_FOUR_OVERLAY_SHOWN_TIME_STAMP, timeStamp).apply()
+    }
+
     companion object {
         const val KEY_FEATURE_COLLECTION_OVERLAY_SHOWN = "KEY_FEATURE_COLLECTION_OVERLAY_SHOWN"
+        const val KEY_PHASE_FOUR_OVERLAY_SHOWN_TIME_STAMP = "KEY_PHASE_FOUR_OVERLAY_SHOWN_TIME_STAMP"
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -62,15 +62,23 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
 
     fun shouldShowFeatureCollectionJetpackOverlayForFirstTime(): Boolean {
         val phase = jetpackFeatureRemovalPhaseHelper.getCurrentPhase() ?: return false
-        val featureCollectionOverlayShown = jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(phase)
-        return !featureCollectionOverlayShown && shouldShowFeatureCollectionOverlayInCurrentPhase(phase)
+        return shouldShowFeatureCollectionOverlayInCurrentPhase(phase)
     }
 
     private fun shouldShowFeatureCollectionOverlayInCurrentPhase(phase: JetpackFeatureRemovalPhase): Boolean {
         return when (phase) {
-            PhaseThree, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> true
+            PhaseThree, PhaseNewUsers, PhaseSelfHostedUsers ->
+                !jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(phase)
+            PhaseFour -> shouldShowPhaseFourFeatureCollectionOverlay()
             else -> false
         }
+    }
+
+    // if the overlay is not shown, then show it
+    // if the overlay is shown and the remote config value is 0, then don't show
+    // if the overlay is shown and the remote config value is not 0, then check the frequency
+    private fun shouldShowPhaseFourFeatureCollectionOverlay(): Boolean{
+        return !jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(PhaseFour)
     }
 
     private fun isInSiteCreationPhase(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -77,8 +77,20 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     // if the overlay is not shown, then show it
     // if the overlay is shown and the remote config value is 0, then don't show
     // if the overlay is shown and the remote config value is not 0, then check the frequency
-    private fun shouldShowPhaseFourFeatureCollectionOverlay(): Boolean{
-        return !jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(PhaseFour)
+    private fun shouldShowPhaseFourFeatureCollectionOverlay(): Boolean {
+        val isOverlayShown = jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(PhaseFour)
+        if (!isOverlayShown) return true
+        val phaseFourOverlayFrequency = jetpackFeatureRemovalPhaseHelper.getPhaseFourOverlayFrequency()
+        if (phaseFourOverlayFrequency == 0) return false
+        val overlayShownDate = jetpackFeatureOverlayShownTracker.getPhaseFourOverlayShownTimeStamp()
+        if (overlayShownDate != null) {
+            val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(
+                Date(overlayShownDate),
+                dateTimeUtilsWrapper.getTodaysDate()
+            )
+            return daysPastOverlayShown >= phaseFourOverlayFrequency
+        }
+        return false
     }
 
     private fun isInSiteCreationPhase(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -77,6 +77,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
     // if the overlay is not shown, then show it
     // if the overlay is shown and the remote config value is 0, then don't show
     // if the overlay is shown and the remote config value is not 0, then check the frequency
+    @Suppress("ReturnCount")
     private fun shouldShowPhaseFourFeatureCollectionOverlay(): Boolean {
         val isOverlayShown = jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(PhaseFour)
         if (!isOverlayShown) return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalOverlayUtil.kt
@@ -82,7 +82,7 @@ class JetpackFeatureRemovalOverlayUtil @Inject constructor(
         val isOverlayShown = jetpackFeatureOverlayShownTracker.getFeatureCollectionOverlayShown(PhaseFour)
         if (!isOverlayShown) return true
         val phaseFourOverlayFrequency = jetpackFeatureRemovalPhaseHelper.getPhaseFourOverlayFrequency()
-        if (phaseFourOverlayFrequency == 0) return false
+        if (phaseFourOverlayFrequency == -1) return false
         val overlayShownDate = jetpackFeatureOverlayShownTracker.getPhaseFourOverlayShownTimeStamp()
         if (overlayShownDate != null) {
             val daysPastOverlayShown = dateTimeUtilsWrapper.daysBetween(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalStaticPostersConfig
+import org.wordpress.android.util.config.PhaseFourOverlayFrequencyConfig
 import javax.inject.Inject
 
 private const val PHASE_ONE_GLOBAL_OVERLAY_FREQUENCY_IN_DAYS = 2
@@ -38,7 +39,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalPhaseFourConfig: JetpackFeatureRemovalPhaseFourConfig,
     private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig,
     private val jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig,
-    private val jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig
+    private val jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig,
+    private val jetpackPhaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig
 ) {
     fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
@@ -154,6 +156,10 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
             is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
             else -> true
         }
+    }
+
+    fun getPhaseFourOverlayFrequency(): Int {
+        return jetpackPhaseFourOverlayFrequencyConfig.getValue()
     }
 }
 // Global overlay frequency is the frequency at which the overlay is shown across the features

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
@@ -76,7 +76,7 @@ class PhaseSelfHostedPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     )
 
 const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD = "phase_four_overlay_frequency_in_days"
-const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE = "4"
+const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE = "0"
 
 @RemoteFieldDefaultGenerater(
     remoteField = PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD,

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
@@ -74,3 +74,16 @@ class PhaseSelfHostedPostLinkConfig @Inject constructor(appConfig: AppConfig) :
         appConfig,
         PHASE_SELF_HOSTED_BLOG_POST_LINK_REMOTE_FIELD
     )
+
+const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD = "phase_four_overlay_frequency_in_days"
+const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE = "4"
+
+@RemoteFieldDefaultGenerater(
+    remoteField = PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD,
+    defaultValue = PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE
+)
+class PhaseFourOverlayFrequencyConfig @Inject constructor(appConfig: AppConfig) :
+    RemoteConfigField<Int>(
+        appConfig,
+        PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD
+    )

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JetpackFeatureRemovalRemoteFields.kt
@@ -76,7 +76,7 @@ class PhaseSelfHostedPostLinkConfig @Inject constructor(appConfig: AppConfig) :
     )
 
 const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD = "phase_four_overlay_frequency_in_days"
-const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE = "0"
+const val PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE = "-1"
 
 @RemoteFieldDefaultGenerater(
     remoteField = PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_REMOTE_FIELD,

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseThreeConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseTwoConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalSelfHostedUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalStaticPostersConfig
+import org.wordpress.android.util.config.PhaseFourOverlayFrequencyConfig
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -54,6 +55,9 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
     @Mock
     private lateinit var jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig
 
+    @Mock
+    private lateinit var phaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig
+
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Before
@@ -66,7 +70,8 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
             jetpackFeatureRemovalPhaseFourConfig,
             jetpackFeatureRemovalNewUsersConfig,
             jetpackFeatureRemovalSelfHostedUsersConfig,
-            jetpackFeatureRemovalStaticPostersConfig
+            jetpackFeatureRemovalStaticPostersConfig,
+            phaseFourOverlayFrequencyConfig
         )
     }
 


### PR DESCRIPTION
## Adds 
Based on the discussion here - pcdRpT-2O8-p2#comment-5649
This PR adds the logic to show the Phase 4 overlay with a frequency according to a remote config value 

## To test:
### Regression - if the Phase 4 overlay is not shown, then show it
- Login to the WordPress app 
- Go to me → Debug settings 
- Enable jp_removal_four 
- Restart App 
- Verify that on app launch, the phase 4 overlay is shown 

### Phase 4 overlay is not shown if the remote config value is -1
- Continue from the above test 
- Restart the app 
- Change the System date +1, + 2 or +n 
- Verify that on app launch, the phase 4 overlay is not shown 

### The remote config value is not -1 case

#### The overlay is not shown when days past is less than the desired frequency 
- Continue from the above test
- Change the PHASE_FOUR_OVERLAY_FREQUENCY_IN_DAYS_DEFAULT_VALUE to n 
- Change the system date to a date less than n 
- Verify that on app launch, the phase 4 overlay is not shown 

#### The overlay is shown when days past is greater than the desired frequency 
- Continue from the above test 
- Change the system date to make system date - date from today  > n 
- Verify that on app launch, phase 4 overlay is shown 

## Regression Notes
1. Potential unintended areas of impact
Jetpack feature overlay is not shown as expected in Phase 4

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Manual testing 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)