### PR TITLE
UI Modernization: Add dashboard personalization feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -169,6 +169,7 @@ android {
         buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
         buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
         buildConfigField "boolean", "BLAZE_MANAGE_CAMPAIGNS", "false"
+        buildConfigField "boolean", "DASHBOARD_PERSONALIZATION", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardPersonalizationFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardPersonalizationFeatureConfig.kt
@@ -4,7 +4,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@Feature(DashboardPersonalizationFeatureConfig.DASHBOARD_PERSONALIZATION_REMOTE_FIELD, true)
+@Feature(DashboardPersonalizationFeatureConfig.DASHBOARD_PERSONALIZATION_REMOTE_FIELD, false)
 class DashboardPersonalizationFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
     appConfig,
     BuildConfig.DASHBOARD_PERSONALIZATION,

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DashboardPersonalizationFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DashboardPersonalizationFeatureConfig.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+@Feature(DashboardPersonalizationFeatureConfig.DASHBOARD_PERSONALIZATION_REMOTE_FIELD, true)
+class DashboardPersonalizationFeatureConfig @Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.DASHBOARD_PERSONALIZATION,
+    DASHBOARD_PERSONALIZATION_REMOTE_FIELD
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+
+    companion object {
+        const val DASHBOARD_PERSONALIZATION_REMOTE_FIELD = "dashboard_personalization"
+    }
+}


### PR DESCRIPTION
Closes #18938 

This PR adds a feature flag -`dashboard_personalization` for enabling/disabling the feature

To test:
1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Remote Features` section
3. Verify that `dashboard_personalization` is visible and is set to false. 

<img width="501" alt="Screenshot 2023-04-27 at 10 59 09 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/f597ed6c-3949-43d6-b8db-be0b7f700b9d">

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
