### PR TITLE
[Site settings] Remove ContactsContract reference from SiteSettingsFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -7,6 +7,7 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.EditTextPreference;
@@ -15,7 +16,6 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
-import android.provider.ContactsContract;
 import android.text.TextUtils;
 import android.util.SparseBooleanArray;
 import android.view.ActionMode;
@@ -1776,8 +1776,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSite == null || mSite.getHasFreePlan()) {
             return;
         }
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE);
+        final Intent intent = new Intent(Intent.ACTION_SENDTO);
+        intent.setData(Uri.parse("mailto:"));
         intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
         intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
                 SiteUtils.getHomeURLOrHostName(mSite)));


### PR DESCRIPTION
In order to remove the `ContactsContract` reference from `SiteSettingsFragment` I had to update the `Intent` used by `Start over` preference. I've use the suggested approach in the [developer docs](https://developer.android.com/guide/components/intents-common#Email) and now the Intent can only be resolved by email apps.

### Before my changes
```
Intent intent = new Intent(Intent.ACTION_SEND);
intent.setType(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE);
intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
                SiteUtils.getHomeURLOrHostName(mSite)));
intent.putExtra(Intent.EXTRA_TEXT, getString(R.string.start_over_email_body, mSite.getUrl()));

```
<p float="left">
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/05f887e0-e95d-4fdc-811a-e2ec40def0f2" width="300" />
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/82827310-5ec2-4a11-8b7c-10976fb54c59" width="300" />
</p>

### Only removing the line `intent.setType(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE);`
```
Intent intent = new Intent(Intent.ACTION_SEND);
intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
                SiteUtils.getHomeURLOrHostName(mSite)));
intent.putExtra(Intent.EXTRA_TEXT, getString(R.string.start_over_email_body, mSite.getUrl()));
```

<p float="left">
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/cab6fda8-9801-4daa-be59-849fd6ab1e53" width="300" />
</p>


### After my changes
```
final Intent intent = new Intent(Intent.ACTION_SENDTO);
intent.setData(Uri.parse("mailto:"));
intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
                SiteUtils.getHomeURLOrHostName(mSite)));
intent.putExtra(Intent.EXTRA_TEXT, getString(R.string.start_over_email_body, mSite.getUrl()));
```

<p float="left">
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/70679251-3b3a-40c3-abd8-2e2f884eab79" width="300" />
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/b6aa9343-9bc0-4cbf-b2e2-54d72cd6e70f" width="300" />
</p>

To test:
> [!IMPORTANT]  
> I need help with this one, because the only way I've managed to test this flow was by mocking a call to `handleStartOver()` method. @develric explained to me (thanks) that apparently the `Start over` does different things depending on the site's active plan. A free plan is going to open a WebView page, [as seen here](https://github.com/wordpress-mobile/WordPress-Android/blob/987f6df868663c0bba55256a08fcbf69683982f6/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java#L557). In theory a business plan triggers the `Intent` changed by this PR, but I couldn't find the `Start over` option in the site with a business plan (the preferences are different). This is why I've only tested this flow by mocking a direct call to `handleStartOver()`.

## Regression Notes
1. Potential unintended areas of impact
Contacting support by email in the context of `Start over`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The whole logic is in the `Fragment` at the moment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
