### PR TITLE
[Social Connections] Fix flickering while loading publicize connections list in Social screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -368,7 +368,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     }
 
     void reload() {
-        getAdapter().reload();
+        getAdapter().refresh();
     }
 
     @Override public void onStart() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -78,17 +78,6 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
     }
 
-    public void reload() {
-        clear();
-        refresh();
-    }
-
-    private void clear() {
-        mServices.clear();
-        mConnections.clear();
-        notifyDataSetChanged();
-    }
-
     @Override
     public int getItemCount() {
         return mServices.size();


### PR DESCRIPTION
Fixes #18792 

While implementing this fix I've found another bug in this flow. I've submitted an issue: https://github.com/wordpress-mobile/WordPress-Android/issues/19045

To test:
See https://github.com/wordpress-mobile/WordPress-Android/issues/18792 for steps to reproduce and expected behavior.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
--

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
