### PR TITLE
Implementation: More menu clicks in blaze card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
 import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_FLOW_SOURCE
+import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_SHOULD_SHOW_OVERLAY
 import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,10 +44,12 @@ class ActivityNavigator @Inject constructor() {
 
     fun openPromoteWithBlaze(
         context: Context,
-        source: BlazeFlowSource
+        source: BlazeFlowSource,
+        shouldShowOverlay: Boolean = false
     ) {
         val intent = Intent(context, BlazePromoteParentActivity::class.java)
         intent.putExtra(ARG_BLAZE_FLOW_SOURCE, source)
+        intent.putExtra(ARG_BLAZE_SHOULD_SHOW_OVERLAY, shouldShowOverlay)
         context.startActivity(intent)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -58,7 +58,7 @@ class BlazeFeatureUtils @Inject constructor(
 
     fun shouldShowBlazeCardEntryPoint(siteModel: SiteModel): Boolean =
         isSiteBlazeEligible(siteModel) &&
-                !isPromoteWithBlazeCardHiddenByUser(siteModel.siteId)
+                !isBlazeCardHiddenByUser(siteModel.siteId)
 
     fun shouldShowBlazeCampaigns() = blazeManageCampaignFeatureConfig.isEnabled()
 
@@ -73,8 +73,8 @@ class BlazeFeatureUtils @Inject constructor(
         )
     }
 
-    fun hidePromoteWithBlazeCard(siteId: Long) {
-        appPrefsWrapper.setShouldHidePromoteWithBlazeCard(siteId, true)
+    fun hideBlazeCard(siteId: Long) {
+        appPrefsWrapper.setShouldHideBlazeCard(siteId, true)
     }
 
     fun trackEntryPointTapped(blazeFlowSource: BlazeFlowSource) {
@@ -84,8 +84,8 @@ class BlazeFeatureUtils @Inject constructor(
         )
     }
 
-    private fun isPromoteWithBlazeCardHiddenByUser(siteId: Long): Boolean {
-        return appPrefsWrapper.getShouldHidePromoteWithBlazeCard(siteId)
+    private fun isBlazeCardHiddenByUser(siteId: Long): Boolean {
+        return appPrefsWrapper.hideBlazeCard(siteId)
     }
 
     fun trackOverlayDisplayed(blazeFlowSource: BlazeFlowSource) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeViewModel.kt
@@ -35,13 +35,15 @@ class BlazeViewModel @Inject constructor(
     private val featuredImageTracker =
         PostListFeaturedImageTracker(dispatcher = dispatcher, mediaStore = mediaStore)
 
-    fun start(source: BlazeFlowSource, blazeUIModel: BlazeUIModel?) {
+    fun start(source: BlazeFlowSource, blazeUIModel: BlazeUIModel?, shouldShowOverlay: Boolean) {
         blazeFlowSource = source
-        blazeUIModel?.let { initializePromoteContentUIState(it) } ?: run { initializePromoteSiteUIState() }
+        blazeUIModel?.let { initializePromoteContentUIState(it) } ?: run {
+            initializePromoteSiteUIState(shouldShowOverlay)
+        }
     }
 
     private fun initializePromoteContentUIState(blazeUIModel: BlazeUIModel) {
-        when(blazeUIModel) {
+        when (blazeUIModel) {
             is PostUIModel -> initializePromotePostUIState(blazeUIModel)
             is PageUIModel -> initializePromotePageUIState(blazeUIModel)
         }
@@ -53,7 +55,8 @@ class BlazeViewModel @Inject constructor(
             featuredImageUrl = siteSelectedSiteRepository.getSelectedSite()?.let {
                 featuredImageTracker.getFeaturedImageUrl(
                     it,
-                    postModel.featuredImageId)
+                    postModel.featuredImageId
+                )
             }
         )
 
@@ -82,16 +85,16 @@ class BlazeViewModel @Inject constructor(
         }
     }
 
-    private fun initializePromoteSiteUIState() {
+    private fun initializePromoteSiteUIState(shouldShowOverlay: Boolean) {
         _promoteUiState.value = BlazeUiState.PromoteScreen.Site
-        _uiState.value = if (shouldShowOverlayAndTrack()) {
+        _uiState.value = if (shouldShowOverlayAndTrack() || shouldShowOverlay) {
             BlazeUiState.PromoteScreen.Site
         } else {
             BlazeUiState.WebViewScreen
         }
     }
 
-    private fun shouldShowOverlayAndTrack() : Boolean  {
+    private fun shouldShowOverlayAndTrack(): Boolean {
         val shouldShowOverlay = !blazeFeatureUtils.shouldHideBlazeOverlay()
         if (shouldShowOverlay) {
             blazeFeatureUtils.trackOverlayDisplayed(blazeFlowSource)

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
 const val ARG_EXTRA_BLAZE_UI_MODEL = "blaze_ui_model"
 const val ARG_BLAZE_FLOW_SOURCE = "blaze_flow_source"
+const val ARG_BLAZE_SHOULD_SHOW_OVERLAY = "blaze_flow_should_show_overlay"
 
 @AndroidEntryPoint
 class BlazePromoteParentActivity : AppCompatActivity() {
@@ -23,7 +24,7 @@ class BlazePromoteParentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_blaze_parent)
-        viewModel.start(getSource(), getBlazeUiModel())
+        viewModel.start(getSource(), getBlazeUiModel(), getShouldShowOverlay())
         observe()
     }
 
@@ -55,4 +56,6 @@ class BlazePromoteParentActivity : AppCompatActivity() {
     private fun getBlazeUiModel(): BlazeUIModel? {
         return intent.getParcelableExtraCompat(ARG_EXTRA_BLAZE_UI_MODEL)
     }
+
+    private fun getShouldShowOverlay(): Boolean = intent.getBooleanExtra(ARG_BLAZE_SHOULD_SHOW_OVERLAY, false)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -60,7 +60,8 @@ class BlazeCardViewModelSlice @Inject constructor(
     }
 
     private fun onCampaignCardLearnMoreClick() {
-        // todo implement the navigation and tracking
+        // todo implement the tracking
+        onLearnMoreClick()
     }
 
     private fun onCampaignCardHideMenuItemClick() {
@@ -74,6 +75,17 @@ class BlazeCardViewModelSlice @Inject constructor(
 
     private fun onPromoteCardLearnMoreClick() {
         // todo implement the navigation and tracking
+        onLearnMoreClick()
+    }
+
+    private fun onLearnMoreClick() {
+        _onNavigation.value =
+            Event(
+                SiteNavigationAction.OpenPromoteWithBlazeOverlay(
+                    source = BlazeFlowSource.DASHBOARD_CARD,
+                    shouldShowBlazeOverlay = true
+                )
+            )
     }
 
     private fun onPromoteCardHideMenuItemClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSlice.kt
@@ -64,11 +64,12 @@ class BlazeCardViewModelSlice @Inject constructor(
     }
 
     private fun onCampaignCardHideMenuItemClick() {
-        // todo implement the hide logic and tracking
+        // todo implement the tracking
+        onHideCardClick()
     }
 
     private fun onCampaignCardMoreMenuClick() {
-        TODO("Not yet implemented")
+        // todo implement the tracking
     }
 
     private fun onPromoteCardLearnMoreClick() {
@@ -80,8 +81,12 @@ class BlazeCardViewModelSlice @Inject constructor(
             AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
             BlazeFlowSource.DASHBOARD_CARD
         )
+        onHideCardClick()
+    }
+
+    private fun onHideCardClick() {
         selectedSiteRepository.getSelectedSite()?.let {
-            blazeFeatureUtils.hidePromoteWithBlazeCard(it.siteId)
+            blazeFeatureUtils.hideBlazeCard(it.siteId)
         }
         _refresh.value = Event(true)
     }
@@ -92,7 +97,6 @@ class BlazeCardViewModelSlice @Inject constructor(
             BlazeFlowSource.DASHBOARD_CARD
         )
     }
-
 
     private fun onCreateCampaignClick() {
         blazeFeatureUtils.trackEntryPointTapped(BlazeFlowSource.DASHBOARD_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -86,16 +86,21 @@ sealed class SiteNavigationAction {
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()
-    data class OpenPromoteWithBlazeOverlay(val source: BlazeFlowSource) : SiteNavigationAction()
+    data class OpenPromoteWithBlazeOverlay(val source: BlazeFlowSource, val shouldShowBlazeOverlay: Boolean = false) :
+        SiteNavigationAction()
+
     object ShowJetpackRemovalStaticPostersView : SiteNavigationAction()
     data class OpenActivityLogDetail(val site: SiteModel, val activityId: String, val isRewindable: Boolean) :
         SiteNavigationAction()
-    data class TriggerCreatePageFlow(val site: SiteModel):SiteNavigationAction()
+
+    data class TriggerCreatePageFlow(val site: SiteModel) : SiteNavigationAction()
     data class OpenPagesDraftsTab(val site: SiteModel, val pageId: Int) : SiteNavigationAction()
     data class OpenPagesScheduledTab(val site: SiteModel, val pageId: Int) : SiteNavigationAction()
-    data class OpenCampaignListingPage(val campaignListingPageSource: CampaignListingPageSource)
-        : SiteNavigationAction()
-    data class OpenCampaignDetailPage(val campaignId: Int, val campaignDetailPageSource: CampaignDetailPageSource)
-        : SiteNavigationAction()
+    data class OpenCampaignListingPage(val campaignListingPageSource: CampaignListingPageSource) :
+        SiteNavigationAction()
+
+    data class OpenCampaignDetailPage(val campaignId: Int, val campaignDetailPageSource: CampaignDetailPageSource) :
+        SiteNavigationAction()
+
     data class OpenDomainTransferPage(val url: String) : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
@@ -218,15 +218,24 @@ private fun CardDropDownMenu(moreMenuOptions: BlazeCampaignsCardModel.MoreMenuOp
         ) {
             DropdownMenuItem(
                 text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_view_all_campaigns)) },
-                onClick = { moreMenuOptions.viewAllCampaignsItemClick.click() }
+                onClick = {
+                    isExpanded = false
+                    moreMenuOptions.viewAllCampaignsItemClick.click()
+                }
             )
             DropdownMenuItem(
                 text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_learn_more)) },
-                onClick = { moreMenuOptions.learnMoreClick.click() }
+                onClick = {
+                    isExpanded = false
+                    moreMenuOptions.learnMoreClick.click()
+                }
             )
             DropdownMenuItem(
                 text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_hide_this)) },
-                onClick = { moreMenuOptions.hideThisMenuItemClick.click() }
+                onClick = {
+                    isExpanded = false
+                    moreMenuOptions.hideThisMenuItemClick.click()
+                }
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -440,10 +440,10 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
         is SiteNavigationAction.OpenJetpackMigrationDeleteWP -> showJetpackMigrationDeleteWP()
         is SiteNavigationAction.OpenJetpackFeatureOverlay -> showJetpackFeatureOverlay(action.source)
-        is SiteNavigationAction.OpenPromoteWithBlazeOverlay -> ActivityLauncher.openPromoteWithBlaze(
+        is SiteNavigationAction.OpenPromoteWithBlazeOverlay -> activityNavigator.openPromoteWithBlaze(
             requireActivity(),
-            null,
-            action.source
+            action.source,
+            action.shouldShowBlazeOverlay
         )
         is SiteNavigationAction.ShowJetpackRemovalStaticPostersView -> {
             ActivityLauncher.showJetpackStaticPoster(requireActivity())

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -337,10 +337,10 @@ class AppPrefsWrapper @Inject constructor() {
     fun setShouldHideDashboardDomainTransferCard(siteId: Long, isHidden: Boolean) =
         AppPrefs.setShouldHideDashboardDomainTransferCard(siteId, isHidden)
 
-    fun getShouldHidePromoteWithBlazeCard(siteId: Long): Boolean =
+    fun hideBlazeCard(siteId: Long): Boolean =
         AppPrefs.getShouldHidePromoteWithBlazeCard(siteId)
 
-    fun setShouldHidePromoteWithBlazeCard(siteId: Long, isHidden: Boolean) =
+    fun setShouldHideBlazeCard(siteId: Long, isHidden: Boolean) =
         AppPrefs.setShouldHidePromoteWithBlazeCard(siteId, isHidden)
 
     fun getShouldHideDashboardDomainCard(siteId: Long): Boolean =

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
@@ -184,6 +184,61 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
             .containsOnly(SiteNavigationAction.OpenCampaignListingPage(CampaignListingPageSource.DASHBOARD_CARD))
     }
 
+    @Test
+    fun `given campaign card built, when learn more menu option clicked, then site navigation is triggered`() {
+        // Given
+        val blazeCardUpdate: MySiteUiState.PartialState.BlazeCardUpdate = mock()
+        whenever(blazeCardUpdate.blazeEligible).thenReturn(true)
+        whenever(blazeCardUpdate.campaign).thenReturn(mock())
+
+        // When
+        val result =
+            blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as CampaignWithBlazeCardBuilderParams
+        result.moreMenuParams.onLearnMoreClick()
+
+        // Then
+        assertThat(navigationActions)
+            .containsOnly(
+                SiteNavigationAction.OpenPromoteWithBlazeOverlay(
+                    source = BlazeFlowSource.DASHBOARD_CARD,
+                    shouldShowBlazeOverlay = true
+                )
+            )
+    }
+
+    @Test
+    fun `given campaign card built, when view all campaings menu option clicked, then site navigation is triggered`() {
+        // Given
+        val blazeCardUpdate: MySiteUiState.PartialState.BlazeCardUpdate = mock()
+        whenever(blazeCardUpdate.blazeEligible).thenReturn(true)
+        whenever(blazeCardUpdate.campaign).thenReturn(mock())
+
+        // When
+        val result =
+            blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as CampaignWithBlazeCardBuilderParams
+        result.moreMenuParams.viewAllCampaignsItemClick()
+
+        // Then
+        assertThat(navigationActions)
+            .containsOnly(SiteNavigationAction.OpenCampaignListingPage(CampaignListingPageSource.DASHBOARD_CARD))
+    }
+
+    @Test
+    fun `given campaign card built, when hide campaings menu option clicked, then site navigation is triggered`() {
+        // Given
+        val blazeCardUpdate: MySiteUiState.PartialState.BlazeCardUpdate = mock()
+        whenever(blazeCardUpdate.blazeEligible).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mock())
+        whenever(blazeCardUpdate.campaign).thenReturn(mock())
+
+        // When
+        val result =
+            blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as CampaignWithBlazeCardBuilderParams
+        result.moreMenuParams.onHideThisCardItemClick()
+
+        // Then
+        verify(blazeFeatureUtils).hideBlazeCard(any())
+    }
 
     @Test
     fun `given promote blaze card built, when card click invoked, then event is triggered`() {
@@ -240,6 +295,28 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
             AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_MENU_ACCESSED,
             BlazeFlowSource.DASHBOARD_CARD
         )
+    }
+
+    @Test
+    fun `given promote blaze card built, when learn more menu option clicked, then site navigation is triggered`() {
+        // Given
+        val blazeCardUpdate: MySiteUiState.PartialState.BlazeCardUpdate = mock()
+        whenever(blazeCardUpdate.blazeEligible).thenReturn(true)
+        whenever(blazeCardUpdate.campaign).thenReturn(null)
+
+        // When
+        val result =
+            blazeCardViewModelSlice.getBlazeCardBuilderParams(blazeCardUpdate) as PromoteWithBlazeCardBuilderParams
+        result.moreMenuParams.onLearnMoreClick()
+
+        // Then
+        assertThat(navigationActions)
+            .containsOnly(
+                SiteNavigationAction.OpenPromoteWithBlazeOverlay(
+                    source = BlazeFlowSource.DASHBOARD_CARD,
+                    shouldShowBlazeOverlay = true
+                )
+            )
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
@@ -219,7 +219,7 @@ class BlazeCardViewModelSliceTest : BaseUnitTest() {
             AnalyticsTracker.Stat.BLAZE_ENTRY_POINT_HIDE_TAPPED,
             BlazeFlowSource.DASHBOARD_CARD
         )
-        verify(blazeFeatureUtils).hidePromoteWithBlazeCard(any())
+        verify(blazeFeatureUtils).hideBlazeCard(any())
         assertThat(refreshActions).containsOnly(true)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
@@ -63,7 +63,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        val result = blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+        val result = blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
 
 
         Assertions.assertThat(result).isNotNull
@@ -77,7 +77,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePost::class.java)
     }
@@ -90,7 +90,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model)
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
@@ -103,7 +103,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model)
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePage::class.java)
     }
@@ -116,7 +116,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model)
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
@@ -125,7 +125,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is false, when started from dashboard card, then uiState is set to site`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
 
-        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null)
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
     }
@@ -134,7 +134,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is true, when started from dashboard card, then uiState is set to webview screen`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
 
-        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null)
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
@@ -143,7 +143,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is false, when started from no campaigns list, then uiState is set to site`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
 
-        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null)
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
     }
@@ -152,7 +152,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is true, when started from no campaigns list, then uiState is set to webview`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
 
-        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null)
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, getShouldShowOverlay())
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeViewModelTest.kt
@@ -63,7 +63,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        val result = blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
+        val result = blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, false)
 
 
         Assertions.assertThat(result).isNotNull
@@ -77,7 +77,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePost::class.java)
     }
@@ -90,7 +90,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PostUIModel(postId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.POSTS_LIST, model, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
@@ -103,7 +103,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.PromotePage::class.java)
     }
@@ -116,7 +116,7 @@ class BlazeViewModelTest : BaseUnitTest() {
         val model = PageUIModel(pageId = 1L, title = "title", featuredImageId = 1L,
             url = "url", featuredImageUrl = "featuredImageUrl"
         )
-        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.PAGES_LIST, model, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }
@@ -125,7 +125,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is false, when started from dashboard card, then uiState is set to site`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
 
-        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
     }
@@ -134,16 +134,25 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is true, when started from dashboard card, then uiState is set to webview screen`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
 
-        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
+    }
+
+    @Test
+    fun `given blaze overlay shown is true, when started from learn more, then uiState is set to site screen`() {
+        whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
+
+        blazeViewModel.start(BlazeFlowSource.DASHBOARD_CARD, null, true)
+
+        Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen::class.java)
     }
 
     @Test
     fun `given blaze overlay shown is false, when started from no campaigns list, then uiState is set to site`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(false)
 
-        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.PromoteScreen.Site::class.java)
     }
@@ -152,7 +161,7 @@ class BlazeViewModelTest : BaseUnitTest() {
     fun `given blaze overlay shown is true, when started from no campaigns list, then uiState is set to webview`() {
         whenever(blazeFeatureUtils.shouldHideBlazeOverlay()).thenReturn(true)
 
-        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, getShouldShowOverlay())
+        blazeViewModel.start(BlazeFlowSource.CAMPAIGN_LISTING_PAGE, null, false)
 
         Assertions.assertThat(uiStates.last()).isInstanceOf(BlazeUiState.WebViewScreen::class.java)
     }


### PR DESCRIPTION
Part of #18943 

## Description 
This PR implements more menu clicks 
1. Learn more click on promote with blaze card 
2. Learn more click on campaign blaze card 
3. Hide this card click on campaign card 
4. View all campaigns click on Campaign card

## To test:
### Promote with blaze card
1. Login to a site with blaze feature enabled and having no campaigns  
2. Click on promote with blaze card 
3. ✅ Verify that the blaze overlay is shown 
4. Click on **Learn more** option in more menu 
5. ✅ Verify that the blaze intro overlay is shown 

### Blaze campaign card - Blaze overlay is shown even when the overlay is shown before
1. Login to a site with blaze campaigns 
2. Click on Create Campaign 
3. ✅  Verify that the blaze intro overlay is shown 
4. Click on **Learn more** option in more menu 
5. ✅  Verify that the blaze intro overlay is shown  

### Blaze campaign card - View all campaigns
1. Login to a site with blaze campaigns  
2. Click on **View all campaings** option in more menu 
3. ✅  Verify that the campaigns listing page is shown

### Merge Instructions 
1. Make sure that https://github.com/wordpress-mobile/WordPress-Android/pull/19056 is merged
2. Remove not ready for merge label
3. Merge as normal 

## Regression Notes
1. Potential unintended areas of impact
More menu options click in the cards are incorrect

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and Unit tests

5. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)