### PR TITLE
[Pre-publish] Make pre-publish bottom-sheet fully scrollable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
@@ -152,6 +152,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                 bottomSheet?.let {
                     val behavior = BottomSheetBehavior.from(it)
                     behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                    behavior.skipCollapsed = true
                 }
             }
             setupMinimumHeightForFragmentContainer()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
@@ -93,6 +93,7 @@ class PrepublishingHomeFragment : Fragment(R.layout.post_prepublishing_home_frag
 
         actionsRecyclerView.layoutManager = layoutManager
         actionsRecyclerView.adapter = adapter
+        actionsRecyclerView.isNestedScrollingEnabled = false
     }
 
     private fun PostPrepublishingHomeFragmentBinding.initViewModel() {

--- a/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
+++ b/WordPress/src/main/res/layout/post_prepublishing_home_fragment.xml
@@ -1,30 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/actions_recycler_view"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:clipToPadding="true"
-        android:descendantFocusability="beforeDescendants"
-        android:scrollbars="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/story_title_header_view" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <org.wordpress.android.ui.stories.StoryTitleHeaderView
-        android:id="@+id/story_title_header_view"
-        android:layout_width="0dp"
-        android:visibility="gone"
-        android:layout_height="wrap_content"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintVertical_bias="1"
-        app:layout_constraintBottom_toTopOf="@id/actions_recycler_view"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/actions_recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:clipToPadding="true"
+            android:descendantFocusability="beforeDescendants"
+            android:scrollbars="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/story_title_header_view" />
+
+        <org.wordpress.android.ui.stories.StoryTitleHeaderView
+            android:id="@+id/story_title_header_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/actions_recycler_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="1"
+            app:layout_constraintVertical_chainStyle="packed" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Internal ref: p1692614308438019-slack-C04PWEZSYFL cc @ParaskP7 

Fixes an issue on Story posts where the title item can be pushed outside the bounds of the Fragment view since it's no an item inside the RecyclerView. This PR makes the bottom sheet scrollable by adding a `NestedScrollView` around the whole fragment UI.

It also makes the bottom sheet non-collapsible to make sure that when the height of the content is bigger than the minimum bottom sheet height, there's no intermediate collapsed state that shows the content partially and makes the bottom-sheet slidable.

To test:
For easier reproduction, it's better to have an account with Jetpack Social available (such as a WPCOM account) but no social connections.

1. Open the Jetpack app
2. Create a Story Post
3. Hit publish (arrow on top-right)
4. **Verify** the pre-publish sheet appears
5. Wait for a few seconds
6. **Verify** the jetpack social item appears pushing content around
   1. Some of the content should be off-screen at this moment
7. Try scrolling the content
8. **Verify** the content scrolls properly and every item/button is accessible

## Regression Notes
1. Potential unintended areas of impact
Incorrect bottom bar height for story posts and blog posts.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

10. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)