### PR TITLE
[Site Picker] Don't filter out Jetpack CP-connected sites when adding a self-hosted site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -19,6 +19,7 @@ import androidx.fragment.app.Fragment;
 import com.wordpress.stories.compose.frame.FrameSaveNotifier;
 import com.wordpress.stories.compose.frame.StorySaveEvents.StorySaveResult;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -1664,7 +1665,8 @@ public class ActivityLauncher {
     public static void addSelfHostedSiteForResult(Activity activity) {
         Intent intent;
         intent = new Intent(activity, LoginActivity.class);
-        LoginMode.SELFHOSTED_ONLY.putInto(intent);
+        LoginMode mode = BuildConfig.IS_JETPACK_APP ? LoginMode.JETPACK_SELFHOSTED : LoginMode.SELFHOSTED_ONLY;
+        mode.putInto(intent);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -168,6 +168,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                     mIsSignupFromLoginEnabled = mBuildConfigWrapper.isSignupEnabled();
                     checkSmartLockPasswordAndStartLogin();
                     break;
+                case JETPACK_SELFHOSTED:
                 case SELFHOSTED_ONLY:
                     mUnifiedLoginTracker.setSource(Source.SELF_HOSTED);
                     showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
@@ -336,6 +337,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
                 ActivityLauncher.showLoginEpilogueForResult(this, oldSitesIds, false);
                 break;
             case SHARE_INTENT:
+            case JETPACK_SELFHOSTED:
             case SELFHOSTED_ONLY:
                 // We are comparing list of site ID's before self-hosted site was added and after, trying to find a
                 // newly added self-hosted site's ID, so we can select it
@@ -762,7 +764,8 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     @Override
     public void saveCredentialsInSmartLock(@Nullable final String username, @Nullable final String password,
                                            @NonNull final String displayName, @Nullable final Uri profilePicture) {
-        if (getLoginMode() == LoginMode.SELFHOSTED_ONLY) {
+        LoginMode mode = getLoginMode();
+        if (mode == LoginMode.SELFHOSTED_ONLY || mode == LoginMode.JETPACK_SELFHOSTED) {
             // bail if we are on the selfhosted flow since we haven't initialized SmartLock-for-Passwords for it.
             // Otherwise, logging in to WPCOM via the site-picker flow (for example) results in a crash.
             // See https://github.com/wordpress-mobile/WordPress-Android/issues/7182#issuecomment-362791364

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     gutenbergMobileVersion = 'v1.101.0'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.41.0'
-    wordPressLoginVersion = '120-cf8c80652bdcb47fd0ea8a0102d1e14a5a695825'
+    wordPressLoginVersion = '1.5.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.7.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     gutenbergMobileVersion = 'v1.101.0'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.41.0'
-    wordPressLoginVersion = '1.4.0'
+    wordPressLoginVersion = '120-cf8c80652bdcb47fd0ea8a0102d1e14a5a695825'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.7.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'


### PR DESCRIPTION
Fixes #18223 
Companion PR: https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/120

Added a new LoginMode inside the LoginFlow library to make sure the internal site fetching there doesn't filter out Jetpack CP-connected sites, which should always be shown in the Jetpack app.

Bug:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/b6246f20-111e-4470-9cda-314d87b75199

Fixed:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/6ae28db9-0a71-472d-95f1-4e1c13683657

## Important
Before merging we need to publish a release version of the LoginFlow library.

## To test
Make sure you have a WP.com account with a self-hosted site connected to it via a plugin that uses Jetpack CP (e.g.: Jetpack Search).

1. Login with a WP.com account
2. Go to the Site Picker
3. **Verify** your CP-connected self-hosted site is shown
4. Add another self-hosted site
5. **Verify** the Jetpack CP-connected site is still on the list

Test with WP as well to make sure the CP-connected site is never shown automatically even after adding a different self-hosted site.

## Regression Notes
1. Potential unintended areas of impact
Issues when adding self-hosted sites.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

9. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
