### PR TITLE
Implement more menu for  Blaze Card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
@@ -29,29 +30,25 @@ class BlazeCardViewModelSlice @Inject constructor(
         return blazeCardUpdate?.let {
             if (it.blazeEligible) {
                 it.campaign?.let { campaign ->
-                    CampaignWithBlazeCardBuilderParams(
-                        campaign = campaign,
-                        onCreateCampaignClick = this::onCreateCampaignClick,
-                        onCampaignClick = this::onCampaignClick,
-                        onCardClick = this::onCampaignsCardClick,
-                        moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
-                            viewAllCampaignsItemClick = this::onViewAllCampaignsClick,
-                            onLearnMoreClick = this::onCampaignCardLearnMoreClick,
-                            onHideThisCardItemClick = this::onCampaignCardHideMenuItemClick,
-                            onMoreMenuClick = this::onCampaignCardMoreMenuClick
-                        )
-                    )
-                } ?: PromoteWithBlazeCardBuilderParams(
-                    onClick = this::onPromoteWithBlazeCardClick,
-                    moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
-                        onLearnMoreClick = this::onPromoteCardLearnMoreClick,
-                        onHideThisCardItemClick = this::onPromoteCardHideMenuItemClick,
-                        onMoreMenuClick = this::onPromoteCardMoreMenuClick
-                    )
-                )
+                    getCampaignWithBlazeCardBuilderParams(campaign)
+                } ?: getPromoteWithBlazeCardBuilderParams()
             } else null
         }
     }
+
+    private fun getCampaignWithBlazeCardBuilderParams(campaign: BlazeCampaignModel) =
+        CampaignWithBlazeCardBuilderParams(
+            campaign = campaign,
+            onCreateCampaignClick = this::onCreateCampaignClick,
+            onCampaignClick = this::onCampaignClick,
+            onCardClick = this::onCampaignsCardClick,
+            moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
+                viewAllCampaignsItemClick = this::onViewAllCampaignsClick,
+                onLearnMoreClick = this::onCampaignCardLearnMoreClick,
+                onHideThisCardItemClick = this::onCampaignCardHideMenuItemClick,
+                onMoreMenuClick = this::onCampaignCardMoreMenuClick
+            )
+        )
 
     private fun onViewAllCampaignsClick() {
         // todo add tracking for the click
@@ -70,6 +67,17 @@ class BlazeCardViewModelSlice @Inject constructor(
     private fun onCampaignCardMoreMenuClick() {
         TODO("Not yet implemented")
     }
+
+    private fun getPromoteWithBlazeCardBuilderParams() =
+        PromoteWithBlazeCardBuilderParams(
+            onClick = this::onPromoteWithBlazeCardClick,
+            moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
+                onLearnMoreClick = this::onPromoteCardLearnMoreClick,
+                onHideThisCardItemClick = this::onPromoteCardHideMenuItemClick,
+                onMoreMenuClick = this::onPromoteCardMoreMenuClick
+            )
+        )
+
 
     private fun onPromoteCardLearnMoreClick() {
         // todo implement the navigation and tracking

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -65,7 +65,7 @@ class BlazeCardViewModelSlice @Inject constructor(
     }
 
     private fun onCampaignCardMoreMenuClick() {
-        TODO("Not yet implemented")
+        // todo implement the logic and tracking
     }
 
     private fun getPromoteWithBlazeCardBuilderParams() =

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -34,20 +34,33 @@ class BlazeCardViewModelSlice @Inject constructor(
                         onCreateCampaignClick = this::onCreateCampaignClick,
                         onCampaignClick = this::onCampaignClick,
                         onCardClick = this::onCampaignsCardClick,
+                        moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
+                            onHideThisCardItemClick = this::onHideMenuItemClick,
+                            onMoreMenuClick = this::onMoreMenuClick,
+                            viewAllCampaignsItemClick = this::onCampaignsCardClick,
+                            onLearnMoreClick = this::onLearnMoreClick
+                        )
                     )
                 } ?: PromoteWithBlazeCardBuilderParams(
                     onClick = this::onPromoteWithBlazeCardClick,
                     moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
-                        onHideThisCardItemClick = this::onPromoteWithBlazeCardHideMenuItemClick,
-                        onMoreMenuClick = this::onPromoteWithBlazeCardMoreMenuClick,
-                        onLearnMoreClick = this::onLearnMoreBlazeClick
+                        onHideThisCardItemClick = this::onHideMenuItemClick,
+                        onMoreMenuClick = this::onMoreMenuClick,
+                        onLearnMoreClick = this::onLearnMoreClick
                     )
                 )
             } else null
         }
     }
 
-    private fun onLearnMoreBlazeClick() {
+    private fun onMoreMenuClick() {
+        blazeFeatureUtils.track(
+            AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_MENU_ACCESSED,
+            BlazeFlowSource.DASHBOARD_CARD
+        )
+    }
+
+    private fun onLearnMoreClick() {
         // todo implement the navigation and tracking
     }
 
@@ -73,7 +86,7 @@ class BlazeCardViewModelSlice @Inject constructor(
             Event(SiteNavigationAction.OpenPromoteWithBlazeOverlay(source = BlazeFlowSource.DASHBOARD_CARD))
     }
 
-    private fun onPromoteWithBlazeCardHideMenuItemClick() {
+    private fun onHideMenuItemClick() {
         blazeFeatureUtils.track(
             AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
             BlazeFlowSource.DASHBOARD_CARD
@@ -82,13 +95,6 @@ class BlazeCardViewModelSlice @Inject constructor(
             blazeFeatureUtils.hidePromoteWithBlazeCard(it.siteId)
         }
         _refresh.value = Event(true)
-    }
-
-    private fun onPromoteWithBlazeCardMoreMenuClick() {
-        blazeFeatureUtils.track(
-            AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_MENU_ACCESSED,
-            BlazeFlowSource.DASHBOARD_CARD
-        )
     }
 
     fun onBlazeMenuItemClick(): SiteNavigationAction {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -37,11 +37,18 @@ class BlazeCardViewModelSlice @Inject constructor(
                     )
                 } ?: PromoteWithBlazeCardBuilderParams(
                     onClick = this::onPromoteWithBlazeCardClick,
-                    onHideMenuItemClick = this::onPromoteWithBlazeCardHideMenuItemClick,
-                    onMoreMenuClick = this::onPromoteWithBlazeCardMoreMenuClick
+                    moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
+                        onHideThisCardItemClick = this::onPromoteWithBlazeCardHideMenuItemClick,
+                        onMoreMenuClick = this::onPromoteWithBlazeCardMoreMenuClick,
+                        onLearnMoreClick = this::onLearnMoreBlazeClick
+                    )
                 )
             } else null
         }
+    }
+
+    private fun onLearnMoreBlazeClick() {
+        // todo implement the navigation and tracking
     }
 
     private fun onCreateCampaignClick() {
@@ -50,7 +57,7 @@ class BlazeCardViewModelSlice @Inject constructor(
             Event(SiteNavigationAction.OpenPromoteWithBlazeOverlay(source = BlazeFlowSource.DASHBOARD_CARD))
     }
 
-        private fun onCampaignClick(campaignId: Int) {
+    private fun onCampaignClick(campaignId: Int) {
         _onNavigation.value =
             Event(SiteNavigationAction.OpenCampaignDetailPage(campaignId, CampaignDetailPageSource.DASHBOARD_CARD))
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -35,16 +35,18 @@ class BlazeCardViewModelSlice @Inject constructor(
                         onCampaignClick = this::onCampaignClick,
                         onCardClick = this::onCampaignsCardClick,
                         moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
-                            onHideThisCardItemClick = this::onHideMenuItemClick,
-                            onMoreMenuClick = this::onMoreMenuClick
+                            viewAllCampaignsItemClick = this::onViewAllCampaignsClick,
+                            onLearnMoreClick = this::onCampaignCardLearnMoreClick,
+                            onHideThisCardItemClick = this::onCampaignCardHideMenuItemClick,
+                            onMoreMenuClick = this::onCampaignCardMoreMenuClick
                         )
                     )
                 } ?: PromoteWithBlazeCardBuilderParams(
                     onClick = this::onPromoteWithBlazeCardClick,
                     moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
-                        onHideThisCardItemClick = this::onHideMenuItemClick,
-                        onMoreMenuClick = this::onMoreMenuClick,
-                        onLearnMoreClick = this::onLearnMoreClick
+                        onLearnMoreClick = this::onPromoteCardLearnMoreClick,
+                        onHideThisCardItemClick = this::onPromoteCardHideMenuItemClick,
+                        onMoreMenuClick = this::onPromoteCardMoreMenuClick
                     )
                 )
             } else null
@@ -57,16 +59,40 @@ class BlazeCardViewModelSlice @Inject constructor(
             Event(SiteNavigationAction.OpenCampaignListingPage(CampaignListingPageSource.DASHBOARD_CARD))
     }
 
-    private fun onMoreMenuClick() {
+    private fun onCampaignCardLearnMoreClick() {
+        // todo implement the navigation and tracking
+    }
+
+    private fun onCampaignCardHideMenuItemClick() {
+        // todo implement the hide logic and tracking
+    }
+
+    private fun onCampaignCardMoreMenuClick() {
+        TODO("Not yet implemented")
+    }
+
+    private fun onPromoteCardLearnMoreClick() {
+        // todo implement the navigation and tracking
+    }
+
+    private fun onPromoteCardHideMenuItemClick() {
+        blazeFeatureUtils.track(
+            AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
+            BlazeFlowSource.DASHBOARD_CARD
+        )
+        selectedSiteRepository.getSelectedSite()?.let {
+            blazeFeatureUtils.hidePromoteWithBlazeCard(it.siteId)
+        }
+        _refresh.value = Event(true)
+    }
+
+    private fun onPromoteCardMoreMenuClick() {
         blazeFeatureUtils.track(
             AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_MENU_ACCESSED,
             BlazeFlowSource.DASHBOARD_CARD
         )
     }
 
-    private fun onLearnMoreClick() {
-        // todo implement the navigation and tracking
-    }
 
     private fun onCreateCampaignClick() {
         blazeFeatureUtils.trackEntryPointTapped(BlazeFlowSource.DASHBOARD_CARD)
@@ -88,17 +114,6 @@ class BlazeCardViewModelSlice @Inject constructor(
         blazeFeatureUtils.trackEntryPointTapped(BlazeFlowSource.DASHBOARD_CARD)
         _onNavigation.value =
             Event(SiteNavigationAction.OpenPromoteWithBlazeOverlay(source = BlazeFlowSource.DASHBOARD_CARD))
-    }
-
-    private fun onHideMenuItemClick() {
-        blazeFeatureUtils.track(
-            AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
-            BlazeFlowSource.DASHBOARD_CARD
-        )
-        selectedSiteRepository.getSelectedSite()?.let {
-            blazeFeatureUtils.hidePromoteWithBlazeCard(it.siteId)
-        }
-        _refresh.value = Event(true)
     }
 
     fun onBlazeMenuItemClick(): SiteNavigationAction {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -36,9 +36,7 @@ class BlazeCardViewModelSlice @Inject constructor(
                         onCardClick = this::onCampaignsCardClick,
                         moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
                             onHideThisCardItemClick = this::onHideMenuItemClick,
-                            onMoreMenuClick = this::onMoreMenuClick,
-                            viewAllCampaignsItemClick = this::onCampaignsCardClick,
-                            onLearnMoreClick = this::onLearnMoreClick
+                            onMoreMenuClick = this::onMoreMenuClick
                         )
                     )
                 } ?: PromoteWithBlazeCardBuilderParams(
@@ -51,6 +49,12 @@ class BlazeCardViewModelSlice @Inject constructor(
                 )
             } else null
         }
+    }
+
+    private fun onViewAllCampaignsClick() {
+        // todo add tracking for the click
+        _onNavigation.value =
+            Event(SiteNavigationAction.OpenCampaignListingPage(CampaignListingPageSource.DASHBOARD_CARD))
     }
 
     private fun onMoreMenuClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -357,9 +357,14 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val title: UiString?,
                         val subtitle: UiString?,
                         val onClick: ListItemInteraction,
-                        val onHideMenuItemClick: ListItemInteraction,
-                        val onMoreMenuClick: ListItemInteraction,
-                    ) : BlazeCard(dashboardCardType = DashboardCardType.PROMOTE_WITH_BLAZE_CARD)
+                        val moreMenuOptions: MoreMenuOptions
+                    ) : BlazeCard(dashboardCardType = DashboardCardType.PROMOTE_WITH_BLAZE_CARD) {
+                        data class MoreMenuOptions(
+                            val onMoreClick: ListItemInteraction,
+                            val hideThisMenuItemClick: ListItemInteraction,
+                            val learnMoreClick: ListItemInteraction
+                        )
+                    }
                 }
 
                 data class DashboardDomainCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -355,9 +355,9 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
 
                         data class MoreMenuOptions(
                             val viewAllCampaignsItemClick: ListItemInteraction,
-                            val onMoreClick: ListItemInteraction,
+                            val learnMoreClick: ListItemInteraction,
                             val hideThisMenuItemClick: ListItemInteraction,
-                            val learnMoreClick: ListItemInteraction
+                            val onMoreClick: ListItemInteraction
                         )
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -331,7 +331,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val title: UiString,
                         val campaign: BlazeCampaignsCardItem,
                         val footer: BlazeCampaignsCardFooter,
-                        val onClick: ListItemInteraction
+                        val onClick: ListItemInteraction,
+                        val moreMenuOptions: MoreMenuOptions
                         ) : BlazeCard(dashboardCardType = DashboardCardType.BLAZE_CAMPAIGNS_CARD) {
                         data class BlazeCampaignsCardItem(
                             val id: Int,
@@ -350,6 +351,13 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         data class BlazeCampaignsCardFooter(
                             val label: UiString,
                             val onClick: ListItemInteraction,
+                        )
+
+                        data class MoreMenuOptions(
+                            val viewAllCampaignsItemClick: ListItemInteraction,
+                            val onMoreClick: ListItemInteraction,
+                            val hideThisMenuItemClick: ListItemInteraction,
+                            val learnMoreClick: ListItemInteraction
                         )
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -170,8 +170,16 @@ sealed class MySiteCardAndItemBuilderParams {
             val campaign: BlazeCampaignModel,
             val onCreateCampaignClick: () -> Unit,
             val onCampaignClick: (campaignId: Int) -> Unit,
-            val onCardClick: () -> Unit
-        ) : BlazeCardBuilderParams()
+            val onCardClick: () -> Unit,
+            val moreMenuParams: MoreMenuParams
+        ) : BlazeCardBuilderParams() {
+            data class MoreMenuParams(
+                val onMoreMenuClick: () -> Unit,
+                val onHideThisCardItemClick: () -> Unit,
+                val viewAllCampaignsItemClick: () -> Unit,
+                val onLearnMoreClick: () -> Unit
+            )
+        }
     }
 
     data class DomainTransferCardBuilderParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -174,10 +174,10 @@ sealed class MySiteCardAndItemBuilderParams {
             val moreMenuParams: MoreMenuParams
         ) : BlazeCardBuilderParams() {
             data class MoreMenuParams(
-                val onMoreMenuClick: () -> Unit,
-                val onHideThisCardItemClick: () -> Unit,
                 val viewAllCampaignsItemClick: () -> Unit,
-                val onLearnMoreClick: () -> Unit
+                val onLearnMoreClick: () -> Unit,
+                val onHideThisCardItemClick: () -> Unit,
+                val onMoreMenuClick: () -> Unit
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -157,9 +157,14 @@ sealed class MySiteCardAndItemBuilderParams {
     sealed class BlazeCardBuilderParams : MySiteCardAndItemBuilderParams() {
         data class PromoteWithBlazeCardBuilderParams(
             val onClick: () -> Unit,
-            val onHideMenuItemClick: () -> Unit,
-            val onMoreMenuClick: () -> Unit
-        ) : BlazeCardBuilderParams()
+            val moreMenuParams : MoreMenuParams
+        ) : BlazeCardBuilderParams() {
+            data class MoreMenuParams(
+                val onMoreMenuClick: () -> Unit,
+                val onHideThisCardItemClick: () -> Unit,
+                val onLearnMoreClick: () -> Unit
+            )
+        }
 
         data class CampaignWithBlazeCardBuilderParams(
             val campaign: BlazeCampaignModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.mysite.cards.blaze
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,9 +12,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,18 +58,24 @@ fun BlazeCampaignsCard(
             Column(
                 modifier = Modifier.padding(top = 16.dp)
             ) {
-                Text(
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-                    text = uiStringText(uiString = blazeCampaignCardModel.title),
-                    style = DashboardCardTypography.smallTitle,
-                    textAlign = TextAlign.Start,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+                        text = uiStringText(uiString = blazeCampaignCardModel.title),
+                        style = DashboardCardTypography.smallTitle,
+                        textAlign = TextAlign.Start,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    CardDropDownMenu(moreMenuOptions = blazeCampaignCardModel.moreMenuOptions)
+                }
                 Column(
                     modifier = Modifier
                         .padding(start = 16.dp, end = 16.dp, bottom = 8.dp)
                         .clickable {
                             blazeCampaignCardModel.campaign.onClick(blazeCampaignCardModel.campaign.id)
-                                   },
+                        },
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     val status = blazeCampaignCardModel.campaign.status
@@ -170,5 +190,44 @@ private fun CampaignStat(title: String, value: UiString, modifier: Modifier = Mo
             style = DashboardCardTypography.largeText,
             textAlign = TextAlign.Start
         )
+    }
+}
+
+
+@Composable
+private fun CardDropDownMenu(moreMenuOptions: BlazeCampaignsCardModel.MoreMenuOptions, modifier: Modifier = Modifier) {
+    Box(modifier = modifier) {
+        var isExpanded by remember { mutableStateOf(false) }
+
+        IconButton(onClick = {
+            isExpanded = true
+            moreMenuOptions.onMoreClick.click()
+        }) {
+            Icon(
+                imageVector = Icons.Rounded.MoreVert,
+                contentDescription = stringResource(id = R.string.more),
+                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            )
+        }
+
+        DropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_view_all_campaigns)) },
+                onClick = { moreMenuOptions.viewAllCampaignsItemClick.click() }
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_learn_more)) },
+                onClick = { moreMenuOptions.learnMoreClick.click() }
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_hide_this)) },
+                onClick = { moreMenuOptions.hideThisMenuItemClick.click() }
+            )
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
@@ -34,14 +34,14 @@ class BlazeCardBuilder @Inject constructor(private val statsUtils: StatsUtils) {
         )
     }
 
-    private fun getMoreMenuOptions(params: CampaignWithBlazeCardBuilderParams): BlazeCampaignsCardModel.MoreMenuOptions {
-        return BlazeCampaignsCardModel.MoreMenuOptions(
+    private fun getMoreMenuOptions(params: CampaignWithBlazeCardBuilderParams) =
+        BlazeCampaignsCardModel.MoreMenuOptions(
             viewAllCampaignsItemClick = ListItemInteraction.create(params.moreMenuParams.viewAllCampaignsItemClick),
             onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
             hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
             learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
         )
-    }
+
 
     private fun getBlazeCardFooter(params: CampaignWithBlazeCardBuilderParams): BlazeCampaignsCardFooter {
         return BlazeCampaignsCardFooter(
@@ -84,11 +84,14 @@ class BlazeCardBuilder @Inject constructor(private val statsUtils: StatsUtils) {
             title = UiString.UiStringRes(R.string.promote_blaze_card_title),
             subtitle = UiString.UiStringRes(R.string.promote_blaze_card_sub_title),
             onClick = ListItemInteraction.create(params.onClick),
-            moreMenuOptions = PromoteWithBlazeCard.MoreMenuOptions(
-                onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
-                hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
-                learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
-            )
+            moreMenuOptions = getMoreMenuOptions(params)
         )
     }
+
+    private fun getMoreMenuOptions(params: PromoteWithBlazeCardBuilderParams) =
+        PromoteWithBlazeCard.MoreMenuOptions(
+            onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
+            hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
+            learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
+        )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
@@ -37,9 +37,9 @@ class BlazeCardBuilder @Inject constructor(private val statsUtils: StatsUtils) {
     private fun getMoreMenuOptions(params: CampaignWithBlazeCardBuilderParams) =
         BlazeCampaignsCardModel.MoreMenuOptions(
             viewAllCampaignsItemClick = ListItemInteraction.create(params.moreMenuParams.viewAllCampaignsItemClick),
-            onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
+            learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick),
             hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
-            learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
+            onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick)
         )
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
@@ -74,8 +74,11 @@ class BlazeCardBuilder @Inject constructor(private val statsUtils: StatsUtils) {
             title = UiString.UiStringRes(R.string.promote_blaze_card_title),
             subtitle = UiString.UiStringRes(R.string.promote_blaze_card_sub_title),
             onClick = ListItemInteraction.create(params.onClick),
-            onHideMenuItemClick = ListItemInteraction.create(params.onHideMenuItemClick),
-            onMoreMenuClick = ListItemInteraction.create(params.onMoreMenuClick)
+            moreMenuOptions = PromoteWithBlazeCard.MoreMenuOptions(
+                onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
+                hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
+                learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCardBuilder.kt
@@ -30,6 +30,16 @@ class BlazeCardBuilder @Inject constructor(private val statsUtils: StatsUtils) {
             campaign = getRecentCampaign(params),
             footer = getBlazeCardFooter(params),
             onClick = ListItemInteraction.create(params.onCardClick),
+            moreMenuOptions = getMoreMenuOptions(params),
+        )
+    }
+
+    private fun getMoreMenuOptions(params: CampaignWithBlazeCardBuilderParams): BlazeCampaignsCardModel.MoreMenuOptions {
+        return BlazeCampaignsCardModel.MoreMenuOptions(
+            viewAllCampaignsItemClick = ListItemInteraction.create(params.moreMenuParams.viewAllCampaignsItemClick),
+            onMoreClick = ListItemInteraction.create(params.moreMenuParams.onMoreMenuClick),
+            hideThisMenuItemClick = ListItemInteraction.create(params.moreMenuParams.onHideThisCardItemClick),
+            learnMoreClick = ListItemInteraction.create(params.moreMenuParams.onLearnMoreClick)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/PromoteWithBlazeCardViewHolder.kt
@@ -22,14 +22,16 @@ class PromoteWithBlazeCardViewHolder(
         mySitePromoteWithBlazeCardCta.setOnClickListener { card.onClick.click() }
         mySitePromoteWithBlazeCardMore.setOnClickListener {
             showMoreMenu(
-                card.onHideMenuItemClick,
-                card.onMoreMenuClick,
+                card.moreMenuOptions.learnMoreClick,
+                card.moreMenuOptions.hideThisMenuItemClick,
+                card.moreMenuOptions.onMoreClick,
                 mySitePromoteWithBlazeCardMore,
             )
         }
     }
 
     private fun showMoreMenu(
+        onLearnMoreClick: ListItemInteraction,
         onHideMenuItemClick: ListItemInteraction,
         onMoreMenuClick: ListItemInteraction,
         anchor: View
@@ -40,6 +42,10 @@ class PromoteWithBlazeCardViewHolder(
             when (it.itemId) {
                 R.id.promote_with_blaze_card_menu_item_hide_this -> {
                     onHideMenuItemClick.click()
+                    return@setOnMenuItemClickListener true
+                }
+                R.id.promote_with_blaze_card_menu_item_learn_more -> {
+                    onLearnMoreClick.click()
                     return@setOnMenuItemClickListener true
                 }
                 else -> return@setOnMenuItemClickListener true

--- a/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
+++ b/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
@@ -2,13 +2,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
-        android:id="@+id/promote_with_blaze_card_menu_item_hide_this"
-        android:title="@string/promote_blaze_card_more_menu_hide_this"
-        android:icon="@drawable/ic_not_visible_white_24dp"/>
-
-    <item
         android:id="@+id/promote_with_blaze_card_menu_item_learn_more"
         android:title="@string/promote_blaze_card_more_menu_learn_more"
         android:icon="@drawable/ic_info_outline_grey_dark_24dp"/>
+
+    <item
+        android:id="@+id/promote_with_blaze_card_menu_item_hide_this"
+        android:title="@string/promote_blaze_card_more_menu_hide_this"
+        android:icon="@drawable/ic_not_visible_white_24dp"/>
 
 </menu>

--- a/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
+++ b/WordPress/src/main/res/menu/promote_with_blaze_card_menu.xml
@@ -5,4 +5,10 @@
         android:id="@+id/promote_with_blaze_card_menu_item_hide_this"
         android:title="@string/promote_blaze_card_more_menu_hide_this"
         android:icon="@drawable/ic_not_visible_white_24dp"/>
+
+    <item
+        android:id="@+id/promote_with_blaze_card_menu_item_learn_more"
+        android:title="@string/promote_blaze_card_more_menu_learn_more"
+        android:icon="@drawable/ic_info_outline_grey_dark_24dp"/>
+
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4643,6 +4643,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Jetpack - Blaze campaigns card -->
     <string name="blaze_campaigns_card_title">Blaze Campaign</string>
     <string name="blaze_campaigns_card_footer_label">Create Campaign</string>
+    <string name="blaze_campaigns_card_more_menu_view_all_campaigns">View All Campaigns</string>
+    <string name="blaze_campaigns_card_more_menu_hide_this" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
+    <string name="blaze_campaigns_card_more_menu_learn_more" translatable="false">@string/learn_more</string>
+
     <string name="campaign_status_active">ACTIVE</string>
     <string name="campaign_status_completed">COMPLETED</string>
     <string name="campaign_status_rejected">REJECTED</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4547,6 +4547,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="promote_blaze_card_title">Promote your content with Blaze</string>
     <string name="promote_blaze_card_sub_title">Display your work across millions of sites.</string>
     <string name="promote_blaze_card_more_menu_hide_this" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
+    <string name="promote_blaze_card_more_menu_learn_more" translatable="false">@string/learn_more</string>
     <string name="promote_blaze_flow_error">The blaze promote flow couldn\'t be loaded</string>
 
     <string name="gutenberg_native_blocks_menu" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Blocks menu</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4643,7 +4643,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Jetpack - Blaze campaigns card -->
     <string name="blaze_campaigns_card_title">Blaze Campaign</string>
     <string name="blaze_campaigns_card_footer_label">Create Campaign</string>
-    <string name="blaze_campaigns_card_more_menu_view_all_campaigns">View All Campaigns</string>
+    <string name="blaze_campaigns_card_more_menu_view_all_campaigns">View all campaigns</string>
     <string name="blaze_campaigns_card_more_menu_hide_this" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
     <string name="blaze_campaigns_card_more_menu_learn_more" translatable="false">@string/learn_more</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
@@ -212,7 +212,7 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
         // When
         val result =
             blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as PromoteWithBlazeCardBuilderParams
-        result.onHideMenuItemClick()
+        result.moreMenuParams.onHideThisCardItemClick()
 
         // Then
         verify(blazeFeatureUtils).track(
@@ -233,7 +233,7 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
         // When
         val result =
             blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as PromoteWithBlazeCardBuilderParams
-        result.onMoreMenuClick()
+        result.moreMenuParams.onMoreMenuClick()
 
         // Then
         verify(blazeFeatureUtils).track(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -216,7 +216,6 @@ class CardsBuilderTest {
                 ),
                 blazeCardBuilderParams = BlazeCardBuilderParams.PromoteWithBlazeCardBuilderParams(
                     mock(),
-                    mock(),
                     mock()
                 ),
                 dashboardCardDomainBuilderParams = DashboardCardDomainBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -338,7 +338,6 @@ class CardsBuilderTest : BaseUnitTest() {
                 ),
                 blazeCardBuilderParams = PromoteWithBlazeCardBuilderParams(
                     mock(),
-                    mock(),
                     mock()
                 ),
                 dashboardCardDomainBuilderParams = DashboardCardDomainBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
@@ -37,12 +37,30 @@ val campaign = BlazeCampaignModel(
 
 val onCreateCampaignClick = { }
 val onCardClick = { }
+
+val onHideCardMenuItemClick = { }
+val onMoreMenuClick = { }
+val onLearnMoreItemClick = { }
+val viewAllCampaignsClick = { }
+
 private var onCampaignClick: ((campaignId: Int) -> Unit) = { }
 val campaignWithBlazeBuilderParams = CampaignWithBlazeCardBuilderParams(
     campaign = campaign,
     onCardClick = onCardClick,
     onCampaignClick = onCampaignClick,
-    onCreateCampaignClick = onCreateCampaignClick
+    onCreateCampaignClick = onCreateCampaignClick,
+    moreMenuParams = CampaignWithBlazeCardBuilderParams.MoreMenuParams(
+        viewAllCampaignsItemClick = viewAllCampaignsClick,
+        onLearnMoreClick = onLearnMoreItemClick,
+        onHideThisCardItemClick = onHideCardMenuItemClick,
+        onMoreMenuClick = onMoreMenuClick
+    )
+)
+
+val moreMenuParams = PromoteWithBlazeCardBuilderParams.MoreMenuParams(
+    onLearnMoreClick = onLearnMoreItemClick,
+    onHideThisCardItemClick = onHideCardMenuItemClick,
+    onMoreMenuClick = onMoreMenuClick
 )
 
 val campaignCardItem = BlazeCampaignsCardItem(
@@ -54,7 +72,7 @@ val campaignCardItem = BlazeCampaignsCardItem(
         impressions = UiString.UiStringText(campaign.impressions.toString()),
         clicks = UiString.UiStringText(campaign.clicks.toString())
     ),
-    onClick = onCampaignClick,
+    onClick = onCampaignClick
 )
 
 val blazeCampaignsCardModel = BlazeCampaignsCardModel(
@@ -65,6 +83,12 @@ val blazeCampaignsCardModel = BlazeCampaignsCardModel(
         onClick = ListItemInteraction.create(onCreateCampaignClick)
     ),
     onClick = ListItemInteraction.create(onCardClick),
+    moreMenuOptions = BlazeCampaignsCardModel.MoreMenuOptions(
+        viewAllCampaignsItemClick = ListItemInteraction.create(viewAllCampaignsClick),
+        learnMoreClick = ListItemInteraction.create(onLearnMoreItemClick),
+        hideThisMenuItemClick = ListItemInteraction.create(onHideCardMenuItemClick),
+        onMoreClick = ListItemInteraction.create(onMoreMenuClick)
+    )
 )
 
 
@@ -84,8 +108,7 @@ class BlazeCardBuilderTest {
         // Arrange
         val params = PromoteWithBlazeCardBuilderParams(
             onClick = { },
-            onHideMenuItemClick = { },
-            onMoreMenuClick = { }
+            moreMenuParams = moreMenuParams
         )
 
         // Act
@@ -102,8 +125,7 @@ class BlazeCardBuilderTest {
             (result.subtitle as UiString.UiStringRes).stringRes
         )
         assertNotNull(result.onClick)
-        assertNotNull(result.onHideMenuItemClick)
-        assertNotNull(result.onMoreMenuClick)
+        assertNotNull(result.moreMenuOptions)
     }
 
     @Test


### PR DESCRIPTION
## Issue 
Part of #18943 

## Description 
This PR implements the more menu for 
1. Promote with Blaze card 
- Added Learn more option 
2. Blaze campaign card 
- View all campaigns 
- Learn more 
- Hide this 

## Screenshots 
| Promote card | Campaigns card   | 
|---|---|
| ![learn_more_promote_blaze_card](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/c0d4fd0a-e084-4dc1-a0ba-83928e2e18fa)|![view_all_campaigns_card](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/51b0d1c8-313b-4dd9-96c0-6af0efcd1901) | 


## To test:

### Promote with blaze card has learn more option 
1. Login to the app with a site having blaze feature but no campaigns 
2. Click on more menu in Promote with Blaze Card
3. ✅  Verify that learn more option is shown 

### Blaze Campaign card has more menu options 
1. Login to the app with a site having blaze feature and campaigns 
2. Click on Blaze Campaign Card 
3. ✅  Verify that View all campaigns is shown 
4. ✅  Verfiy that learn more option is shown 
5. ✅  Verify that hide this option is shown 

## Regression Notes
1. Potential unintended areas of impact

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)