### PR TITLE
Today stats card - moves tracking events to viewmodel slice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -73,10 +73,6 @@ class CardsTracker @Inject constructor(
         trackCardItemClicked(Type.QUICK_START.label, quickStartTaskType.toSubtypeValue().label)
     }
 
-    fun trackTodaysStatsCardGetMoreViewsNudgeClicked() {
-        trackCardItemClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS_NUDGE.label)
-    }
-
     fun trackTodaysStatsCardFooterLinkClicked() {
         trackCardFooterLinkClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS.label)
     }
@@ -127,7 +123,7 @@ class CardsTracker @Inject constructor(
         )
     }
 
-    private fun trackCardItemClicked(type: String, subtype: String) {
+    fun trackCardItemClicked(type: String, subtype: String) {
         val props = mapOf(TYPE to type, SUBTYPE to subtype)
         if (type == Type.QUICK_START.label) {
             quickStartTracker.track(Stat.MY_SITE_DASHBOARD_CARD_ITEM_TAPPED, props)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -73,10 +73,6 @@ class CardsTracker @Inject constructor(
         trackCardItemClicked(Type.QUICK_START.label, quickStartTaskType.toSubtypeValue().label)
     }
 
-    fun trackTodaysStatsCardFooterLinkClicked() {
-        trackCardFooterLinkClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS.label)
-    }
-
     fun trackTodaysStatsCardClicked() {
         trackCardItemClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS.label)
     }
@@ -113,7 +109,7 @@ class CardsTracker @Inject constructor(
         trackCardMoreMenuClicked(Type.ACTIVITY.label)
     }
 
-    private fun trackCardFooterLinkClicked(type: String, subtype: String) {
+    fun trackCardFooterLinkClicked(type: String, subtype: String) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -73,10 +73,6 @@ class CardsTracker @Inject constructor(
         trackCardItemClicked(Type.QUICK_START.label, quickStartTaskType.toSubtypeValue().label)
     }
 
-    fun trackTodaysStatsCardClicked() {
-        trackCardItemClicked(Type.STATS.label, StatsSubtype.TODAYS_STATS.label)
-    }
-
     fun trackPostCardFooterLinkClicked(postCardType: PostCardType) {
         trackCardFooterLinkClicked(Type.POST.label, postCardType.toSubtypeValue().label)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -18,7 +18,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
 
-    fun getTodaysStatsBuilderParams(todaysStatsCardModel: TodaysStatsCardModel?) : TodaysStatsCardBuilderParams {
+    fun getTodaysStatsBuilderParams(todaysStatsCardModel: TodaysStatsCardModel?): TodaysStatsCardBuilderParams {
         return TodaysStatsCardBuilderParams(
             todaysStatsCard = todaysStatsCardModel,
             onTodaysStatsCardClick = this::onTodaysStatsCardClick,
@@ -37,9 +37,11 @@ class TodaysStatsViewModelSlice @Inject constructor(
         navigateToTodaysStats()
     }
 
-    @Suppress("EmptyFunctionBlock")
     private fun onGetMoreViewsClick() {
-        cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
+        cardsTracker.trackCardItemClicked(
+            CardsTracker.Type.STATS.label,
+            CardsTracker.StatsSubtype.TODAYS_STATS_NUDGE.label
+        )
         if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
             _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -36,7 +36,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
     }
 
     private fun onTodaysStatsCardClick() {
-        cardsTracker.trackTodaysStatsCardClicked()
+        cardsTracker.trackCardItemClicked(CardsTracker.Type.STATS.label, CardsTracker.StatsSubtype.TODAYS_STATS.label)
         navigateToTodaysStats()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -28,7 +28,10 @@ class TodaysStatsViewModelSlice @Inject constructor(
     }
 
     private fun onTodaysStatsCardFooterLinkClick() {
-        cardsTracker.trackTodaysStatsCardFooterLinkClicked()
+        cardsTracker.trackCardFooterLinkClicked(
+            CardsTracker.Type.STATS.label,
+            CardsTracker.StatsSubtype.TODAYS_STATS.label
+        )
         navigateToTodaysStats()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -59,13 +59,6 @@ class CardsTrackerTest {
     }
 
     @Test
-    fun `when today's stats card footer link is clicked, then today's stats card footer click event is tracked`() {
-        cardsTracker.trackTodaysStatsCardFooterLinkClicked()
-
-        verifyFooterLinkClickedTracked(Type.STATS, StatsSubtype.TODAYS_STATS.label)
-    }
-
-    @Test
     fun `when today's stats card is clicked, then today's stats card item click event is tracked`() {
         cardsTracker.trackTodaysStatsCardClicked()
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -58,15 +58,6 @@ class CardsTrackerTest {
         verifyQuickStartCardItemClickedTracked(QuickStartSubtype.CUSTOMIZE.label)
     }
 
-    /* TODAY'S STATS CARD */
-
-    @Test
-    fun `when today's stats card get more views link is clicked, then today's stats nudge event is tracked`() {
-        cardsTracker.trackTodaysStatsCardGetMoreViewsNudgeClicked()
-
-        verifyCardItemClickedTracked(Type.STATS, StatsSubtype.TODAYS_STATS_NUDGE.label)
-    }
-
     @Test
     fun `when today's stats card footer link is clicked, then today's stats card footer click event is tracked`() {
         cardsTracker.trackTodaysStatsCardFooterLinkClicked()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -13,7 +13,6 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.MenuItemType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PagesSubType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
-import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.StatsSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
@@ -56,13 +55,6 @@ class CardsTrackerTest {
         cardsTracker.trackQuickStartCardItemClicked(QuickStartTaskType.CUSTOMIZE)
 
         verifyQuickStartCardItemClickedTracked(QuickStartSubtype.CUSTOMIZE.label)
-    }
-
-    @Test
-    fun `when today's stats card is clicked, then today's stats card item click event is tracked`() {
-        cardsTracker.trackTodaysStatsCardClicked()
-
-        verifyCardItemClickedTracked(Type.STATS, StatsSubtype.TODAYS_STATS.label)
     }
 
     /* POST CARDS */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class TodaysStatsViewModelSliceTest  : BaseUnitTest() {
+class TodaysStatsViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var cardsTracker: CardsTracker
 
@@ -86,6 +86,9 @@ class TodaysStatsViewModelSliceTest  : BaseUnitTest() {
                         TodaysStatsCardBuilder.URL_GET_MORE_VIEWS_AND_TRAFFIC
                     )
                 )
-            verify(cardsTracker).trackTodaysStatsCardGetMoreViewsNudgeClicked()
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.STATS.label,
+                CardsTracker.StatsSubtype.TODAYS_STATS_NUDGE.label
+            )
         }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -59,7 +59,10 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
             params.onTodaysStatsCardClick()
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
-            verify(cardsTracker).trackTodaysStatsCardClicked()
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.STATS.label,
+                CardsTracker.StatsSubtype.TODAYS_STATS.label
+            )
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -70,7 +70,10 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
             params.onFooterLinkClick()
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
-            verify(cardsTracker).trackTodaysStatsCardFooterLinkClicked()
+            verify(cardsTracker).trackCardFooterLinkClicked(
+                CardsTracker.Type.STATS.label,
+                CardsTracker.StatsSubtype.TODAYS_STATS.label
+            )
         }
 
     @Test


### PR DESCRIPTION
Parent #18944 

## Description 
This PR moves the tracking events of stats card to `TodaysStatsViewModelSlice` from cards tracker

## To test:
- Install the app
- Login to the app
- Select a site in which you have stats access and have zero view|visitors|likes stats
- Navigate to the My Site tab
- Verify the tracking event on card click 
- ✅ 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"stats","subtype":"todays_stats"}
- Click on the top tips nudge below the todays stats card 
- ✅ 🔵 Tracked: my_site_dashboard_card_item_tapped, Properties: {"type":"stats","subtype":"todays_stats_nudge"}


## Regression Notes
1. Potential unintended areas of impact
Tracking events for the stats card is not working as expected 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
