### PR TITLE
Integrate gutenberg-mobile release 1.101.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = '6075-e68756ed3541f0990a4cd4f7474365cbc08918bc'
+    gutenbergMobileVersion = 'v1.101.1'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.41.1'
     wordPressLoginVersion = '1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = 'v1.101.0'
+    gutenbergMobileVersion = '6075-0d9028d5cc6b5ad06e970ea487aee2961738aeb2'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.41.1'
     wordPressLoginVersion = '1.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = '6075-0d9028d5cc6b5ad06e970ea487aee2961738aeb2'
+    gutenbergMobileVersion = '6075-e68756ed3541f0990a4cd4f7474365cbc08918bc'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.41.1'
     wordPressLoginVersion = '1.4.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.101.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6075

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.