### PR TITLE
Dashboard Personalization: Post cards more menu tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -72,10 +72,6 @@ class CardsTracker @Inject constructor(
         trackCardItemClicked(Type.QUICK_START.label, quickStartTaskType.toSubtypeValue().label)
     }
 
-    fun trackPostItemClicked(postCardType: PostCardType) {
-        trackCardItemClicked(Type.POST.label, postCardType.toSubtypeValue().label)
-    }
-
     fun trackActivityCardItemClicked() {
         trackCardItemClicked(Type.ACTIVITY.label, ActivityLogSubtype.ACTIVITY_LOG.label)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -72,10 +72,6 @@ class CardsTracker @Inject constructor(
         trackCardItemClicked(Type.QUICK_START.label, quickStartTaskType.toSubtypeValue().label)
     }
 
-    fun trackPostCardFooterLinkClicked(postCardType: PostCardType) {
-        trackCardFooterLinkClicked(Type.POST.label, postCardType.toSubtypeValue().label)
-    }
-
     fun trackPostItemClicked(postCardType: PostCardType) {
         trackCardItemClicked(Type.POST.label, postCardType.toSubtypeValue().label)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -90,7 +90,7 @@ class PostsCardViewModelSlice @Inject constructor(
 
     enum class PostMenuItemType(val label: String) {
         VIEW_ALL_DRAFTS("view_all_drafts"),
-        VIEW_ALL_SCHEDULED_POSTS("scheduled_posts"),
+        VIEW_ALL_SCHEDULED_POSTS("view_all_scheduled_posts"),
         HIDE_THIS("hide_this")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.posts
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
@@ -36,12 +35,14 @@ class PostsCardViewModelSlice @Inject constructor(
     }
 
     private fun onMoreMenuClick(postCardType: PostCardType) {
-        // todo: annmarie implement cards tracker
-        Log.i(javaClass.simpleName, "***=> onMoreMenuClick $postCardType")
+        cardsTracker.trackCardMoreMenuClicked(postCardType.toPostMenuCardValue().label)
     }
 
     private fun onHideThisMenuItemClick(postCardType: PostCardType) {
-        // todo: annmarie implement cards tracker
+        cardsTracker.trackCardMoreMenuItemClicked(
+            postCardType.toPostMenuCardValue().label,
+            PostMenuItemType.HIDE_THIS.label
+        )
         appPrefsWrapper.setShouldHidePostDashboardCard(
             selectedSiteRepository.getSelectedSite()!!.siteId,
             postCardType.name,
@@ -51,8 +52,14 @@ class PostsCardViewModelSlice @Inject constructor(
     }
 
     private fun onViewPostsMenuItemClick(postCardType: PostCardType) {
+        cardsTracker.trackCardMoreMenuItemClicked(
+            card = postCardType.toPostMenuCardValue().label,
+            item = when (postCardType) {
+                PostCardType.DRAFT -> PostMenuItemType.VIEW_ALL_DRAFTS.label
+                PostCardType.SCHEDULED -> PostMenuItemType.VIEW_ALL_SCHEDULED_POSTS.label
+            }
+        )
         onPostCardViewAllClick(postCardType)
-        // todo: annmarie implement cards tracker
     }
 
     private fun onPostItemClick(params: PostCardBuilderParams.PostItemClickParams) {
@@ -70,7 +77,6 @@ class PostsCardViewModelSlice @Inject constructor(
 
     private fun onPostCardViewAllClick(postCardType: PostCardType) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-           // todo: annmarie implement tracking cardsTracker.trackPostCardFooterLinkClicked(postCardType)
             _onNavigation.value = when (postCardType) {
                 PostCardType.DRAFT -> Event(SiteNavigationAction.OpenDraftsPosts(site))
                 PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
@@ -80,5 +86,23 @@ class PostsCardViewModelSlice @Inject constructor(
 
     private fun trackPostItemClicked(postCardType: PostCardType) {
         cardsTracker.trackCardItemClicked(CardsTracker.Type.POST.label, postCardType.toSubtypeValue().label)
+    }
+
+    enum class PostMenuItemType(val label: String) {
+        VIEW_ALL_DRAFTS("view_all_drafts"),
+        VIEW_ALL_SCHEDULED_POSTS("scheduled_posts"),
+        HIDE_THIS("hide_this")
+    }
+
+    enum class PostMenuCard(val label: String) {
+        DRAFT_POSTS("draft_posts"),
+        SCHEDULED_POSTS("scheduled_posts")
+    }
+
+    private fun PostCardType.toPostMenuCardValue(): PostMenuCard {
+        return when (this) {
+            PostCardType.DRAFT -> PostMenuCard.DRAFT_POSTS
+            PostCardType.SCHEDULED -> PostMenuCard.SCHEDULED_POSTS
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSlice.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBu
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.mysite.cards.dashboard.toSubtypeValue
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -56,7 +57,7 @@ class PostsCardViewModelSlice @Inject constructor(
 
     private fun onPostItemClick(params: PostCardBuilderParams.PostItemClickParams) {
         selectedSiteRepository.getSelectedSite()?.let { site ->
-            cardsTracker.trackPostItemClicked(params.postCardType)
+            trackPostItemClicked(params.postCardType)
             when (params.postCardType) {
                 PostCardType.DRAFT -> _onNavigation.value =
                     Event(SiteNavigationAction.EditDraftPost(site, params.postId))
@@ -75,5 +76,9 @@ class PostsCardViewModelSlice @Inject constructor(
                 PostCardType.SCHEDULED -> Event(SiteNavigationAction.OpenScheduledPosts(site))
             }
         }
+    }
+
+    private fun trackPostItemClicked(postCardType: PostCardType) {
+        cardsTracker.trackCardItemClicked(CardsTracker.Type.POST.label, postCardType.toSubtypeValue().label)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -10,10 +10,8 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.ActivityLogSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.MenuItemType
-import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.PostSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.QuickStartSubtype
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker.Type
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.quickstart.QuickStartTracker
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -53,21 +51,6 @@ class CardsTrackerTest {
         cardsTracker.trackQuickStartCardItemClicked(QuickStartTaskType.CUSTOMIZE)
 
         verifyQuickStartCardItemClickedTracked(QuickStartSubtype.CUSTOMIZE.label)
-    }
-
-    /* POST CARDS */
-    @Test
-    fun `when post draft item is clicked, then post item event is tracked`() {
-        cardsTracker.trackPostItemClicked(PostCardType.DRAFT)
-
-        verifyCardItemClickedTracked(Type.POST, PostSubtype.DRAFT.label)
-    }
-
-    @Test
-    fun `when post scheduled item is clicked, then post item event is tracked`() {
-        cardsTracker.trackPostItemClicked(PostCardType.SCHEDULED)
-
-        verifyCardItemClickedTracked(Type.POST, PostSubtype.SCHEDULED.label)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTrackerTest.kt
@@ -57,20 +57,6 @@ class CardsTrackerTest {
 
     /* POST CARDS */
     @Test
-    fun `when post draft footer link is clicked, then post draft event is tracked`() {
-        cardsTracker.trackPostCardFooterLinkClicked(PostCardType.DRAFT)
-
-        verifyFooterLinkClickedTracked(Type.POST, PostSubtype.DRAFT.label)
-    }
-
-    @Test
-    fun `when post scheduled footer link is clicked, then post scheduled event is tracked`() {
-        cardsTracker.trackPostCardFooterLinkClicked(PostCardType.SCHEDULED)
-
-        verifyFooterLinkClickedTracked(Type.POST, PostSubtype.SCHEDULED.label)
-    }
-
-    @Test
     fun `when post draft item is clicked, then post item event is tracked`() {
         cardsTracker.trackPostItemClicked(PostCardType.DRAFT)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -115,7 +115,10 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             )
         )
 
-        verify(cardsTracker).trackCardItemClicked(CardsTracker.Type.POST.label, CardsTracker.PostSubtype.SCHEDULED.label)
+        verify(cardsTracker).trackCardItemClicked(
+            CardsTracker.Type.POST.label,
+            CardsTracker.PostSubtype.SCHEDULED.label
+        )
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostsCardViewModelSlice.PostMenuItemType
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostsCardViewModelSlice.PostMenuCard
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -77,6 +79,10 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             )
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.EditDraftPost(site, postId))
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.POST.label,
+                CardsTracker.PostSubtype.DRAFT.label
+            )
         }
 
     @Test
@@ -92,6 +98,10 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             )
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.EditScheduledPost(site, postId))
+            verify(cardsTracker).trackCardItemClicked(
+                CardsTracker.Type.POST.label,
+                CardsTracker.PostSubtype.SCHEDULED.label
+            )
         }
 
     @Test
@@ -129,7 +139,10 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
         params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.DRAFT)
 
         assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
-        // todo: annmarie verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            PostMenuCard.DRAFT_POSTS.label,
+            PostMenuItemType.VIEW_ALL_DRAFTS.label
+        )
     }
 
     @Test
@@ -140,6 +153,10 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.SCHEDULED)
 
             assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenScheduledPosts(site))
+            verify(cardsTracker).trackCardMoreMenuItemClicked(
+                PostMenuCard.SCHEDULED_POSTS.label,
+                PostMenuItemType.VIEW_ALL_SCHEDULED_POSTS.label
+            )
         }
 
     @Test
@@ -157,6 +174,21 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given drafts post card, when more menu item hide this is accessed, then hide card is tracked`() = test {
+        val siteId = 1L
+        whenever(selectedSiteRepository.getSelectedSite()?.siteId).thenReturn(siteId)
+
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.moreMenuClickParams.onHideThisMenuItemClick.invoke(PostCardType.DRAFT)
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            PostMenuCard.DRAFT_POSTS.label,
+            PostMenuItemType.HIDE_THIS.label
+        )
+    }
+
+    @Test
     fun `given scheduled post card, when more menu item hide this is accessed, then hide card is invoked`() = test {
         val siteId = 1L
         whenever(selectedSiteRepository.getSelectedSite()?.siteId).thenReturn(siteId)
@@ -168,5 +200,20 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
         verify(appPrefsWrapper).setShouldHidePostDashboardCard(siteId, PostCardType.SCHEDULED.name, true)
 
         assertThat(refreshEvents).containsOnly(true)
+    }
+
+    @Test
+    fun `given scheduled post card, when more menu item hide this is accessed, then hide card is tracked`() = test {
+        val siteId = 1L
+        whenever(selectedSiteRepository.getSelectedSite()?.siteId).thenReturn(siteId)
+
+        val params = postsCardViewModelSlice.getPostsCardBuilderParams(mock())
+
+        params.moreMenuClickParams.onHideThisMenuItemClick.invoke(PostCardType.SCHEDULED)
+
+        verify(cardsTracker).trackCardMoreMenuItemClicked(
+            PostMenuCard.SCHEDULED_POSTS.label,
+            PostMenuItemType.HIDE_THIS.label
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/posts/PostsCardViewModelSliceTest.kt
@@ -105,7 +105,7 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             )
         )
 
-        verify(cardsTracker).trackPostItemClicked(PostCardType.SCHEDULED)
+        verify(cardsTracker).trackCardItemClicked(CardsTracker.Type.POST.label, CardsTracker.PostSubtype.SCHEDULED.label)
     }
 
     @Test
@@ -119,7 +119,7 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
             )
         )
 
-        verify(cardsTracker).trackPostItemClicked(PostCardType.DRAFT)
+        verify(cardsTracker).trackCardItemClicked(CardsTracker.Type.POST.label, CardsTracker.PostSubtype.DRAFT.label)
     }
 
     @Test
@@ -129,7 +129,7 @@ class PostsCardViewModelSliceTest : BaseUnitTest() {
         params.moreMenuClickParams.onViewPostsMenuItemClick(PostCardType.DRAFT)
 
         assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenDraftsPosts(site))
-        //  verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
+        // todo: annmarie verify(cardsTracker).trackPostCardFooterLinkClicked(PostCardType.DRAFT)
     }
 
     @Test


### PR DESCRIPTION
Closes #18945 & #18946

This PR adds track events for the more menu actions of the Scheduled and Draft post cards. This PR also removes post card footer action tracking events.

**Merge Instructions**
- Ensure #19075, #19089, and #19090 have been merged
- Ensure the parent branch is set to `feature/dashboard-personalization`
- Remove the Not Ready for Merge label
- Merge as normal
- 
## To Test
- Login to the app 
- Select a site in which that has both drafts and scheduled posts
- Enable log collection

**Draft Post Tracking**
- Go to Draft Posts Card > Tap on more menu 
- ✅ Verify the log contains 🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"draft_posts"}
- Tap on the " View all drafts" menu item
- ✅  Verify the log contains  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"draft_posts","item":"view_all_drafts"}
- Navigate back to dashboard
- Go to Draft Posts Card > Tap on more menu 
- Tap on the Hide this item 
- ✅  Verify the log contains 🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"draft_posts","item":"hide_this"}

**Scheduled Posts Tracking**
- Go to Scheduled Posts Card > Tap on more menu 
- ✅ Verify the log contains 🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"scheduled_posts"}
- Tap on the " View all drafts" menu item
- ✅  Verify the log contains  🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"scheduled_posts","item":"view_all_scheduled_posts"}
- Navigate back to dashboard
- Go to Draft Card > Tap on more menu 
- Tap on the Hide this item 
- ✅  Verify the log contains 🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"scheduled_posts","item":"hide_this"}



## Regression Notes
1. Potential unintended areas of impact
Events are not tracked

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
