### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to All SDK Override Methods for Fragments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -57,7 +58,7 @@ public class ShareIntentReceiverFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
         if (context instanceof ShareIntentFragmentListener) {
             mShareIntentFragmentListener = (ShareIntentFragmentListener) context;
@@ -76,7 +77,7 @@ public class ShareIntentReceiverFragment extends Fragment {
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         ViewGroup layout = (ViewGroup) inflater.inflate(R.layout.share_intent_receiver_fragment, container, false);
         initButtonsContainer(layout);
@@ -95,14 +96,14 @@ public class ShareIntentReceiverFragment extends Fragment {
         loadSavedState(savedInstanceState);
     }
 
-    private void loadSavedState(Bundle savedInstanceState) {
+    private void loadSavedState(@Nullable Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             mLastUsedBlogLocalId = savedInstanceState.getInt(ARG_LAST_USED_BLOG_LOCAL_ID);
         }
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         int selectedItemLocalId = mAdapter.getSelectedItemLocalId();
         if (selectedItemLocalId != -1) {
@@ -129,7 +130,7 @@ public class ShareIntentReceiverFragment extends Fragment {
     private void addShareActionListener(final Button button, final ShareAction shareAction) {
         button.setOnClickListener(new OnClickListener() {
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 mShareIntentFragmentListener.share(shareAction, mAdapter.getSelectedItemLocalId());
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -154,7 +154,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         mDoLoginUpdate = requireArguments().getBoolean(ARG_DO_LOGIN_UPDATE, false);
@@ -165,7 +165,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         initViewModel();
     }
@@ -301,7 +301,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
         if (context instanceof LoginEpilogueListener) {
             mLoginEpilogueListener = (LoginEpilogueListener) context;
@@ -370,15 +370,15 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     }
 
     @Override
-    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
     }
 
     @Override
-    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
     }
 
     @Override
-    public void afterTextChanged(Editable s) {
+    public void afterTextChanged(@NonNull Editable s) {
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -188,14 +188,14 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         headerAvatarLayout.setEnabled(mIsEmailSignup);
         headerAvatarLayout.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 mUnifiedLoginTracker.trackClick(Click.SELECT_AVATAR);
                 mMediaPickerLauncher.showGravatarPicker(SignupEpilogueFragment.this);
             }
         });
         headerAvatarLayout.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
-            public boolean onLongClick(View view) {
+            public boolean onLongClick(@NonNull View v) {
                 ToastUtils.showToast(getActivity(), getString(R.string.content_description_add_avatar),
                         ToastUtils.Duration.SHORT);
                 return true;
@@ -214,15 +214,15 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         mEditTextDisplayName.setText(mDisplayName);
         mEditTextDisplayName.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
             }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
             }
 
             @Override
-            public void afterTextChanged(Editable s) {
+            public void afterTextChanged(@NonNull Editable s) {
                 mDisplayName = s.toString();
                 mHeaderDisplayName.setText(mDisplayName);
             }
@@ -232,14 +232,14 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         mEditTextUsername.setText(mUsername);
         mEditTextUsername.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 mUnifiedLoginTracker.trackClick(Click.EDIT_USERNAME);
                 launchDialog();
             }
         });
         mEditTextUsername.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
-            public void onFocusChange(View view, boolean hasFocus) {
+            public void onFocusChange(@NonNull View v, boolean hasFocus) {
                 if (hasFocus) {
                     launchDialog();
                 }
@@ -247,7 +247,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         });
         mEditTextUsername.setOnKeyListener(new View.OnKeyListener() {
             @Override
-            public boolean onKey(View view, int keyCode, KeyEvent event) {
+            public boolean onKey(@NonNull View v, int keyCode, @NonNull KeyEvent event) {
                 // Consume keyboard events except for Enter (i.e. click/tap) and Tab (i.e. focus/navigation).
                 // The onKey method returns true if the listener has consumed the event and false otherwise
                 // allowing hardware keyboard users to tap and navigate, but not input text as expected.
@@ -269,7 +269,8 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 (OnScrollChangeListener) (v, scrollX, scrollY, oldScrollX, oldScrollY) -> showBottomShadowIfNeeded());
         // We must use onGlobalLayout here otherwise canScrollVertically will always return false
         mScrollView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
-            @Override public void onGlobalLayout() {
+            @Override
+            public void onGlobalLayout() {
                 mScrollView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 showBottomShadowIfNeeded();
             }
@@ -289,7 +290,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     protected void setupBottomButton(Button button) {
         button.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 mUnifiedLoginTracker.trackClick(Click.CONTINUE);
                 updateAccountOrContinue();
             }
@@ -297,7 +298,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
@@ -364,7 +365,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         if (isAdded()) {
@@ -434,7 +435,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
         if (context instanceof SignupEpilogueListener) {
@@ -468,7 +469,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(KEY_PHOTO_URL, mPhotoUrl);
         outState.putString(KEY_DISPLAY_NAME, mDisplayName);
@@ -482,15 +483,15 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     }
 
     @Override
-    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
     }
 
     @Override
-    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
     }
 
     @Override
-    public void afterTextChanged(Editable s) {
+    public void afterTextChanged(@NonNull Editable s) {
     }
 
     @Override
@@ -665,7 +666,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     protected void showErrorDialog(String message) {
         DialogInterface.OnClickListener dialogListener = new DialogInterface.OnClickListener() {
             @Override
-            public void onClick(DialogInterface dialog, int which) {
+            public void onClick(@Nullable DialogInterface dialog, int which) {
                 switch (which) {
                     case DialogInterface.BUTTON_NEGATIVE:
                         undoChanges();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -224,7 +224,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -277,9 +277,11 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     }
 
     // touching the file resulted in the MethodLength, it's suppressed until we get time to refactor this method
-    @SuppressWarnings("checkstyle:MethodLength")
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    @SuppressWarnings("checkstyle:MethodLength")
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.comment_detail_fragment, container, false);
 
         mMediumOpacity = ResourcesCompat.getFloat(
@@ -337,15 +339,15 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         mEditReply.initializeWithPrefix('@');
         mEditReply.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
             }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
             }
 
             @Override
-            public void afterTextChanged(Editable s) {
+            public void afterTextChanged(@NonNull Editable s) {
                 mSubmitReplyBtn.setEnabled(!TextUtils.isEmpty(s.toString().trim()));
             }
         });
@@ -641,7 +643,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == INTENT_COMMENT_EDITOR && resultCode == Activity.RESULT_OK) {
             reloadComment();
@@ -1639,8 +1641,9 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         }
     }
 
+    @Nullable
     @Override
-    @Nullable public View getScrollableViewForUniqueIdProvision() {
+    public View getScrollableViewForUniqueIdProvision() {
         return mNestedScrollView;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -100,8 +100,10 @@ public class HistoryDetailContainerFragment extends Fragment {
         return fragment;
     }
 
+    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.history_detail_container_fragment, container, false);
 
         mIsFragmentRecreated = savedInstanceState != null;
@@ -227,20 +229,20 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.history_detail, menu);
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         MenuItem viewMode = menu.findItem(R.id.history_toggle_view);
         viewMode.setTitle(isInVisualPreview() ? R.string.history_preview_html : R.string.history_preview_visual);
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.history_load) {
             Intent intent = new Intent();
             intent.putExtra(KEY_REVISION, mRevision);
@@ -353,6 +355,7 @@ public class HistoryDetailContainerFragment extends Fragment {
             mRevisions = (ArrayList<Revision>) revisions.clone();
         }
 
+        @NonNull
         @Override
         public Fragment getItem(int position) {
             return HistoryDetailFragment.Companion.newInstance(mRevisions.get(position));
@@ -364,7 +367,7 @@ public class HistoryDetailContainerFragment extends Fragment {
         }
 
         @Override
-        public void restoreState(Parcelable state, ClassLoader loader) {
+        public void restoreState(@Nullable Parcelable state, @Nullable ClassLoader loader) {
             try {
                 super.restoreState(state, loader);
             } catch (IllegalStateException exception) {
@@ -372,6 +375,7 @@ public class HistoryDetailContainerFragment extends Fragment {
             }
         }
 
+        @Nullable
         @Override
         public Parcelable saveState() {
             Bundle bundle = (Bundle) super.saveState();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -15,6 +15,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.fragment.app.Fragment;
@@ -197,7 +198,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -268,14 +269,16 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(QuickStartEvent.KEY, mQuickStartEvent);
         saveState(outState);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
 
         View view = inflater.inflate(R.layout.media_grid_fragment, container, false);
@@ -301,7 +304,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         });
         mRecycler.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
-            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
                 if (newState == RecyclerView.SCROLL_STATE_IDLE) {
                     getAdapter().setLoadThumbnails(true);
@@ -311,7 +314,8 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
         mActionableEmptyView = (ActionableEmptyView) view.findViewById(R.id.actionable_empty_view);
         mActionableEmptyView.button.setOnClickListener(new OnClickListener() {
-            @Override public void onClick(View view) {
+            @Override
+            public void onClick(@NonNull View v) {
                 if (isAdded() && getActivity() instanceof MediaBrowserActivity) {
                     ((MediaBrowserActivity) getActivity()).showAddMediaPopup();
                 }
@@ -359,7 +363,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
 
         try {
@@ -849,7 +853,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
-        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+        public boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             mActionMode = mode;
             int selectCount = getAdapter().getSelectedItemCount();
             MenuInflater inflater = mode.getMenuInflater();
@@ -861,7 +865,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         @Override
-        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+        public boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             MenuItem mnuConfirm = menu.findItem(R.id.mnu_confirm_selection);
             mnuConfirm.setVisible(mBrowserType.isPicker());
 
@@ -870,7 +874,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         @Override
-        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+        public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
             if (item.getItemId() == R.id.mnu_confirm_selection) {
                 setResultIdsAndFinish();
             }
@@ -878,7 +882,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         @Override
-        public void onDestroyActionMode(ActionMode mode) {
+        public void onDestroyActionMode(@NonNull ActionMode mode) {
             setSwipeToRefreshEnabled(true);
             getAdapter().setInMultiSelect(false);
             mActionMode = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -146,8 +146,10 @@ public class MediaPreviewFragment extends Fragment {
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
 
         View view = inflater.inflate(R.layout.media_preview_fragment, container, false);
@@ -330,7 +332,8 @@ public class MediaPreviewFragment extends Fragment {
     }
 
     private class PlayerEventListener implements Player.EventListener {
-        @Override public void onLoadingChanged(boolean isLoading) {
+        @Override
+        public void onLoadingChanged(boolean isLoading) {
             showProgress(isLoading);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -133,19 +133,19 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.people_invite, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         menu.getItem(0).setEnabled(!mInviteOperationInProgress); // here pass the index of send menu item
         super.onPrepareOptionsMenu(menu);
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         if (mCurrentRole != null) {
             outState.putString(KEY_SELECTED_ROLE, mCurrentRole);
@@ -154,7 +154,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
         updateSiteOrFinishActivity();
@@ -178,8 +178,10 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         setRetainInstance(true);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(final LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         setHasOptionsMenu(true);
         View rootView = inflater.inflate(R.layout.people_invite_fragment, container, false);
 
@@ -329,11 +331,13 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         }
 
         mUsernamesEmails.setItemsManager(new ItemsManagerInterface() {
-            @Override public void onRemoveItem(@NonNull String item) {
+            @Override
+            public void onRemoveItem(@NonNull String item) {
                 removeUsername(item);
             }
 
-            @Override public void onAddItem(@NonNull String item) {
+            @Override
+            public void onAddItem(@NonNull String item) {
                 addUsername(item, null);
             }
         });
@@ -375,16 +379,16 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
 
         mCustomMessageEditText.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
             }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
                 mCustomMessage = mCustomMessageEditText.getText().toString();
             }
 
             @Override
-            public void afterTextChanged(Editable s) {
+            public void afterTextChanged(@NonNull Editable s) {
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -93,19 +93,21 @@ public class PeopleListFragment extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.people_list, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         setHasOptionsMenu(true);
 
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.people_list_fragment, container, false);
@@ -260,7 +262,8 @@ public class PeopleListFragment extends Fragment {
         }
     }
 
-    @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // important for accessibility - talkback
         getActivity().setTitle(R.string.people);
@@ -474,7 +477,8 @@ public class PeopleListFragment extends Fragment {
             }
         }
 
-        @Override public void onViewRecycled(@NonNull ViewHolder holder) {
+        @Override
+        public void onViewRecycled(@NonNull ViewHolder holder) {
             super.onViewRecycled(holder);
             PeopleViewHolder peopleViewHolder = (PeopleViewHolder) holder;
         }
@@ -498,7 +502,7 @@ public class PeopleListFragment extends Fragment {
             }
 
             @Override
-            public void onClick(View v) {
+            public void onClick(@NonNull View v) {
                 if (mOnPersonSelectedListener != null) {
                     Person person = getPerson(getBindingAdapterPosition());
                     mOnPersonSelectedListener.onPersonSelected(person);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -12,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
@@ -80,7 +81,7 @@ public class PersonDetailFragment extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
 
@@ -110,13 +111,15 @@ public class PersonDetailFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.person_detail, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.person_detail_fragment, container, false);
 
         Toolbar toolbar = rootView.findViewById(R.id.toolbar_main);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -71,7 +71,7 @@ public class PluginListFragment extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -133,8 +133,10 @@ public class PluginListFragment extends Fragment {
                   });
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.plugin_list_fragment, container, false);
 
         mRecycler = view.findViewById(R.id.recycler);
@@ -154,7 +156,7 @@ public class PluginListFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, @NonNull MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         menu.clear();
         super.onCreateOptionsMenu(menu, inflater);
     }
@@ -211,7 +213,8 @@ public class PluginListFragment extends Fragment {
             diffResult.dispatchUpdatesTo(this);
         }
 
-        private @Nullable Object getItem(int position) {
+        @Nullable
+        private Object getItem(int position) {
             return mItems.getItem(position);
         }
 
@@ -233,16 +236,16 @@ public class PluginListFragment extends Fragment {
         }
 
         @Override
-        public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
+        public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
             ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
             if (plugin == null) {
                 return;
             }
 
-            PluginViewHolder holder = (PluginViewHolder) viewHolder;
-            holder.mName.setText(plugin.getDisplayName());
-            holder.mAuthor.setText(plugin.getAuthorName());
-            mImageManager.load(holder.mIcon, ImageType.PLUGIN, StringUtils.notNullStr(plugin.getIcon()));
+            PluginViewHolder pluginHolder = (PluginViewHolder) holder;
+            pluginHolder.mName.setText(plugin.getDisplayName());
+            pluginHolder.mAuthor.setText(plugin.getAuthorName());
+            mImageManager.load(pluginHolder.mIcon, ImageType.PLUGIN, StringUtils.notNullStr(plugin.getIcon()));
 
             if (plugin.isInstalled()) {
                 @StringRes int textResId;
@@ -250,38 +253,46 @@ public class PluginListFragment extends Fragment {
                 @DrawableRes int drawableResId;
                 if (PluginUtils.isAutoManaged(mViewModel.getSite(), plugin)) {
                     textResId = R.string.plugin_auto_managed;
-                    colorResId = ContextExtensionsKt
-                            .getColorResIdFromAttribute(holder.mStatusIcon.getContext(), R.attr.wpColorSuccess);
+                    colorResId = ContextExtensionsKt.getColorResIdFromAttribute(
+                            pluginHolder.mStatusIcon.getContext(),
+                            R.attr.wpColorSuccess
+                    );
                     drawableResId = android.R.color.transparent;
                 } else if (PluginUtils.isUpdateAvailable(plugin)) {
                     textResId = R.string.plugin_needs_update;
-                    colorResId = ContextExtensionsKt
-                            .getColorResIdFromAttribute(holder.mStatusIcon.getContext(), R.attr.wpColorWarningDark);
+                    colorResId = ContextExtensionsKt.getColorResIdFromAttribute(
+                            pluginHolder.mStatusIcon.getContext(),
+                            R.attr.wpColorWarningDark
+                    );
                     drawableResId = R.drawable.ic_sync_white_24dp;
                 } else if (plugin.isActive()) {
                     textResId = R.string.plugin_active;
-                    colorResId = ContextExtensionsKt
-                            .getColorResIdFromAttribute(holder.mStatusIcon.getContext(), R.attr.wpColorSuccess);
+                    colorResId = ContextExtensionsKt.getColorResIdFromAttribute(
+                            pluginHolder.mStatusIcon.getContext(),
+                            R.attr.wpColorSuccess
+                    );
                     drawableResId = R.drawable.ic_checkmark_white_24dp;
                 } else {
                     textResId = R.string.plugin_inactive;
-                    colorResId = ContextExtensionsKt
-                            .getColorResIdFromAttribute(holder.mStatusIcon.getContext(), R.attr.wpColorOnSurfaceMedium);
+                    colorResId = ContextExtensionsKt.getColorResIdFromAttribute(
+                            pluginHolder.mStatusIcon.getContext(),
+                            R.attr.wpColorOnSurfaceMedium
+                    );
                     drawableResId = R.drawable.ic_cross_white_24dp;
                 }
 
-                holder.mStatusText.setText(textResId);
-                holder.mStatusText.setTextColor(
-                        AppCompatResources.getColorStateList(holder.mStatusText.getContext(), colorResId));
-                ColorUtils.INSTANCE.setImageResourceWithTint(holder.mStatusIcon, drawableResId, colorResId);
-                holder.mStatusText.setVisibility(View.VISIBLE);
-                holder.mStatusIcon.setVisibility(View.VISIBLE);
-                holder.mRatingBar.setVisibility(View.GONE);
+                pluginHolder.mStatusText.setText(textResId);
+                pluginHolder.mStatusText.setTextColor(
+                        AppCompatResources.getColorStateList(pluginHolder.mStatusText.getContext(), colorResId));
+                ColorUtils.INSTANCE.setImageResourceWithTint(pluginHolder.mStatusIcon, drawableResId, colorResId);
+                pluginHolder.mStatusText.setVisibility(View.VISIBLE);
+                pluginHolder.mStatusIcon.setVisibility(View.VISIBLE);
+                pluginHolder.mRatingBar.setVisibility(View.GONE);
             } else {
-                holder.mStatusText.setVisibility(View.GONE);
-                holder.mStatusIcon.setVisibility(View.GONE);
-                holder.mRatingBar.setVisibility(View.VISIBLE);
-                holder.mRatingBar.setRating(plugin.getAverageStarRating());
+                pluginHolder.mStatusText.setVisibility(View.GONE);
+                pluginHolder.mStatusIcon.setVisibility(View.GONE);
+                pluginHolder.mRatingBar.setVisibility(View.VISIBLE);
+                pluginHolder.mRatingBar.setRating(plugin.getAverageStarRating());
             }
 
             if (position == getItemCount() - 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -180,7 +180,7 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
         mDispatcher.register(this);
@@ -256,7 +256,8 @@ public class EditPostSettingsFragment extends Fragment {
         }
     }
 
-    @Override public void onResume() {
+    @Override
+    public void onResume() {
         super.onResume();
         mJetpackSocialViewModel.onResume(JetpackSocialFlow.POST_SETTINGS);
     }
@@ -270,6 +271,7 @@ public class EditPostSettingsFragment extends Fragment {
         super.onDestroy();
     }
 
+    @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
@@ -309,8 +311,8 @@ public class EditPostSettingsFragment extends Fragment {
 
         OnClickListener showContextMenuListener = new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
-                view.showContextMenu();
+            public void onClick(@NonNull View v) {
+                v.showContextMenu();
             }
         };
 
@@ -326,7 +328,7 @@ public class EditPostSettingsFragment extends Fragment {
 
         mFeaturedImageButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 launchFeaturedMediaPicker();
             }
         });
@@ -334,7 +336,7 @@ public class EditPostSettingsFragment extends Fragment {
         mExcerptContainer = rootView.findViewById(R.id.post_excerpt_container);
         mExcerptContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showPostExcerptDialog();
             }
         });
@@ -342,7 +344,7 @@ public class EditPostSettingsFragment extends Fragment {
         LinearLayout parentContainer = rootView.findViewById(R.id.post_parent_container);
         parentContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showPageParentActivity();
             }
         });
@@ -350,7 +352,7 @@ public class EditPostSettingsFragment extends Fragment {
         final LinearLayout slugContainer = rootView.findViewById(R.id.post_slug_container);
         slugContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showSlugDialog();
             }
         });
@@ -360,7 +362,7 @@ public class EditPostSettingsFragment extends Fragment {
         LinearLayout categoriesContainer = rootView.findViewById(R.id.post_categories_container);
         categoriesContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showCategoriesActivity();
             }
         });
@@ -368,7 +370,7 @@ public class EditPostSettingsFragment extends Fragment {
         LinearLayout tagsContainer = rootView.findViewById(R.id.post_tags_container);
         tagsContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showTagsActivity();
             }
         });
@@ -376,7 +378,7 @@ public class EditPostSettingsFragment extends Fragment {
         final LinearLayout statusContainer = rootView.findViewById(R.id.post_status_container);
         statusContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showStatusDialog();
             }
         });
@@ -384,7 +386,7 @@ public class EditPostSettingsFragment extends Fragment {
         mFormatContainer = rootView.findViewById(R.id.post_format_container);
         mFormatContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showPostFormatDialog();
             }
         });
@@ -394,14 +396,14 @@ public class EditPostSettingsFragment extends Fragment {
         final LinearLayout passwordContainer = rootView.findViewById(R.id.post_password_container);
         passwordContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 showPostPasswordDialog();
             }
         });
 
         mPublishDateContainer.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) {
+            public void onClick(@NonNull View v) {
                 FragmentActivity activity = getActivity();
                 if (activity instanceof EditPostSettingsCallback) {
                     ((EditPostSettingsCallback) activity).onEditPostPublishedSettingsClick();
@@ -418,13 +420,15 @@ public class EditPostSettingsFragment extends Fragment {
 
 
         mPublishedViewModel.getOnUiModel().observe(getViewLifecycleOwner(), new Observer<PublishUiModel>() {
-            @Override public void onChanged(PublishUiModel uiModel) {
+            @Override
+            public void onChanged(@NonNull PublishUiModel uiModel) {
                 updatePublishDateTextView(uiModel.getPublishDateLabel(),
                         Objects.requireNonNull(getEditPostRepository().getPost()));
             }
         });
         mPublishedViewModel.getOnPostStatusChanged().observe(getViewLifecycleOwner(), new Observer<PostStatus>() {
-            @Override public void onChanged(PostStatus postStatus) {
+            @Override
+            public void onChanged(@NonNull PostStatus postStatus) {
                 updatePostStatus(postStatus);
             }
         });
@@ -438,7 +442,8 @@ public class EditPostSettingsFragment extends Fragment {
         return rootView;
     }
 
-    @Override public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         setupJetpackSocialViewModel();
     }
@@ -470,7 +475,8 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+    public void onCreateContextMenu(@NonNull ContextMenu menu, @NonNull View v,
+                                    @Nullable ContextMenu.ContextMenuInfo menuInfo) {
         if (mFeaturedImageRetryOverlay.getVisibility() == View.VISIBLE) {
             menu.add(0, RETRY_FEATURED_IMAGE_UPLOAD_MENU_ID, 0,
                     getString(R.string.post_settings_retry_featured_image));
@@ -483,7 +489,7 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public boolean onContextItemSelected(MenuItem item) {
+    public boolean onContextItemSelected(@NonNull MenuItem item) {
         SiteModel site = getSite();
         PostImmutableModel post = getEditPostRepository().getPost();
         if (site == null || post == null) {
@@ -558,7 +564,7 @@ public class EditPostSettingsFragment extends Fragment {
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         if (data != null || ((requestCode == RequestCodes.TAKE_PHOTO
@@ -1275,10 +1281,12 @@ public class EditPostSettingsFragment extends Fragment {
                 mImageManager.loadWithResultListener(mFeaturedImageView, ImageType.IMAGE,
                         currentFeaturedImageState.getMediaUri(), ScaleType.FIT_CENTER,
                         null, new RequestListener<Drawable>() {
-                            @Override public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
+                            @Override
+                            public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {
                             }
 
-                            @Override public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
+                            @Override
+                            public void onResourceReady(@NonNull Drawable resource, @Nullable Object model) {
                                 if (currentFeaturedImageState.getUiState() == FeaturedImageState.REMOTE_IMAGE_LOADING) {
                                     updateFeaturedImageViews(FeaturedImageState.REMOTE_IMAGE_SET);
                                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/TagsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/TagsFragment.java
@@ -52,7 +52,8 @@ public abstract class TagsFragment extends Fragment implements TextWatcher, View
 
     protected abstract String getTagsFromEditPostRepositoryOrArguments();
 
-    @Override public void onCreate(@Nullable Bundle savedInstanceState) {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         if (getArguments() != null) {
@@ -65,19 +66,22 @@ public abstract class TagsFragment extends Fragment implements TextWatcher, View
         }
     }
 
-    @Override public void onDetach() {
+    @Override
+    public void onDetach() {
         super.onDetach();
         mTagsSelectedListener = null;
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         return inflater.inflate(getContentLayout(), container, false);
     }
 
-    @Override public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         RecyclerView recyclerView = (RecyclerView) view.findViewById(R.id.tags_suggestion_list);
@@ -123,7 +127,7 @@ public abstract class TagsFragment extends Fragment implements TextWatcher, View
     }
 
     @Override
-    public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
+    public boolean onKey(@NonNull View view, int keyCode, @NonNull KeyEvent keyEvent) {
         if ((keyEvent.getAction() == KeyEvent.ACTION_DOWN)
             && (keyCode == KeyEvent.KEYCODE_ENTER)) {
             // Since we don't allow new lines, we should add comma on "enter" to separate the tags
@@ -138,18 +142,18 @@ public abstract class TagsFragment extends Fragment implements TextWatcher, View
     }
 
     @Override
-    public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+    public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
         // No-op
     }
 
     @Override
-    public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+    public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
         filterListForCurrentText();
-        mTagsSelectedListener.onTagsSelected(charSequence.toString());
+        mTagsSelectedListener.onTagsSelected(s.toString());
     }
 
     @Override
-    public void afterTextChanged(Editable editable) {
+    public void afterTextChanged(@NonNull Editable s) {
         // No-op
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
@@ -7,6 +7,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -49,7 +51,7 @@ public class MyProfileFragment extends Fragment implements TextInputDialogFragme
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
     }
@@ -76,8 +78,10 @@ public class MyProfileFragment extends Fragment implements TextInputDialogFragme
         super.onStop();
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.my_profile_fragment, container, false);
 
         mFirstName = rootView.findViewById(R.id.first_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -63,15 +63,17 @@ public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         setHasOptionsMenu(true);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.site_settings_tag_detail_fragment, container, false);
 
         mNameView = view.findViewById(R.id.edit_name);
@@ -95,20 +97,20 @@ public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         menu.clear();
         inflater.inflate(R.menu.tag_detail, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.menu_trash).setVisible(!mIsNewTerm);
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.menu_trash && mListener != null) {
             mListener.onRequestDeleteTag(mTerm);
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.wordpress.android.R;
@@ -59,7 +60,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
     }
 
     @Override
-    public void setArguments(Bundle args) {
+    public void setArguments(@Nullable Bundle args) {
         super.setArguments(args);
 
         if (args != null) {
@@ -69,7 +70,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -86,8 +87,10 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment
         outState.putString(PublicizeConstants.ARG_SERVICE_ID, mServiceId);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.publicize_detail_fragment, container, false);
 
         mConnectionsContainer = rootView.findViewById(R.id.connections_container);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -98,7 +98,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -130,8 +130,10 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.publicize_list_fragment, container, false);
 
         mRecycler = rootView.findViewById(R.id.recycler_view);
@@ -179,7 +181,8 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         return rootView;
     }
 
-    @Override public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         initViewModel();
         observeUIState();
@@ -266,13 +269,15 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     private void showQuickStartFocusPoint() {
         // we are waiting for RecyclerView to populate itself with views and then grab the first one when it's ready
         mRecycler.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-            @Override public void onGlobalLayout() {
+            @Override
+            public void onGlobalLayout() {
                 RecyclerView.ViewHolder holder = mRecycler.findViewHolderForAdapterPosition(0);
                 if (holder != null) {
                     final View quickStartTarget = holder.itemView;
 
                     quickStartTarget.post(new Runnable() {
-                        @Override public void run() {
+                        @Override
+                        public void run() {
                             if (getView() == null) {
                                 return;
                             }
@@ -371,12 +376,14 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         getAdapter().reload();
     }
 
-    @Override public void onStart() {
+    @Override
+    public void onStart() {
         super.onStart();
         EventBus.getDefault().register(this);
     }
 
-    @Override public void onStop() {
+    @Override
+    public void onStop() {
         super.onStop();
         EventBus.getDefault().unregister(this);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -12,6 +12,7 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.greenrobot.eventbus.EventBus;
 import org.wordpress.android.R;
@@ -60,7 +61,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     }
 
     @Override
-    public void setArguments(Bundle args) {
+    public void setArguments(@Nullable Bundle args) {
         super.setArguments(args);
 
         if (args != null) {
@@ -71,7 +72,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -83,7 +84,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putInt(PublicizeConstants.ARG_CONNECTION_ID, mConnectionId);
@@ -91,8 +92,10 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         mWebView.saveState(outState);
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.publicize_webview_fragment, container, false);
 
         mProgress = rootView.findViewById(R.id.progress);
@@ -109,7 +112,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState == null) {
@@ -165,7 +168,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         }
 
         @Override
-        public void onPageFinished(WebView view, String url) {
+        public void onPageFinished(@NonNull WebView view, @Nullable String url) {
             super.onPageFinished(view, url);
 
             // does this url denotes that we made it past the auth stage?
@@ -197,7 +200,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         }
 
         @Override
-        public void onProgressChanged(WebView view, int newProgress) {
+        public void onProgressChanged(@NonNull WebView view, int newProgress) {
             super.onProgressChanged(view, newProgress);
             if (newProgress == 100 && isAdded()) {
                 mProgress.setVisibility(View.GONE);
@@ -205,7 +208,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         }
 
         @Override
-        public void onReceivedTitle(WebView view, String title) {
+        public void onReceivedTitle(@NonNull WebView view, @Nullable String title) {
             super.onReceivedTitle(view, title);
             if (title != null && !title.startsWith("http")) {
                 setTitle(title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -11,6 +11,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 
@@ -56,13 +57,13 @@ public class ReaderBlogFragment extends Fragment
     }
 
     @Override
-    public void setArguments(Bundle args) {
+    public void setArguments(@Nullable Bundle args) {
         super.setArguments(args);
         restoreState(args);
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
         if (savedInstanceState != null) {
@@ -72,8 +73,10 @@ public class ReaderBlogFragment extends Fragment
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.reader_fragment_list, container, false);
         mRecyclerView = view.findViewById(R.id.recycler_view);
 
@@ -100,7 +103,8 @@ public class ReaderBlogFragment extends Fragment
             actionableEmptyView.subtitle.setText(R.string.reader_empty_followed_blogs_description);
             actionableEmptyView.button.setText(R.string.reader_empty_followed_blogs_button_discover);
             actionableEmptyView.button.setOnClickListener(new OnClickListener() {
-                @Override public void onClick(View view) {
+                @Override
+                public void onClick(@NonNull View v) {
                     ReaderTag tag = ReaderUtils.getTagFromEndpoint(ReaderTag.DISCOVER_PATH);
 
                     if (!ReaderTagTable.tagExists(tag)) {
@@ -139,7 +143,7 @@ public class ReaderBlogFragment extends Fragment
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mRecyclerView.setAdapter(getBlogAdapter());
     }
@@ -153,7 +157,7 @@ public class ReaderBlogFragment extends Fragment
         super.onSaveInstanceState(outState);
     }
 
-    private void restoreState(Bundle args) {
+    private void restoreState(@Nullable Bundle args) {
         if (args != null) {
             if (args.containsKey(ARG_BLOG_TYPE)) {
                 mBlogType = (ReaderBlogType) args.getSerializable(ARG_BLOG_TYPE);
@@ -174,7 +178,7 @@ public class ReaderBlogFragment extends Fragment
      * note this will only be called for followed blogs
      */
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.reader_subs, menu);
 
@@ -185,25 +189,25 @@ public class ReaderBlogFragment extends Fragment
 
         searchMenu.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 return true;
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 return true;
             }
         });
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
-            public boolean onQueryTextSubmit(String query) {
+            public boolean onQueryTextSubmit(@NonNull String query) {
                 setSearchFilter(query);
                 return false;
             }
 
             @Override
-            public boolean onQueryTextChange(String newText) {
+            public boolean onQueryTextChange(@NonNull String newText) {
                 // when the fragment is recreated this will be called with an empty query
                 // string, causing the existing search query to be lost - work around this
                 // by ignoring the next search performed after recreation

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
@@ -8,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import org.wordpress.android.R;
@@ -41,7 +43,7 @@ public class ReaderPhotoViewerFragment extends Fragment {
     }
 
     @Override
-    public void setArguments(Bundle args) {
+    public void setArguments(@Nullable Bundle args) {
         super.setArguments(args);
         if (args != null) {
             mImageUrl = args.getString(ReaderConstants.ARG_IMAGE_URL);
@@ -49,8 +51,10 @@ public class ReaderPhotoViewerFragment extends Fragment {
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.reader_fragment_photo_viewer, container, false);
         mPhotoView = (ReaderPhotoView) view.findViewById(R.id.photo_view);
 
@@ -64,7 +68,7 @@ public class ReaderPhotoViewerFragment extends Fragment {
 
     @SuppressWarnings("deprecation")
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
         if (activity instanceof PhotoViewListener) {
             mPhotoViewListener = (PhotoViewListener) activity;
@@ -78,7 +82,7 @@ public class ReaderPhotoViewerFragment extends Fragment {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putString(ReaderConstants.ARG_IMAGE_URL, mImageUrl);
         outState.putBoolean(ReaderConstants.ARG_IS_PRIVATE, mIsPrivate);
         super.onSaveInstanceState(outState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -349,7 +349,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     @Override
-    public void setArguments(Bundle args) {
+    public void setArguments(@Nullable Bundle args) {
         super.setArguments(args);
 
         if (args != null) {
@@ -378,7 +378,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -846,7 +846,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
@@ -1043,8 +1042,10 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
         mRecyclerView = rootView.findViewById(R.id.reader_recycler_view);
 
@@ -1215,7 +1216,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 if (getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mReaderTracker.track(AnalyticsTracker.Stat.READER_SEARCH_LOADED);
                 }
@@ -1231,27 +1232,26 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 requireActivity().finish();
                 return false;
             }
         });
 
         mSearchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-                                               @Override
-                                               public boolean onQueryTextSubmit(String query) {
-                                                   submitSearchQuery(query);
-                                                   return true;
-                                               }
+            @Override
+            public boolean onQueryTextSubmit(@NonNull String query) {
+                submitSearchQuery(query);
+                return true;
+            }
 
-                                               @Override
-                                               public boolean onQueryTextChange(String newText) {
-                                                   populateSearchSuggestions(newText);
-                                                   showSearchMessageOrSuggestions();
-                                                   return true;
-                                               }
-                                           }
-        );
+            @Override
+            public boolean onQueryTextChange(@NonNull String newText) {
+                populateSearchSuggestions(newText);
+                showSearchMessageOrSuggestions();
+                return true;
+            }
+        });
     }
 
     private void showSearchMessageOrSuggestions() {
@@ -1459,7 +1459,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mSiteSearchAdapterPos = 0;
 
             mSearchTabs.addOnTabSelectedListener(new OnTabSelectedListener() {
-                @Override public void onTabSelected(Tab tab) {
+                @Override
+                public void onTabSelected(@NonNull Tab tab) {
                     if (tab.getPosition() == TAB_POSTS) {
                         mRecyclerView.setAdapter(getPostAdapter());
                         if (mPostSearchAdapterPos > 0) {
@@ -1485,7 +1486,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     }
                 }
 
-                @Override public void onTabUnselected(Tab tab) {
+                @Override
+                public void onTabUnselected(@NonNull Tab tab) {
                     if (tab.getPosition() == TAB_POSTS) {
                         mPostSearchAdapterPos = mRecyclerView.getCurrentPosition();
                     } else if (tab.getPosition() == TAB_SITES) {
@@ -1493,7 +1495,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     }
                 }
 
-                @Override public void onTabReselected(Tab tab) {
+                @Override
+                public void onTabReselected(@NonNull Tab tab) {
                     mRecyclerView.smoothScrollToPosition(0);
                 }
             });
@@ -1781,7 +1784,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
         mActionableEmptyView.button.setText(R.string.reader_empty_followed_blogs_button_followed);
         mActionableEmptyView.button.setVisibility(View.VISIBLE);
         mActionableEmptyView.button.setOnClickListener(new View.OnClickListener() {
-            @Override public void onClick(View view) {
+            @Override
+            public void onClick(@NonNull View v) {
                 setCurrentTagFromEmptyViewButton(ActionableEmptyViewButtonType.FOLLOWED);
             }
         });
@@ -1848,7 +1852,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
 
             mActionableEmptyView.button.setOnClickListener(new View.OnClickListener() {
-                @Override public void onClick(View view) {
+                @Override
+                public void onClick(@NonNull View v) {
                     setCurrentTagFromEmptyViewButton(button);
                 }
             });
@@ -2444,11 +2449,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         Animation.AnimationListener listener = new Animation.AnimationListener() {
             @Override
-            public void onAnimationStart(Animation animation) {
+            public void onAnimationStart(@NonNull Animation animation) {
             }
 
             @Override
-            public void onAnimationEnd(Animation animation) {
+            public void onAnimationEnd(@NonNull Animation animation) {
                 if (isAdded()) {
                     mNewPostsBar.setVisibility(View.GONE);
                     mIsAnimatingOutNewPostsBar = false;
@@ -2456,7 +2461,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
 
             @Override
-            public void onAnimationRepeat(Animation animation) {
+            public void onAnimationRepeat(@NonNull Animation animation) {
             }
         };
         AniUtils.startAnimation(mNewPostsBar, R.anim.reader_top_bar_out, listener);
@@ -2722,7 +2727,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                               Snackbar.LENGTH_LONG
                       ).setAction(getString(R.string.reader_followed_blog_notifications_action),
                               new View.OnClickListener() {
-                                  @Override public void onClick(View view) {
+                                  @Override
+                                  public void onClick(@NonNull View v) {
                                       mReaderTracker.trackBlog(
                                               AnalyticsTracker.Stat.FOLLOWED_BLOG_NOTIFICATIONS_READER_ENABLED,
                                               blogId,
@@ -2789,7 +2795,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == RequestCodes.SITE_PICKER && resultCode == Activity.RESULT_OK) {
             int siteLocalId = data.getIntExtra(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -46,20 +47,23 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
         return fragment;
     }
 
-    @Override public void onCreate(@Nullable Bundle savedInstanceState) {
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         mBlogId = getArguments().getLong(ARG_BLOG_ID);
         mPostId = getArguments().getLong(ARG_POST_ID);
     }
 
-    @Nullable @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         return new ReaderWebView(getActivity());
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         // check network again to detect disconnects during loading + configuration change
@@ -69,7 +73,8 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
                 ((ReaderWebView) view).setIsPrivatePost(post.isPrivate);
                 ((ReaderWebView) view).setBlogSchemeIsHttps(UrlUtils.isHttps(post.getBlogUrl()));
                 ((ReaderWebView) view).setPageFinishedListener(new ReaderWebView.ReaderWebViewPageFinishedListener() {
-                    @Override public void onPageFinished(WebView view, String url) {
+                    @Override
+                    public void onPageFinished(WebView view, String url) {
                         selfRemoveFragment();
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import org.wordpress.android.R;
@@ -29,8 +30,10 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
         return new ReaderTagFragment();
     }
 
+    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.reader_fragment_list, container, false);
         mRecyclerView = view.findViewById(R.id.recycler_view);
         return view;
@@ -57,7 +60,7 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mRecyclerView.setAdapter(getTagAdapter());
         refresh();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaRetainedFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaRetainedFragment.java
@@ -52,12 +52,13 @@ public class StockMediaRetainedFragment extends Fragment {
     private StockMediaRetainedData mData;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setRetainInstance(true);
     }
 
-    @Nullable StockMediaRetainedData getData() {
+    @Nullable
+    StockMediaRetainedData getData() {
         return mData;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -18,6 +18,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 
@@ -111,7 +112,7 @@ public class ThemeBrowserFragment extends Fragment
     @Inject QuickStartUtilsWrapper mQuickStartUtilsWrapper;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
@@ -130,7 +131,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
         try {
             mCallback = (ThemeBrowserFragmentCallback) activity;
@@ -148,8 +149,10 @@ public class ThemeBrowserFragment extends Fragment
         mCallback = null;
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.theme_browser_fragment, container, false);
 
         mActionableEmptyView = view.findViewById(R.id.actionable_empty_view);
@@ -189,7 +192,7 @@ public class ThemeBrowserFragment extends Fragment
 
     @Override
     @SuppressWarnings("deprecation")
-    public void onActivityCreated(Bundle savedInstanceState) {
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
         getAdapter().setThemeList(fetchThemes());
@@ -206,7 +209,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.search, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
@@ -222,7 +225,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.menu_search) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_SEARCH, mSite);
             return true;
@@ -231,7 +234,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public boolean onQueryTextSubmit(String query) {
+    public boolean onQueryTextSubmit(@NonNull String query) {
         getAdapter().getFilter().filter(query);
         if (mSearchView != null) {
             mSearchView.clearFocus();
@@ -240,13 +243,13 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public boolean onQueryTextChange(String newText) {
+    public boolean onQueryTextChange(@NonNull String newText) {
         getAdapter().getFilter().filter(newText);
         return true;
     }
 
     @Override
-    public void onMovedToScrapHeap(View view) {
+    public void onMovedToScrapHeap(@NonNull View view) {
         // cancel image fetch requests if the view has been moved to recycler.
         ImageView niv = view.findViewById(R.id.theme_grid_item_image);
         if (niv != null) {
@@ -476,11 +479,13 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     private class ThemeDataSetObserver extends DataSetObserver {
-        @Override public void onChanged() {
+        @Override
+        public void onChanged() {
             updateDisplay();
         }
 
-        @Override public void onInvalidated() {
+        @Override
+        public void onInvalidated() {
             updateDisplay();
         }
     }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -45,6 +45,7 @@ import android.webkit.URLUtil;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -219,7 +220,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         ProfilingUtils.start("Visual Editor Startup");
@@ -230,8 +231,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_aztec_editor, container, false);
         mFragmentView = view;
 
@@ -269,15 +272,15 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         mTitle.addTextChangedListener(new TextWatcher() {
             @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
             }
 
             @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
             }
 
             @Override
-            public void afterTextChanged(Editable s) {
+            public void afterTextChanged(@NonNull Editable s) {
                 for (int i = s.length(); i > 0; i--) {
                     if (s.subSequence(i - 1, i).toString().equals("\n")) {
                         s.replace(i - 1, i, " ");
@@ -307,7 +310,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mTitle.setOnFocusChangeListener(
                 new View.OnFocusChangeListener() {
                     @Override
-                    public void onFocusChange(View view, boolean hasFocus) {
+                    public void onFocusChange(@NonNull View v, boolean hasFocus) {
                         mFormattingToolbar.enableFormatButtons(!hasFocus);
                     }
                 }
@@ -389,7 +392,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return view;
     }
 
-    @Override public void onDestroyView() {
+    @Override
+    public void onDestroyView() {
         super.onDestroyView();
         mContent.getContentChangeWatcher().unregisterObserver(this);
     }
@@ -439,7 +443,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
 
         try {
@@ -450,17 +454,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putParcelable(ATTR_TAPPED_MEDIA_PREDICATE, mTappedMediaPredicate);
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_aztec, menu);
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         // TODO: disable undo/redo in media mode
         boolean canRedo = mContent.history.redoValid();
         boolean canUndo = mContent.history.undoValid();
@@ -502,7 +506,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.undo) {
             if (mContent.getVisibility() == View.VISIBLE) {
                 mContent.undo();
@@ -796,14 +800,15 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             new MaterialAlertDialogBuilder(getActivity())
                     .setMessage(R.string.editor_failed_uploads_switch_html)
                     .setPositiveButton(R.string.editor_remove_failed_uploads, new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int id) {
+                        @Override
+                        public void onClick(@Nullable DialogInterface dialog, int which) {
                             // Clear failed uploads and switch to HTML mode
                             removeAllFailedMediaUploads();
                             toggleHtmlMode();
                         }
                     }).setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
                 @Override
-                public void onClick(DialogInterface dialog, int which) {
+                public void onClick(@Nullable DialogInterface dialog, int which) {
                     // nothing special to do
                 }
             })
@@ -1080,7 +1085,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     mContent.refreshText();
                 }
 
-                @Override public void onImageFailed() {
+                @Override
+                public void onImageFailed() {
                     if (!isAdded()) {
                         // the fragment is detached
                         return;
@@ -1088,7 +1094,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     replaceDrawable(getLoadingMediaErrorPlaceholder(null));
                 }
 
-                @Override public void onImageLoaded(Drawable drawable) {
+                @Override
+                public void onImageLoaded(Drawable drawable) {
                     if (!isAdded()) {
                         // the fragment is detached
                         return;
@@ -1106,7 +1113,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     replaceDrawable(drawable);
                 }
 
-                @Override public void onImageLoading(Drawable drawable) {
+                @Override
+                public void onImageLoading(Drawable drawable) {
                 }
             }, maxMediaSize);
             mActionStartedAt = System.currentTimeMillis();
@@ -1158,7 +1166,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
-    @Override public void appendMediaFiles(Map<String, MediaFile> mediaList) {
+    @Override
+    public void appendMediaFiles(Map<String, MediaFile> mediaList) {
         for (Map.Entry<String, MediaFile> pair : mediaList.entrySet()) {
             appendMediaFile(pair.getValue(), pair.getKey(), null);
         }
@@ -1221,7 +1230,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mContent.removeMedia(MediaPredicate.getLocalMediaIdPredicate(mediaId));
     }
 
-    @Override public void mediaSelectionCancelled() {
+    @Override
+    public void mediaSelectionCancelled() {
         // noop implementation for shared interface with block editor
     }
 
@@ -1341,7 +1351,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             return attrs.getIndex(mAttributeName) > -1 && attrs.getValue(mAttributeName).equals(mId);
         }
 
-        protected MediaPredicate(Parcel in) {
+        protected MediaPredicate(@NonNull Parcel in) {
             mId = in.readString();
             mAttributeName = in.readString();
         }
@@ -1359,11 +1369,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         @SuppressWarnings("unused")
         public static final Parcelable.Creator<MediaPredicate> CREATOR = new Parcelable.Creator<MediaPredicate>() {
+            @NonNull
             @Override
-            public MediaPredicate createFromParcel(Parcel in) {
+            public MediaPredicate createFromParcel(@NonNull Parcel in) {
                 return new MediaPredicate(in);
             }
 
+            @NonNull
             @Override
             public MediaPredicate[] newArray(int size) {
                 return new MediaPredicate[size];
@@ -1447,7 +1459,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         // Toggle action bar auto-hiding for the new orientation
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -1461,7 +1473,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public boolean onTouch(View view, MotionEvent event) {
+    public boolean onTouch(@NonNull View v, @NonNull MotionEvent event) {
         // In landscape mode, if the title or content view has received a touch event, the keyboard will be
         // displayed and the action bar should hide
         if (event.getAction() == MotionEvent.ACTION_UP
@@ -1531,7 +1543,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         @Override
-        public boolean onDrag(View view, DragEvent dragEvent) {
+        public boolean onDrag(@NonNull View v, @NonNull DragEvent dragEvent) {
             switch (dragEvent.getAction()) {
                 case DragEvent.ACTION_DRAG_STARTED:
                     return isSupported(dragEvent.getClipDescription(), DRAGNDROP_SUPPORTED_MIMETYPES_TEXT)
@@ -1677,13 +1689,16 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         ToastUtils.showToast(getActivity(), message).show();
     }
 
-    @Override public void showEditorHelp() {
+    @Override
+    public void showEditorHelp() {
     }
 
-    @Override public void onUndoPressed() {
+    @Override
+    public void onUndoPressed() {
     }
 
-    @Override public void onRedoPressed() {
+    @Override
+    public void onRedoPressed() {
     }
 
     private void onMediaTapped(@NonNull final AztecAttributes attrs, int naturalWidth, int naturalHeight,
@@ -1724,7 +1739,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
                 builder.setPositiveButton(R.string.stop_upload_dialog_button_yes,
                         new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
+                            @Override
+                            public void onClick(@Nullable DialogInterface dialog, int which) {
                                 if (mUploadingMediaProgressMax.containsKey(localMediaId)) {
                                     mEditorFragmentListener.onMediaUploadCancelClicked(localMediaId);
 
@@ -1740,13 +1756,18 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                     ToastUtils.showToast(getActivity(), R.string.upload_finished_toast).show();
                                 }
 
-                                dialog.dismiss();
+                                if (dialog != null) {
+                                    dialog.dismiss();
+                                }
                             }
                         });
 
                 builder.setNegativeButton(R.string.stop_upload_dialog_button_no, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.dismiss();
+                    @Override
+                    public void onClick(@Nullable DialogInterface dialog, int which) {
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                     }
                 });
 
@@ -1865,7 +1886,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == EDITOR_MEDIA_SETTINGS) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -7,6 +7,7 @@ import android.text.Editable;
 import android.view.DragEvent;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.Consumer;
 import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
@@ -108,7 +109,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     protected HashMap<String, String> mCustomHttpHeaders;
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
         try {
             mEditorFragmentListener = (EditorFragmentListener) activity;
@@ -118,7 +119,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(FEATURED_IMAGE_SUPPORT_KEY, mFeaturedImageSupported);
@@ -126,7 +127,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState != null) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
+import androidx.annotation.Nullable;
 import androidx.core.util.Consumer;
 import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
@@ -120,7 +121,7 @@ public class GutenbergContainerFragment extends Fragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         GutenbergPropsBuilder gutenbergPropsBuilder = getArguments().getParcelable(ARG_GUTENBERG_PROPS_BUILDER);

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -195,7 +195,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @SuppressWarnings("unchecked")
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         if (getGutenbergContainerFragment() == null) {
@@ -227,8 +227,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
+    @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_gutenberg_editor, container, false);
 
         initializeSavingProgressDialog();
@@ -241,7 +243,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         ViewGroup gutenbergContainer = view.findViewById(R.id.gutenberg_container);
         getGutenbergContainerFragment().attachToContainer(gutenbergContainer,
                 new OnMediaLibraryButtonListener() {
-                    @Override public void onMediaLibraryImageButtonClicked(boolean allowMultipleSelection) {
+                    @Override
+                    public void onMediaLibraryImageButtonClicked(boolean allowMultipleSelection) {
                         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
                         mEditorFragmentListener.onAddMediaImageClicked(allowMultipleSelection);
                     }
@@ -258,12 +261,14 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         mEditorFragmentListener.onAddLibraryMediaClicked(allowMultipleSelection);
                     }
 
-                    @Override public void onMediaLibraryFileButtonClicked(boolean allowMultipleSelection) {
+                    @Override
+                    public void onMediaLibraryFileButtonClicked(boolean allowMultipleSelection) {
                         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
                         mEditorFragmentListener.onAddLibraryFileClicked(allowMultipleSelection);
                     }
 
-                    @Override public void onMediaLibraryAudioButtonClicked(boolean allowMultipleSelection) {
+                    @Override
+                    public void onMediaLibraryAudioButtonClicked(boolean allowMultipleSelection) {
                         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
                         mEditorFragmentListener.onAddLibraryAudioFileClicked(allowMultipleSelection);
                     }
@@ -328,7 +333,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         return otherMediaFileOptions;
                     }
 
-                    @Override public ArrayList<MediaOption> onGetOtherMediaAudioFileOptions() {
+                    @Override
+                    public ArrayList<MediaOption> onGetOtherMediaAudioFileOptions() {
                         return initOtherMediaAudioFileOptions();
                     }
 
@@ -361,7 +367,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     }
                 },
                 new OnReattachMediaSavingQueryListener() {
-                    @Override public void onQueryCurrentProgressForSavingMedia() {
+                    @Override
+                    public void onQueryCurrentProgressForSavingMedia() {
                         // TODO: probably go through mFailedMediaIds, and see if any block in the post content
                         // has these mediaFIleIds. If there's a match, mark such a block in FAILED state.
                         updateFailedMediaState();
@@ -441,7 +448,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     }
                 },
                 new OnGutenbergDidRequestEmbedFullscreenPreviewListener() {
-                    @Override public void gutenbergDidRequestEmbedFullscreenPreview(String html, String title) {
+                    @Override
+                    public void gutenbergDidRequestEmbedFullscreenPreview(String html, String title) {
                         openGutenbergEmbedWebViewActivity(html, title);
                     }
                 },
@@ -453,16 +461,19 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 },
 
                 new ShowSuggestionsUtil() {
-                    @Override public void showUserSuggestions(Consumer<String> onResult) {
+                    @Override
+                    public void showUserSuggestions(Consumer<String> onResult) {
                         mEditorFragmentListener.showUserSuggestions(onResult);
                     }
 
-                    @Override public void showXpostSuggestions(Consumer<String> onResult) {
+                    @Override
+                    public void showXpostSuggestions(Consumer<String> onResult) {
                         mEditorFragmentListener.showXpostSuggestions(onResult);
                     }
                 },
                 new OnMediaFilesCollectionBasedBlockEditorListener() {
-                    @Override public void onRequestMediaFilesEditorLoad(ArrayList<Object> mediaFiles, String blockId) {
+                    @Override
+                    public void onRequestMediaFilesEditorLoad(ArrayList<Object> mediaFiles, String blockId) {
                         // let's first calculate the hash on this mediaFiles array, this will let us
                         // identify the block later when we need to replace it as we come back from the Story
                         // composer
@@ -472,7 +483,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         mEditorFragmentListener.onStoryComposerLoadRequested(mediaFiles, blockId);
                     }
 
-                    @Override public void onCancelUploadForMediaCollection(ArrayList<Object> mediaFiles) {
+                    @Override
+                    public void onCancelUploadForMediaCollection(ArrayList<Object> mediaFiles) {
                         if (getActivity() != null) {
                             getActivity().runOnUiThread(() -> {
                                 showCancelMediaCollectionUploadDialog(mediaFiles);
@@ -480,7 +492,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         }
                     }
 
-                    @Override public void onRetryUploadForMediaCollection(ArrayList<Object> mediaFiles) {
+                    @Override
+                    public void onRetryUploadForMediaCollection(ArrayList<Object> mediaFiles) {
                         if (getActivity() != null) {
                             getActivity().runOnUiThread(() -> {
                                 showRetryMediaCollectionUploadDialog(mediaFiles);
@@ -488,7 +501,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         }
                     }
 
-                    @Override public void onCancelSaveForMediaCollection(ArrayList<Object> mediaFiles) {
+                    @Override
+                    public void onCancelSaveForMediaCollection(ArrayList<Object> mediaFiles) {
                         if (getActivity() != null) {
                             getActivity().runOnUiThread(() -> {
                                 showCancelMediaCollectionSaveDialog(mediaFiles);
@@ -496,7 +510,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         }
                     }
 
-                    @Override public void onMediaFilesBlockReplaceSync(ArrayList<Object> mediaFiles, String blockId) {
+                    @Override
+                    public void onMediaFilesBlockReplaceSync(ArrayList<Object> mediaFiles, String blockId) {
                         if (mStoryBlockReplacedSignalWait) {
                             // in case we were expecting a fresh block replacement sync signal, let the fragment
                             // listener know so it can process all of the pending block save / update / upload events
@@ -773,7 +788,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         return otherMediaOptions;
     }
 
-    @Override public void onResume() {
+    @Override
+    public void onResume() {
         super.onResume();
 
         setEditorProgressBarVisibility(!mEditorDidMount);
@@ -861,7 +877,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         builder.setTitle(getString(R.string.stop_upload_dialog_title));
         builder.setPositiveButton(R.string.stop_upload_dialog_button_yes,
                 new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
+                @Override
+                public void onClick(@Nullable DialogInterface dialog, int which) {
                         if (mUploadingMediaProgressMax.containsKey(String.valueOf(localMediaId))) {
                             mEditorFragmentListener.onMediaUploadCancelClicked(String.valueOf(localMediaId));
                             // remove from editor
@@ -872,13 +889,18 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                         } else {
                             ToastUtils.showToast(getActivity(), R.string.upload_finished_toast).show();
                         }
-                        dialog.dismiss();
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                     }
                 });
 
         builder.setNegativeButton(R.string.stop_upload_dialog_button_no, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
+            @Override
+            public void onClick(@Nullable DialogInterface dialog, int which) {
+                if (dialog != null) {
+                    dialog.dismiss();
+                }
             }
         });
 
@@ -897,15 +919,21 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         }
         builder.setPositiveButton(R.string.retry_failed_upload_yes,
                 new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.dismiss();
+                    @Override
+                    public void onClick(@Nullable DialogInterface dialog, int which) {
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                         mEditorFragmentListener.onMediaRetryAllClicked(mFailedMediaIds);
                     }
                 });
 
         builder.setNegativeButton(R.string.retry_failed_upload_remove, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
+            @Override
+            public void onClick(@Nullable DialogInterface dialog, int which) {
+                if (dialog != null) {
+                    dialog.dismiss();
+                }
                 mEditorFragmentListener.onMediaDeleted(String.valueOf(mediaId));
                 mFailedMediaIds.remove(String.valueOf(mediaId));
                 getGutenbergContainerFragment().clearMediaFileURL(mediaId);
@@ -953,8 +981,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         builder.setTitle(getString(R.string.stop_upload_dialog_title));
         builder.setPositiveButton(R.string.stop_upload_dialog_button_yes,
                 new DialogInterface.OnClickListener() {
+                    @Override
                     @SuppressWarnings("unchecked")
-                    public void onClick(DialogInterface dialog, int id) {
+                    public void onClick(@Nullable DialogInterface dialog, int which) {
                         mEditorFragmentListener.onCancelUploadForMediaCollection(mediaFiles);
                         // now signal Gutenberg upload failed, and remove the mediaIds from our tracking map
                         for (Object mediaFile : mediaFiles) {
@@ -966,13 +995,18 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                             getGutenbergContainerFragment().mediaFileUploadFailed(localMediaId);
                             mUploadingMediaProgressMax.remove(localMediaId);
                         }
-                        dialog.dismiss();
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                     }
                 });
 
         builder.setNegativeButton(R.string.stop_upload_dialog_button_no, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
+            @Override
+            public void onClick(@Nullable DialogInterface dialog, int which) {
+                if (dialog != null) {
+                    dialog.dismiss();
+                }
             }
         });
 
@@ -987,15 +1021,21 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         builder.setTitle(getString(R.string.retry_failed_upload_title));
         builder.setPositiveButton(R.string.retry_failed_upload_yes,
                 new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
+                    @Override
+                    public void onClick(@Nullable DialogInterface dialog, int which) {
                         mEditorFragmentListener.onRetryUploadForMediaCollection(mediaFiles);
-                        dialog.dismiss();
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                     }
                 });
 
         builder.setNegativeButton(R.string.dialog_button_cancel, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int id) {
-                dialog.dismiss();
+            @Override
+            public void onClick(@Nullable DialogInterface dialog, int which) {
+                if (dialog != null) {
+                    dialog.dismiss();
+                }
             }
         });
 
@@ -1011,8 +1051,11 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         builder.setMessage(getString(R.string.stop_save_dialog_message));
         builder.setPositiveButton(R.string.stop_save_dialog_ok_button,
                 new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.dismiss();
+                    @Override
+                    public void onClick(@Nullable DialogInterface dialog, int which) {
+                        if (dialog != null) {
+                            dialog.dismiss();
+                        }
                     }
                 });
 
@@ -1026,7 +1069,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(@NonNull Activity activity) {
         super.onAttach(activity);
 
         try {
@@ -1049,7 +1092,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onSaveInstanceState(Bundle outState) {
+    public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, mEditorDidMount);
         outState.putString(ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH, mExternallyEditedBlockOriginalHash);
@@ -1058,22 +1101,20 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_gutenberg, menu);
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        if (menu != null) {
-            MenuItem debugMenuItem = menu.findItem(R.id.debugmenu);
-            debugMenuItem.setVisible(BuildConfig.DEBUG);
-        }
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+        MenuItem debugMenuItem = menu.findItem(R.id.debugmenu);
+        debugMenuItem.setVisible(BuildConfig.DEBUG);
 
         super.onPrepareOptionsMenu(menu);
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.debugmenu) {
             getGutenbergContainerFragment().showDevOptionsDialog();
             return true;
@@ -1209,7 +1250,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             throw new EditorFragmentNotAddedException();
         }
         return getGutenbergContainerFragment().getTitleAndContent(originalContent, new OnGetContentInterrupted() {
-            @Override public void onGetContentInterrupted(InterruptedException ie) {
+            @Override
+            public void onGetContentInterrupted(InterruptedException ie) {
                 AppLog.e(T.EDITOR, ie);
                 Thread.currentThread().interrupt();
             }
@@ -1237,7 +1279,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
             throw new EditorFragmentNotAddedException();
         }
         return getGutenbergContainerFragment().getContent(originalContent, new OnGetContentInterrupted() {
-            @Override public void onGetContentInterrupted(InterruptedException ie) {
+            @Override
+            public void onGetContentInterrupted(InterruptedException ie) {
                 AppLog.e(T.EDITOR, ie);
                 Thread.currentThread().interrupt();
             }
@@ -1408,7 +1451,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         super.onDestroy();
     }
 
-    @Override public void mediaSelectionCancelled() {
+    @Override
+    public void mediaSelectionCancelled() {
         getGutenbergContainerFragment().mediaSelectionCancelled();
     }
 
@@ -1473,28 +1517,33 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().updateTheme(editorTheme);
     }
 
-    @Override public void onMediaSaveReattached(String localId, float currentProgress) {
+    @Override
+    public void onMediaSaveReattached(String localId, float currentProgress) {
         mUploadingMediaProgressMax.put(localId, currentProgress);
         getGutenbergContainerFragment().mediaFileSaveProgress(localId, currentProgress);
     }
 
-    @Override public void onMediaSaveSucceeded(String localId, String mediaUrl) {
+    @Override
+    public void onMediaSaveSucceeded(String localId, String mediaUrl) {
         mUploadingMediaProgressMax.remove(localId);
         getGutenbergContainerFragment().mediaFileSaveSucceeded(localId, mediaUrl);
     }
 
-    @Override public void onMediaSaveProgress(String localId, float progress) {
+    @Override
+    public void onMediaSaveProgress(String localId, float progress) {
         mUploadingMediaProgressMax.put(localId, progress);
         getGutenbergContainerFragment().mediaFileSaveProgress(localId, progress);
     }
 
-    @Override public void onMediaSaveFailed(String localId) {
+    @Override
+    public void onMediaSaveFailed(String localId) {
         getGutenbergContainerFragment().mediaFileSaveFailed(localId);
         mFailedMediaIds.add(localId);
         mUploadingMediaProgressMax.remove(localId);
     }
 
-    @Override public void onStorySaveResult(String storyFirstMediaId, boolean success) {
+    @Override
+    public void onStorySaveResult(String storyFirstMediaId, boolean success) {
         if (!success) {
             mFailedMediaIds.add(storyFirstMediaId);
         }
@@ -1502,11 +1551,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().onStorySaveResult(storyFirstMediaId, success);
     }
 
-    @Override public void onMediaModelCreatedForFile(String oldId, String newId, String oldUrl) {
+    @Override
+    public void onMediaModelCreatedForFile(String oldId, String newId, String oldUrl) {
         getGutenbergContainerFragment().onMediaModelCreatedForFile(oldId, newId, oldUrl);
     }
 
-    @Override public void onStoryMediaSavedToRemote(String localId, String remoteId, String oldUrl, String newUrl) {
+    @Override
+    public void onStoryMediaSavedToRemote(String localId, String remoteId, String oldUrl, String newUrl) {
         mUploadingMediaProgressMax.remove(localId);
         // this method may end up being called twice if the original FluxC OnMediaUploaded event was correctly caught
         // when posted, and can be retriggered by StoriesEventListener in the case a Gutenberg instance is re-mounted
@@ -1529,11 +1580,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().showEditorHelp();
     }
 
-    @Override public void onUndoPressed() {
+    @Override
+    public void onUndoPressed() {
         getGutenbergContainerFragment().onUndoPressed();
     }
 
-    @Override public void onRedoPressed() {
+    @Override
+    public void onRedoPressed() {
         getGutenbergContainerFragment().onRedoPressed();
     }
 


### PR DESCRIPTION
Parent #18909

This PR adds any missing nullability annotation to all SDK override methods on `Fragment` classes.

FYI: Note the fact that `Dialog Fragment` and `Preference Fragment` related classes are excluded from this PR and instead will be handled in separate isolated PRs ([here](https://github.com/wordpress-mobile/WordPress-Android/issues/18911) and [here](https://github.com/wordpress-mobile/WordPress-Android/issues/18917)).

-----

Note that the nullability information wasn't available on all of the super method signatures and thus I had to make a call on making a method's parameter and/or its return value either `NonNull` or `Nullable`. Thus, and in order to make the best call possible, I researched each such method separately `(*)`, used [ChatGPT](https://chat.openai.com/) to increase my confidence, and based my call on existing usages of such methods.

While doing so I also documented all those methods and grouped them per package, per library, see below:

<details>
    <summary>Methods + Nullability</summary>

```java
android
  os
    Parcelable.java (Interface) -> Creator<T> (Interface)
    - @NonNull T createFromParcel(@NonNull Parcel source) { ... } (*)
    - @NonNull T[] newArray(int size) { ... } (*)
  app
    Fragment.java (Class)
    - void onActivityCreated(@Nullable Bundle savedInstanceState) { ... }
    - void onCreate(@Nullable Bundle savedInstanceState) { ... }
    - @Nullable View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) { ... } (*)
    - void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) { .. } (*)
    - void onPrepareOptionsMenu(@NonNull Menu menu) { ... } (*)
    - boolean onOptionsItemSelected(@NonNull MenuItem item) { ... } (*)
  view
    View.java (Class) -> OnClickListener (Interface)
    - void onClick(@NonNull View v) { ... } (*)
    View.java (Class) -> OnLongClickListener (Interface)
    - boolean onLongClick(@NonNull View v) { ... } (*)
    View.java (Class) -> OnFocusChangeListener (Interface)
    - void onFocusChange(@NonNull View v, boolean hasFocus) { ... } (*)
    View.java (Class) -> OnTouchListener (Interface)
    - boolean onTouch(@NonNull View v, @NonNull MotionEvent event) { ... } (*)
    View.java (Class) -> OnDragListener (Interface)
    - boolean onDrag(@NonNull View v, @NonNull DragEvent dragEvent) { ... } (*)
    View.java (Class) -> OnKeyListener (Interface)
    - boolean onKey(@NonNull View v, int keyCode, @NonNull KeyEvent event) { ... } (*)
    View.java (Class) -> OnKeyListener (Interface)
    - boolean onKey(@NonNull View v, int keyCode, @NonNull KeyEvent event) { ... } (*)
    MenuItem.java (Interface) -> OnActionExpandListener (Interface)
    - boolean onMenuItemActionExpand(@NonNull MenuItem item) { ... }
    - boolean onMenuItemActionCollapse(@NonNull MenuItem item) { ... }
    animation
      Animation.java (Abstract Class) -> AnimationListener (Interface)
      - void onAnimationStart(@NonNull Animation animation) { ... } (*)
      - void onAnimationEnd(@NonNull Animation animation) { ... } (*)
      - void onAnimationRepeat(@NonNull Animation animation) { ... } (*)
  widget
    AbsListView.java (Abstract Class) -> RecyclerListener (Interface)
    - void onMovedToScrapHeap(@NonNull View view) { ... } (*)
  content
    DialogInterface.java (Interface) -> OnClickListener (Interface)
    - void onClick(@Nullable DialogInterface dialog, int which) { ... } (*)
  text
    TextWatcher.java (Interface)
    - void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) { ... } (*)
    - void onTextChanged(@NonNull CharSequence s, int start, int before, int count) { ... } (*)
    - void afterTextChanged(@NonNull Editable s) { ... } (*) + (⚠️)
  webkit
    WebChromeClient.java (Class)
    - void onPageFinished(@NonNull WebView view, @Nullable String url) { ... } (*)
    WebViewClient.java (Class)
    - void onProgressChanged(@NonNull WebView view, int newProgress) { ... } (*)
    - void onReceivedTitle(@NonNull WebView view, @Nullable String title) { ... } (*)
androidx
  fragment
    app
      Fragment.java (Class)
      - void onAttach(@NonNull Context context) { ... }
      - void onAttach(@NonNull Activity activity) { ... }
      - void setArguments(@Nullable Bundle args) { ... }
      - void onActivityCreated(@Nullable Bundle savedInstanceState) { ... }
      - void onCreate(@Nullable Bundle savedInstanceState) { ... }
      - @Nullable View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) { ... }
      - void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) { ... }
      - void onSaveInstanceState(@NonNull Bundle outState) { ... }
      - void onViewStateRestored(@Nullable Bundle savedInstanceState) { ... }
      - void onConfigurationChanged(@NonNull Configuration newConfig) { ... }
      - void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) { ... }
      - void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) { ... }
      - void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) { ... }
      - void onPrepareOptionsMenu(@NonNull Menu menu) { ... }
      - boolean onOptionsItemSelected(@NonNull MenuItem item) { ... }
      - void onCreateContextMenu(@NonNull ContextMenu menu, @NonNull View v, @Nullable ContextMenuInfo menuInfo) { ... }
      - boolean onContextItemSelected(@NonNull MenuItem item) { ... }
      FragmentStatePagerAdapter.java (Abstract Class)
      - @NonNull Fragment getItem(int position) { ... }
      - void restoreState(@Nullable Parcelable state, @Nullable ClassLoader loader) { ... }
      - @Nullable Parcelable saveState() { ... }
  appcompat
    widget
      SearchView.java (Class) -> OnQueryTextListener (Interface)
      - boolean onQueryTextSubmit(@NonNull String query) { ... } (*) + (⚠️)
      - boolean onQueryTextChange(@NonNull String newText) { ... } (*) + (⚠️)
    view
      ActionMode.java (Abstract Class) -> Callback (Interface)
      - boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) { ... } (*)
      - boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) { ... } (*)
      - boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) { ... } (*)
      - void onDestroyActionMode(@NonNull ActionMode mode) { ... } (*)
  recyclerview
    widget
      RecyclerView.java (Class) -> Adapter<VH extends ViewHolder> (Abstract Class)
      - @NonNull VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) { ... }
      - void onBindViewHolder(@NonNull VH holder, int position) { ... }
      RecyclerView.java (Class) -> RecyclerListener (Interface)
      - void onViewRecycled(@NonNull ViewHolder holder) { ... }
      RecyclerView.java (Class) -> OnScrollListener (Interface)
      - void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) { ... }
      - void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) { ... }
  lifecycle
    Observer.java (Interface)
    - void onChanged(@NonNull T value) { ... } (*)
com
  google
    android
      material
        tabs
          TabLayout.java (Class) -> BaseOnTabSelectedListener<T extends Tab> (Interface)
          - void onTabSelected(@NonNull TabLayout.Tab tab) { ... } (*)
          - void onTabUnselected(@NonNull TabLayout.Tab tab) { ... } (*)
          - void onTabReselected(@NonNull TabLayout.Tab tab) { ... } (*)
```

</details>

<details>
    <summary>Methods + Nullability to Triple Check</summary>

```java
android.text.TextWatcher.java (Interface)
- void afterTextChanged(@NonNull Editable s) { ... } (*) + (⚠️)
androidx.appcompat.widget.SearchView.java (Class) -> OnQueryTextListener (Interface)
- boolean onQueryTextSubmit(@NonNull String query) { ... } (*) + (⚠️)
- boolean onQueryTextChange(@NonNull String newText) { ... } (*) + (⚠️)
```

</details>

`(*)`: Nullability info not available on the super method signature and thus arbitrary added.
`(⚠️)`: Better to double (triple) check that this `@NonNull` added won't cause us any trouble!

-----

Nullability Annotation List:

1. [Add missing n-a to sdk override methods for editor abstract](https://github.com/wordpress-mobile/WordPress-Android/commit/7899a655ea0d31cb78d691707fcc54a6d492e8ab)
2. [Add missing n-a to sdk override methods for aztec editor](https://github.com/wordpress-mobile/WordPress-Android/commit/bf3811e121fb5f47d6f857034daee7db0262ff0a)
3. [Add missing n-a to sdk override methods for gutenberg editor](https://github.com/wordpress-mobile/WordPress-Android/commit/794a9ac7a484f82940ca35cdfbb474a88ff220ea)
4. [Add missing n-a to sdk override methods for gutenberg ctr](https://github.com/wordpress-mobile/WordPress-Android/commit/fb618efac8193db517432f1eafc153ff7dab617a)
5. [Add missing n-a to sdk override methods for shared intent rec](https://github.com/wordpress-mobile/WordPress-Android/commit/9fcf2811ba7e5fbfe7b85f5e26f61fedab1d260b)
6. [Add missing n-a to sdk override methods for login epilogue](https://github.com/wordpress-mobile/WordPress-Android/commit/d382dd5412c8b47953e28c7232824895a8b44107)
7. [Add missing n-a to sdk override methods for signup epilogue](https://github.com/wordpress-mobile/WordPress-Android/commit/1d2776ee27a52b3e1b57067a4fb83cfaec2a2395)
8. [Add missing n-a to sdk override methods for comment detail](https://github.com/wordpress-mobile/WordPress-Android/commit/28135d1dae7dae7edf5ddb9114bf6f23e7bd6cc4)
9. [Add missing n-a to sdk override methods for history detail](https://github.com/wordpress-mobile/WordPress-Android/commit/24e283a8bb57d1b3b274424ec96dc93614b41fa4)
10. [Add missing n-a to sdk override methods for media grid](https://github.com/wordpress-mobile/WordPress-Android/commit/b85771d0e6c9055ee8ddc2401530b41fbc620ce1)
11. [Add missing n-a to sdk override methods for media preview](https://github.com/wordpress-mobile/WordPress-Android/commit/a34eb193897934e43084430545c3e2f7fb8fe4e1)
12. [Add missing n-a to sdk override methods for people invite](https://github.com/wordpress-mobile/WordPress-Android/commit/021ee48d3e6b77af423c62302be4ec88d62161ed)
13. [Add missing n-a to sdk override methods for people list](https://github.com/wordpress-mobile/WordPress-Android/commit/2b493e16de24d5c66112390df607e74a8ed812a7)
14. [Add missing n-a to sdk override methods for person detail](https://github.com/wordpress-mobile/WordPress-Android/commit/61a9fbb579293fe2d365ddead99646623afa6952)
15. [Add missing n-a to sdk override methods for plugin list](https://github.com/wordpress-mobile/WordPress-Android/commit/19cf29affad913fec1d0b7169b018c478e2f3839)
16. [Add missing n-a to sdk override methods for edit post settings](https://github.com/wordpress-mobile/WordPress-Android/commit/1b619a91209c859920ac82b69f3656454d081de0)
17. [Add missing n-a to sdk override methods for tags](https://github.com/wordpress-mobile/WordPress-Android/commit/a4521c76275e23038fc2cadd4f4ac5fce6a42c5a)
18. [Add missing n-a to sdk override methods for my profile](https://github.com/wordpress-mobile/WordPress-Android/commit/625c4d7e810af8b2deebcd30cab757afd84f1210)
19. [Add missing n-a to sdk override methods for site settings td](https://github.com/wordpress-mobile/WordPress-Android/commit/0eac8ccba74b54b864e355c791dd339026dd2c30)
20. [Add missing n-a to sdk override methods for publicize detail](https://github.com/wordpress-mobile/WordPress-Android/commit/d4f1612ad9ccd43ec7a04cbe10fd1c0ccbd1aaf3)
21. [Add missing n-a to sdk override methods for publicize list](https://github.com/wordpress-mobile/WordPress-Android/commit/02d79721d91b4affb266f9c23c1fb5c06b317545)
22. [Add missing n-a to sdk override methods for publicize web view](https://github.com/wordpress-mobile/WordPress-Android/commit/ee20b57e00195b198ef0f335a1b99381677a97a0)
23. [Add missing n-a to sdk override methods for reader blog](https://github.com/wordpress-mobile/WordPress-Android/commit/cb7ff06e49c0fa148bcd15b233d86bb76b66c411)
24. [Add missing n-a to sdk override methods for reader photo vwr](https://github.com/wordpress-mobile/WordPress-Android/commit/d4bd5e59dd924330f97136ea59d9ad58c14ea7f7)
25. [Add missing n-a to sdk override methods for reader post list](https://github.com/wordpress-mobile/WordPress-Android/commit/4bc6b3344e34a68c2271b29f67b3f733b2f0a0fe)
26. [Add missing n-a to sdk override methods for reader post wvc](https://github.com/wordpress-mobile/WordPress-Android/commit/d21db1dbe680c4c6cbb0ff5d0964f434a88900f4)
27. [Add missing n-a to sdk override methods for reader tag](https://github.com/wordpress-mobile/WordPress-Android/commit/c171a7a300c8ce7c2dff5e0228d0c568218c2335)
28. [Add missing n-a to sdk override methods for stock media rtn](https://github.com/wordpress-mobile/WordPress-Android/commit/cdbfd2bf0b0fe9c84f86e46f7fddf164dc2947ad)
29. [Add missing n-a to sdk override methods for them browser](https://github.com/wordpress-mobile/WordPress-Android/commit/164ee6bd66880ab1d7c43399d3efc4040ae3256a)

-----

## To test:

1. Smoke test both, the WordPress and Jetpack apps, and see if everything is working as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

45. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

46. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)