### PR TITLE
Contact Support: Improve bot opening

### DIFF
--- a/WordPress/src/jetpack/assets/bot_widget.js
+++ b/WordPress/src/jetpack/assets/bot_widget.js
@@ -30,25 +30,10 @@ DocsBotAI.init = function (c) {
                             // Open DocsBotAI after shadowRoot is loaded
                             window.DocsBotAI.open();
 
-                            // Observe the shadowRoot for changes (including header appearance)
-                            const shadowRootObserver = new MutationObserver(function (mutationsList, observer) {
-                                const header = shadowRoot.querySelector("div > div > div > div.docsbot-chat-header");
-                                const closeButton = shadowRoot.querySelector("div > div > div > a");
-                                if (header) {
-                                    header.style.display = "none"; // hide the header
-                                }
-
-                                if (closeButton) {
-                                    closeButton.style.display = "none"; // hide the close button
-                                }
-                                // Disconnect the observer since we've achieved our goal
-                                shadowRootObserver.disconnect();
-                            });
-
-                            shadowRootObserver.observe(shadowRoot, { childList: true, subtree: true });
-
-                            resolve(shadowRoot);
-                            observer.disconnect();
+                            const linkElem = document.createElement("link");
+                            linkElem.setAttribute("rel", "stylesheet");
+                            linkElem.setAttribute("href", "/assets/support_chat_widget.css");
+                            shadowRoot.appendChild(linkElem);
                         }
                     };
 

--- a/WordPress/src/jetpack/assets/bot_widget.js
+++ b/WordPress/src/jetpack/assets/bot_widget.js
@@ -28,7 +28,7 @@ DocsBotAI.init = function (c) {
                             localStorage.removeItem("docsbot_chat_history");
 
                             // Open DocsBotAI after shadowRoot is loaded
-                            window.DocsBotAI.open();  // Assuming there's an openChat() function
+                            window.DocsBotAI.open();
 
                             // Observe the shadowRoot for changes (including header appearance)
                             const shadowRootObserver = new MutationObserver(function (mutationsList, observer) {

--- a/WordPress/src/jetpack/assets/bot_widget.js
+++ b/WordPress/src/jetpack/assets/bot_widget.js
@@ -1,10 +1,16 @@
-;
-window.DocsBotAI = window.DocsBotAI || {}, DocsBotAI.init = function(c) {
-    return new Promise(function(e, o) {
-        var t = document.createElement("script");
-        t.type = "text/javascript", t.async = !0, t.src = "https://widget.docsbot.ai/chat.js";
-        var n = document.getElementsByTagName("script")[0];
-        n.parentNode.insertBefore(t, n), t.addEventListener("load", function() {
+window.DocsBotAI = window.DocsBotAI || {};
+
+DocsBotAI.init = function(c) {
+    return new Promise(function(resolve, reject) {
+        const chatScript = document.createElement("script");
+        chatScript.type = "text/javascript";
+        chatScript.async = true;
+        chatScript.src = "https://widget.docsbot.ai/chat.js";
+
+        const firstScript = document.getElementsByTagName("script")[0];
+        firstScript.parentNode.insertBefore(chatScript, firstScript);
+
+        chatScript.addEventListener("load", function() {
             window.DocsBotAI.mount({
                 id: c.id,
                 supportCallback: c.supportCallback,
@@ -12,21 +18,38 @@ window.DocsBotAI = window.DocsBotAI || {}, DocsBotAI.init = function(c) {
                 options: c.options,
                 signature: c.signature
             });
-            var t;
-            t = function(n) {
-                return new Promise(function(e) {
-                    if (document.querySelector(n)) return e(document.querySelector(n));
-                    var o = new MutationObserver(function(t) {
-                        document.querySelector(n) && (e(document.querySelector(n)), o.disconnect())
-                    });
-                    o.observe(document.body, {
-                        childList: !0,
-                        subtree: !0
-                    })
+
+            const waitForShadowRoot = function(selector) {
+                return new Promise(function(resolve) {
+                    const elementCheck = function(mutationsList, observer) {
+                        if (document.querySelector(selector)) {
+                            const shadowRoot = document.querySelector(selector).shadowRoot;
+                            if (shadowRoot) {
+                                resolve(shadowRoot);
+                                observer.disconnect();
+                            }
+                        }
+                    };
+
+                    const observer = new MutationObserver(elementCheck);
+                    observer.observe(document.body, { childList: true, subtree: true });
+                });
+            };
+
+            waitForShadowRoot("#docsbotai-root")
+                .then(function(shadowRoot) {
+                    // Open DocsBotAI after shadowRoot is loaded
+                    window.DocsBotAI.open();
+
+                    resolve(shadowRoot);
                 })
-            }, t && t("#docsbotai-root").then(e).catch(o)
-        }), t.addEventListener("error", function(t) {
-            o(t.message)
-        })
-    })
+                .catch(reject);
+        });
+
+        chatScript.addEventListener("error", function(error) {
+            reject(error.message);
+        });
+    });
 };
+
+

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -34,7 +34,10 @@
                 questions: [
                     decodeURIComponent(urlParams.questionOne),
                     decodeURIComponent(urlParams.questionTwo),
-                    decodeURIComponent(urlParams.questionThree)
+                    decodeURIComponent(urlParams.questionThree),
+                    decodeURIComponent(urlParams.questionFour),
+                    decodeURIComponent(urlParams.questionFive),
+                    decodeURIComponent(urlParams.questionSix)
                 ] // Array of example questions to show in the widget. Three are picked at random.
             },
         });

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -37,14 +37,6 @@
                     decodeURIComponent(urlParams.questionThree)
                 ] // Array of example questions to show in the widget. Three are picked at random.
             },
-        }).then(() => {
-            // Safely do stuff here after the widget is loaded.
-            setTimeout(() => {
-                resetConversation();
-
-                hideTopCloseButton();
-                hideTopHeader();
-            }, 200)
         });
     }
 
@@ -67,26 +59,6 @@
             }, {}) :
             {}
     }
-
-    function hideTopCloseButton() {
-        const closeButton = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > a");
-        if (closeButton && closeButton !== null && closeButton !== 'undefined') {
-            closeButton.style.display = 'none';
-        }
-    }
-
-    function hideTopHeader() {
-        const header = document.querySelector("#docsbotai-root").shadowRoot.querySelector("div > div > div > div.docsbot-chat-header");
-        if (header && header !== null && header !== 'undefined') {
-            header.style.display = 'none';
-        }
-    }
-
-    function resetConversation() {
-        // reset button was in top header
-        localStorage.removeItem("docsbot_chat_history");
-    }
-
 
     document.addEventListener( 'DOMContentLoaded', init );
 } ) ();

--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -39,17 +39,12 @@
             },
         }).then(() => {
             // Safely do stuff here after the widget is loaded.
-            let timerId = setInterval(() => {
-                openDocsBot(); // wait for init
-            }, 200);
-
             setTimeout(() => {
-                clearInterval(timerId)
-
-                hideTopCloseButton(); // hide after init
-                hideTopHeader();
                 resetConversation();
-            }, 300);
+
+                hideTopCloseButton();
+                hideTopHeader();
+            }, 200)
         });
     }
 
@@ -71,17 +66,6 @@
                 return qd
             }, {}) :
             {}
-    }
-
-    function openDocsBot() {
-        const widget = document.querySelector("#docsbotai-root").shadowRoot.querySelector("a.floating-button");
-        if (widget && widget !== null && typeof widget !== 'undefined') {
-            widget.click();
-        }
-
-        if ( 'function' === typeof window.DocsBotAI ) {
-            DocsBotAI.open();
-        }
     }
 
     function hideTopCloseButton() {

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -742,7 +742,8 @@
         <activity
             android:name=".support.SupportWebViewActivity"
             android:screenOrientation="portrait"
-            android:theme="@style/WordPress.NoActionBar"/>
+            android:theme="@style/WordPress.NoActionBar"
+            tools:ignore="LockedOrientationActivity"/>
 
         <!-- Lib activities-->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -741,6 +741,7 @@
 
         <activity
             android:name=".support.SupportWebViewActivity"
+            android:screenOrientation="portrait"
             android:theme="@style/WordPress.NoActionBar"/>
 
         <!-- Lib activities-->

--- a/WordPress/src/main/assets/support_chat_widget.css
+++ b/WordPress/src/main/assets/support_chat_widget.css
@@ -1,0 +1,16 @@
+.docsbot-chat-header,
+.mobile-close-button,
+a.floating-button {
+    display: none !important;
+}
+
+.docsbot-wrapper {
+    width: 100% !important;
+    height: 100% !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    max-height: none !important;
+}

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -132,6 +132,9 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         val suggestions: String,
         val questionOne: String,
         val questionTwo: String,
-        val questionThree: String
+        val questionThree: String,
+        val questionFour: String,
+        val questionFive: String,
+        val questionSix: String
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -178,7 +178,7 @@ class HelpActivity : LocaleAwareActivity() {
     private fun launchSupportWidget() {
         openChatWidget.launch(
             BotOptions(
-                id = BuildConfig.DOCSBOTAI_ID,
+                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
                 inputPlaceholder = getString(R.string.contact_support_input_placeholder),
                 firstMessage = getString(R.string.contact_support_first_message),
                 getSupport = getString(R.string.contact_support_get_support),

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -185,7 +185,10 @@ class HelpActivity : LocaleAwareActivity() {
                 suggestions = getString(R.string.contact_support_suggestions),
                 questionOne = getString(R.string.contact_support_question_one),
                 questionTwo = getString(R.string.contact_support_question_two),
-                questionThree = getString(R.string.contact_support_question_three)
+                questionThree = getString(R.string.contact_support_question_three),
+                questionFour = getString(R.string.contact_support_question_four),
+                questionFive = getString(R.string.contact_support_question_five),
+                questionSix = getString(R.string.contact_support_question_six)
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -178,7 +178,7 @@ class HelpActivity : LocaleAwareActivity() {
     private fun launchSupportWidget() {
         openChatWidget.launch(
             BotOptions(
-                id = "TqTdebbGjJeUjrmBIFjh/YbAMwiheXLs2Ue5j7elH", // BuildConfig.DOCSBOT_ID,
+                id = BuildConfig.DOCSBOTAI_ID,
                 inputPlaceholder = getString(R.string.contact_support_input_placeholder),
                 firstMessage = getString(R.string.contact_support_first_message),
                 getSupport = getString(R.string.contact_support_get_support),

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2283,9 +2283,12 @@
     <string name="contact_support_first_message">What can we help you with?</string>
     <string name="contact_support_get_support">Contact support</string>
     <string name="contact_support_suggestions">Not sure what to ask?</string>
-    <string name="contact_support_question_one">How do I change home page?</string>
-    <string name="contact_support_question_two">Account or billing issues?</string>
-    <string name="contact_support_question_three">Need to report an error or crash?</string>
+    <string name="contact_support_question_one">What is my site address?</string>
+    <string name="contact_support_question_two">Help, my site is down!</string>
+    <string name="contact_support_question_three">I can\'t upload photos/videos</string>
+    <string name="contact_support_question_four">Why can\'t I login?</string>
+    <string name="contact_support_question_five">I forgot my login information</string>
+    <string name="contact_support_question_six">How can I use my custom domain in the app?</string>
 
     <!--My Site-->
     <string name="my_site_header_content">Content</string>


### PR DESCRIPTION
Ensure bot opens always in full screen, instead of chat widget

Fixes #18828 

To test:

Setup
- Launch Jetpack app
- Go to `Me` (Tap on Avatar in the bottom nav)
- Tap `Debug Settings`
- Find `contact_support` under `Remote features` tab 
- Enable it, and return to Help screen

Case 1
- Tap on Contact Support on Help screen
- `Verify` it launches Support Bot in full screen
- `Verify` Close button, and Chat header are hidden

Case 2
- Tap back button <-, return to Help screen
- Wait for 5-10 min
- `Tap` on Contact us
- `Verify` it launches Support Bot in full screen

Case 3
For completeness, check the following
- `Send a message...` in the text field
- `Verify` bot responds with an answer
- `Verify` there's a `Contact support` button below response
- `Tap` on the `Contact support`
- `Verify` the chat windows is closed, and returns to Help screen
- `Observe` in AS Logcat Chat history is logged

>**Note**
> Also set orientation to Portrait.  Since, it's not set for landscape for now
> Further enhancements could be done in the next PRs

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
