### PR TITLE
EditPostActivity - Check for mSite before accessing the site's icon URL

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -831,16 +831,18 @@ public class EditPostActivity extends LocaleAwareActivity implements
         View closeHeader = mToolbar.findViewById(R.id.edit_post_header);
         closeHeader.setOnClickListener(v -> handleBackPressed());
 
-        // Update site icon
-        String siteIconUrl = SiteUtils.getSiteIconUrl(
-                mSite,
-                getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small)
-        );
-        ImageView siteIcon = mToolbar.findViewById(R.id.close_editor_site_icon);
-        ImageType blavatarType = SiteUtils.getSiteImageType(
-                mSite.isWpForTeamsSite(), BlavatarShape.SQUARE_WITH_ROUNDED_CORNERES);
-        mImageManager.loadImageWithCorners(siteIcon, blavatarType, siteIconUrl,
-                getResources().getDimensionPixelSize(R.dimen.edit_post_header_image_corner_radius));
+        if (mSite != null) {
+            // Update site icon if mSite is available, if not it will use the placeholder.
+            String siteIconUrl = SiteUtils.getSiteIconUrl(
+                    mSite,
+                    getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small)
+            );
+            ImageView siteIcon = mToolbar.findViewById(R.id.close_editor_site_icon);
+            ImageType blavatarType = SiteUtils.getSiteImageType(
+                    mSite.isWpForTeamsSite(), BlavatarShape.SQUARE_WITH_ROUNDED_CORNERES);
+            mImageManager.loadImageWithCorners(siteIcon, blavatarType, siteIconUrl,
+                    getResources().getDimensionPixelSize(R.dimen.edit_post_header_image_corner_radius));
+        }
     }
 
     private void presentNewPageNoticeIfNeeded() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/18954

Recent reports of crashes started after the recent Editor UX changes, specifically the new site icon that's shown in the nav bar.

I couldn't find a way to reproduce it but by looking at the reports I tried:

- Opening the editor of a new site
- Opening the editor by long-pressing on the app icon
- Opening the editor by long-pressing on the app icon without an internet connection
- Changing to different sites
- Opening the editor after removing the current site's icon

Since there are no reproduction steps I went with the approach of other places of this activity that check for `mSite` to not be `null` before accessing it.

To test:

### Open the editor with a site that has a custom site icon

- Open the editor
- **Expect** to see your site's icon in the navigation bar

### Open the editor with a site that has no custom site icon

- Open the editor
- **Expect** to see the default site icon placeholder

### Open the editor after removing a custom site icon

- Open the app
- Remove your current custom site icon
- Open the editor
- **Expect** to see the default site icon placeholder

### Open the editor from the apps launcher with a site that has a custom site icon

- On your device's apps launcher, long-press on the Jetpack app
- Tap on `New post`
- **Expect** to see the editor launch
- **Expect** to see your site's icon in the navigation bar

## Regression Notes
1. Potential unintended areas of impact
It just affects the editor

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
None, it just adds a check before setting the site's icon.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
