### PR TITLE
Dashboard Cards: Remove "Create Next Post" card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1509,7 +1509,7 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { site ->
             cardsTracker.trackPostItemClicked(params.postCardType)
             when (params.postCardType) {
-                PostCardType.CREATE_FIRST, PostCardType.CREATE_NEXT -> _onNavigation.value =
+                PostCardType.CREATE_FIRST -> _onNavigation.value =
                     Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
 
                 PostCardType.DRAFT -> _onNavigation.value =
@@ -1529,9 +1529,7 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { site ->
             cardsTracker.trackPostCardFooterLinkClicked(postCardType)
             _onNavigation.value = when (postCardType) {
-                PostCardType.CREATE_FIRST, PostCardType.CREATE_NEXT ->
-                    Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-
+                PostCardType.CREATE_FIRST -> Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
                 PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
                 PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -47,7 +47,6 @@ class CardsTracker @Inject constructor(
 
     enum class PostSubtype(val label: String) {
         CREATE_FIRST("create_first"),
-        CREATE_NEXT("create_next"),
         DRAFT("draft"),
         SCHEDULED("scheduled")
     }
@@ -171,7 +170,6 @@ fun DashboardCardType.toTypeValue(): Type {
 fun PostCardType.toSubtypeValue(): PostSubtype {
     return when (this) {
         PostCardType.CREATE_FIRST -> PostSubtype.CREATE_FIRST
-        PostCardType.CREATE_NEXT -> PostSubtype.CREATE_NEXT
         PostCardType.DRAFT -> PostSubtype.DRAFT
         PostCardType.SCHEDULED -> PostSubtype.SCHEDULED
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -45,9 +45,7 @@ class PostCardBuilder @Inject constructor(
             val posts = params.posts
             posts?.hasPublished?.takeIf { !posts.hasDraftsOrScheduledPosts() }
                 ?.let { hasPublished ->
-                    if (hasPublished) {
-                        add(createNextPostCard(params.onPostItemClick, params.onFooterLinkClick))
-                    } else {
+                    if (!hasPublished) {
                         add(createFirstPostCard(params.onPostItemClick, params.onFooterLinkClick))
                     }
                 }
@@ -73,24 +71,6 @@ class PostCardBuilder @Inject constructor(
         ),
         onClick = ListItemInteraction.create(
             PostItemClickParams(postCardType = PostCardType.CREATE_FIRST, postId = NOT_SET),
-            onPostItemClick
-        )
-    )
-
-    private fun createNextPostCard(
-        onPostItemClick: (params: PostItemClickParams) -> Unit,
-        onFooterLinkClick: (postCardType: PostCardType) -> Unit
-    ) = PostCardWithoutPostItems(
-        postCardType = PostCardType.CREATE_NEXT,
-        title = UiStringRes(R.string.my_site_create_next_post_title),
-        excerpt = UiStringRes(R.string.my_site_create_next_post_excerpt),
-        imageRes = R.drawable.img_write_212dp,
-        footerLink = FooterLink(
-            label = UiStringRes(R.string.my_site_post_card_link_create_post),
-            onClick = onFooterLinkClick
-        ),
-        onClick = ListItemInteraction.create(
-            PostItemClickParams(postCardType = PostCardType.CREATE_NEXT, postId = NOT_SET),
             onPostItemClick
         )
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardType.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
 enum class PostCardType(val id: Int) {
     CREATE_FIRST(0),
-    CREATE_NEXT(1),
     DRAFT(2),
     SCHEDULED(3)
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1690,16 +1690,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `given create next card, when footer link is clicked, then editor is opened to create new post`() =
-        test {
-            initSelectedSite()
-
-            requireNotNull(onPostCardFooterLinkClick).invoke(PostCardType.CREATE_NEXT)
-
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-        }
-
-    @Test
     fun `given draft post card, when footer link is clicked, then draft posts screen is opened`() = test {
         initSelectedSite()
 
@@ -1743,16 +1733,6 @@ class MySiteViewModelTest : BaseUnitTest() {
             initSelectedSite()
 
             requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
-
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-        }
-
-    @Test
-    fun `when create next post card is clicked, then editor is opened to create new post`() =
-        test {
-            initSelectedSite()
-
-            requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_NEXT, NOT_SET))
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
         }
@@ -1802,15 +1782,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
 
         verify(cardsTracker).trackPostItemClicked(PostCardType.CREATE_FIRST)
-    }
-
-    @Test
-    fun `given create next post card, when item is clicked, then event is tracked`() = test {
-        initSelectedSite()
-
-        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_NEXT, NOT_SET))
-
-        verify(cardsTracker).trackPostItemClicked(PostCardType.CREATE_NEXT)
     }
 
     /* DASHBOARD BLOGGING PROMPT CARD */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -50,13 +50,6 @@ class CardsShownTrackerTest {
     }
 
     @Test
-    fun `when post card create next card is shown, then create next shown event is tracked`() {
-        cardsShownTracker.track(buildDashboardCards(PostCardType.CREATE_NEXT))
-
-        verifyCardShownTracked(Type.POST.label, PostSubtype.CREATE_NEXT.label)
-    }
-
-    @Test
     fun `when post card scheduled card is shown, then scheduled shown event is tracked`() {
         cardsShownTracker.track(buildDashboardCards(PostCardType.SCHEDULED))
 
@@ -105,7 +98,7 @@ class CardsShownTrackerTest {
         cards = mutableListOf<DashboardCard>().apply {
             when (postCardType) {
                 PostCardType.SCHEDULED, PostCardType.DRAFT -> addAll(buildPostCardsWithItems(postCardType))
-                PostCardType.CREATE_FIRST, PostCardType.CREATE_NEXT -> addAll(
+                PostCardType.CREATE_FIRST -> addAll(
                     buildPostCardsWithoutItems(
                         postCardType
                     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -88,13 +88,6 @@ class CardsTrackerTest {
     }
 
     @Test
-    fun `when post create next footer link is clicked, then post create next event is tracked`() {
-        cardsTracker.trackPostCardFooterLinkClicked(PostCardType.CREATE_NEXT)
-
-        verifyFooterLinkClickedTracked(Type.POST, PostSubtype.CREATE_NEXT.label)
-    }
-
-    @Test
     fun `when post draft footer link is clicked, then post draft event is tracked`() {
         cardsTracker.trackPostCardFooterLinkClicked(PostCardType.DRAFT)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -149,68 +149,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         )
     }
 
-    /* CREATE NEXT POST CARD */
-
-    @Test
-    fun `given published post without draft + sched post, when card is built, then create next card exists`() {
-        val posts = getPosts(hasPublished = true)
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateNextPostCard()).isNotNull
-    }
-
-    @Test
-    fun `given no published post with draft post, when card is built, then create next card not exists`() {
-        val posts = getPosts(hasPublished = false, draftPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateNextPostCard()).isNull()
-    }
-
-    @Test
-    fun `given no published post with scheduled post, when card is built, then create next card not exists`() {
-        val posts = getPosts(hasPublished = false, scheduledPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateNextPostCard()).isNull()
-    }
-
-    @Test
-    fun `given published post not present, when card is built, then create next card not exists`() {
-        val posts = getPosts(hasPublished = false)
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateNextPostCard()).isNull()
-    }
-
-    @Test
-    fun `given create next post, when card is built, then it contains correct preset elements`() {
-        val posts = getPosts(hasPublished = true)
-
-        val postsCard = buildPostsCard(posts).filterCreateNextPostCard()
-
-        assertThat(postsCard).isEqualTo(
-            PostCardWithoutPostItems(
-                postCardType = PostCardType.CREATE_NEXT,
-                title = UiStringRes(R.string.my_site_create_next_post_title),
-                excerpt = UiStringRes(R.string.my_site_create_next_post_excerpt),
-                imageRes = R.drawable.img_write_212dp,
-                footerLink = FooterLink(
-                    label = UiStringRes(R.string.my_site_post_card_link_create_post),
-                    onClick = onPostCardFooterLinkClick
-                ),
-                ListItemInteraction.create(
-                    PostItemClickParams(postCardType = PostCardType.CREATE_NEXT, postId = NOT_SET),
-                    onPostItemClick
-                )
-            )
-        )
-    }
-
     /* DRAFT POST CARD */
 
     @Test
@@ -368,13 +306,6 @@ class PostCardBuilderTest : BaseUnitTest() {
                 it.dashboardCardType == DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS
             } as? List<PostCardWithoutPostItems>
             )?.firstOrNull { it.postCardType == PostCardType.CREATE_FIRST }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun List<PostCard>.filterCreateNextPostCard() = (
-            filter {
-                it.dashboardCardType == DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS
-            } as? List<PostCardWithoutPostItems>
-            )?.firstOrNull { it.postCardType == PostCardType.CREATE_NEXT }
 
     @Suppress("UNCHECKED_CAST")
     private fun List<PostCard>.filterDraftPostCard() = (


### PR DESCRIPTION
Closes #18939 

Changes made in this PR include: 
- Removes the logic for build the `Create Your Next Post` dashboard card
- Removes all tests related to the card

Note: This PR does NOT remove the `PostCardWithoutPostItems` post card type; that will follow in the next PR for removing create first post card.

**To test:**
- Install the app
- Login
- Navigate to a site in which you have published posts
- ✅ Verify the Create next Post card is not shown
- Navigate to a site in which you have draft posts
- ✅ Verify the drafts post card is shown
- Navigate to a site in which you have scheduled posts
- ✅ Verify the scheduled post card is shown

## Regression Notes
1. Potential unintended areas of impact
The dashboard still shows a create next post card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:N/A
