### PR TITLE
Dashboard Personalization: Post Card more menu click implementation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -313,7 +313,12 @@ class MySiteViewModel @Inject constructor(
     val onTrackWithTabSource = _onTrackWithTabSource as LiveData<Event<MySiteTrackWithTabSource>>
     val selectTab: LiveData<Event<TabNavigation>> = _selectTab
     val refresh =
-        merge(blazeCardViewModelSlice.refresh, pagesCardViewModelSlice.refresh, todaysStatsViewModelSlice.refresh)
+        merge(
+            blazeCardViewModelSlice.refresh,
+            pagesCardViewModelSlice.refresh,
+            todaysStatsViewModelSlice.refresh,
+            postsCardViewModelSlice.refresh
+        )
     val domainTransferCardRefresh = domainTransferCardViewModel.refresh
 
     private var shouldMarkUpdateSiteTitleTaskComplete = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostCardBuilder.kt
@@ -45,13 +45,16 @@ class PostCardBuilder @Inject constructor(
         mutableListOf<PostCard>().apply {
             val posts = params.posts
             posts?.draft?.takeIf {
-                it.isNotEmpty() && shouldShowCard(PostCardType.DRAFT)}?.let { add(it.createDraftPostsCard(params)) }
+                it.isNotEmpty() && shouldShowCard(PostCardType.DRAFT)
+            }?.let { add(it.createDraftPostsCard(params)) }
             posts?.scheduled?.takeIf {
-                it.isNotEmpty() && shouldShowCard(PostCardType.SCHEDULED)}?.let { add(it.createScheduledPostsCard(params)) }
+                it.isNotEmpty() && shouldShowCard(PostCardType.SCHEDULED)
+            }?.let { add(it.createScheduledPostsCard(params)) }
         }.toList()
 
     private fun shouldShowCard(postCardType: PostCardType) =
-        appPrefsWrapper.getShouldHidePostDashboardCard(siteRepository.getSelectedSite()!!.siteId, postCardType.name).not()
+        appPrefsWrapper.getShouldHidePostDashboardCard(siteRepository.getSelectedSite()!!.siteId, postCardType.name)
+            .not()
     private fun createPostErrorCard() = PostCard.Error(
         title = UiStringRes(R.string.posts)
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -7,15 +7,20 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBu
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class PostsCardViewModelSlice @Inject constructor(
     private val cardsTracker: CardsTracker,
-    private val selectedSiteRepository: SelectedSiteRepository
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation
+
+    private val _refresh = MutableLiveData<Event<Boolean>>()
+    val refresh = _refresh
 
     fun getPostsCardBuilderParams(postsCardModel: PostsCardModel?) : PostCardBuilderParams {
        return  PostCardBuilderParams(
@@ -35,9 +40,13 @@ class PostsCardViewModelSlice @Inject constructor(
     }
 
     private fun onHideThisMenuItemClick(postCardType: PostCardType) {
-        // todo: annmarie implement logic
         // todo: annmarie implement cards tracker
-        Log.i(javaClass.simpleName, "***=> onHideThisMenuItemClick $postCardType")
+        appPrefsWrapper.setShouldHidePostDashboardCard(
+            selectedSiteRepository.getSelectedSite()!!.siteId,
+            postCardType.name,
+            true
+        )
+        refresh.postValue(Event(true))
     }
 
     private fun onViewPostsMenuItemClick(postCardType: PostCardType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -41,9 +41,8 @@ class PostsCardViewModelSlice @Inject constructor(
     }
 
     private fun onViewPostsMenuItemClick(postCardType: PostCardType) {
-        // todo: annmarie implement logic
+        onPostCardViewAllClick(postCardType)
         // todo: annmarie implement cards tracker
-        Log.i(javaClass.simpleName, "***=> onViewPostsMenuItemClick $postCardType")
     }
 
     private fun onPostItemClick(params: PostCardBuilderParams.PostItemClickParams) {
@@ -59,14 +58,13 @@ class PostsCardViewModelSlice @Inject constructor(
         }
     }
 
-    // todo: annmarie - repurpose for menu item click
-//    private fun onPostCardFooterLinkClick(postCardType: PostCardType) {
-//        selectedSiteRepository.getSelectedSite()?.let { site ->
-//            cardsTracker.trackPostCardFooterLinkClicked(postCardType)
-//            _onNavigation.value = when (postCardType) {
-//                PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
-//                PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
-//            }
-//        }
-//    }
+    private fun onPostCardViewAllClick(postCardType: PostCardType) {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+           // todo: annmarie implement tracking cardsTracker.trackPostCardFooterLinkClicked(postCardType)
+            _onNavigation.value = when (postCardType) {
+                PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
+                PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
+            }
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -201,7 +201,8 @@ public class AppPrefs {
         SHOULD_SHOW_JETPACK_SOCIAL_NO_CONNECTIONS,
         SHOULD_HIDE_ACTIVITY_DASHBOARD_CARD,
         SHOULD_HIDE_PAGES_DASHBOARD_CARD,
-        SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD
+        SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD,
+        SHOULD_HIDE_POST_DASHBOARD_CARD
     }
 
     /**
@@ -1755,5 +1756,18 @@ public class AppPrefs {
 
     public static Boolean getShouldHideTodaysStatsDashboardCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHideTodaysStatsDashboardCardKey(siteId), false);
+    }
+
+    public static void setShouldHidePostDashboardCard(final long siteId, final String postType,
+                                                      final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHidePostDashboardCardKey(siteId, postType), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHidePostDashboardCardKey(long siteId, final String postType) {
+        return DeletablePrefKey.SHOULD_HIDE_POST_DASHBOARD_CARD.name() + postType + siteId;
+    }
+
+    public static Boolean getShouldHidePostDashboardCard(final long siteId, final String postType) {
+        return prefs().getBoolean(getSiteIdHidePostDashboardCardKey(siteId, postType), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -394,6 +394,15 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideTodaysStatsDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideTodaysStatsDashboardCard(siteId)
 
+    fun setShouldHidePostDashboardCard(
+        siteId: Long,
+        postCardType: String,
+        isHidden: Boolean
+    ) = AppPrefs.setShouldHidePostDashboardCard(siteId, postCardType, isHidden)
+
+    fun getShouldHidePostDashboardCard(siteId: Long, postCardType: String,): Boolean =
+        AppPrefs.getShouldHidePostDashboardCard(siteId, postCardType)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -26,11 +27,16 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var selectedSiteRepository: SelectedSiteRepository
 
+    @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     private lateinit var postsCardViewModelSlice: PostsCardViewModelSlice
 
     private val site = mock<SiteModel>()
 
     private lateinit var navigationActions: MutableList<SiteNavigationAction>
+
+    private lateinit var refreshEvents: MutableList<Boolean>
 
     private val postId = 100
 
@@ -38,7 +44,8 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
     fun setUp() {
         postsCardViewModelSlice = PostsCardViewModelSlice(
             cardsTracker,
-            selectedSiteRepository
+            selectedSiteRepository,
+            appPrefsWrapper
         )
 
         navigationActions = mutableListOf()
@@ -48,6 +55,12 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             }
         }
 
+        refreshEvents = mutableListOf()
+        postsCardViewModelSlice.refresh.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                refreshEvents.add(it)
+            }
+        }
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
     }
 
@@ -116,16 +129,44 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
         params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.DRAFT)
 
         assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
-      //  verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
+        //  verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
     }
+
     @Test
-    fun `given scheduled post card, when footer link is clicked, then scheduled posts screen is opened`() =
+    fun `given scheduled post card, when view all scheduled posts is clicked, then scheduled posts screen is opened`() =
         test {
             val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
 
             params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.SCHEDULED)
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenScheduledPosts(site))
-           // verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
         }
+
+    @Test
+    fun `given drafts post card, when more menu item hide this is accessed, then hide card is invoked`() = test {
+        val siteId = 1L
+        whenever(selectedSiteRepository.getSelectedSite()?.siteId).thenReturn(siteId)
+
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.moreMenuClickParams.onHideThisMenuItemClick.invoke(PostCardType.DRAFT)
+
+        verify(appPrefsWrapper).setShouldHidePostDashboardCard(siteId, PostCardType.DRAFT.name, true)
+
+        assertThat(refreshEvents).containsOnly(true)
+    }
+
+    @Test
+    fun `given scheduled post card, when more menu item hide this is accessed, then hide card is invoked`() = test {
+        val siteId = 1L
+        whenever(selectedSiteRepository.getSelectedSite()?.siteId).thenReturn(siteId)
+
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.moreMenuClickParams.onHideThisMenuItemClick.invoke(PostCardType.SCHEDULED)
+
+        verify(appPrefsWrapper).setShouldHidePostDashboardCard(siteId, PostCardType.SCHEDULED.name, true)
+
+        assertThat(refreshEvents).containsOnly(true)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -108,4 +108,24 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
 
         verify(cardsTracker).trackPostItemClicked(PostCardType.DRAFT)
     }
+
+    @Test
+    fun `given draft post card, when view all drafts posts is clicked, then draft posts screen is opened`() = test {
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.DRAFT)
+
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
+      //  verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
+    }
+    @Test
+    fun `given scheduled post card, when footer link is clicked, then scheduled posts screen is opened`() =
+        test {
+            val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+            params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.SCHEDULED)
+
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenScheduledPosts(site))
+           // verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
+        }
 }


### PR DESCRIPTION
Part of #18945 and #18946

This PR implements the more menu item clicks for the Scheduled and Drafts Post cards
- Handle the navigation click when tapping `View all drafts` and `View all scheduled posts` menu item taps
- Handle setting the app preferences for hiding the Scheduled and Drafts Post cards
- Check the `hide this` app preference while building the card. Note: this could not be accomplished in CardsSource like the other cards, because "post" cards are returned as a single unit from the network call.

**Merge Instructions**
- Ensure #19075 & #19089 have been merged
- Ensure the parent branch is set to `feature/dashboard-personalization`
- Remove the Not Ready for Merge label
- Merge as normal

**To test:**
- Install the app
- Login to the app and select a site that has both drafts and scheduled posts
- ✅ Verify the drafts and scheduled posts cards are shown
- Tap on drafts card > more menu
- Tap on the Hide this more menu item
- ✅ Verify the dashboard refresh indicator is showing
- ✅ Verify the drafts post card is hidden
- Tap on scheduled post card > more menu
- Tap on the Hide this more menu item
- ✅ Verify the dashboard refresh indicator is showing
- ✅ Verify the scheduled card is hidden
- Switch to another site that has has both drafts and scheduled posts
- ✅ Verify the drafts and scheduled posts cards are shown
- Switch back to the original site
- ✅ Verify the drafts and scheduled posts cards are not shown

## Regression Notes
1. Potential unintended areas of impact
Navigation and hide this actions do not work in the post drafts and scheduled cards

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit and manual tests

3. What automated tests I added (or what prevented me from doing so)
PostCardBuilderTest

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
