### PR TITLE
Disable domain purchasing during site creation on Jetpack

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -219,7 +219,7 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
-            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "true"
+            buildConfigField "boolean", "ENABLE_SITE_CREATION_DOMAIN_PURCHASING", "false"
 
             manifestPlaceholders = [magicLinkScheme:"jetpack"]
 


### PR DESCRIPTION
### Description

This PR turns the feature flag _off_ for the domain purchasing in site creation feature in Jetpack.

To test:

https://github.com/wordpress-mobile/WordPress-Android/pull/18986

1. Install the Jetpack app & login
2. Tap the ▽ icon at the right of the site name on the My Site screen
3. Tap the + icon at the top right on the Site picker screen
4. Select ⊕ Create WordPress.com site on the modal dialog
5. Tap Skip at top right on the first step (topic screen)
6. Tap Skip at top right on the next step (theme screen)
7. Enter a search query (whatever you want here)
8. Expect that there are no prices or "free" listed next to the domains on the right side

## Regression Notes
1. Potential unintended areas of impact
N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

11. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
