### PR TITLE
Contact Support: Navigation improvements for links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -18,6 +18,7 @@ import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.network.utils.toMap
 import org.wordpress.android.support.SupportWebViewActivity.OpenChatWidget.Companion.CHAT_HISTORY
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 
 class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
@@ -47,6 +48,10 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         intent.putExtra(CHAT_HISTORY, chatHistory)
         setResult(RESULT_OK, intent)
         finish()
+    }
+
+    override fun onRedirectToExternalBrowser(url: String) {
+        ActivityLauncher.openUrlExternal(this, url)
     }
 
     private fun setupWebView() {

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewClient.kt
@@ -13,6 +13,7 @@ class SupportWebViewClient(
 ) : ErrorManagedWebViewClient(listener) {
     interface SupportWebViewClientListener : ErrorManagedWebViewClientListener {
         fun onChatSessionClosed(chatHistory: String)
+        fun onRedirectToExternalBrowser(url: String)
     }
 
     override fun shouldInterceptRequest(
@@ -28,6 +29,11 @@ class SupportWebViewClient(
         url: String
     ): WebResourceResponse? {
         return assetLoader.shouldInterceptRequest(Uri.parse(url))
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        listener.onRedirectToExternalBrowser(request.url.toString())
+        return true
     }
 }
 


### PR DESCRIPTION
Fixes #18978 

Before the change, Source links or links from within the chat messages opened in the app . The solution is to open them in the system browser so the state of the chat could be preserved and users could more easily navigate the support docs.

Some of the provided links are broken but it's not a part of this PR to investigate that (p1692109164682589-slack-C05ALSVN5K5)

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/5852d017-24de-44e0-af57-698f3835c8f2

To test:
1. Open Jetpack
2. Help & Support -> Contact Support
3. Ask chat bot to provide some helpful links
4. Tap on links
5. Make sure they open in the system browser
6. Come back to the chat and select "Sources" at the bottom of the message
7. Make sure links open in the system browser

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.