### PR TITLE
Dashboard Personalization: Posts extract to view model slice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.posts
+
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+class PostsCardViewModelSlice @Inject constructor(
+    private val cardsTracker: CardsTracker,
+    private val selectedSiteRepository: SelectedSiteRepository
+) {
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation
+
+    fun getPostsCardBuilderParams(postsCardModel: PostsCardModel?) : PostCardBuilderParams {
+       return  PostCardBuilderParams(
+            posts = postsCardModel,
+            onPostItemClick = this::onPostItemClick,
+            onFooterLinkClick = this::onPostCardFooterLinkClick
+        )
+    }
+
+    private fun onPostItemClick(params: PostCardBuilderParams.PostItemClickParams) {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            cardsTracker.trackPostItemClicked(params.postCardType)
+            when (params.postCardType) {
+                PostCardType.DRAFT -> _onNavigation.value =
+                    Event(SiteNavigationAction.EditDraftPost(site, params.postId))
+
+                PostCardType.SCHEDULED -> _onNavigation.value =
+                    Event(SiteNavigationAction.EditScheduledPost(site, params.postId))
+            }
+        }
+    }
+
+    private fun onPostCardFooterLinkClick(postCardType: PostCardType) {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            cardsTracker.trackPostCardFooterLinkClicked(postCardType)
+            _onNavigation.value = when (postCardType) {
+                PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
+                PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
+            }
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -1,0 +1,132 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.posts
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class PostsCardViewModelSliceTest : BaseUnitTest() {
+    @Mock
+    lateinit var cardsTracker: CardsTracker
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    private lateinit var postsCardViewModelSlice: PostsCardViewModelSlice
+
+    private val site = mock<SiteModel>()
+
+    private lateinit var navigationActions: MutableList<SiteNavigationAction>
+
+    private val postId = 100
+
+    @Before
+    fun setUp() {
+        postsCardViewModelSlice = PostsCardViewModelSlice(
+            cardsTracker,
+            selectedSiteRepository
+        )
+
+        navigationActions = mutableListOf()
+        postsCardViewModelSlice.onNavigation.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                navigationActions.add(it)
+            }
+        }
+
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+    }
+
+    @Test
+    fun `given draft post card, when footer link is clicked, then draft posts screen is opened`() = test {
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.onFooterLinkClick(PostCardType.DRAFT)
+
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
+        verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
+    }
+
+    @Test
+    fun `given scheduled post card, when footer link is clicked, then scheduled posts screen is opened`() =
+        test {
+            val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+            params.onFooterLinkClick(PostCardType.SCHEDULED)
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenScheduledPosts(site))
+            verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
+        }
+
+    @Test
+    fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
+        test {
+            val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+            params.onPostItemClick(
+                MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams(
+                    PostCardType.DRAFT,
+                    postId
+                )
+            )
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.EditDraftPost(site, postId))
+        }
+
+    @Test
+    fun `given scheduled post card, when post item is clicked, then post is opened for edit scheduled`() =
+        test {
+            val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+            params.onPostItemClick(
+                MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams(
+                    PostCardType.SCHEDULED,
+                    postId
+                )
+            )
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
+        }
+
+    @Test
+    fun `given scheduled post card, when item is clicked, then event is tracked`() = test {
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.onPostItemClick(
+            MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams(
+                PostCardType.SCHEDULED,
+                postId
+            )
+        )
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.SCHEDULED)
+    }
+
+    @Test
+    fun `given draft post card, when item is clicked, then event is tracked`() = test {
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.onPostItemClick(
+            MySiteCardAndItemBuilderParams.PostCardBuilderParams.PostItemClickParams(
+                PostCardType.DRAFT,
+                postId
+            )
+        )
+
+        verify(cardsTracker).trackPostItemClicked(PostCardType.DRAFT)
+    }
+}


### PR DESCRIPTION
Part of #18945 and #18946 

This PR splits the posts cards logic from `MySiteViewModel`

- Created `PostsCardViewModelSlice`
- Moved posts logic from `MySiteViewModel` to `PostsCardViewModelSlice`
- Refactor `MySiteViewModelTest` by moving posts tests to `PostsCardViewModelSliceTest`

**To test:**
- Install the app
- Login to the app
- Select a site in which you have created posts (drafts and scheduled)
- Navigate to the My Site tab
- ✅ Verify the drafts posts card is shown in the dashboard
- ✅ Verify the scheduled posts card is shown in the dashboard

## Regression Notes
1. Potential unintended areas of impact
The drafts and scheduled post cards are not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and uni testing

3. What automated tests I added (or what prevented me from doing so)
PostsCardViewModelSliceTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
