### PR TITLE
Create ZD ticket from account closure error dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 23.2
 -----
-
+* [*] The Zendesk ticket screen will be displayed for error dialogs resulting from account closure. [https://github.com/wordpress-mobile/WordPress-Android/pull/19023]
 
 23.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -25,6 +25,7 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
+import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment
@@ -85,6 +86,10 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
 
     @set:Inject
     lateinit var navigationHandler: AccountSettingsNavigationHandler
+
+    @Inject
+    lateinit var zendeskHelper: ZendeskHelper
+
     private lateinit var usernamePreference: Preference
     private lateinit var emailPreference: EditTextPreferenceWithValidation
     private lateinit var primarySitePreference: DetailListPreference
@@ -405,18 +410,18 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
 
     private fun handleUserAction(action: AccountClosureAction) {
         when (action) {
-            AccountClosureAction.HELP_VIEWED -> viewHelp()
+            AccountClosureAction.SUPPORT_CONTACTED -> contactSupport()
             AccountClosureAction.ACCOUNT_CLOSED -> signOut()
             AccountClosureAction.USER_LOGGED_OUT -> {
                 ActivityLauncher.showMainActivity(context, true)
             }
         }
     }
-    private fun viewHelp() = ActivityLauncher.viewHelp(
+
+    private fun contactSupport() = zendeskHelper.createNewTicket(
         context,
         HelpActivity.Origin.ACCOUNT_CLOSURE_DIALOG,
-        null,
-        null,
+        null
     )
 
     private fun signOut() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsViewModel.kt
@@ -25,8 +25,8 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Dismissed
-import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Error
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Default
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Error
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened.Success
 import org.wordpress.android.ui.prefs.accountsettings.usecase.AccountClosureUseCase
 import org.wordpress.android.ui.prefs.accountsettings.usecase.FetchAccountSettingsUseCase
@@ -370,7 +370,7 @@ class AccountSettingsViewModel @Inject constructor(
 
     companion object {
         enum class AccountClosureAction {
-            HELP_VIEWED, ACCOUNT_CLOSED, USER_LOGGED_OUT;
+            SUPPORT_CONTACTED, ACCOUNT_CLOSED, USER_LOGGED_OUT;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureUi.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.AccountClosureUiState.Opened
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.Companion.AccountClosureAction.ACCOUNT_CLOSED
-import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.Companion.AccountClosureAction.HELP_VIEWED
+import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel.Companion.AccountClosureAction.SUPPORT_CONTACTED
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -31,7 +31,7 @@ fun AccountClosureUi(viewModel: AccountSettingsViewModel) {
 
                 is Opened.Error -> DialogErrorUi(
                     onDismissRequest = { viewModel.dismissAccountClosureDialog() },
-                    onHelpRequested = { viewModel.userAction(HELP_VIEWED) },
+                    onHelpRequested = { viewModel.userAction(SUPPORT_CONTACTED) },
                     it.errorType,
                 )
                 is Opened.Success -> DialogSuccessUi(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2796,7 +2796,7 @@
     <string name="close_account">Close Account</string>
     <string name="account_closure_dialog_message">To confirm, please re-enter your username before closing.</string>
     <string name="account_closure_dialog_title">Confirm Close Account…</string>
-    <string name="account_closure_dialog_error_title">Couldn\'t close account automatically"</string>
+    <string name="account_closure_dialog_error_title">Couldn\'t close account automatically!</string>
     <string name="account_closure_dialog_error_unauthorized">You\'re not authorized to close the account.</string>
     <string name="account_closure_dialog_error_atomic_site">This user account cannot be closed immediately because it has active purchases. Please contact our support team to finish deleting the account.</string>
     <string name="account_closure_dialog_error_chargebacked_site">This user account cannot be closed if there are unresolved chargebacks.</string>


### PR DESCRIPTION
The "Contact Support" button for error dialogs within the account closure flow should always open the screen for creating a ZD ticket. Previously, it would open the Help screen, which did not allow users to create a support ticket.

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/29422b22-9a3b-47a4-b4c1-e86f0a0a1bd8

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/a0278c05-ae22-47d2-a755-8bf6c1039408

>>> **Note**
> I've requested a review from you, @guarani, but testing the functional side of the implementation would suffice. @ravishanker can review it from the Android perspective.

To test:
1. Open the WP app.
2. Log in to an account with an existing subscription. This will result in an error from the backend when attempting to close the account.
3. Go to "Me → Account Settings"
4. Tap the "Close Account" button.
5. Type your username and tap the "Confirm" button.
6. Confirm an error dialog with "Couldn't close account automatically" displayed.
7. Tap the "Contact Support" button.
8. Confirm that the ZD ticket screen is launched, as shown in the after video.
9. _Optional:_ If you wish to be extra cautious, you can create a ticket and observe it on ZD.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing.

3. What automated tests I added (or what prevented me from doing so)
This only modifies the navigation of an existing button. I haven't added a new test and made sure the current tests have passed.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
