### PR TITLE
Dashboard Personalization: Todays Stats extract to view model slice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -1,0 +1,62 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
+
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+class TodaysStatsViewModelSlice @Inject constructor(
+    private val cardsTracker: CardsTracker,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+) {
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation
+
+    fun getTodaysStatsBuilderParams(todaysStatsCardModel: TodaysStatsCardModel?) : TodaysStatsCardBuilderParams {
+        return TodaysStatsCardBuilderParams(
+            todaysStatsCard = todaysStatsCardModel,
+            onTodaysStatsCardClick = this::onTodaysStatsCardClick,
+            onGetMoreViewsClick = this::onGetMoreViewsClick,
+            onFooterLinkClick = this::onTodaysStatsCardFooterLinkClick
+        )
+    }
+
+    private fun onTodaysStatsCardFooterLinkClick() {
+        cardsTracker.trackTodaysStatsCardFooterLinkClicked()
+        navigateToTodaysStats()
+    }
+
+    private fun onTodaysStatsCardClick() {
+        cardsTracker.trackTodaysStatsCardClicked()
+        navigateToTodaysStats()
+    }
+
+    @Suppress("EmptyFunctionBlock")
+    private fun onGetMoreViewsClick() {
+        cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
+        if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
+        } else {
+            _onNavigation.value = Event(
+                SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(
+                    TodaysStatsCardBuilder.URL_GET_MORE_VIEWS_AND_TRAFFIC
+                )
+            )
+        }
+    }
+
+    private fun navigateToTodaysStats() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
+            _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
+        } else {
+            _onNavigation.value = Event(SiteNavigationAction.OpenStatsInsights(selectedSite))
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -1,0 +1,91 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class TodaysStatsViewModelSliceTest  : BaseUnitTest() {
+    @Mock
+    lateinit var cardsTracker: CardsTracker
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    private lateinit var todaysStatsViewModelSlice: TodaysStatsViewModelSlice
+
+    private lateinit var navigationActions: MutableList<SiteNavigationAction>
+
+    private val site = mock<SiteModel>()
+
+    @Before
+    fun setUp() {
+        todaysStatsViewModelSlice = TodaysStatsViewModelSlice(
+            cardsTracker,
+            selectedSiteRepository,
+            jetpackFeatureRemovalPhaseHelper
+        )
+        navigationActions = mutableListOf()
+        todaysStatsViewModelSlice.onNavigation.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                navigationActions.add(it)
+            }
+        }
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+    }
+
+    @Test
+    fun `given todays stat card, when card item is clicked, then stats page is opened`() =
+        test {
+            val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+            params.onTodaysStatsCardClick()
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
+            verify(cardsTracker).trackTodaysStatsCardClicked()
+        }
+
+    @Test
+    fun `given todays stat card, when footer link is clicked, then stats page is opened`() =
+        test {
+            val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+            params.onFooterLinkClick()
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
+            verify(cardsTracker).trackTodaysStatsCardFooterLinkClicked()
+        }
+
+    @Test
+    fun `given todays stat card, when get more views url is clicked, then external link is opened`() =
+        test {
+            val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+            params.onGetMoreViewsClick()
+
+            assertThat(navigationActions)
+                .containsOnly(
+                    SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(
+                        TodaysStatsCardBuilder.URL_GET_MORE_VIEWS_AND_TRAFFIC
+                    )
+                )
+            verify(cardsTracker).trackTodaysStatsCardGetMoreViewsNudgeClicked()
+        }
+}


### PR DESCRIPTION
Part of #18944 

This PR splits todays stats logic from MySiteViewModel
- Created `TodaysStatsViewModelSlice`
- Moved todays stats logic from `MySiteViewModel` to `TodaysStatsViewModelSlice`
- Refactor `MySiteViewModelTest` by moving today stats tests to `TodaysStatsViewModelSliceTest`

**Merge Instructions**
- Ensure PR #19042 has been merged
- Double check that the base branch is set to `feature/dashboard-personalization`
- Remove the do not merge label
- Merge as normal

**To test:**
- Install the app
- Login to the app
- Select a site in which you have stats access
- Navigate to the My Site tab
- ✅ Verify the stats card shows in the dashboard
- Using the site selector, select a site in which you don't have stats access
- ✅ Verify the stats card is not shown in the dashboard

## Regression Notes
1. Potential unintended areas of impact
Stats card shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit testing

3. What automated tests I added (or what prevented me from doing so)
TodaysStatsViewModelSliceTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
