### PR TITLE
[Reader] Mute all videos by default to avoid hearing the audio of another post in the displayed post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -103,7 +103,6 @@ public class ReaderWebView extends WPWebView {
             this.setWebChromeClient(mReaderChromeClient);
             this.setWebViewClient(new ReaderWebViewClient(this));
             this.getSettings().setUserAgentString(WordPress.getUserAgent());
-            this.getSettings().setMediaPlaybackRequiresUserGesture(false);
 
             // Enable third-party cookies since they are disabled by default;
             // we need third-party cookies to support authenticated images


### PR DESCRIPTION
Fixes #18870 

To test:
Steps to reproduce can be found in the issue description https://github.com/wordpress-mobile/WordPress-Android/issues/18870

## Regression Notes
1. Potential unintended areas of impact
Unexpected problems with videos in the Reader.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
 _

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
