### PR TITLE
[Android 14] Update compileSdkVersion to 34

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/flows/LoginFlow.kt
@@ -6,12 +6,9 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.EditText
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matchers

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksribbon/QuickLinkRibbonViewHolder.kt
@@ -72,7 +72,7 @@ class QuickLinkRibbonViewHolder(
         }
 
         override fun onScroll(
-            e1: MotionEvent,
+            e1: MotionEvent?,
             e2: MotionEvent,
             distanceX: Float,
             distanceY: Float

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.kt
@@ -32,6 +32,9 @@ class AppSettingsActivity : LocaleAwareActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    // overridePendingTransition is deprecated in SDK 34 in favor of overrideActivityTransition, but the latter requires
+    // SDK 34. overridePendingTransition still works on Android 14 so using it should be safe for now.
+    @Suppress("DEPRECATION")
     override fun recreate() {
         startActivity(
             Intent(this, this::class.java).apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/NoSiteToReblogActivity.kt
@@ -11,6 +11,9 @@ import android.R as AndroidR
  * Serves as an intermediate screen where the user is informed that a site is needed for the reblog action
  */
 class NoSiteToReblogActivity : AppCompatActivity() {
+    // overridePendingTransition is deprecated in SDK 34 in favor of overrideActivityTransition, but the latter requires
+    // SDK 34. overridePendingTransition still works on Android 14 so using it should be safe for now.
+    @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1492,6 +1492,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         renderer?.beginRender()
     }
 
+    // overridePendingTransition is deprecated in SDK 34 in favor of overrideActivityTransition, but the latter requires
+    // SDK 34. overridePendingTransition still works on Android 14 so using it should be safe for now.
+    @Suppress("DEPRECATION")
     private fun handleDirectOperation() = when (directOperation) {
         DirectOperation.COMMENT_JUMP, DirectOperation.COMMENT_REPLY, DirectOperation.COMMENT_LIKE -> {
             viewModel.post?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardViewHolder.kt
@@ -64,7 +64,7 @@ class ReaderInterestsCardViewHolder(
         }
 
         override fun onScroll(
-            e1: MotionEvent,
+            e1: MotionEvent?,
             e2: MotionEvent,
             distanceX: Float,
             distanceY: Float

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LineChartMarkerView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/LineChartMarkerView.kt
@@ -101,17 +101,15 @@ class LineChartMarkerView @Inject constructor(
         return offset
     }
 
-    override fun draw(canvas: Canvas?, posX: Float, posY: Float) {
+    override fun draw(canvas: Canvas, posX: Float, posY: Float) {
         super.draw(canvas, posX, posY)
 
-        val saveId = canvas?.save()
+        val saveId = canvas.save()
 
         drawToolTip(canvas, posX, posY)
         draw(canvas)
 
-        saveId?.let {
-            canvas.restoreToCount(it)
-        }
+        canvas.restoreToCount(saveId)
     }
 
     @Suppress("LongMethod")

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/SuggestionActivity.kt
@@ -203,6 +203,9 @@ class SuggestionActivity : LocaleAwareActivity() {
         }
     }
 
+    // overridePendingTransition is deprecated in SDK 34 in favor of overrideActivityTransition, but the latter requires
+    // SDK 34. overridePendingTransition still works on Android 14 so using it should be safe for now.
+    @Suppress("DEPRECATION")
     override fun finish() {
         super.finish()
         overridePendingTransition(R.anim.do_nothing, R.anim.do_nothing)

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 ext {
     minSdkVersion = 24
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     targetSdkVersion = 33
 }
 


### PR DESCRIPTION
Part of #19016 

The first step for supporting [partial video/image access](https://developer.android.com/about/versions/14/changes/partial-photo-video-access), introduced in Android 14, is bumping the `compileSdkVersion` to 34, required for using a newly introduced permission.

This PR only updates the `compileSdkVersion` and makes minimal adjustments to make the project compile and run exactly as before. No extra warnings or errors were added when updating the compileSdkVersion, so no behavior should have changed.

The main change that I could find was the deprecation of `overridePendingTransition`, but right now it doesn't seem to make sense to migrate to the new API for overriding the transition animation, which is `overrideActivityTransition`. Since that _needs_ SDK 34 and the `overridePendingTransition` is still working as expected, I just suppressed the warnings for now, which seems to make sense.

## To test
Neither updating `compileSdkVersion` nor the minor changes made here changes how code is executed at all, so a smoke test of the app should be enough to confirm everything works as expected.

## Regression Notes
1. Potential unintended areas of impact
Breakage of any app flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested main app flows, such as Home, Reader, Settings, Me, and Post & Page creation.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
