### PR TITLE
Attach signed apks to GitHub release

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -135,30 +135,39 @@ platform :android do
   end
 
   #####################################################################################
-  # download_signed_apk_from_google_play
+  # download_signed_apks_from_google_play
   # -----------------------------------------------------------------------------------
-  # This lane downloads the signed apk from Play Store for the given version and app
+  # This lane downloads the signed apks from Play Store for the given app and version
+  #
+  # If no argument is provided, it'll download both WordPress & Jetpack apks using the version from version.properties
+  # If only 'app' argument is provided, it'll download the apk for the given app using the version from version.properties
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane download_signed_apk_from_google_play app:<wordpress|jetpack> version:<versionName,versionCode>
+  # bundle exec fastlane download_signed_apks_from_google_play # Download WordPress & Jetpack apks using the version from version.properties
+  # bundle exec fastlane download_signed_apks_from_google_play app:<wordpress|jetpack> # Download given app's apk using the version from version.properties
+  # bundle exec fastlane download_signed_apks_from_google_play app:<wordpress|jetpack> version:<versionName,versionCode>
   #####################################################################################
-  lane :download_signed_apk_from_google_play do |options|
-    app = get_app_name_option!(options)
-    package_name = APP_SPECIFIC_VALUES[app.to_sym][:package_name]
-    version = options[:version] || android_get_release_version() # default to current release version
+  lane :download_signed_apks_from_google_play do |options|
+    # If no `app:` is specified, call this for both WordPress and Jetpack
+    apps = options[:app].nil? ? %i[wordpress jetpack] : Array(options[:app]&.downcase&.to_sym)
 
-    if version.is_a?(String) # for when calling from command line
-      (version_name, version_code) = version.split(',')
-      UI.user_error!('Please pass the `version` option as a comma-separated `name,code` value') if version_code.nil?
-      version = { 'name' => version_name, 'code' => version_code }
+    apps.each do |app|
+      package_name = APP_SPECIFIC_VALUES[app.to_sym][:package_name]
+      version = options[:version] || android_get_release_version() # default to current release version
+
+      if version.is_a?(String) # for when calling from command line
+        (version_name, version_code) = version.split(',')
+        UI.user_error!('Please pass the `version` option as a comma-separated `name,code` value') if version_code.nil?
+        version = { 'name' => version_name, 'code' => version_code }
+      end
+
+      download_universal_apk_from_google_play(
+          package_name: package_name,
+          version_code: version['code'],
+          destination: signed_apk_path(app, version),
+          json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
+      )
     end
-
-    download_universal_apk_from_google_play(
-        package_name: package_name,
-        version_code: version['code'],
-        destination: signed_apk_path(app, version),
-        json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
-    )
   end
 
   #####################################################################################

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -280,7 +280,7 @@ platform :android do
     apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [get_app_name_option!(options)]
     versions = options[:version].nil? ? [android_get_release_version()] : [options[:version]]
 
-    download_signed_apks_from_google_play()
+    download_signed_apks_from_google_play(app: options[:app])
 
     release_assets = apps.flat_map do |app|
       versions.flat_map { |vers| [bundle_file_path(app, vers), signed_apk_path(app, vers)] }

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -280,8 +280,10 @@ platform :android do
     apps = options[:app].nil? ? ['wordpress', 'jetpack'] : [get_app_name_option!(options)]
     versions = options[:version].nil? ? [android_get_release_version()] : [options[:version]]
 
+    download_signed_apks_from_google_play()
+
     release_assets = apps.flat_map do |app|
-      versions.flat_map { |vers| bundle_file_path(app, vers) }
+      versions.flat_map { |vers| [bundle_file_path(app, vers), signed_apk_path(app, vers)] }
     end.select { |f| File.exist?(f) }
 
     release_title = versions.last['name']


### PR DESCRIPTION
This PR builds on https://github.com/wordpress-mobile/WordPress-Android/pull/18813 and makes the `app` argument of `download_signed_apks_from_google_play` optional by downloading both apks. This was an improvement suggested by @AliSoftware 🙇 in another PR that updates WPAndroid's release scenario. The PR also updates the `create_gh_release` lane to first download the signed apks and then attach them to its assets.

I am proposing that we rename `download_signed_apk_from_google_play` as `download_signed_apks_from_google_play`. I think we are likely going to call this lane without any arguments in most cases, so the plural version makes more sense to me.

The PR is targeting `release/23.0` as I'd like to test these changes on Friday's release finalization. I am AFK next week and I wanted to make sure everything is working as expected to avoid @ParaskP7 - who is covering the WPAndroid releases next week 🙇‍♂️ - dealing with any potential issues.

_I suggest reviewing this PR by enabling [`Hide whitespace` feature](https://github.blog/2018-05-01-ignore-white-space-in-code-review/)._

### To test:

**Verify both apks are downloaded when no `app` argument is given**

* Run `bundle exec fastlane download_signed_apks_from_google_play` and verify that both signed apks are downloaded.

**Verify the GitHub assets includes the signed apks**

* Run `touch build/jpandroid-23.0-rc-1.aab && touch build/wpandroid-23.0-rc-1.aab`. Unless we bundle the apps prior to this test, the `.aab` files won't be in the `build` folder. This is just a quick way to create those files as we'll only verify their path.
* Add `next` to [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/d2a01f10b43c3a516af259d6d2fd12359909cd7b/fastlane/lanes/release.rb#L293). This will make it so that `create_gh_release` lane quits early, so we can inspect the information printed out in [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/d2a01f10b43c3a516af259d6d2fd12359909cd7b/fastlane/lanes/release.rb#L292). Alternatively, you can comment out the rest of the lane.
* Run `bundle exec fastlane create_gh_release`.
* Verify that the assets printed out includes both `aab` and `apk` files.

Here is my test: (formatted for easier viewing)

```
[17:37:19]: Creating release for 23.0-rc-1 with the following assets: 
["~/WordPress-Android/build/wpandroid-23.0-rc-1.aab",
"~/WordPress-Android/build/wpandroid-23.0-rc-1.apk",
"~/WordPress-Android/build/jpandroid-23.0-rc-1.aab",
"~/WordPress-Android/build/jpandroid-23.0-rc-1.apk"]
```