### PR TITLE
[Jetpack Social] Hide Jetpack Social container if PostStatus is PRIVATE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -938,7 +938,7 @@ public class EditPostSettingsFragment extends Fragment {
                     postImmutableModel -> {
                         updatePostStatusRelatedViews(postImmutableModel);
                         updateSaveButton();
-                        mJetpackSocialViewModel.onPostVisibilityChanged();
+                        mJetpackSocialViewModel.onPostStatusChanged();
                         return null;
                     });
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -938,6 +938,7 @@ public class EditPostSettingsFragment extends Fragment {
                     postImmutableModel -> {
                         updatePostStatusRelatedViews(postImmutableModel);
                         updateSaveButton();
+                        mJetpackSocialViewModel.onPostVisibilityChanged();
                         return null;
                     });
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
@@ -391,7 +391,7 @@ class EditorJetpackSocialViewModel @Inject constructor(
         if (trackEvent) jetpackSocialSharingTracker.trackAddConnectionCtaDisplayed(jetpackSocialFlow)
     }
 
-    fun onPostVisibilityChanged() {
+    fun onPostStatusChanged() {
         startJetpackSocial()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
@@ -85,7 +85,11 @@ class EditorJetpackSocialViewModel @Inject constructor(
         this.siteModel = siteModel
         this.editPostRepository = editPostRepository
 
-        if (jetpackSocialFeatureConfig.isEnabled() && !editPostRepository.isPage) {
+        startJetpackSocial()
+    }
+
+    private fun startJetpackSocial() {
+        if (shouldShowJetpackSocial()) {
             launch {
                 shareLimit = getJetpackSocialShareLimitStatusUseCase.execute(siteModel)
                 loadConnections()
@@ -164,8 +168,7 @@ class EditorJetpackSocialViewModel @Inject constructor(
     }
 
     private suspend fun loadJetpackSocialIfSupported() {
-        val showJetpackSocial = jetpackSocialFeatureConfig.isEnabled() && siteModel.supportsPublicize()
-        if (!showJetpackSocial) {
+        if (!shouldShowJetpackSocial()) {
             _jetpackSocialContainerVisibility.postValue(JetpackSocialContainerVisibility.ALL_HIDDEN)
             return
         }
@@ -186,6 +189,11 @@ class EditorJetpackSocialViewModel @Inject constructor(
             _jetpackSocialUiState.postValue(mapLoaded())
         }
     }
+
+    private fun shouldShowJetpackSocial() = jetpackSocialFeatureConfig.isEnabled()
+            && !editPostRepository.isPage
+            && siteModel.supportsPublicize()
+            && currentPost?.status != PostStatus.PRIVATE.toString()
 
     private suspend fun mapLoaded(): JetpackSocialUiState.Loaded {
         val shareMessage = jetpackSocialShareMessage.ifEmpty {
@@ -381,6 +389,10 @@ class EditorJetpackSocialViewModel @Inject constructor(
         }
 
         if (trackEvent) jetpackSocialSharingTracker.trackAddConnectionCtaDisplayed(jetpackSocialFlow)
+    }
+
+    fun onPostVisibilityChanged() {
+        startJetpackSocial()
     }
 
     data class JetpackSocialContainerVisibility(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
@@ -550,7 +550,7 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should start jetpack social if onPostVisibilityChanged is called`() {
-        classToTest.onPostVisibilityChanged()
+        classToTest.onPostStatusChanged()
         verify(showJetpackSocialContainerObserver).onChanged(any())
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModelTest.kt
@@ -16,7 +16,9 @@ import org.wordpress.android.R
 import org.wordpress.android.datasets.wrappers.PublicizeTableWrapper
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.post.PostStatus
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.models.PublicizeConnection
@@ -112,6 +114,27 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
     fun `Should NOT load jetpack social if FF is disabled`() = test {
         whenever(jetpackSocialFeatureConfig.isEnabled())
             .thenReturn(false)
+        classToTest.start(FAKE_SITE_MODEL, editPostRepository)
+        verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any(), any())
+    }
+
+    @Test
+    fun `Should NOT load jetpack social if post is page`() = test {
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(editPostRepository.isPage).thenReturn(true)
+        classToTest.start(FAKE_SITE_MODEL, editPostRepository)
+        verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any(), any())
+    }
+
+    @Test
+    fun `Should NOT load jetpack social if PostStatus is PRIVATE`() = test {
+        whenever(jetpackSocialFeatureConfig.isEnabled())
+            .thenReturn(true)
+        whenever(editPostRepository.isPage).thenReturn(false)
+        whenever(editPostRepository.getPost()).thenReturn(PostModel().apply {
+            setStatus(PostStatus.PRIVATE.toString())
+        })
         classToTest.start(FAKE_SITE_MODEL, editPostRepository)
         verify(getPublicizeConnectionsForUserUseCase, never()).execute(any(), any(), any())
     }
@@ -523,6 +546,12 @@ class EditorJetpackSocialViewModelTest : BaseUnitTest() {
 
         classToTest.onJetpackSocialConnectionClick(mock(), false, JetpackSocialFlow.PRE_PUBLISHING)
         verify(jetpackSocialSharingTracker).trackConnectionToggled(JetpackSocialFlow.PRE_PUBLISHING, false)
+    }
+
+    @Test
+    fun `Should start jetpack social if onPostVisibilityChanged is called`() {
+        classToTest.onPostVisibilityChanged()
+        verify(showJetpackSocialContainerObserver).onChanged(any())
     }
 
     private fun fakeSiteModel(supportsPublicize: Boolean = false): SiteModel = FAKE_SITE_MODEL.apply {


### PR DESCRIPTION
Fixes #18927

To test:
You should not be able to reproduce the bug anymore. Steps to reproduce can be found in https://github.com/wordpress-mobile/WordPress-Android/issues/18927

## Regression Notes
1. Potential unintended areas of impact
Jetpack Social containers should continue to work as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + unit testing.

3. What automated tests I added (or what prevented me from doing so)
Updated `EditorJetpackSocialViewModelTest.kt`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
