### PR TITLE
 Pages card: Hide implementation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -162,7 +162,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             viewPager.setCurrentItem(navTarget.position, navTarget.smoothAnimation)
         }
 
-        viewModel.blazeCardRefresh.observe(viewLifecycleOwner) {
+        viewModel.refresh.observe(viewLifecycleOwner) {
             viewModel.refresh()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -311,7 +311,7 @@ class MySiteViewModel @Inject constructor(
     val onShowJetpackIndividualPluginOverlay = _onShowJetpackIndividualPluginOverlay as LiveData<Event<Unit>>
     val onTrackWithTabSource = _onTrackWithTabSource as LiveData<Event<MySiteTrackWithTabSource>>
     val selectTab: LiveData<Event<TabNavigation>> = _selectTab
-    val blazeCardRefresh = blazeCardViewModelSlice.refresh
+    val refresh = merge(blazeCardViewModelSlice.refresh, pagesCardViewModelSlice.refresh)
     val domainTransferCardRefresh = domainTransferCardViewModel.refresh
 
     private var shouldMarkUpdateSiteTitleTaskComplete = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.DashboardActivityLogCardFeatureUtils
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -25,7 +26,8 @@ class CardsSource @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val cardsStore: CardsStore,
     private val dashboardActivityLogCardFeatureUtils: DashboardActivityLogCardFeatureUtils,
-    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) : MySiteRefreshSource<CardsUpdate> {
     override val refresh = MutableLiveData(false)
 
@@ -104,7 +106,8 @@ class CardsSource @Inject constructor(
     }.toList()
 
     private fun shouldRequestPagesCard(selectedSite: SiteModel): Boolean {
-        return (selectedSite.hasCapabilityEditPages || selectedSite.isSelfHostedAdmin)
+        return (selectedSite.hasCapabilityEditPages || selectedSite.isSelfHostedAdmin) &&
+                !appPrefsWrapper.getShouldHidePagesDashboardCard(selectedSite.siteId)
     }
 
     private fun MediatorLiveData<CardsUpdate>.postErrorState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.DashboardCardType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
-import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.quickstart.QuickStartTracker
 import org.wordpress.android.ui.quickstart.QuickStartType

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -97,10 +97,6 @@ class CardsTracker @Inject constructor(
         trackCardFooterLinkClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
     }
 
-    fun trackPagesItemClicked(pageCardType: PagesCardContentType) {
-        trackCardItemClicked(Type.PAGES.label, pageCardType.toSubtypeValue().label)
-    }
-
     fun trackPagesCardFooterClicked() {
         trackCardFooterLinkClicked(Type.PAGES.label, PagesSubType.CREATE_PAGE.label)
     }
@@ -123,7 +119,7 @@ class CardsTracker @Inject constructor(
         )
     }
 
-    private fun trackCardItemClicked(type: String, subtype: String) {
+    fun trackCardItemClicked(type: String, subtype: String) {
         val props = mapOf(TYPE to type, SUBTYPE to subtype)
         if (type == Type.QUICK_START.label) {
             quickStartTracker.track(Stat.MY_SITE_DASHBOARD_CARD_ITEM_TAPPED, props)
@@ -195,13 +191,7 @@ fun PostCardType.toSubtypeValue(): PostSubtype {
     }
 }
 
-fun PagesCardContentType.toSubtypeValue(): CardsTracker.PagesSubType {
-    return when (this) {
-        PagesCardContentType.DRAFT -> CardsTracker.PagesSubType.DRAFT
-        PagesCardContentType.PUBLISH -> CardsTracker.PagesSubType.PUBLISHED
-        PagesCardContentType.SCHEDULED -> CardsTracker.PagesSubType.SCHEDULED
-    }
-}
+
 
 fun QuickStartTaskType.toSubtypeValue(): QuickStartSubtype {
     return when (this) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -97,10 +97,6 @@ class CardsTracker @Inject constructor(
         trackCardFooterLinkClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
     }
 
-    fun trackPagesCardFooterClicked() {
-        trackCardFooterLinkClicked(Type.PAGES.label, PagesSubType.CREATE_PAGE.label)
-    }
-
     fun trackActivityCardMenuItemClicked(menuItemType: MenuItemType) {
         trackCardMoreMenuItemClicked(Type.ACTIVITY.label, menuItemType.label)
     }
@@ -109,7 +105,7 @@ class CardsTracker @Inject constructor(
         trackCardMoreMenuClicked(Type.ACTIVITY.label)
     }
 
-    private fun trackCardFooterLinkClicked(type: String, subtype: String) {
+    fun trackCardFooterLinkClicked(type: String, subtype: String) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_FOOTER_ACTION_TAPPED,
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -18,6 +18,9 @@ class PagesCardViewModelSlice @Inject constructor(
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
 
+    private val _refresh = MutableLiveData<Event<Boolean>>()
+    val refresh = _refresh
+
     fun getPagesCardBuilderParams(pagesCardModel: PagesCardModel?): PagesCardBuilderParams {
         return PagesCardBuilderParams(
             pageCard = pagesCardModel,
@@ -46,6 +49,7 @@ class PagesCardViewModelSlice @Inject constructor(
     private fun onPagesCardHideThisCardClick() {
         cardsTracker.trackCardMoreMenuItemClicked(CardsTracker.Type.PAGES.label, PagesMenuItemType.HIDE_THIS.label)
         appPrefsWrapper.setShouldHidePagesDashboardCard(selectedSiteRepository.getSelectedSite()!!.siteId, true)
+        _refresh.postValue(Event(true))
     }
 
     private fun onPagesItemClick(params: PagesCardBuilderParams.PagesItemClickParams) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -53,7 +53,7 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onPagesItemClick(params: PagesCardBuilderParams.PagesItemClickParams) {
-        cardsTracker.trackPagesItemClicked(params.pagesCardType)
+        cardsTracker.trackCardItemClicked(CardsTracker.Type.PAGES.label, params.pagesCardType.toSubtypeValue().label)
         _onNavigation.value = Event(getNavigationActionForPagesItem(params.pagesCardType, params.pageId))
     }
 
@@ -96,4 +96,12 @@ class PagesCardViewModelSlice @Inject constructor(
 enum class PagesMenuItemType(val label: String) {
     ALL_PAGES("all_pages"),
     HIDE_THIS("hide_this")
+}
+
+fun PagesCardContentType.toSubtypeValue(): CardsTracker.PagesSubType {
+    return when (this) {
+        PagesCardContentType.DRAFT -> CardsTracker.PagesSubType.DRAFT
+        PagesCardContentType.PUBLISH -> CardsTracker.PagesSubType.PUBLISHED
+        PagesCardContentType.SCHEDULED -> CardsTracker.PagesSubType.SCHEDULED
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -6,12 +6,14 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardB
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class PagesCardViewModelSlice @Inject constructor(
     private val cardsTracker: CardsTracker,
-    private val selectedSiteRepository: SelectedSiteRepository
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
@@ -43,7 +45,7 @@ class PagesCardViewModelSlice @Inject constructor(
 
     private fun onPagesCardHideThisCardClick() {
         cardsTracker.trackCardMoreMenuItemClicked(CardsTracker.Type.PAGES.label, PagesMenuItemType.HIDE_THIS.label)
-        // todo implement the logic to hide the card and add tracking logic
+        appPrefsWrapper.setShouldHidePagesDashboardCard(selectedSiteRepository.getSelectedSite()!!.siteId, true)
     }
 
     private fun onPagesItemClick(params: PagesCardBuilderParams.PagesItemClickParams) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSlice.kt
@@ -83,7 +83,10 @@ class PagesCardViewModelSlice @Inject constructor(
     }
 
     private fun onPagesCardFooterLinkClick() {
-        cardsTracker.trackPagesCardFooterClicked()
+        cardsTracker.trackCardFooterLinkClicked(
+            CardsTracker.Type.PAGES.label,
+            CardsTracker.PagesSubType.CREATE_PAGE.label
+        )
         _onNavigation.value =
             Event(
                 SiteNavigationAction.TriggerCreatePageFlow(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -200,6 +200,7 @@ public class AppPrefs {
         // Should show Jetpack Social no connections UI
         SHOULD_SHOW_JETPACK_SOCIAL_NO_CONNECTIONS,
         SHOULD_HIDE_ACTIVITY_DASHBOARD_CARD,
+        SHOULD_HIDE_PAGES_DASHBOARD_CARD
     }
 
     /**
@@ -1729,5 +1730,17 @@ public class AppPrefs {
 
     public static Boolean getShouldHideActivityDashboardCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHideActivityDashboardCardKey(siteId), false);
+    }
+
+    public static void setShouldHidePagesDashboardCard(final long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHidePagesDashboardCardKey(siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHidePagesDashboardCardKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_PAGES_DASHBOARD_CARD.name() + siteId;
+    }
+
+    public static Boolean getShouldHidePagesDashboardCard(final long siteId) {
+        return prefs().getBoolean(getSiteIdHidePagesDashboardCardKey(siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -378,7 +378,6 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideActivityDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideActivityDashboardCard(siteId)
 
-
     fun setShouldHidePagesDashboardCard(
         siteId: Long,
         isHidden: Boolean

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -377,6 +377,16 @@ class AppPrefsWrapper @Inject constructor() {
 
     fun getShouldHideActivityDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideActivityDashboardCard(siteId)
+
+
+    fun setShouldHidePagesDashboardCard(
+        siteId: Long,
+        isHidden: Boolean
+    ) = AppPrefs.setShouldHidePagesDashboardCard(siteId, isHidden)
+
+    fun getShouldHidePagesDashboardCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHidePagesDashboardCard(siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -195,7 +195,7 @@ class CardsSourceTest : BaseUnitTest() {
             .thenReturn(isDashboardCardActivityLogEnabled)
         whenever(siteModel.hasCapabilityEditPages).thenReturn(isRequestPages)
         whenever(appPrefsWrapper.getShouldHidePagesDashboardCard(siteModel.id.toLong()))
-            .thenReturn(isDashboardCardActivityLogEnabled)
+            .thenReturn(isPagesCardHidden)
     }
 
     /* GET DATA */

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -194,7 +195,7 @@ class CardsSourceTest : BaseUnitTest() {
         whenever(dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(siteModel))
             .thenReturn(isDashboardCardActivityLogEnabled)
         whenever(siteModel.hasCapabilityEditPages).thenReturn(isRequestPages)
-        whenever(appPrefsWrapper.getShouldHidePagesDashboardCard(siteModel.id.toLong()))
+        whenever(appPrefsWrapper.getShouldHidePagesDashboardCard(any()))
             .thenReturn(isPagesCardHidden)
     }
 
@@ -202,6 +203,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `when build is invoked, then start collecting cards from store (database)`() = test {
+        setUpMocks()
         cardSource.refresh.observeForever { }
 
         cardSource.build(testScope(), SITE_LOCAL_ID).observeForever { }
@@ -245,6 +247,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `when build is invoked, then cards are fetched from store (network)`() = test {
+        setUpMocks()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(CARDS_MODEL)))
         cardSource.refresh.observeForever { }
 
@@ -291,6 +294,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given error, when build is invoked, then error snackbar with stale message is also shown (network)`() = test {
+        setUpMocks()
         val result = mutableListOf<CardsUpdate>()
         val testData = CardsResult(model = listOf(TODAYS_STATS_CARDS_MODEL, POSTS_MODEL))
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = testData.model)))
@@ -321,6 +325,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given no error, when refresh is invoked, then data is only loaded from get cards (database)`() = test {
+        setUpMocks()
         val filteredData = CardsResult(model = data.model?.filterIsInstance<PostsCardModel>()?.toList())
         val result = mutableListOf<CardsUpdate>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = filteredData.model)))
@@ -338,6 +343,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given error, when refresh is invoked, then error snackbar with stale message also shown (network)`() = test {
+        setUpMocks()
         val testData = CardsResult(model = listOf(TODAYS_STATS_CARDS_MODEL, POSTS_MODEL))
         val result = mutableListOf<CardsUpdate>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = testData.model)))
@@ -365,6 +371,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `when build is invoked, then refresh is set to true`() = test {
+        setUpMocks()
         val result = mutableListOf<Boolean>()
         cardSource.refresh.observeForever { result.add(it) }
 
@@ -377,6 +384,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `when refresh is invoked, then refresh is set to false`() = test {
+        setUpMocks()
         val testData = CardsResult(model = listOf(TODAYS_STATS_CARDS_MODEL, POSTS_MODEL))
         val result = mutableListOf<Boolean>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = testData.model)))
@@ -398,6 +406,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given no error, when data has been refreshed, then refresh is set to true`() = test {
+        setUpMocks()
         val testData = CardsResult(model = listOf(TODAYS_STATS_CARDS_MODEL, POSTS_MODEL))
         val result = mutableListOf<Boolean>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = testData.model)))
@@ -418,6 +427,7 @@ class CardsSourceTest : BaseUnitTest() {
 
     @Test
     fun `given error, when data has been refreshed, then refresh is set to false`() = test {
+        setUpMocks()
         val testData = CardsResult(model = listOf(TODAYS_STATS_CARDS_MODEL, POSTS_MODEL))
         val result = mutableListOf<Boolean>()
         whenever(cardsStore.getCards(siteModel)).thenReturn(flowOf(CardsResult(model = testData.model)))

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -117,13 +117,6 @@ class CardsTrackerTest {
     }
 
     @Test
-    fun `when pages card footer link is clicked, then footer link clicked is tracked`() {
-        cardsTracker.trackPagesCardFooterClicked()
-
-        verifyFooterLinkClickedTracked(Type.PAGES, PagesSubType.CREATE_PAGE.label)
-    }
-
-    @Test
     fun `when activity card hide this menu item is clicked, then hide this event is tracked`() {
         cardsTracker.trackActivityCardMenuItemClicked(MenuItemType.HIDE_THIS)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -124,27 +124,6 @@ class CardsTrackerTest {
     }
 
     @Test
-    fun `when page draft item is clicked, then page item event is tracked`() {
-        cardsTracker.trackPagesItemClicked(PagesCardContentType.DRAFT)
-
-        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.DRAFT.label)
-    }
-
-    @Test
-    fun `when page published item is clicked, then page item event is tracked`() {
-        cardsTracker.trackPagesItemClicked(PagesCardContentType.PUBLISH)
-
-        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.PUBLISHED.label)
-    }
-
-    @Test
-    fun `when page scheduled item is clicked, then page item event is tracked`() {
-        cardsTracker.trackPagesItemClicked(PagesCardContentType.SCHEDULED)
-
-        verifyCardItemClickedTracked(Type.PAGES, PagesSubType.SCHEDULED.label)
-    }
-
-    @Test
     fun `when activity card hide this menu item is clicked, then hide this event is tracked`() {
         cardsTracker.trackActivityCardMenuItemClicked(MenuItemType.HIDE_THIS)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -10,12 +10,10 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.MenuItemType
-import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PagesSubType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.StatsSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
-import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.quickstart.QuickStartTracker
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
@@ -87,7 +87,7 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPagesDraftsTab(site, MOCK_PAGE_ID))
             verify(cardsTracker).trackCardItemClicked(
                 CardsTracker.Type.PAGES.label,
-                CardsTracker.PagesSubType.DRAFT.name
+                CardsTracker.PagesSubType.DRAFT.label
             )
         }
 
@@ -102,7 +102,7 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPagesScheduledTab(site, MOCK_PAGE_ID))
             verify(cardsTracker).trackCardItemClicked(
                 CardsTracker.Type.PAGES.label,
-                CardsTracker.PagesSubType.SCHEDULED.name
+                CardsTracker.PagesSubType.SCHEDULED.label
             )
         }
 
@@ -117,7 +117,7 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
             verify(cardsTracker).trackCardItemClicked(
                 CardsTracker.Type.PAGES.label,
-                CardsTracker.PagesSubType.PUBLISHED.name
+                CardsTracker.PagesSubType.PUBLISHED.label
             )
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PagesCardB
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 private const val MOCK_PAGE_ID = 1
 
@@ -28,6 +29,9 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var selectedSiteRepository: SelectedSiteRepository
 
+    @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     private lateinit var pagesCardViewModelSlice: PagesCardViewModelSlice
 
     private lateinit var navigationActions: MutableList<SiteNavigationAction>
@@ -38,7 +42,8 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
     fun setUp() {
         pagesCardViewModelSlice = PagesCardViewModelSlice(
             cardsTracker,
-            selectedSiteRepository
+            selectedSiteRepository,
+            appPrefsWrapper
         )
         navigationActions = mutableListOf()
         pagesCardViewModelSlice.onNavigation.observeForever { event ->
@@ -68,7 +73,10 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             pagesCardParams.onPagesItemClick.invoke(pagesParams)
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPagesDraftsTab(site, MOCK_PAGE_ID))
-            verify(cardsTracker).trackPagesItemClicked(PagesCardContentType.DRAFT)
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.PAGES.label,
+                CardsTracker.PagesSubType.DRAFT.name
+            )
         }
 
     @Test
@@ -80,7 +88,10 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             pagesCardParams.onPagesItemClick.invoke(pagesParams)
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPagesScheduledTab(site, MOCK_PAGE_ID))
-            verify(cardsTracker).trackPagesItemClicked(PagesCardContentType.SCHEDULED)
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.PAGES.label,
+                CardsTracker.PagesSubType.SCHEDULED.name
+            )
         }
 
     @Test
@@ -92,7 +103,10 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             pagesCardParams.onPagesItemClick.invoke(pagesParams)
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
-            verify(cardsTracker).trackPagesItemClicked(PagesCardContentType.PUBLISH)
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.PAGES.label,
+                CardsTracker.PagesSubType.PUBLISHED.name
+            )
         }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/pages/PagesCardViewModelSliceTest.kt
@@ -62,6 +62,10 @@ class PagesCardViewModelSliceTest : BaseUnitTest() {
             pagesCardParams.onFooterLinkClick()
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.TriggerCreatePageFlow(site))
+            verify(cardsTracker).trackCardFooterLinkClicked(
+                CardsTracker.Type.PAGES.label,
+                CardsTracker.PagesSubType.CREATE_PAGE.label
+            )
         }
 
     @Test


### PR DESCRIPTION
## Issue 
Parent https://github.com/wordpress-mobile/WordPress-Android/issues/18947

## Description 
This PR implements the hide menu click for Pages card


## To test:
1.  Login to the app 
2. Go to dashboard 
3. Verify that the pages card is shown 
4. Click on More menu → Hide this 
5. Verify that dashboard refreshing is indicated 
6. Verify that pages card is hidden 
7. Switch to another site 
8. Verify that the pages card is shown


## Regression Notes
1. Potential unintended areas of impact
Pages card is not hidden 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Unit tests

3. What automated tests I added (or what prevented me from doing so)
Unit tests 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)