### PR TITLE
Dashboard Personalization: Todays Stats Implement Hide This

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -312,7 +312,8 @@ class MySiteViewModel @Inject constructor(
     val onShowJetpackIndividualPluginOverlay = _onShowJetpackIndividualPluginOverlay as LiveData<Event<Unit>>
     val onTrackWithTabSource = _onTrackWithTabSource as LiveData<Event<MySiteTrackWithTabSource>>
     val selectTab: LiveData<Event<TabNavigation>> = _selectTab
-    val refresh = merge(blazeCardViewModelSlice.refresh, pagesCardViewModelSlice.refresh)
+    val refresh =
+        merge(blazeCardViewModelSlice.refresh, pagesCardViewModelSlice.refresh, todaysStatsViewModelSlice.refresh)
     val domainTransferCardRefresh = domainTransferCardViewModel.refresh
 
     private var shouldMarkUpdateSiteTitleTaskComplete = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -99,7 +99,7 @@ class CardsSource @Inject constructor(
     }
 
     private fun getCardTypes(selectedSite: SiteModel) = mutableListOf<Type>().apply {
-        add(Type.TODAYS_STATS)
+        if (shouldRequestStatsCard(selectedSite)) add(Type.TODAYS_STATS)
         if (shouldRequestPagesCard(selectedSite)) add(Type.PAGES)
         if (dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(selectedSite)) add(Type.ACTIVITY)
         add(Type.POSTS)
@@ -108,6 +108,10 @@ class CardsSource @Inject constructor(
     private fun shouldRequestPagesCard(selectedSite: SiteModel): Boolean {
         return (selectedSite.hasCapabilityEditPages || selectedSite.isSelfHostedAdmin) &&
                 !appPrefsWrapper.getShouldHidePagesDashboardCard(selectedSite.siteId)
+    }
+
+    private fun shouldRequestStatsCard(selectedSite: SiteModel): Boolean {
+        return !appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(selectedSite.siteId)
     }
 
     private fun MediatorLiveData<CardsUpdate>.postErrorState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -20,6 +20,9 @@ class TodaysStatsViewModelSlice @Inject constructor(
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
 
+    private val _refresh = MutableLiveData<Event<Boolean>>()
+    val refresh = _refresh
+
     fun getTodaysStatsBuilderParams(todaysStatsCardModel: TodaysStatsCardModel?): TodaysStatsCardBuilderParams {
         return TodaysStatsCardBuilderParams(
             todaysStatsCard = todaysStatsCardModel,
@@ -64,6 +67,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
             TodaysStatsMenuItemType.HIDE_THIS.label
         )
         appPrefsWrapper.setShouldHideTodaysStatsDashboardCard(selectedSiteRepository.getSelectedSite()!!.siteId, true)
+        _refresh.postValue(Event(true))
     }
 
     private fun onViewStatsMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -7,13 +7,15 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStat
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class TodaysStatsViewModelSlice @Inject constructor(
     private val cardsTracker: CardsTracker,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
@@ -61,7 +63,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
             CardsTracker.Type.STATS.label,
             TodaysStatsMenuItemType.HIDE_THIS.label
         )
-        // todo implement the logic to hide the card
+        appPrefsWrapper.setShouldHideTodaysStatsDashboardCard(selectedSiteRepository.getSelectedSite()!!.siteId, true)
     }
 
     private fun onViewStatsMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -200,7 +200,8 @@ public class AppPrefs {
         // Should show Jetpack Social no connections UI
         SHOULD_SHOW_JETPACK_SOCIAL_NO_CONNECTIONS,
         SHOULD_HIDE_ACTIVITY_DASHBOARD_CARD,
-        SHOULD_HIDE_PAGES_DASHBOARD_CARD
+        SHOULD_HIDE_PAGES_DASHBOARD_CARD,
+        SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD
     }
 
     /**
@@ -1742,5 +1743,17 @@ public class AppPrefs {
 
     public static Boolean getShouldHidePagesDashboardCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHidePagesDashboardCardKey(siteId), false);
+    }
+
+    public static void setShouldHideTodaysStatsDashboardCard(final long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHideTodaysStatsDashboardCardKey(siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHideTodaysStatsDashboardCardKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD.name() + siteId;
+    }
+
+    public static Boolean getShouldHideTodaysStatsDashboardCard(final long siteId) {
+        return prefs().getBoolean(getSiteIdHideTodaysStatsDashboardCardKey(siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -386,6 +386,14 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHidePagesDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHidePagesDashboardCard(siteId)
 
+    fun setShouldHideTodaysStatsDashboardCard(
+        siteId: Long,
+        isHidden: Boolean
+    ) = AppPrefs.setShouldHideTodaysStatsDashboardCard(siteId, isHidden)
+
+    fun getShouldHideTodaysStatsDashboardCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHideTodaysStatsDashboardCard(siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {


### PR DESCRIPTION
Closes #18944 

This PR implements the logic for hiding the `todays_stats` dashboard card when the "hide this" more menu item is tapped.

**Merge Instructions**
- Ensure PR #19058 has been merged
- Remove Not Ready for Merge
- Ensure base branch is feature/dashboard-personalization
- Merge as normal

**To test:**
- Install the app
- Login to the app and select a site that has stats access
- ✅ Verify the todays stats card is shown
- Tap on todays stats card > more menu
- Tap on the Hide this more menu item
- ✅ Verify the dashboard refresh indicator is showing
- ✅ Verify the todays stats card is hidden
- Switch to another site that has stats access
- ✅ Verify the todays stats card is shown.

## Regression Notes
1. Potential unintended areas of impact
Todays stats card is not hidden

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
`CardsSourceTest` and `TodaysStatsViewModelSliceTest`

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
