### PR TITLE
Dashboard Personalization: Today's stats card more menu tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.todaysstats
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
@@ -54,20 +53,22 @@ class TodaysStatsViewModelSlice @Inject constructor(
     }
 
     private fun onMoreMenuClick() {
-        // todo: track click cardsTracker.trackCardMoreMenuClicked(CardsTracker.Type.TODAYS_STATS.label)
-        Log.i(javaClass.simpleName, "***=> onMoreMenuClick")
+        cardsTracker.trackCardMoreMenuClicked(CardsTracker.Type.STATS.label)
     }
 
     private fun onHideThisMenuItemClick() {
-        // todo: track click cardsTracker.trackCardMoreMenuItemClicked
-        // todo implement the logic to hide the card and add tracking logic
-        Log.i(javaClass.simpleName, "***=> onHideThisMenuItemClick")
+        cardsTracker.trackCardMoreMenuItemClicked(
+            CardsTracker.Type.STATS.label,
+            TodaysStatsMenuItemType.HIDE_THIS.label
+        )
+        // todo implement the logic to hide the card
     }
 
     private fun onViewStatsMenuItemClick() {
-        // todo: track click
-        Log.i(javaClass.simpleName, "***=> onViewStatsMenuItemClick")
-        // cardsTracker.trackCardMoreMenuItemClicked(
+        cardsTracker.trackCardMoreMenuItemClicked(
+            CardsTracker.Type.STATS.label,
+            TodaysStatsMenuItemType.VIEW_STATS.label
+        )
         navigateToTodaysStats()
     }
 
@@ -79,4 +80,9 @@ class TodaysStatsViewModelSlice @Inject constructor(
             _onNavigation.value = Event(SiteNavigationAction.OpenStatsInsights(selectedSite))
         }
     }
+}
+
+enum class TodaysStatsMenuItemType(val label: String) {
+    VIEW_STATS("view_stats"),
+    HIDE_THIS("hide_this")
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -101,10 +101,10 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
         params.moreMenuClickParams.onViewStatsMenuItemClick.invoke()
 
         verify(cardsTracker).trackCardMoreMenuItemClicked(
-            CardsTracker.Type.PAGES.label,
+            CardsTracker.Type.STATS.label,
             TodaysStatsMenuItemType.VIEW_STATS.label
         )
-        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
     }
 
 
@@ -115,7 +115,7 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
         params.moreMenuClickParams.onHideThisMenuItemClick.invoke()
 
         verify(cardsTracker).trackCardMoreMenuItemClicked(
-            CardsTracker.Type.PAGES.label,
+            CardsTracker.Type.STATS.label,
             TodaysStatsMenuItemType.HIDE_THIS.label
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -83,4 +83,40 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
                 CardsTracker.StatsSubtype.TODAYS_STATS_NUDGE.label
             )
         }
+
+
+    @Test
+    fun `given todays stats card, when more menu is accessed, then event is tracked`() = test {
+        val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+        params.moreMenuClickParams.onMoreMenuClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuClicked(CardsTracker.Type.STATS.label)
+    }
+
+    @Test
+    fun `given todays stats card, when more menu item view stats is accessed, then event is tracked`() = test {
+        val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+        params.moreMenuClickParams.onViewStatsMenuItemClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            CardsTracker.Type.PAGES.label,
+            TodaysStatsMenuItemType.VIEW_STATS.label
+        )
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenPages(site))
+    }
+
+
+    @Test
+    fun `given todays stats card, when more menu item hide this is accessed, then event is tracked`() = test {
+        val params = todaysStatsViewModelSlice.getTodaysStatsBuilderParams(mock())
+
+        params.moreMenuClickParams.onHideThisMenuItemClick.invoke()
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            CardsTracker.Type.PAGES.label,
+            TodaysStatsMenuItemType.HIDE_THIS.label
+        )
+    }
 }


### PR DESCRIPTION
Parent #18944 

This PR adds tracking more menu events for the Today's Stats dashboard card
NOTE: iOS tracks the cards as "todays_stats", this PR has Android using 'stats' instead. Would love to hear thoughts on if this should be the same.

## To test:
- Login to the app 
- Select a site in which you has stats access
- Go to Stats Card 
- Tap the more menu 
- ✅ Verify the log contains 🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"stats"}
- Tap on the " View stats" menu item
- ✅  Verify the log contains  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"stats","item":"view_stats"} 
- Navigate back to dashboard
- Tap the stats care more menu 
- Tap on the Hide this item 
- ✅  Verify the log contains  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"stats","item":"hide_this”}

## Regression Notes
1. Potential unintended areas of impact
The events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
Add tests to `TodaysStatsViewModelSliceTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
