### PR TITLE
Dashboard Cards: Remove "Create First Post" card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -55,7 +55,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         TODAYS_STATS_CARD_ERROR,
         TODAYS_STATS_CARD,
         POST_CARD_ERROR,
-        POST_CARD_WITHOUT_POST_ITEMS,
         POST_CARD_WITH_POST_ITEMS,
         BLOGGING_PROMPT_CARD,
         PROMOTE_WITH_BLAZE_CARD,
@@ -243,18 +242,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                     data class Error(
                         override val title: UiString
                     ) : PostCard(dashboardCardType = DashboardCardType.POST_CARD_ERROR), ErrorWithinCard
-
-                    data class PostCardWithoutPostItems(
-                        val postCardType: PostCardType,
-                        val title: UiString,
-                        val excerpt: UiString,
-                        @DrawableRes val imageRes: Int,
-                        override val footerLink: FooterLink,
-                        val onClick: ListItemInteraction
-                    ) : PostCard(
-                        dashboardCardType = DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS,
-                        footerLink = footerLink
-                    )
 
                     data class PostCardWithPostItems(
                         val postCardType: PostCardType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1509,9 +1509,6 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { site ->
             cardsTracker.trackPostItemClicked(params.postCardType)
             when (params.postCardType) {
-                PostCardType.CREATE_FIRST -> _onNavigation.value =
-                    Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-
                 PostCardType.DRAFT -> _onNavigation.value =
                     Event(SiteNavigationAction.EditDraftPost(site, params.postId))
 
@@ -1529,7 +1526,6 @@ class MySiteViewModel @Inject constructor(
         selectedSiteRepository.getSelectedSite()?.let { site ->
             cardsTracker.trackPostCardFooterLinkClicked(postCardType)
             _onNavigation.value = when (postCardType) {
-                PostCardType.CREATE_FIRST -> Event(SiteNavigationAction.OpenEditorToCreateNewPost(site))
                 PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
                 PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -79,7 +79,6 @@ sealed class SiteNavigationAction {
 
     data class OpenDraftsPosts(val site: SiteModel) : SiteNavigationAction()
     data class OpenScheduledPosts(val site: SiteModel) : SiteNavigationAction()
-    data class OpenEditorToCreateNewPost(val site: SiteModel) : SiteNavigationAction()
     data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsAdapter.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorWithinCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
@@ -51,8 +50,6 @@ class CardsAdapter(
             DashboardCardType.TODAYS_STATS_CARD_ERROR.ordinal,
             DashboardCardType.POST_CARD_ERROR.ordinal -> ErrorWithinCardViewHolder(parent, uiHelpers)
             DashboardCardType.TODAYS_STATS_CARD.ordinal -> TodaysStatsCardViewHolder(parent, uiHelpers)
-            DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS.ordinal ->
-                PostCardViewHolder.PostCardWithoutPostItemsViewHolder(parent, imageManager, uiHelpers)
             DashboardCardType.POST_CARD_WITH_POST_ITEMS.ordinal ->
                 PostCardViewHolder.PostCardWithPostItemsViewHolder(parent, imageManager, uiHelpers)
             DashboardCardType.BLOGGING_PROMPT_CARD.ordinal -> BloggingPromptCardViewHolder(
@@ -115,7 +112,6 @@ class CardsAdapter(
                 oldItem is ErrorWithinCard && newItem is ErrorWithinCard -> true
                 oldItem is TodaysStatsCardWithData && newItem is TodaysStatsCardWithData -> true
                 oldItem is PostCardWithPostItems && newItem is PostCardWithPostItems -> true
-                oldItem is PostCardWithoutPostItems && newItem is PostCardWithoutPostItems -> true
                 oldItem is BloggingPromptCardWithData && newItem is BloggingPromptCardWithData -> true
                 oldItem is PromoteWithBlazeCard && newItem is PromoteWithBlazeCard -> true
                 oldItem is BlazeCampaignsCardModel && newItem is BlazeCampaignsCardModel -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.mysite.cards.dashboard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.cards.blaze.BlazeCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityCardBuilder
@@ -35,10 +34,8 @@ class CardsBuilder @Inject constructor(
             if (dashboardCardsBuilderParams.showErrorCard) {
                 add(createErrorCard(dashboardCardsBuilderParams.onErrorRetryClick))
             } else {
-                var bloggingPromptCardAdded = false
                 bloggingPromptCardBuilder.build(dashboardCardsBuilderParams.bloggingPromptCardBuilderParams)
                     ?.let {
-                        bloggingPromptCardAdded = true
                         add(it)
                     }
 
@@ -63,17 +60,7 @@ class CardsBuilder @Inject constructor(
                 todaysStatsCardBuilder.build(dashboardCardsBuilderParams.todaysStatsCardBuilderParams)
                     ?.let { add(it) }
 
-                // if blogging prompt card is visible and the post card is "Write first/next post" we only show
-                // blogging prompt, since they are very similar
-                val postCards = postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams)
-                val hasNextPostPrompt = postCards.find {
-                    it.dashboardCardType == POST_CARD_WITHOUT_POST_ITEMS
-                } != null
-                val showPostCards = !hasNextPostPrompt || !bloggingPromptCardAdded
-
-                if (showPostCards) {
-                    addAll(postCards)
-                }
+                addAll(postCardBuilder.build(dashboardCardsBuilderParams.postCardBuilderParams))
 
                 pagesCardBuilder.build(dashboardCardsBuilderParams.pagesCardBuilderParams)?.let { add(it) }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
@@ -61,12 +60,6 @@ class CardsShownTracker @Inject constructor(
             Pair(
                 card.dashboardCardType.toTypeValue().label,
                 Type.POST.label
-            )
-        )
-        is PostCardWithoutPostItems -> trackCardShown(
-            Pair(
-                card.dashboardCardType.toTypeValue().label,
-                card.postCardType.toSubtypeValue().label
             )
         )
         is PostCardWithPostItems -> trackCardShown(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -46,7 +46,6 @@ class CardsTracker @Inject constructor(
     }
 
     enum class PostSubtype(val label: String) {
-        CREATE_FIRST("create_first"),
         DRAFT("draft"),
         SCHEDULED("scheduled")
     }
@@ -153,7 +152,6 @@ fun DashboardCardType.toTypeValue(): Type {
         DashboardCardType.TODAYS_STATS_CARD_ERROR -> Type.ERROR
         DashboardCardType.TODAYS_STATS_CARD -> Type.STATS
         DashboardCardType.POST_CARD_ERROR -> Type.ERROR
-        DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS -> Type.POST
         DashboardCardType.POST_CARD_WITH_POST_ITEMS -> Type.POST
         DashboardCardType.BLOGGING_PROMPT_CARD -> Type.BLOGGING_PROMPT
         DashboardCardType.PROMOTE_WITH_BLAZE_CARD -> Type.PROMOTE_WITH_BLAZE
@@ -169,7 +167,6 @@ fun DashboardCardType.toTypeValue(): Type {
 
 fun PostCardType.toSubtypeValue(): PostSubtype {
     return when (this) {
-        PostCardType.CREATE_FIRST -> PostSubtype.CREATE_FIRST
         PostCardType.DRAFT -> PostSubtype.DRAFT
         PostCardType.SCHEDULED -> PostSubtype.SCHEDULED
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
 import org.wordpress.android.R
-import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel.PostCardModel
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardErrorType
@@ -10,7 +9,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems.PostItem
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -43,36 +41,12 @@ class PostCardBuilder @Inject constructor(
     private fun buildPostCardsWithData(params: PostCardBuilderParams) =
         mutableListOf<PostCard>().apply {
             val posts = params.posts
-            posts?.hasPublished?.takeIf { !posts.hasDraftsOrScheduledPosts() }
-                ?.let { hasPublished ->
-                    if (!hasPublished) {
-                        add(createFirstPostCard(params.onPostItemClick, params.onFooterLinkClick))
-                    }
-                }
             posts?.draft?.takeIf { it.isNotEmpty() }?.let { add(it.createDraftPostsCard(params)) }
             posts?.scheduled?.takeIf { it.isNotEmpty() }?.let { add(it.createScheduledPostsCard(params)) }
         }.toList()
 
     private fun createPostErrorCard() = PostCard.Error(
         title = UiStringRes(R.string.posts)
-    )
-
-    private fun createFirstPostCard(
-        onPostItemClick: (params: PostItemClickParams) -> Unit,
-        onFooterLinkClick: (postCardType: PostCardType) -> Unit
-    ) = PostCardWithoutPostItems(
-        postCardType = PostCardType.CREATE_FIRST,
-        title = UiStringRes(R.string.my_site_create_first_post_title),
-        excerpt = UiStringRes(R.string.my_site_create_first_post_excerpt),
-        imageRes = R.drawable.img_write_212dp,
-        footerLink = FooterLink(
-            label = UiStringRes(R.string.my_site_post_card_link_create_post),
-            onClick = onFooterLinkClick
-        ),
-        onClick = ListItemInteraction.create(
-            PostItemClickParams(postCardType = PostCardType.CREATE_FIRST, postId = NOT_SET),
-            onPostItemClick
-        )
     )
 
     private fun List<PostCardModel>.createDraftPostsCard(params: PostCardBuilderParams) =
@@ -96,8 +70,6 @@ class PostCardBuilder @Inject constructor(
                 onClick = params.onFooterLinkClick
             )
         )
-
-    private fun PostsCardModel.hasDraftsOrScheduledPosts() = draft.isNotEmpty() || scheduled.isNotEmpty()
 
     private fun List<PostCardModel>.mapToDraftPostItems(
         onPostItemClick: (params: PostItemClickParams) -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardType.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
 enum class PostCardType(val id: Int) {
-    CREATE_FIRST(0),
     DRAFT(2),
     SCHEDULED(3)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
@@ -4,10 +4,8 @@ import android.view.ViewGroup
 import androidx.viewbinding.ViewBinding
 import org.wordpress.android.databinding.MySiteCardToolbarBinding
 import org.wordpress.android.databinding.MySitePostCardWithPostItemsBinding
-import org.wordpress.android.databinding.MySitePostCardWithoutPostItemsBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
@@ -18,26 +16,6 @@ sealed class PostCardViewHolder<T : ViewBinding>(
     override val binding: T
 ) : CardViewHolder<T>(binding) {
     abstract fun bind(card: PostCard)
-
-    class PostCardWithoutPostItemsViewHolder(
-        parent: ViewGroup,
-        private val imageManager: ImageManager,
-        private val uiHelpers: UiHelpers
-    ) : PostCardViewHolder<MySitePostCardWithoutPostItemsBinding>(
-        parent.viewBinding(MySitePostCardWithoutPostItemsBinding::inflate)
-    ) {
-        override fun bind(card: PostCard) = with(binding) {
-            val postCard = card as PostCardWithoutPostItems
-            uiHelpers.setTextOrHide(title, postCard.title)
-            uiHelpers.setTextOrHide(excerpt, postCard.excerpt)
-            imageManager.load(image, postCard.imageRes)
-            uiHelpers.setTextOrHide(mySiteCardFooterLink.linkLabel, postCard.footerLink.label)
-            mySiteCardFooterLink.linkLabel.setOnClickListener {
-                postCard.footerLink.onClick.invoke(card.postCardType)
-            }
-            itemView.setOnClickListener { postCard.onClick.click() }
-        }
-    }
 
     class PostCardWithPostItemsViewHolder(
         parent: ViewGroup,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -444,15 +444,6 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.DRAFTS)
         is SiteNavigationAction.OpenScheduledPosts ->
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
-        is SiteNavigationAction.OpenEditorToCreateNewPost ->
-            ActivityLauncher.addNewPostForResult(
-                requireActivity(),
-                action.site,
-                false,
-                PagePostCreationSourcesDetail.POST_FROM_MY_SITE,
-                -1,
-                null
-            )
         // The below navigation is temporary and as such not utilizing the 'action.postId' in order to navigate to the
         // 'Edit Post' screen. Instead, it fallbacks to navigating to the 'Posts' screen and targeting a specific tab.
         is SiteNavigationAction.EditDraftPost ->

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -119,7 +119,6 @@ import org.wordpress.android.ui.mysite.cards.dashboard.domain.DashboardCardDomai
 import org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer.DomainTransferCardViewModel
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.plans.PlansCardUtils
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder.Companion.NOT_SET
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder.Companion.URL_GET_MORE_VIEWS_AND_TRAFFIC
 import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardHelper
@@ -1678,17 +1677,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         }
 
     /* DASHBOARD POST CARD - FOOTER LINK */
-
-    @Test
-    fun `given create first card, when footer link is clicked, then editor is opened to create new post`() =
-        test {
-            initSelectedSite()
-
-            requireNotNull(onPostCardFooterLinkClick).invoke(PostCardType.CREATE_FIRST)
-
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-        }
-
     @Test
     fun `given draft post card, when footer link is clicked, then draft posts screen is opened`() = test {
         initSelectedSite()
@@ -1726,17 +1714,6 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     /* DASHBOARD POST CARD */
-
-    @Test
-    fun `when create first post card is clicked, then editor is opened to create new post`() =
-        test {
-            initSelectedSite()
-
-            requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
-
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenEditorToCreateNewPost(site))
-        }
-
     @Test
     fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
         test {
@@ -1773,15 +1750,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.DRAFT, postId))
 
         verify(cardsTracker).trackPostItemClicked(PostCardType.DRAFT)
-    }
-
-    @Test
-    fun `given create first post card, when item is clicked, then event is tracked`() = test {
-        initSelectedSite()
-
-        requireNotNull(onPostItemClick).invoke(PostItemClickParams(PostCardType.CREATE_FIRST, NOT_SET))
-
-        verify(cardsTracker).trackPostItemClicked(PostCardType.CREATE_FIRST)
     }
 
     /* DASHBOARD BLOGGING PROMPT CARD */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BlazeCard.PromoteWithBlazeCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.TodaysStatsCard.TodaysStatsCardWithData
@@ -39,7 +38,6 @@ import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityCardBuil
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.DRAFT
 import org.wordpress.android.ui.mysite.cards.dashboard.todaysstats.TodaysStatsCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.domain.DashboardDomainCardBuilder
@@ -156,25 +154,14 @@ class CardsBuilderTest : BaseUnitTest() {
 
         assertThat(cards.findBloggingPromptCard()).isNotNull
         assertThat(cards.findPostCardWithPosts()).isNull()
-        assertThat(cards.findNextPostCard()).isNull()
     }
 
     @Test
-    fun `given no blogging prompt and no posts, next post card is visible and prompt card is not`() {
-        val cards = buildDashboardCards(hasBlogginPrompt = false, hasPostsForPostCard = false)
-
-        assertThat(cards.findBloggingPromptCard()).isNull()
-        assertThat(cards.findPostCardWithPosts()).isNull()
-        assertThat(cards.findNextPostCard()).isNotNull
-    }
-
-    @Test
-    fun `given no blogging prompt and posts, next post card is not visible and prompt card is visible`() {
+    fun `given no blogging prompt and posts, prompt card is visible`() {
         val cards = buildDashboardCards(hasBlogginPrompt = false, hasPostsForPostCard = true)
 
         assertThat(cards.findBloggingPromptCard()).isNull()
         assertThat(cards.findPostCardWithPosts()).isNotNull
-        assertThat(cards.findNextPostCard()).isNull()
     }
 
     /* ERROR CARD */
@@ -270,9 +257,6 @@ class CardsBuilderTest : BaseUnitTest() {
     private fun DashboardCards.findPostCardWithPosts() =
         this.cards.find { it is PostCardWithPostItems } as? PostCardWithPostItems
 
-    private fun DashboardCards.findNextPostCard() =
-        this.cards.find { it is PostCardWithoutPostItems } as? PostCardWithoutPostItems
-
     private fun DashboardCards.findBloggingPromptCard() =
         this.cards.find { it is BloggingPromptCard } as? BloggingPromptCard
 
@@ -316,17 +300,6 @@ class CardsBuilderTest : BaseUnitTest() {
         )
     )
 
-    private fun createPostPromptCards() = listOf(
-        PostCardWithoutPostItems(
-            postCardType = CREATE_FIRST,
-            title = UiStringText(""),
-            excerpt = UiStringText(""),
-            imageRes = 0,
-            footerLink = FooterLink(UiStringText(""), onClick = mock()),
-            onClick = mock()
-        )
-    )
-
     private fun buildDashboardCards(
         hasTodaysStats: Boolean = false,
         hasPostsForPostCard: Boolean = false,
@@ -340,7 +313,7 @@ class CardsBuilderTest : BaseUnitTest() {
         hasActivityCard: Boolean = false
     ): DashboardCards {
         doAnswer { if (hasTodaysStats) todaysStatsCard else null }.whenever(todaysStatsCardBuilder).build(any())
-        doAnswer { if (hasPostsForPostCard) createPostCards() else createPostPromptCards() }.whenever(postCardBuilder)
+        doAnswer { if (hasPostsForPostCard) createPostCards() else emptyList() }.whenever(postCardBuilder)
             .build(any())
         doAnswer { if (hasBlogginPrompt) blogingPromptCard else null }.whenever(bloggingPromptCardsBuilder).build(any())
         doAnswer { if (isEligibleForBlaze) promoteWithBlazeCard else null }.whenever(blazeCardBuilder)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
@@ -40,13 +39,6 @@ class CardsShownTrackerTest {
         cardsShownTracker.trackQuickStartCardShown(NewSiteQuickStartType)
 
         verifyQuickStartCardShownTracked(Type.QUICK_START.label, "quick_start_${NewSiteQuickStartType.trackingLabel}")
-    }
-
-    @Test
-    fun `when post card create first card is shown, then create first shown event is tracked`() {
-        cardsShownTracker.track(buildDashboardCards(PostCardType.CREATE_FIRST))
-
-        verifyCardShownTracked(Type.POST.label, PostSubtype.CREATE_FIRST.label)
     }
 
     @Test
@@ -98,26 +90,9 @@ class CardsShownTrackerTest {
         cards = mutableListOf<DashboardCard>().apply {
             when (postCardType) {
                 PostCardType.SCHEDULED, PostCardType.DRAFT -> addAll(buildPostCardsWithItems(postCardType))
-                PostCardType.CREATE_FIRST -> addAll(
-                    buildPostCardsWithoutItems(
-                        postCardType
-                    )
-                )
             }
         }
     )
-
-    private fun buildPostCardsWithoutItems(postCardType: PostCardType) =
-        listOf(
-            PostCardWithoutPostItems(
-                postCardType = postCardType,
-                title = UiStringText(""),
-                footerLink = FooterLink(UiStringText(""), onClick = mock()),
-                excerpt = UiStringText(""),
-                imageRes = 0,
-                onClick = mock()
-            )
-        )
 
     private fun buildPostCardsWithItems(postCardType: PostCardType) = listOf(
         PostCardWithPostItems(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -79,14 +79,6 @@ class CardsTrackerTest {
     }
 
     /* POST CARDS */
-
-    @Test
-    fun `when post create first footer link is clicked, then post create first event is tracked`() {
-        cardsTracker.trackPostCardFooterLinkClicked(PostCardType.CREATE_FIRST)
-
-        verifyFooterLinkClickedTracked(Type.POST, PostSubtype.CREATE_FIRST.label)
-    }
-
     @Test
     fun `when post draft footer link is clicked, then post draft event is tracked`() {
         cardsTracker.trackPostCardFooterLinkClicked(PostCardType.DRAFT)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -14,16 +14,11 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithoutPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType.POST_CARD_ERROR
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder.Companion.NOT_SET
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType.CREATE_FIRST
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.LocaleManagerWrapper
@@ -85,68 +80,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         val postsCard = buildPostsCard(posts)
 
         assertThat(postsCard.filterPostErrorCard()).isInstanceOf(PostCard.Error::class.java)
-    }
-
-    /* CREATE FIRST POST CARD */
-
-    @Test
-    fun `given no published post without draft + sched post, when card is built, then create first card exists`() {
-        val posts = getPosts(hasPublished = false)
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateFirstPostCard()).isNotNull
-    }
-
-    @Test
-    fun `given published post exists with draft post, when card is built, then create first card not exists`() {
-        val posts = getPosts(hasPublished = true, draftPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateFirstPostCard()).isNull()
-    }
-
-    @Test
-    fun `given published post exists with scheduled post, when card is built, then create first card not exists`() {
-        val posts = getPosts(hasPublished = true, scheduledPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateFirstPostCard()).isNull()
-    }
-
-    @Test
-    fun `given published post present, when card is built, then create first post card not exists`() {
-        val posts = getPosts(hasPublished = true)
-
-        val postsCard = buildPostsCard(posts)
-
-        assertThat(postsCard.filterCreateFirstPostCard()).isNull()
-    }
-
-    @Test
-    fun `given create first post, when card is built, then it contains correct preset elements`() {
-        val posts = getPosts(hasPublished = false)
-
-        val postsCard = buildPostsCard(posts).filterCreateFirstPostCard()
-
-        assertThat(postsCard).isEqualTo(
-            PostCardWithoutPostItems(
-                postCardType = PostCardType.CREATE_FIRST,
-                title = UiStringRes(R.string.my_site_create_first_post_title),
-                excerpt = UiStringRes(R.string.my_site_create_first_post_excerpt),
-                imageRes = R.drawable.img_write_212dp,
-                footerLink = FooterLink(
-                    label = UiStringRes(R.string.my_site_post_card_link_create_post),
-                    onClick = onPostCardFooterLinkClick
-                ),
-                onClick = ListItemInteraction.create(
-                    PostItemClickParams(postCardType = CREATE_FIRST, postId = NOT_SET),
-                    onPostItemClick
-                )
-            )
-        )
     }
 
     /* DRAFT POST CARD */
@@ -299,13 +232,6 @@ class PostCardBuilderTest : BaseUnitTest() {
     }
 
     private fun List<PostCard>.filterPostErrorCard() = firstOrNull { it.dashboardCardType == POST_CARD_ERROR }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun List<PostCard>.filterCreateFirstPostCard() = (
-            filter {
-                it.dashboardCardType == DashboardCardType.POST_CARD_WITHOUT_POST_ITEMS
-            } as? List<PostCardWithoutPostItems>
-            )?.firstOrNull { it.postCardType == PostCardType.CREATE_FIRST }
 
     @Suppress("UNCHECKED_CAST")
     private fun List<PostCard>.filterDraftPostCard() = (


### PR DESCRIPTION
Closes #18953 

Changes made in this PR include: 
- Removes the logic for build the `Create Your First Post` dashboard card
- Removes all tests related to the card
- Removes the remaining logic for `PostCardWithoutPostItems`; including the adapter and binding logic

Merge Instructions
- Verify that PR #18960 has been merged
- Remove "do not merge label"
- Merge as normal

**To test:**
- Install the app
- Login
- Navigate to a site in which you have no published posts
- ✅ Verify the Create First Post card is not shown
- Navigate to a site in which you have draft posts
- ✅ Verify the drafts post card is shown
- Navigate to a site in which you have scheduled posts
- ✅ Verify the scheduled post card is shown


## Regression Notes
1. Potential unintended areas of impact
The dashboard still shows a create first post card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:N/A
