### PR TITLE
Implements the tracking for more menu item clicks - Pages Card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -136,7 +136,7 @@ class CardsTracker @Inject constructor(
         }
     }
 
-    private fun trackCardMoreMenuItemClicked(card: String, item: String) {
+    fun trackCardMoreMenuItemClicked(card: String, item: String) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_MENU_ITEM_TAPPED,
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -117,10 +117,6 @@ class CardsTracker @Inject constructor(
         trackCardMoreMenuClicked(Type.ACTIVITY.label)
     }
 
-    fun trackPagesCardMoreMenuClicked(){
-        trackCardMoreMenuClicked(Type.PAGES.label)
-    }
-
     private fun trackCardFooterLinkClicked(type: String, subtype: String) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
@@ -150,7 +146,7 @@ class CardsTracker @Inject constructor(
         )
     }
 
-    private fun trackCardMoreMenuClicked(type: String) {
+    fun trackCardMoreMenuClicked(type: String) {
         analyticsTrackerWrapper.track(Stat.MY_SITE_DASHBOARD_CONTEXTUAL_MENU_ACCESSED, mapOf(CARD to type))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -117,6 +117,10 @@ class CardsTracker @Inject constructor(
         trackCardMoreMenuClicked(Type.ACTIVITY.label)
     }
 
+    fun trackPagesCardMoreMenuClicked(){
+        trackCardMoreMenuClicked(Type.PAGES.label)
+    }
+
     private fun trackCardFooterLinkClicked(type: String, subtype: String) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -30,7 +30,7 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onPagesCardMoreMenuClick() {
-        cardsTracker.trackPagesCardMoreMenuClicked()
+        cardsTracker.trackCardMoreMenuClicked(CardsTracker.Type.PAGES.label)
     }
 
     private fun onAllPagesMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -30,7 +30,7 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onPagesCardMoreMenuClick() {
-        // todo implement the tracking
+        cardsTracker.trackPagesCardMoreMenuClicked()
     }
 
     private fun onAllPagesMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -42,6 +42,7 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onPagesCardHideThisCardClick() {
+        cardsTracker.trackCardMoreMenuItemClicked(CardsTracker.Type.PAGES.label, PagesMenuItemType.HIDE_THIS.label)
         // todo implement the logic to hide the card and add tracking logic
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -34,7 +34,7 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onAllPagesMenuItemClick() {
-        // todo implement the tracking for navigation to all pages
+        cardsTracker.trackCardMoreMenuItemClicked(CardsTracker.Type.PAGES.label, PagesMenuItemType.ALL_PAGES.label)
         _onNavigation.value = Event(
             SiteNavigationAction
                 .OpenPages(requireNotNull(selectedSiteRepository.getSelectedSite()))
@@ -84,4 +84,9 @@ class PagesCardViewModelSlice @Inject constructor(
                 )
             )
     }
+}
+
+enum class PagesMenuItemType(val label: String) {
+    ALL_PAGES("all_pages"),
+    HIDE_THIS("hide_this")
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams.PagesItemClickParams
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
@@ -94,4 +95,39 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
             verify(cardsTracker).trackPagesItemClicked(PagesCardContentType.PUBLISH)
         }
+
+    @Test
+    fun `given pages card, when more menu is accessed, then event is tracked`() = test {
+        val pagesCardParams = pagesCardViewModelSlice.getPagesCardBuilderParams(mock())
+
+        pagesCardParams.moreMenuClickParams.onMoreMenuClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuClicked(CardsTracker.Type.PAGES.label)
+    }
+
+    @Test
+    fun `given pages card, when more menu item all pages is accessed, then event is tracked`() = test {
+        val pagesCardParams = pagesCardViewModelSlice.getPagesCardBuilderParams(mock())
+
+        pagesCardParams.moreMenuClickParams.onAllPagesItemClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            CardsTracker.Type.PAGES.label,
+            PagesMenuItemType.ALL_PAGES.label
+        )
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
+    }
+
+
+    @Test
+    fun `given pages card, when more menu item hide this is accessed, then event is tracked`() = test {
+        val pagesCardParams = pagesCardViewModelSlice.getPagesCardBuilderParams(mock())
+
+        pagesCardParams.moreMenuClickParams.onHideThisCardItemClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            CardsTracker.Type.PAGES.label,
+            PagesMenuItemType.HIDE_THIS.label
+        )
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardBuilderParams.PagesItemClickParams
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction


### PR DESCRIPTION
## Fixes 
Issue - #18947

## Description 
This PR implements the tracking for 
- Click on more menu 
- Click on all pages in more menu 
- Click on Hide this item in more menu

## To test:
- Login to the app 
- Go to Pages Card 
- Click at more menu 
- Verify that the event  - 🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"pages"} is triggered
- Click on All Pages Option
- Verify that the event is  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"pages","item":"all_pages"} triggered
- Click on Hide this Option 
- Verify the event triggered  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"pages","item":"hide_this”}


## Regression Notes
1. Potential unintended areas of impact
Pages card clicks are not tracked correctly 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test and unit test

3. What automated tests I added (or what prevented me from doing so)
Unit tests 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
