### PR TITLE
Dashboard Personalization: Add more menu to drafts and scheduled posts dashboard cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -252,7 +252,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val postCardType: PostCardType,
                         val title: UiString,
                         val postItems: List<PostItem>,
-                        override val footerLink: FooterLink
+                        override val footerLink: FooterLink,
+                        val moreMenuOptions: MoreMenuOptions
                     ) : PostCard(
                         dashboardCardType = DashboardCardType.POST_CARD_WITH_POST_ITEMS,
                         footerLink = footerLink
@@ -269,6 +270,11 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                     data class FooterLink(
                         val label: UiString,
                         val onClick: (postCardType: PostCardType) -> Unit
+                    )
+                    data class MoreMenuOptions(
+                        val onMoreClick: (postCardType: PostCardType) -> Unit,
+                        val allPostsMenuItemClick: (postCardType: PostCardType) -> Unit,
+                        val hideThisMenuItemClick: (postCardType: PostCardType) -> Unit
                     )
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -242,8 +242,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                 }
 
                 sealed class PostCard(
-                    override val dashboardCardType: DashboardCardType,
-                    open val footerLink: FooterLink? = null
+                    override val dashboardCardType: DashboardCardType
                 ) : DashboardCard(dashboardCardType) {
                     data class Error(
                         override val title: UiString
@@ -253,12 +252,10 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val postCardType: PostCardType,
                         val title: UiString,
                         val postItems: List<PostItem>,
-                        override val footerLink: FooterLink,
                         @MenuRes val moreMenuResId: Int,
                         val moreMenuOptions: MoreMenuOptions
                     ) : PostCard(
-                        dashboardCardType = DashboardCardType.POST_CARD_WITH_POST_ITEMS,
-                        footerLink = footerLink
+                        dashboardCardType = DashboardCardType.POST_CARD_WITH_POST_ITEMS
                     ) {
                         data class PostItem(
                             val title: UiString,
@@ -273,11 +270,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                             val onHideThisMenuItemClick: (postCardType: PostCardType) -> Unit
                         )
                     }
-
-                    data class FooterLink(
-                        val label: UiString,
-                        val onClick: (postCardType: PostCardType) -> Unit
-                    )
                 }
 
                 sealed class ActivityCard(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite
 
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import androidx.annotation.MenuRes
 import androidx.annotation.StringRes
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.avatars.TrainOfAvatarsItem
@@ -253,6 +254,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val title: UiString,
                         val postItems: List<PostItem>,
                         override val footerLink: FooterLink,
+                        @MenuRes val moreMenuResId: Int,
                         val moreMenuOptions: MoreMenuOptions
                     ) : PostCard(
                         dashboardCardType = DashboardCardType.POST_CARD_WITH_POST_ITEMS,
@@ -265,16 +267,16 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                             val isTimeIconVisible: Boolean = false,
                             val onClick: ListItemInteraction
                         )
+                        data class MoreMenuOptions(
+                            val onMoreMenuClick: (postCardType: PostCardType) -> Unit,
+                            val onViewPostsMenuItemClick: (postCardType: PostCardType) -> Unit,
+                            val onHideThisMenuItemClick: (postCardType: PostCardType) -> Unit
+                        )
                     }
 
                     data class FooterLink(
                         val label: UiString,
                         val onClick: (postCardType: PostCardType) -> Unit
-                    )
-                    data class MoreMenuOptions(
-                        val onMoreClick: (postCardType: PostCardType) -> Unit,
-                        val allPostsMenuItemClick: (postCardType: PostCardType) -> Unit,
-                        val hideThisMenuItemClick: (postCardType: PostCardType) -> Unit
                     )
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -90,7 +90,6 @@ sealed class MySiteCardAndItemBuilderParams {
     data class PostCardBuilderParams(
         val posts: PostsCardModel?,
         val onPostItemClick: (params: PostItemClickParams) -> Unit,
-        val onFooterLinkClick: (postCardType: PostCardType) -> Unit,
         val moreMenuClickParams : MoreMenuParams
     ) : MySiteCardAndItemBuilderParams() {
         data class PostItemClickParams(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -90,11 +90,17 @@ sealed class MySiteCardAndItemBuilderParams {
     data class PostCardBuilderParams(
         val posts: PostsCardModel?,
         val onPostItemClick: (params: PostItemClickParams) -> Unit,
-        val onFooterLinkClick: (postCardType: PostCardType) -> Unit
+        val onFooterLinkClick: (postCardType: PostCardType) -> Unit,
+        val moreMenuClickParams : MoreMenuParams
     ) : MySiteCardAndItemBuilderParams() {
         data class PostItemClickParams(
             val postCardType: PostCardType,
             val postId: Int
+        )
+        data class MoreMenuParams(
+            val onMoreMenuClick: (postCardType: PostCardType) -> Unit,
+            val onHideThisMenuItemClick: (postCardType: PostCardType) -> Unit,
+            val onViewPostsMenuItemClick: (postCardType: PostCardType) -> Unit
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardError
 import org.wordpress.android.fluxc.store.dashboard.CardsStore.PostCardErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems.PostItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
@@ -54,10 +53,6 @@ class PostCardBuilder @Inject constructor(
             postCardType = PostCardType.DRAFT,
             title = UiStringRes(R.string.my_site_post_card_draft_title),
             postItems = mapToDraftPostItems(params.onPostItemClick),
-            footerLink = FooterLink(
-                label = UiStringRes(R.string.my_site_post_card_link_go_to_drafts),
-                onClick = params.onFooterLinkClick
-            ),
             moreMenuResId = R.menu.dashboard_card_draft_posts_menu,
             moreMenuOptions = PostCardWithPostItems.MoreMenuOptions(
                 onMoreMenuClick = params.moreMenuClickParams.onMoreMenuClick,
@@ -71,10 +66,6 @@ class PostCardBuilder @Inject constructor(
             postCardType = PostCardType.SCHEDULED,
             title = UiStringRes(R.string.my_site_post_card_scheduled_title),
             postItems = mapToScheduledPostItems(params.onPostItemClick),
-            footerLink = FooterLink(
-                label = UiStringRes(R.string.my_site_post_card_link_go_to_scheduled_posts),
-                onClick = params.onFooterLinkClick
-            ),
             moreMenuResId = R.menu.dashboard_card_scheduled_posts_menu,
             moreMenuOptions = PostCardWithPostItems.MoreMenuOptions(
                 onMoreMenuClick = params.moreMenuClickParams.onMoreMenuClick,
@@ -125,6 +116,5 @@ class PostCardBuilder @Inject constructor(
 
     companion object {
         private const val MONTH_DAY_FORMAT = "MMM d"
-        const val NOT_SET = -1
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -57,6 +57,12 @@ class PostCardBuilder @Inject constructor(
             footerLink = FooterLink(
                 label = UiStringRes(R.string.my_site_post_card_link_go_to_drafts),
                 onClick = params.onFooterLinkClick
+            ),
+            moreMenuResId = R.menu.dashboard_card_draft_posts_menu,
+            moreMenuOptions = PostCardWithPostItems.MoreMenuOptions(
+                onMoreMenuClick = params.moreMenuClickParams.onMoreMenuClick,
+                onHideThisMenuItemClick = params.moreMenuClickParams.onHideThisMenuItemClick,
+                onViewPostsMenuItemClick = params.moreMenuClickParams.onViewPostsMenuItemClick
             )
         )
 
@@ -68,6 +74,12 @@ class PostCardBuilder @Inject constructor(
             footerLink = FooterLink(
                 label = UiStringRes(R.string.my_site_post_card_link_go_to_scheduled_posts),
                 onClick = params.onFooterLinkClick
+            ),
+            moreMenuResId = R.menu.dashboard_card_scheduled_posts_menu,
+            moreMenuOptions = PostCardWithPostItems.MoreMenuOptions(
+                onMoreMenuClick = params.moreMenuClickParams.onMoreMenuClick,
+                onHideThisMenuItemClick = params.moreMenuClickParams.onHideThisMenuItemClick,
+                onViewPostsMenuItemClick = params.moreMenuClickParams.onViewPostsMenuItemClick
             )
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
@@ -34,10 +34,6 @@ sealed class PostCardViewHolder<T : ViewBinding>(
             val postCard = card as PostCardWithPostItems
             mySiteToolbar.update(postCard)
             (postItems.adapter as PostItemsAdapter).update(postCard.postItems)
-            uiHelpers.setTextOrHide(mySiteCardFooterLink.linkLabel, postCard.footerLink.label)
-            mySiteCardFooterLink.linkLabel.setOnClickListener {
-                postCard.footerLink.onClick.invoke(card.postCardType)
-            }
         }
 
         private fun MySiteCardToolbarBinding.update(card: PostCardWithPostItems) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardViewHolder.kt
@@ -1,14 +1,16 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
+import android.view.View
 import android.view.ViewGroup
+import android.widget.PopupMenu
 import androidx.viewbinding.ViewBinding
+import org.wordpress.android.R
 import org.wordpress.android.databinding.MySiteCardToolbarBinding
 import org.wordpress.android.databinding.MySitePostCardWithPostItemsBinding
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.cards.dashboard.CardViewHolder
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
 
@@ -30,7 +32,7 @@ sealed class PostCardViewHolder<T : ViewBinding>(
 
         override fun bind(card: PostCard) = with(binding) {
             val postCard = card as PostCardWithPostItems
-            mySiteToolbar.update(postCard.title)
+            mySiteToolbar.update(postCard)
             (postItems.adapter as PostItemsAdapter).update(postCard.postItems)
             uiHelpers.setTextOrHide(mySiteCardFooterLink.linkLabel, postCard.footerLink.label)
             mySiteCardFooterLink.linkLabel.setOnClickListener {
@@ -38,8 +40,35 @@ sealed class PostCardViewHolder<T : ViewBinding>(
             }
         }
 
-        private fun MySiteCardToolbarBinding.update(title: UiString?) {
-            uiHelpers.setTextOrHide(mySiteCardToolbarTitle, title)
+        private fun MySiteCardToolbarBinding.update(card: PostCardWithPostItems) {
+            uiHelpers.setTextOrHide(mySiteCardToolbarTitle, card.title)
+            mySiteCardToolbarMore.visibility = View.VISIBLE
+            mySiteCardToolbarMore.setOnClickListener {
+                showMoreMenu(card)
+            }
+        }
+
+        private fun MySiteCardToolbarBinding.showMoreMenu(card: PostCardWithPostItems) {
+            card.moreMenuOptions.onMoreMenuClick.invoke(card.postCardType)
+            val popupMenu = PopupMenu(itemView.context, mySiteCardToolbarMore)
+            popupMenu.setOnMenuItemClickListener {
+                when (it.itemId) {
+                    R.id.post_card_menu_item_view_all -> {
+                        card.moreMenuOptions.onViewPostsMenuItemClick.invoke(card.postCardType)
+                        return@setOnMenuItemClickListener true
+                    }
+
+                    R.id.post_card_menu_item_hide_this -> {
+                        card.moreMenuOptions.onHideThisMenuItemClick.invoke(card.postCardType)
+                        return@setOnMenuItemClickListener true
+                    }
+
+                    else -> return@setOnMenuItemClickListener true
+                }
+            }
+
+            popupMenu.inflate(card.moreMenuResId)
+            popupMenu.show()
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
@@ -20,8 +21,30 @@ class PostsCardViewModelSlice @Inject constructor(
        return  PostCardBuilderParams(
             posts = postsCardModel,
             onPostItemClick = this::onPostItemClick,
-            onFooterLinkClick = this::onPostCardFooterLinkClick
+            onFooterLinkClick = this::onPostCardFooterLinkClick,
+            moreMenuClickParams = PostCardBuilderParams.MoreMenuParams(
+               onMoreMenuClick = this::onMoreMenuClick,
+               onHideThisMenuItemClick = this::onHideThisMenuItemClick,
+               onViewPostsMenuItemClick = this::onViewPostsMenuItemClick
+           )
         )
+    }
+
+    private fun onMoreMenuClick(postCardType: PostCardType) {
+        // todo: annmarie implement cards tracker
+        Log.i(javaClass.simpleName, "***=> onMoreMenuClick $postCardType")
+    }
+
+    private fun onHideThisMenuItemClick(postCardType: PostCardType) {
+        // todo: annmarie implement logic
+        // todo: annmarie implement cards tracker
+        Log.i(javaClass.simpleName, "***=> onHideThisMenuItemClick $postCardType")
+    }
+
+    private fun onViewPostsMenuItemClick(postCardType: PostCardType) {
+        // todo: annmarie implement logic
+        // todo: annmarie implement cards tracker
+        Log.i(javaClass.simpleName, "***=> onViewPostsMenuItemClick $postCardType")
     }
 
     private fun onPostItemClick(params: PostCardBuilderParams.PostItemClickParams) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -21,7 +21,6 @@ class PostsCardViewModelSlice @Inject constructor(
        return  PostCardBuilderParams(
             posts = postsCardModel,
             onPostItemClick = this::onPostItemClick,
-            onFooterLinkClick = this::onPostCardFooterLinkClick,
             moreMenuClickParams = PostCardBuilderParams.MoreMenuParams(
                onMoreMenuClick = this::onMoreMenuClick,
                onHideThisMenuItemClick = this::onHideThisMenuItemClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -59,13 +59,14 @@ class PostsCardViewModelSlice @Inject constructor(
         }
     }
 
-    private fun onPostCardFooterLinkClick(postCardType: PostCardType) {
-        selectedSiteRepository.getSelectedSite()?.let { site ->
-            cardsTracker.trackPostCardFooterLinkClicked(postCardType)
-            _onNavigation.value = when (postCardType) {
-                PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
-                PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
-            }
-        }
-    }
+    // todo: annmarie - repurpose for menu item click
+//    private fun onPostCardFooterLinkClick(postCardType: PostCardType) {
+//        selectedSiteRepository.getSelectedSite()?.let { site ->
+//            cardsTracker.trackPostCardFooterLinkClicked(postCardType)
+//            _onNavigation.value = when (postCardType) {
+//                PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
+//                PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
+//            }
+//        }
+//    }
 }

--- a/WordPress/src/main/res/layout/my_site_post_card_with_post_items.xml
+++ b/WordPress/src/main/res/layout/my_site_post_card_with_post_items.xml
@@ -28,15 +28,5 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/my_site_toolbar" />
 
-        <include
-            android:id="@+id/my_site_card_footer_link"
-            layout="@layout/my_site_card_footer_link"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_small"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/post_items" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/menu/dashboard_card_draft_posts_menu.xml
+++ b/WordPress/src/main/res/menu/dashboard_card_draft_posts_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/post_card_menu_item_view_all"
+        android:title="@string/my_site_post_card_menu_view_all_drafts"
+        android:icon="@drawable/ic_posts_white_24dp"/>
+
+    <item
+        android:id="@+id/post_card_menu_item_hide_this"
+        android:title="@string/my_site_post_card_menu_hide_this"
+        android:icon="@drawable/ic_not_visible_white_24dp"/>
+</menu>

--- a/WordPress/src/main/res/menu/dashboard_card_scheduled_posts_menu.xml
+++ b/WordPress/src/main/res/menu/dashboard_card_scheduled_posts_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/post_card_menu_item_view_all"
+        android:title="@string/my_site_post_card_menu_view_all_scheduled_posts"
+        android:icon="@drawable/ic_posts_white_24dp"/>
+
+    <item
+        android:id="@+id/post_card_menu_item_hide_this"
+        android:title="@string/my_site_post_card_menu_hide_this"
+        android:icon="@drawable/ic_not_visible_white_24dp"/>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2376,6 +2376,9 @@
     <string name="my_site_post_card_link_create_post">Create a post</string>
     <string name="my_site_post_card_link_go_to_drafts">Go to drafts</string>
     <string name="my_site_post_card_link_go_to_scheduled_posts">Go to scheduled posts</string>
+    <string name="my_site_post_card_menu_hide_this" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
+    <string name="my_site_post_card_menu_view_all_drafts">View all drafts</string>
+    <string name="my_site_post_card_menu_view_all_scheduled_posts">View all scheduled posts</string>
 
     <!-- My Site - Error Card -->
     <string name="my_site_error_card_title">Some data hasn\'t loaded</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2374,8 +2374,6 @@
     <string name="my_site_create_next_post_title">Create your next post</string>
     <string name="my_site_create_next_post_excerpt">Posting regularly helps build your audience!</string>
     <string name="my_site_post_card_link_create_post">Create a post</string>
-    <string name="my_site_post_card_link_go_to_drafts">Go to drafts</string>
-    <string name="my_site_post_card_link_go_to_scheduled_posts">Go to scheduled posts</string>
     <string name="my_site_post_card_menu_hide_this" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
     <string name="my_site_post_card_menu_view_all_drafts">View all drafts</string>
     <string name="my_site_post_card_menu_view_all_scheduled_posts">View all scheduled posts</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -201,7 +201,7 @@ class CardsBuilderTest {
             dashboardCardsBuilderParams = DashboardCardsBuilderParams(
                 onErrorRetryClick = mock(),
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
-                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
+                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(),
                     false,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -201,7 +201,7 @@ class CardsBuilderTest {
             dashboardCardsBuilderParams = DashboardCardsBuilderParams(
                 onErrorRetryClick = mock(),
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
-                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock(), mock()),
+                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(),
                     false,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.Das
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.DashboardDomainCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.DashboardPlansCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PagesCard.PagesCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.BlazeCard.PromoteWithBlazeCard
@@ -296,7 +295,6 @@ class CardsBuilderTest : BaseUnitTest() {
             postCardType = DRAFT,
             title = UiStringText(""),
             postItems = emptyList(),
-            footerLink = FooterLink(UiStringText(""), onClick = mock()),
             moreMenuResId = 0,
             moreMenuOptions = mock()
         )
@@ -331,7 +329,7 @@ class CardsBuilderTest : BaseUnitTest() {
                 showErrorCard = showErrorCard,
                 onErrorRetryClick = { },
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
-                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock(), mock()),
+                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(), false, false, false, mock(), mock(), mock(), mock(), mock(), mock()
                 ),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -296,7 +296,9 @@ class CardsBuilderTest : BaseUnitTest() {
             postCardType = DRAFT,
             title = UiStringText(""),
             postItems = emptyList(),
-            footerLink = FooterLink(UiStringText(""), onClick = mock())
+            footerLink = FooterLink(UiStringText(""), onClick = mock()),
+            moreMenuResId = 0,
+            moreMenuOptions = mock()
         )
     )
 
@@ -329,7 +331,7 @@ class CardsBuilderTest : BaseUnitTest() {
                 showErrorCard = showErrorCard,
                 onErrorRetryClick = { },
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
-                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
+                postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock(), mock()),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(), false, false, false, mock(), mock(), mock(), mock(), mock(), mock()
                 ),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ActivityCard.ActivityCardWithItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.ErrorCard
-import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.FooterLink
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
@@ -98,7 +97,6 @@ class CardsShownTrackerTest {
             postCardType = postCardType,
             title = UiStringText(""),
             postItems = emptyList(),
-            footerLink = FooterLink(UiStringText(""), onClick = mock()),
             moreMenuResId = 0,
             moreMenuOptions = mock()
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTrackerTest.kt
@@ -98,7 +98,9 @@ class CardsShownTrackerTest {
             postCardType = postCardType,
             title = UiStringText(""),
             postItems = emptyList(),
-            footerLink = FooterLink(UiStringText(""), onClick = mock())
+            footerLink = FooterLink(UiStringText(""), onClick = mock()),
+            moreMenuResId = 0,
+            moreMenuOptions = mock()
         )
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -49,7 +49,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         date = POST_DATE
     )
 
-    private val onPostCardFooterLinkClick: (PostCardType) -> Unit = { }
     private val onPostItemClick: (params: PostItemClickParams) -> Unit = { }
     private val onMoreMenuClick: (PostCardType) -> Unit = { }
     private val onHideThisMenuItemClick: (PostCardType) -> Unit = { }
@@ -105,16 +104,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         assertThat(postsCard.filterDraftPostCard()).isNull()
     }
 
-    @Test
-    fun `given draft post, when card is built, then it contains go to drafts link`() {
-        val posts = getPosts(draftPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts).filterDraftPostCard()
-
-        assertThat(postsCard?.footerLink?.label)
-            .isEqualTo(UiStringRes(R.string.my_site_post_card_link_go_to_drafts))
-    }
-
     /* SCHEDULED POST CARD */
 
     @Test
@@ -133,16 +122,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         val postsCard = buildPostsCard(posts)
 
         assertThat(postsCard.filterScheduledPostCard()).isNull()
-    }
-
-    @Test
-    fun `given scheduled post, when card is built, then it contains go to scheduled posts link`() {
-        val posts = getPosts(scheduledPosts = listOf(post))
-
-        val postsCard = buildPostsCard(posts).filterScheduledPostCard()
-
-        assertThat(postsCard?.footerLink?.label)
-            .isEqualTo(UiStringRes(R.string.my_site_post_card_link_go_to_scheduled_posts))
     }
 
     /* DRAFT OR SCHEDULED POST ITEM - TITLE */
@@ -255,7 +234,6 @@ class PostCardBuilderTest : BaseUnitTest() {
         PostCardBuilderParams(
             posts = posts,
             onPostItemClick = onPostItemClick,
-            onFooterLinkClick = onPostCardFooterLinkClick,
             moreMenuClickParams = PostCardBuilderParams.MoreMenuParams(
                 onMoreMenuClick = onMoreMenuClick,
                 onHideThisMenuItemClick = onHideThisMenuItemClick,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilderTest.kt
@@ -51,6 +51,9 @@ class PostCardBuilderTest : BaseUnitTest() {
 
     private val onPostCardFooterLinkClick: (PostCardType) -> Unit = { }
     private val onPostItemClick: (params: PostItemClickParams) -> Unit = { }
+    private val onMoreMenuClick: (PostCardType) -> Unit = { }
+    private val onHideThisMenuItemClick: (PostCardType) -> Unit = { }
+    private val onViewPostsMenuItemClick: (PostCardType) -> Unit = { }
 
     @Before
     fun setUp() {
@@ -247,11 +250,16 @@ class PostCardBuilderTest : BaseUnitTest() {
             } as? List<PostCardWithPostItems>
             )?.firstOrNull { it.postCardType == PostCardType.SCHEDULED }
 
+
     private fun buildPostsCard(posts: PostsCardModel) = builder.build(
         PostCardBuilderParams(
             posts = posts,
             onPostItemClick = onPostItemClick,
-            onFooterLinkClick = onPostCardFooterLinkClick
+            onFooterLinkClick = onPostCardFooterLinkClick,
+            moreMenuClickParams = PostCardBuilderParams.MoreMenuParams(
+                onMoreMenuClick = onMoreMenuClick,
+                onHideThisMenuItemClick = onHideThisMenuItemClick,
+                onViewPostsMenuItemClick = onViewPostsMenuItemClick)
         )
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -52,27 +52,6 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given draft post card, when footer link is clicked, then draft posts screen is opened`() = test {
-        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
-
-        params.onFooterLinkClick(PostCardType.DRAFT)
-
-        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
-        verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
-    }
-
-    @Test
-    fun `given scheduled post card, when footer link is clicked, then scheduled posts screen is opened`() =
-        test {
-            val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
-
-            params.onFooterLinkClick(PostCardType.SCHEDULED)
-
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenScheduledPosts(site))
-            verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
-        }
-
-    @Test
     fun `given draft post card, when post item is clicked, then post is opened for edit draft`() =
         test {
             val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())


### PR DESCRIPTION
Part of #18945 and #18946

This PR includes
- Adds the more menu to the drafts and scheduled posts dashboard card
- Removes the footer link from the drafts and scheduled posts dashboard cards
- Updates unit tests

**Not included**: tracking, go-to and hide this logic

Drafts | Scheduled | No Footers
--|--|--
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/018c85ae-1ded-4bb9-88b4-707c5c7689ad"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/526e38bc-954f-45cb-80a8-5dbc5fb52d85">  | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/6afe09b4-c8e4-4a94-9629-71a3d0318660">

**Merge Instructions**
- Ensure #19075 has been merged
- Ensure the parent branch is set to `feature/dashboard-personalization`
- Remove the Not Ready for Merge label
- Merge as normal

**To test:**
- Install the app
- Login to the app
- Select a site in which you have created posts (drafts and scheduled)
- Navigate to the My Site tab
- ✅ Verify the drafts posts card is shown in the dashboard
- Tap the More Menu
- ✅ Verify the drafts posts card more menu is shown
- ✅ Verify the scheduled posts card is shown in the dashboard
- Tap the More Menu
- ✅ Verify the scheduled posts card more menu is shown

## Regression Notes
1. Potential unintended areas of impact
The drafts/scheduled dashboard cards do not show the more menu

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
See all test classes in this PR

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
