### PR TITLE
Add logic to remove empty categories from site settings page

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -38,6 +38,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.collection.SparseArrayCompat;
@@ -1112,6 +1113,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         initBloggingSection();
+        removeEmptyCategories();
     }
 
     private void updateHomepageSummary() {
@@ -1989,6 +1991,53 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_category);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_format);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_related_posts);
+    }
+
+    private boolean isEmptyCategory(@StringRes int section) {
+        PreferenceCategory pref = (PreferenceCategory) findPreference(getString(section));
+        return (pref != null && pref.getPreferenceCount() == 0);
+    }
+
+    private void removeEmptyCategories() {
+        if (isEmptyCategory(R.string.pref_key_site_general)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_general);
+        }
+        if (isEmptyCategory(R.string.pref_key_blogging)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_blogging);
+        }
+        if (isEmptyCategory(R.string.pref_key_homepage)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_homepage);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_account)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_editor)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_editor);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_writing)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_quota)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_quota);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_traffic)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_traffic);
+        }
+        if (isEmptyCategory(R.string.pref_key_jetpack_performance_settings)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_jetpack_performance_settings);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_discussion)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_site_discussion);
+        }
+        if (isEmptyCategory(R.string.pref_key_jetpack_settings)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen,
+                    R.string.pref_key_jetpack_settings);
+        }
+        if (isEmptyCategory(R.string.pref_key_site_advanced)) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
+        }
     }
 
     private void removeNonSelfHostedPreferences() {


### PR DESCRIPTION
Fixes #18899 
Add a method to check if a parent category is empty. Then added another method to make use of that to remove empty categories from the Site Settings screen.

Behavior:
Before Change | After Change
--|--
<img width="385" alt="Screenshot 2023-08-20 at 4 43 59 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/57671001/afcebe12-eaf2-41b9-8faa-bb9a75baab87"> | <img width="385" alt="Screenshot 2023-08-20 at 4 40 06 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/57671001/138a7c07-42d2-4230-a5af-3b8e469ce026">

To test:

1. Launch the app.
2. Add a self-hosted site.
3. Navigate to "My Site → Site Settings".
Feel free to navigate back and check any other already created sites' settings.

## Regression Notes
1. Potential unintended areas of impact
Site Settings Screens

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Tests

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [X] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)