### PR TITLE
Contact support update chat styles

### DIFF
--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -14,3 +14,30 @@ a.floating-button {
     bottom: 0 !important;
     max-height: none !important;
 }
+
+.docsbot-chat-bot-message {
+    font-size: 16px;
+}
+
+.docsbot-chat-suggested-questions-container span {
+    font-size: 16px;
+}
+
+.docsbot-chat-suggested-questions-container button {
+    height: 48px;
+    font-size: 16px;
+}
+
+.docsbot-chat-bot-message-meta {
+    margin-top: 16px;
+}
+
+.docsbot-chat-input {
+    height: 48px;
+    font-size: 16px !important;
+}
+
+.docsbot-chat-bot-message-support a {
+    height: 48px;
+    font-size: 16px;
+}

--- a/WordPress/src/jetpack/res/values/colors.xml
+++ b/WordPress/src/jetpack/res/values/colors.xml
@@ -22,4 +22,7 @@
 
     <color name="text_color_jetpack_login_label_primary">#80008710</color>
     <color name="text_color_jetpack_login_label_secondary">@color/jetpack_green_50</color>
+
+    <!-- Support Chat Bot -->
+    <color name="docsbot_chat_container">#F9FAF9</color>
 </resources>

--- a/WordPress/src/jetpack/res/values/colors.xml
+++ b/WordPress/src/jetpack/res/values/colors.xml
@@ -23,6 +23,4 @@
     <color name="text_color_jetpack_login_label_primary">#80008710</color>
     <color name="text_color_jetpack_login_label_secondary">@color/jetpack_green_50</color>
 
-    <!-- Support Chat Bot -->
-    <color name="docsbot_chat_container">#F9FAF9</color>
 </resources>

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -30,7 +30,6 @@ import org.wordpress.android.widgets.WPSnackbar
 import java.util.UUID
 import javax.inject.Inject
 
-
 @AndroidEntryPoint
 class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
     @Inject

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -7,14 +7,14 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
-import android.view.View
-import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.activity.viewModels
+import androidx.appcompat.widget.Toolbar
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
 import androidx.webkit.WebViewAssetLoader.ResourcesPathHandler
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.BuildConfig
@@ -29,6 +29,7 @@ import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.widgets.WPSnackbar
 import java.util.UUID
 import javax.inject.Inject
+
 
 @AndroidEntryPoint
 class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.SupportWebViewClientListener {
@@ -52,15 +53,14 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
         viewModel.start(chatIdProperty)
         toggleNavbarVisibility(false)
 
-        // set send message box to appear above system navigation bar
-        val previewContainer = findViewById<View>(R.id.preview_container)
-        val params = previewContainer.layoutParams as ViewGroup.MarginLayoutParams
-        params.bottomMargin = resources.getDimensionPixelSize(R.dimen.margin_64dp)
-        previewContainer.layoutParams = params
-
         supportActionBar?.title = getString(R.string.help)
         supportActionBar?.subtitle = ""
         window.navigationBarColor = getColor(R.color.docsbot_chat_container)
+
+        // Prevent AppBar scrolling away
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        val toolbarLayoutParams = toolbar.layoutParams as AppBarLayout.LayoutParams
+        toolbarLayoutParams.scrollFlags = AppBarLayout.LayoutParams.SCROLL_FLAG_NO_SCROLL
 
         setupWebView()
         setupJsInterfaceForWebView()

--- a/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/SupportWebViewActivity.kt
@@ -60,6 +60,7 @@ class SupportWebViewActivity : WPWebViewActivity(), SupportWebViewClient.Support
 
         supportActionBar?.title = getString(R.string.help)
         supportActionBar?.subtitle = ""
+        window.navigationBarColor = getColor(R.color.docsbot_chat_container)
 
         setupWebView()
         setupJsInterfaceForWebView()

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -122,4 +122,7 @@
     <color name="dashboard_card_plans_info_background">@color/gray_0</color>
     <color name="dashboard_card_plans_info_text_color">@color/gray_20</color>
 
+    <!-- Support Chat Bot -->
+    <color name="docsbot_chat_container">#F9FAF9</color>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2281,7 +2281,7 @@
     <string name="support_ticket_subject">WordPress for Android Support</string>
 
     <string name="contact_support_input_placeholder">Send a message…</string>
-    <string name="contact_support_first_message">What can we help you with?</string>
+    <string name="contact_support_first_message">What can I help you with?</string>
     <string name="contact_support_get_support">Contact support</string>
     <string name="contact_support_suggestions">Not sure what to ask?</string>
     <string name="contact_support_question_one">What is my site address?</string>


### PR DESCRIPTION
Fixes #19048 

Updates styles as per design feedback See in Figma here: 8XpccoIS1hlR9QJrmIQdW2-fi-2648%3A5405e
- Match bottom system navigation bar color with chat container color
- Prevent AppBar scrolling away with content.
- Replace "we" with "I"
- Set font size to 16px
- Set tap targets to 48px
- Increase top margin of **Sources** 

| Initial | Chat |
|--------|--------|
|![Screenshot_20230824_105439](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/645f5985-4d48-479c-9dda-7f5398181309)| ![Screenshot_20230824_105459](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/7ca50f50-8c31-4357-bbe3-7f0a1f6f013c)| 

To test:

- Enable feature flag (Me -> Debug settings -> `contact_support_chatbot`)
- Launch Jetpack app
- Go to `Me` (Tap on Avatar in the bottom nav)
- Tap on Help -> Contact Support
- `Verify` it launches Support Bot as shown above
- `Verify` the screen elements match changes listed above, and as shown in the screenshots 


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
