### PR TITLE
[Tech Debt] Remove GET_ACCOUNTS permission

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
 
     <!-- Dangerous permissions, access must be requested at runtime -->
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Required for storing and retrieving screenshots, taking photos, accessing media files -->

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.7.0'
+    wordPressUtilsVersion = '132-d05d096886354a8a9d687d345701db65178262f0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '132-d05d096886354a8a9d687d345701db65178262f0'
+    wordPressUtilsVersion = '3.8.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug


### PR DESCRIPTION
Internal reference: p8Qyks-6RS-p2#comment-2782
WordPress-Utils PR: https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/132

Recently the app faced some rejections in Google Play pointing to "Contacts" information being used by the app. We don't use Contacts information anywhere but it seems we have this unused `GET_ACCOUNTS` permission in our manifest that seems to count as a Contacts permission.

Even though we don't use nor ask for it in runtime, the fact that it's declared may be the cause why Google believes we use Contact data, as this permission makes a "Contacts permissions" appear in the App Info permission list.

### Important
**Before merging we need to point to a release version of the WordPress-Utils library.**

### Before the change:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/031432f4-a26d-470c-af19-22a548e42f45

### After the change:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/bcd2cff4-4787-417c-878e-34509b0f9017

## To test
As shown above, a good test would be:
1. Install a previous version of the app
2. **Verify** it shows a "Contacts permission" in the App Info
3. Install this version of the app from this PR
4. **Verify** the permission is gone

Also, even though the removed permission and classes in WordPress-Utils were unused, it might be good to run some smoke/sanity tests in main app features and flows to make sure nothing stopped working.

## Regression Notes
1. Potential unintended areas of impact
See testing section above.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A