### PR TITLE
[JP Social/Post] Share message improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.compose.BackHandler
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +15,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -57,6 +59,7 @@ class EditJetpackSocialShareMessageActivity : AppCompatActivity() {
                     is UiState.Loaded -> {
                         Loaded(state)
                     }
+
                     is UiState.Initial -> {
                         // no-op
                     }
@@ -67,45 +70,54 @@ class EditJetpackSocialShareMessageActivity : AppCompatActivity() {
 
     @Composable
     private fun Loaded(state: UiState.Loaded) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(Margin.ExtraLarge.value)
-        ) {
-            MainTopAppBar(
-                title = state.appBarLabel,
-                navigationIcon = NavigationIcons.BackIcon,
-                onNavigationIconClick = state.onBackClick,
-            )
-            var shareMessage by remember { mutableStateOf(state.currentShareMessage) }
-            val focusRequester = remember { FocusRequester() }
-            OutlinedTextField(
-                modifier = Modifier
-                    .padding(vertical = Margin.ExtraLarge.value)
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester),
-                value = shareMessage,
-                onValueChange = {
-                    val truncatedMessage = it.take(state.shareMessageMaxLength)
-                    shareMessage = truncatedMessage
-                    viewModel.updateShareMessage(truncatedMessage)
-                },
-                colors = TextFieldDefaults.outlinedTextFieldColors(
-                    textColor = MaterialTheme.colors.onSurface,
-                    disabledTextColor = MaterialTheme.colors.onSurface
-                ),
-            )
-            Text(
-                text = state.customizeMessageDescription,
-                style = MaterialTheme.typography.body2,
-                color = MaterialTheme.colors.onSurface,
-            )
-            LaunchedEffect(Unit) {
-                // Without a delay the soft keyboard is not shown
-                delay(DELAY_SOFT_KEYBOARD_IN_MS)
-                focusRequester.requestFocus()
+        Scaffold(
+            topBar = {
+                MainTopAppBar(
+                    title = state.appBarLabel,
+                    navigationIcon = NavigationIcons.BackIcon,
+                    onNavigationIconClick = state.onBackClick,
+                )
+            }
+        ) { contentPadding ->
+            Box(
+                modifier = Modifier.padding(contentPadding)
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(Margin.ExtraLarge.value)
+                ) {
+                    var shareMessage by remember { mutableStateOf(state.currentShareMessage) }
+                    val focusRequester = remember { FocusRequester() }
+                    OutlinedTextField(
+                        modifier = Modifier
+                            .padding(vertical = Margin.ExtraLarge.value)
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester),
+                        value = shareMessage,
+                        onValueChange = {
+                            val truncatedMessage = it.take(state.shareMessageMaxLength)
+                            shareMessage = truncatedMessage
+                            viewModel.updateShareMessage(truncatedMessage)
+                        },
+                        colors = TextFieldDefaults.outlinedTextFieldColors(
+                            textColor = MaterialTheme.colors.onSurface,
+                            disabledTextColor = MaterialTheme.colors.onSurface
+                        ),
+                    )
+                    Text(
+                        text = state.customizeMessageDescription,
+                        style = MaterialTheme.typography.body2,
+                        color = MaterialTheme.colors.onSurface,
+                    )
+                    LaunchedEffect(Unit) {
+                        // Without a delay the soft keyboard is not shown
+                        delay(DELAY_SOFT_KEYBOARD_IN_MS)
+                        focusRequester.requestFocus()
+                    }
+                }
             }
         }
         BackHandler(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
@@ -57,7 +57,7 @@ class EditJetpackSocialShareMessageActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.start(
-            currentShareMessage = requireNotNull(intent.getStringExtra(EXTRA_SOCIAL_SHARE_MESSAGE))
+            initialShareMessage = requireNotNull(intent.getStringExtra(EXTRA_SOCIAL_SHARE_MESSAGE))
         )
         observeActionEvents()
         setContent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
@@ -13,11 +13,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.lifecycleScope
@@ -36,6 +41,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppThemeEditor
@@ -134,6 +140,23 @@ class EditJetpackSocialShareMessageActivity : AppCompatActivity() {
                             textColor = MaterialTheme.colors.onSurface,
                             disabledTextColor = MaterialTheme.colors.onSurface
                         ),
+                        trailingIcon = {
+                            IconButton(
+                                modifier = Modifier.padding(end = Margin.Small.value),
+                                onClick = {
+                                    val newValue = TextFieldValue()
+                                    shareTextFieldValue = newValue
+                                    viewModel.updateShareMessage(newValue.text)
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Default.Clear,
+                                    contentDescription = stringResource(
+                                        R.string.post_settings_jetpack_social_share_message_clear
+                                    ),
+                                )
+                            }
+                        }
                     )
                     Text(
                         text = state.customizeMessageDescription,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
@@ -25,16 +25,15 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
     private val _actionEvents = Channel<ActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
 
-    private var startingShareMessage = ""
-    private var updatedShareMessage = ""
+    private var currentShareMessage = ""
 
     fun start(currentShareMessage: String) {
-        this.startingShareMessage = currentShareMessage
+        this.currentShareMessage = currentShareMessage
         _uiState.value = Loaded(
             appBarLabel = stringProvider.getString(
                 R.string.post_settings_jetpack_social_share_message_title
             ),
-            currentShareMessage = shareMessage(),
+            currentShareMessage = currentShareMessage,
             shareMessageMaxLength = SHARE_MESSAGE_MAX_LENGTH,
             customizeMessageDescription = stringProvider.getString(
                 R.string.post_settings_jetpack_social_share_message_description
@@ -44,7 +43,7 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
     }
 
     fun updateShareMessage(shareMessage: String) {
-        updatedShareMessage = shareMessage
+        currentShareMessage = shareMessage
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -52,16 +51,11 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
         viewModelScope.launch {
             _actionEvents.send(
                 ActionEvent.FinishActivity(
-                    updatedShareMessage = shareMessage(),
+                    updatedShareMessage = currentShareMessage,
                 )
             )
         }
     }
-
-    private fun shareMessage(): String =
-        updatedShareMessage.ifEmpty {
-            startingShareMessage
-        }
 
     sealed class UiState {
         object Initial : UiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
@@ -51,7 +51,7 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
         viewModelScope.launch {
             _actionEvents.send(
                 ActionEvent.FinishActivity(
-                    updatedShareMessage = currentShareMessage,
+                    updatedShareMessage = currentShareMessage.trim(),
                 )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageViewModel.kt
@@ -26,9 +26,10 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
     val actionEvents = _actionEvents.receiveAsFlow()
 
     private var currentShareMessage = ""
+    private var hasChangedMessage = false
 
-    fun start(currentShareMessage: String) {
-        this.currentShareMessage = currentShareMessage
+    fun start(initialShareMessage: String) {
+        if (!hasChangedMessage) currentShareMessage = initialShareMessage
         _uiState.value = Loaded(
             appBarLabel = stringProvider.getString(
                 R.string.post_settings_jetpack_social_share_message_title
@@ -44,6 +45,7 @@ class EditJetpackSocialShareMessageViewModel @Inject constructor(
 
     fun updateShareMessage(shareMessage: String) {
         currentShareMessage = shareMessage
+        hasChangedMessage = true
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1719,6 +1719,7 @@
     <string name="post_settings_jetpack_social_subscribe_share_more">Subscribe to share more</string>
     <string name="post_settings_jetpack_social_share_message_title">Customize the message</string>
     <string name="post_settings_jetpack_social_share_message_description">Customize the message you want to share. If you don\'t add your own text here, we\'ll use the post\'s title as the message.</string>
+    <string name="post_settings_jetpack_social_share_message_clear">Clear</string>
     <string name="jetpack_social_social_shares_remaining">%1$d social shares remaining</string>
     <string name="jetpack_social_social_shares_remaining_one">1 social share remaining</string>
     <string name="jetpack_social_social_shares_title_not_sharing">Not sharing to social</string>


### PR DESCRIPTION
Fixes #18834 

Fixes/improves the Share Message screen as follows:
- Start the cursor at the end of the text;
- Add 'x' button to clear all text
- Saving with empty message reverts to post title and not previous message
- Remove extra padding around the top bar

## To test
Pre-req: have a site with Jetpack Social plugin (or WPCOM site) with 1 or more social networks connected for post sharing.

1. Open Jepack app
2. Select the site
3. Go to `Posts`
4. Create a new post / open a post from Drafts
5. Go to the `Post Settings`
6. Tap the `Message` item in the Social section
7. **Verify** the fixes and improvements above
8. Go back to the post editor
9. Tap `Publish`
10. On the bottom sheet, tap the social item
11. Tap the `Message` item
12. **Verify** the fixes and improvements above here as well

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
