### PR TITLE
Don't return to the chat bot screen again after ticket creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -121,6 +121,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
 
     private fun showZendeskTickets() {
         zendeskHelper.showAllTickets(this, originFromExtras, selectedSiteFromExtras, extraTagsFromExtras)
+        finish()
     }
 
     override fun onRedirectToExternalBrowser(url: String) {


### PR DESCRIPTION
Fixes: #18902 

An improvement to navigation from creating ticket according to https://github.com/wordpress-mobile/WordPress-Android/pull/18961#pullrequestreview-1579624424.

Now, tapping the bac button on the Tickets screen after creating a ticket it'll return to the Help screen, not to the chat bot screen again.

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/9b522df7-710b-4c1b-82cb-165a2bb6b28d

To test:
1. Launch JP app.
2. Enable "Contact Support via DocsBot" feature flag.
3. Help & Support -> Contact Support
4. Ask bot a question
5. Tap "Contact support"
6. Tap the back button on the Tickets screen.
7. Ensure it returns to the Help screen.

## Regression Notes
1. Potential unintended areas of impact
None

4. What I did to test those areas of impact (or what existing automated tests I relied on)
None

5. What automated tests I added (or what prevented me from doing so)
This is too specific a case to add a UI test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)