### PR TITLE
Create ZD ticket from chat bot

### DIFF
--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -12,7 +12,6 @@
             supportCallback: function(event, history) {
                 event.preventDefault() // Optionally prevent default behavior opening the url.
                 console.log(history) // Safely access the chat history.
-                DocsBotAI.close() // Close the widget.
                 sendAndroidMessage(history)
             },
             options: {

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -12,7 +12,7 @@
             supportCallback: function(event, history) {
                 event.preventDefault() // Optionally prevent default behavior opening the url.
                 console.log(history) // Safely access the chat history.
-                sendAndroidMessage(history)
+                sendAndroidMessage(JSON.stringify(history))
             },
             options: {
                 botName: "Jetpack Mobile",

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.accounts.HelpActivity
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.widgets.WPSnackbar
 import javax.inject.Inject
@@ -65,6 +66,8 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
 
     override fun onSupportTapped(chatHistory: String) {
         zendeskHelper.requireIdentity(this, selectedSiteFromExtras) {
+            showTicketCreatingMessage()
+
             val description = zendeskHelper.parseChatHistory(
                 getString(R.string.contact_support_bot_ticket_comment_start),
                 getString(R.string.contact_support_bot_ticket_comment_question),
@@ -73,7 +76,12 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             )
             createNewZendeskRequest(description, object : ZendeskHelper.CreateRequestCallback() {
                 override fun onSuccess() {
-                    showTicketMessage()
+                    showZendeskTickets()
+                    ToastUtils.showToast(
+                        this@SupportWebViewActivity,
+                        R.string.contact_support_bot_ticket_message,
+                        ToastUtils.Duration.LONG
+                    )
                 }
 
                 override fun onError() {
@@ -94,18 +102,12 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         )
     }
 
-    private fun showTicketMessage() {
+    private fun showTicketCreatingMessage() {
         WPSnackbar.make(
             findViewById(R.id.webview_wrapper),
-            R.string.contact_support_bot_ticket_message,
-            Snackbar.LENGTH_LONG
-        ).apply {
-            setAction(R.string.contact_support_bot_ticket_button) {
-                showZendeskTickets()
-                finish()
-            }
-            show()
-        }
+            R.string.contact_support_bot_ticket_loading,
+            Snackbar.LENGTH_INDEFINITE
+        ).show()
     }
 
     private fun showTicketErrorMessage() {

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -72,10 +72,17 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         zendeskHelper.requireIdentity(this, selectedSiteFromExtras) {
             progress.isVisible = true
             val description = zendeskHelper.parseChatHistory(chatHistory)
-            createNewZendeskRequest(description) {
-                progress.isVisible = false
-                showTicketMessage()
-            }
+            createNewZendeskRequest(description, object : ZendeskHelper.CreateRequestCallback() {
+                override fun onSuccess() {
+                    progress.isVisible = false
+                    showTicketMessage()
+                }
+
+                override fun onError() {
+                    progress.isVisible = false
+                    showTicketErrorMessage()
+                }
+            })
         }
     }
 
@@ -87,17 +94,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         }
     }
 
-    private fun createNewZendeskRequest(description: String, complete: () -> Unit) {
-        val callback = object : ZendeskHelper.CreateRequestCallback() {
-            override fun onSuccess() {
-                complete()
-            }
-
-            override fun onError() {
-                complete()
-            }
-        }
-
+    private fun createNewZendeskRequest(description: String, callback: ZendeskHelper.CreateRequestCallback) {
         zendeskHelper.createRequest(
             this,
             originFromExtras,
@@ -120,6 +117,14 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             }
             show()
         }
+    }
+
+    private fun showTicketErrorMessage() {
+        WPSnackbar.make(
+            findViewById(R.id.webview_wrapper),
+            R.string.contact_support_bot_ticket_error,
+            Snackbar.LENGTH_LONG
+        ).show()
     }
 
     private fun showZendeskTickets() {

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -43,7 +43,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         return true
     }
 
-    override fun onChatSessionClosed(chatHistory: String) {
+    override fun onSupportTapped(chatHistory: String) {
         intent.putExtra(CHAT_HISTORY, chatHistory)
         setResult(RESULT_OK, intent)
         finish()
@@ -57,7 +57,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         mWebView.webViewClient = SupportWebViewClient(this, assetLoader)
 
         // Setup debugging; See https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews
-        if ( 0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
+        if (0 != applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) {
             WebView.setWebContentsDebuggingEnabled(true)
         }
 
@@ -76,7 +76,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             allowedOriginRules
         ) { message ->
             Log.d("Chat history", message)
-            onChatSessionClosed(message)
+            onSupportTapped(message)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -10,13 +10,11 @@ import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.core.view.isVisible
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
 import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.textview.MaterialTextView
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -43,8 +41,6 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         intent.extras?.getSerializableCompat<SiteModel>(WordPress.SITE)
     }
 
-    lateinit var progress: ViewGroup
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
@@ -58,7 +54,6 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         supportActionBar?.title = getString(R.string.help)
         supportActionBar?.subtitle = ""
 
-        setupLoadingIndicator()
         setupWebView()
         setupJsInterfaceForWebView()
     }
@@ -70,7 +65,6 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
 
     override fun onSupportTapped(chatHistory: String) {
         zendeskHelper.requireIdentity(this, selectedSiteFromExtras) {
-            progress.isVisible = true
             val description = zendeskHelper.parseChatHistory(
                 getString(R.string.contact_support_bot_ticket_comment_start),
                 getString(R.string.contact_support_bot_ticket_comment_question),
@@ -79,23 +73,13 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
             )
             createNewZendeskRequest(description, object : ZendeskHelper.CreateRequestCallback() {
                 override fun onSuccess() {
-                    progress.isVisible = false
                     showTicketMessage()
                 }
 
                 override fun onError() {
-                    progress.isVisible = false
                     showTicketErrorMessage()
                 }
             })
-        }
-    }
-
-    private fun setupLoadingIndicator() {
-        progress = findViewById(R.id.progress_layout)
-        progress.findViewById<MaterialTextView>(R.id.progress_text).apply {
-            setText(R.string.contact_support_bot_ticket_loading)
-            isVisible = true
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -11,16 +11,20 @@ import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.view.isVisible
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
 import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
+import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.Companion.CHAT_HISTORY
 import org.wordpress.android.ui.WPWebViewActivity
 
 class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
+    lateinit var progress: ViewGroup
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
@@ -34,6 +38,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         supportActionBar?.title = getString(R.string.help)
         supportActionBar?.subtitle = ""
 
+        setupLoadingIndicator()
         setupWebView()
         setupJsInterfaceForWebView()
     }
@@ -47,6 +52,14 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         intent.putExtra(CHAT_HISTORY, chatHistory)
         setResult(RESULT_OK, intent)
         finish()
+    }
+
+    private fun setupLoadingIndicator() {
+        progress = findViewById(R.id.progress_layout)
+        progress.findViewById<MaterialTextView>(R.id.progress_text).apply {
+            setText(R.string.contact_support_bot_ticket_loading)
+            isVisible = true
+        }
     }
 
     private fun setupWebView() {

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -71,7 +71,12 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
     override fun onSupportTapped(chatHistory: String) {
         zendeskHelper.requireIdentity(this, selectedSiteFromExtras) {
             progress.isVisible = true
-            val description = zendeskHelper.parseChatHistory(chatHistory)
+            val description = zendeskHelper.parseChatHistory(
+                getString(R.string.contact_support_bot_ticket_comment_start),
+                getString(R.string.contact_support_bot_ticket_comment_question),
+                getString(R.string.contact_support_bot_ticket_comment_answer),
+                chatHistory
+            )
             createNewZendeskRequest(description, object : ZendeskHelper.CreateRequestCallback() {
                 override fun onSuccess() {
                     progress.isVisible = false

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
@@ -12,7 +12,7 @@ class SupportWebViewClient(
     private val assetLoader: WebViewAssetLoader
 ) : ErrorManagedWebViewClient(listener) {
     interface SupportWebViewClientListener : ErrorManagedWebViewClientListener {
-        fun onChatSessionClosed(chatHistory: String)
+        fun onSupportTapped(chatHistory: String)
     }
 
     override fun shouldInterceptRequest(

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
 import androidx.preference.PreferenceManager
+import com.google.gson.Gson
 import com.zendesk.logger.Logger
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
@@ -143,8 +144,13 @@ class ZendeskHelper(
         }
     }
 
-    fun parseChatHistory(chatHistory: String): String {
-        return chatHistory
+    fun parseChatHistory(startMessage: String, question: String, answer: String, chatHistory: String): String {
+        val messageList = Gson().fromJson(chatHistory, ArrayList<ArrayList<String>>().javaClass)
+        var description = startMessage
+        messageList.forEach {
+            description = description + "\n>\n" + question + "\n>\n" + it.first() + "\n>\n" + answer + "\n>\n" + it[1]
+        }
+        return description
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -144,7 +144,6 @@ class ZendeskHelper(
     }
 
     fun parseChatHistory(chatHistory: String): String {
-        // TODO: parse the chat history
         return chatHistory
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -143,6 +143,11 @@ class ZendeskHelper(
         }
     }
 
+    fun parseChatHistory(chatHistory: String): String {
+        // TODO: parse the chat history
+        return chatHistory
+    }
+
     @Suppress("LongParameterList")
     fun createRequest(
         context: Context,
@@ -301,7 +306,7 @@ class ZendeskHelper(
      * Otherwise, it'll show a dialog for the user to enter an email and name through a helper function which then
      * will be used to set the identity and call the callback. It'll also try to enable the push notifications.
      */
-    private fun requireIdentity(
+    fun requireIdentity(
         context: Context,
         selectedSite: SiteModel?,
         onIdentitySet: () -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -92,12 +92,6 @@ class HelpActivity : LocaleAwareActivity() {
         intent.extras?.get(WordPress.SITE) as SiteModel?
     }
 
-    private val openChatWidget = registerForActivityResult(SupportWebViewActivity.OpenChatWidget()) {
-        it?.let {
-            viewModel.sendChatHistory(it)
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         with(HelpActivityBinding.inflate(layoutInflater)) {
@@ -175,7 +169,7 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun launchSupportWidget() {
-        val botOptions = SupportWebViewActivity.OpenChatWidget.BotOptions(
+        val botOptions = SupportWebViewActivity.BotOptions(
             id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
             inputPlaceholder = getString(R.string.contact_support_input_placeholder),
             firstMessage = getString(R.string.contact_support_first_message),
@@ -185,14 +179,14 @@ class HelpActivity : LocaleAwareActivity() {
             questionTwo = getString(R.string.contact_support_question_two),
             questionThree = getString(R.string.contact_support_question_three)
         )
-        openChatWidget.launch(
-            SupportWebViewActivity.OpenChatWidget.Args(
-                originFromExtras,
-                selectedSiteFromExtras,
-                extraTagsFromExtras,
-                botOptions
-            )
+        val intent = SupportWebViewActivity.createIntent(
+            this,
+            originFromExtras,
+            selectedSiteFromExtras,
+            extraTagsFromExtras,
+            botOptions
         )
+        startActivity(intent)
     }
 
     private fun createNewZendeskTicket() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.SupportHelper
 import org.wordpress.android.support.SupportWebViewActivity
-import org.wordpress.android.support.SupportWebViewActivity.BotOptions
 import org.wordpress.android.support.ZendeskExtraTags
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
@@ -176,16 +175,22 @@ class HelpActivity : LocaleAwareActivity() {
     }
 
     private fun launchSupportWidget() {
+        val botOptions = SupportWebViewActivity.OpenChatWidget.BotOptions(
+            id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
+            inputPlaceholder = getString(R.string.contact_support_input_placeholder),
+            firstMessage = getString(R.string.contact_support_first_message),
+            getSupport = getString(R.string.contact_support_get_support),
+            suggestions = getString(R.string.contact_support_suggestions),
+            questionOne = getString(R.string.contact_support_question_one),
+            questionTwo = getString(R.string.contact_support_question_two),
+            questionThree = getString(R.string.contact_support_question_three)
+        )
         openChatWidget.launch(
-            BotOptions(
-                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
-                inputPlaceholder = getString(R.string.contact_support_input_placeholder),
-                firstMessage = getString(R.string.contact_support_first_message),
-                getSupport = getString(R.string.contact_support_get_support),
-                suggestions = getString(R.string.contact_support_suggestions),
-                questionOne = getString(R.string.contact_support_question_one),
-                questionTwo = getString(R.string.contact_support_question_two),
-                questionThree = getString(R.string.contact_support_question_three)
+            SupportWebViewActivity.OpenChatWidget.Args(
+                originFromExtras,
+                selectedSiteFromExtras,
+                extraTagsFromExtras,
+                botOptions
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +12,6 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.support.SupportWebViewActivity.ChatCompletionEvent
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
@@ -50,10 +48,5 @@ class HelpViewModel @Inject constructor(
         if (!accountStore.hasAccessToken() && siteStore.hasSiteAccessedViaXMLRPC()) {
             dispatcher.dispatch(SiteActionBuilder.newRemoveAllSitesAction())
         }
-    }
-
-    fun sendChatHistory(event: ChatCompletionEvent) {
-        // Submit to Zendesk
-        Log.d("Chat History: ", event.chatHistory)
     }
 }

--- a/WordPress/src/main/res/layout/progress_layout.xml
+++ b/WordPress/src/main/res/layout/progress_layout.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
@@ -12,8 +11,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:textAppearance="?attr/textAppearanceHeadline6"
-        android:visibility="gone"
-        tools:text="Creating support ticket…" />
+        android:visibility="gone" />
 
     <ProgressBar
         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/progress_layout.xml
+++ b/WordPress/src/main/res/layout/progress_layout.xml
@@ -13,7 +13,7 @@
         android:gravity="center"
         android:textAppearance="?attr/textAppearanceHeadline6"
         android:visibility="gone"
-        tools:text="We're creating your new site!" />
+        tools:text="Creating support ticket…" />
 
     <ProgressBar
         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2290,6 +2290,9 @@
     <string name="contact_support_bot_ticket_message">Ticket created</string>
     <string name="contact_support_bot_ticket_button">See ticket</string>
     <string name="contact_support_bot_ticket_error">Error submitting support ticket</string>
+    <string name="contact_support_bot_ticket_comment_start">Jetpack Mobile Bot transcript:</string>
+    <string name="contact_support_bot_ticket_comment_question">Question:</string>
+    <string name="contact_support_bot_ticket_comment_answer">Answer:</string>
 
     <!--My Site-->
     <string name="my_site_header_content">Content</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2289,6 +2289,7 @@
     <string name="contact_support_bot_ticket_loading">Creating support ticket…</string>
     <string name="contact_support_bot_ticket_message">Ticket created</string>
     <string name="contact_support_bot_ticket_button">See ticket</string>
+    <string name="contact_support_bot_ticket_error">Error submitting support ticket</string>
 
     <!--My Site-->
     <string name="my_site_header_content">Content</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2286,6 +2286,9 @@
     <string name="contact_support_question_one">How do I change home page?</string>
     <string name="contact_support_question_two">Account or billing issues?</string>
     <string name="contact_support_question_three">Need to report an error or crash?</string>
+    <string name="contact_support_bot_ticket_loading">Creating support ticket…</string>
+    <string name="contact_support_bot_ticket_message">Ticket created</string>
+    <string name="contact_support_bot_ticket_button">See ticket</string>
 
     <!--My Site-->
     <string name="my_site_header_content">Content</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2283,9 +2283,9 @@
     <string name="contact_support_first_message">What can we help you with?</string>
     <string name="contact_support_get_support">Contact support</string>
     <string name="contact_support_suggestions">Not sure what to ask?</string>
-    <string name="contact_support_question_one">How do I change home page?</string>
-    <string name="contact_support_question_two">Account or billing issues?</string>
-    <string name="contact_support_question_three">Need to report an error or crash?</string>
+    <string name="contact_support_question_one">What is my site address?</string>
+    <string name="contact_support_question_two">Help, my site is down!</string>
+    <string name="contact_support_question_three">I can\'t upload photos/videos</string>
     <string name="contact_support_question_four">Why can\'t I login?</string>
     <string name="contact_support_question_five">I forgot my login information</string>
     <string name="contact_support_question_six">How can I use my custom domain in the app?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2291,7 +2291,6 @@
     <string name="contact_support_question_six">How can I use my custom domain in the app?</string>
     <string name="contact_support_bot_ticket_loading">Creating support ticket…</string>
     <string name="contact_support_bot_ticket_message">Ticket created</string>
-    <string name="contact_support_bot_ticket_button">See ticket</string>
     <string name="contact_support_bot_ticket_error">Error submitting support ticket</string>
     <string name="contact_support_bot_ticket_comment_start">Jetpack Mobile Bot transcript:</string>
     <string name="contact_support_bot_ticket_comment_question">Question:</string>


### PR DESCRIPTION
Fixes: #18901, #18902 
This adds the ability to create ZD tickets from chatbot screen.

A release note for the project will be added later.

### Success flow

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/40633230-f4c0-4bee-b5dc-e837aefe56ec

### No email set flow

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/1a0e97b1-2c22-4e3b-932a-e9d2afadf3e3

### Error flow

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/bec2a81d-789a-49ee-8476-79fe23ed9f78

To test:
1. Open Jetpack app
2. Enable "Contact Support via DocsBot" feature flag
3. Help & Support -> Contact Support
4. Ask bot a question
5. Confirm that below the answer "Contact support" button appears
6. Tap "Contact support"
7. Confirm if support identity hasn't been set, alert prompting for email appears
8. Confirm loading indicator is shown
9. Confirm success message is shown
10. Confirm ticket appears under "Tickets" section


## Regression Notes
1. Potential unintended areas of impact
This introduces a new feature. I do not anticipate any alterations to the existing features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing will be performed at the end of the project.
