### PR TITLE
Integrate gutenberg-mobile release 1.102.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
 23.1
 -----
 * [*] Block editor: Hide undo/redo buttons when using the HTML editor [https://github.com/wordpress-mobile/WordPress-Android/pull/18889]
-
+* [*] Block editor: Display custom color value in mobile Cover Block color picker [https://github.com/WordPress/gutenberg/pull/51414]
+* [**] Block editor: Display outline around selected Social Link block [https://github.com/WordPress/gutenberg/pull/53377]
 
 23.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = 'v1.101.0'
+    gutenbergMobileVersion = '6089-760986d06dc285cb5df21a7fcf2b924c34a08616'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = 'trunk-eebc6c32e3a9d088c062124692b644bcf741ad34'
     wordPressLoginVersion = '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.2.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = '6089-760986d06dc285cb5df21a7fcf2b924c34a08616'
+    gutenbergMobileVersion = 'v1.102.0'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = 'trunk-eebc6c32e3a9d088c062124692b644bcf741ad34'
     wordPressLoginVersion = '1.5.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.102.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6089

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.