### PR TITLE
[Jetpack Social] Update social network icons in social connections screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeServiceIcon.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeServiceIcon.kt
@@ -29,6 +29,7 @@ enum class PublicizeServiceIcon(
          *
          * @param serviceId The name of the service, as returned by the Publicize API.
          */
+        @JvmStatic
         fun fromServiceId(serviceId: String): PublicizeServiceIcon? {
             return values().find { it.serviceId == serviceId }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -22,9 +22,8 @@ import org.wordpress.android.models.PublicizeConnectionList;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.models.PublicizeServiceList;
 import org.wordpress.android.ui.publicize.PublicizeConstants;
-import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.ui.publicize.PublicizeServiceIcon;
 import org.wordpress.android.util.image.ImageManager;
-import org.wordpress.android.util.image.ImageType;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -118,9 +117,13 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
                 mConnections.getServiceConnectionsForUser(mCurrentUserId, service.getId());
 
         holder.mTxtService.setText(service.getLabel());
-        String iconUrl = PhotonUtils.getPhotonImageUrl(service.getIconUrl(), mBlavatarSz, mBlavatarSz);
-        mImageManager.load(holder.mImgIcon, ImageType.BLAVATAR, iconUrl);
-
+        final PublicizeServiceIcon icon = PublicizeServiceIcon.fromServiceId(service.getId());
+        if (icon != null) {
+            holder.mImgIcon.setVisibility(View.VISIBLE);
+            mImageManager.load(holder.mImgIcon, icon.getIconResId());
+        } else {
+            holder.mImgIcon.setVisibility(View.INVISIBLE);
+        }
         if (connections.size() > 0) {
             holder.mTxtUser.setText(connections.getUserDisplayNames());
             holder.mTxtUser.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixes #18974 

To test:
1 - Install JP app and log in;
2 - Navigate to `"My Site"` tab;
3 - Select `"MENU"`;
4 - Tap on `"Social"`;
5 - Observe the services list: social networks without any connected account should be using the new design;

<img width="300" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/c9edaab0-77a1-4243-834a-91e2a12e256e">

6 - Connect any account;
7 - Move back to services list:  the social network with a connected account should be using the new design;
<img width="300" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/94a0fc6f-b9f0-4a33-b4ba-d88b114cfdc9">

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
--

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
