### PR TITLE
[Permissions] Clean-up storage permissions and video recording

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.TaskStackBuilder;
@@ -23,9 +22,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.MediaUtils;
-import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 
 import java.util.ArrayList;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -149,45 +149,17 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode,
-                                           @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        boolean allGranted = WPPermissionUtils.setPermissionListAsked(
-                this, requestCode, permissions, grantResults, true);
-        if (allGranted && requestCode == WPPermissionUtils.SHARE_MEDIA_PERMISSION_REQUEST_CODE) {
-            // permissions granted
-            share(ShareAction.valueOf(mShareActionName), mClickedSiteLocalId);
-        } else {
-            Toast.makeText(this, R.string.share_media_permission_required, Toast.LENGTH_LONG).show();
-        }
-    }
-
-    @Override
     public void share(ShareAction shareAction, int selectedSiteLocalId) {
-        if (checkAndRequestPermissions()) {
-            bumpAnalytics(shareAction, selectedSiteLocalId);
-            Intent intent = new Intent(this, shareAction.targetClass);
-            startActivityAndFinish(intent, selectedSiteLocalId);
-        } else {
-            mShareActionName = shareAction.name();
-            mClickedSiteLocalId = selectedSiteLocalId;
-        }
+        mShareActionName = shareAction.name();
+        mClickedSiteLocalId = selectedSiteLocalId;
+
+        bumpAnalytics(shareAction, selectedSiteLocalId);
+        Intent intent = new Intent(this, shareAction.targetClass);
+        startActivityAndFinish(intent, selectedSiteLocalId);
     }
 
     private boolean isSharingText() {
         return "text/plain".equals(getIntent().getType());
-    }
-
-    private boolean checkAndRequestPermissions() {
-        if (!isSharingText()) {
-            // If we're sharing media, we must check we have Storage permission (needed for media upload).
-            if (!PermissionUtils
-                    .checkAndRequestStoragePermission(this, WPPermissionUtils.SHARE_MEDIA_PERMISSION_REQUEST_CODE)) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private void startActivityAndFinish(@NonNull Intent intent, int mSelectedSiteLocalId) {
@@ -234,8 +206,8 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
         analyticsProperties.put("share_to", shareAction.analyticsName);
 
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SHARE_TO_WP_SUCCEEDED,
-                                            selectedSite,
-                                            analyticsProperties);
+                selectedSite,
+                analyticsProperties);
 
         if (doesContainMediaAndWasSharedToMediaLibrary(shareAction, numberOfMediaShared)) {
             trackMediaAddedToMediaLibrary(selectedSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -480,9 +480,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         );
     }
 
-    private void checkRecordedVideoDurationBeforeUploadAndTrack() {
-        Uri uri = MediaUtils.getLastRecordedVideoUri(this);
-
+    private void checkRecordedVideoDurationBeforeUploadAndTrack(Uri uri) {
         if (mMediaUtilsWrapper.isProhibitedVideoDuration(this, mSite, uri)) {
             ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, LONG);
         } else {
@@ -522,7 +520,8 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
                 break;
             case RequestCodes.TAKE_VIDEO:
                 if (resultCode == Activity.RESULT_OK) {
-                    checkRecordedVideoDurationBeforeUploadAndTrack();
+                    Uri uri = data.getData();
+                    checkRecordedVideoDurationBeforeUploadAndTrack(uri);
                 }
                 break;
             case RequestCodes.MEDIA_SETTINGS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -233,10 +233,6 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                 mediaCapturePath -> mMediaCapturePath = mediaCapturePath);
     }
 
-    private void launchCameraForVideo() {
-        WPMediaUtils.launchVideoCamera(this);
-    }
-
     private void launchPictureLibrary(boolean multiSelect) {
         WPMediaUtils.launchPictureLibrary(this, multiSelect);
     }
@@ -361,9 +357,6 @@ public class PhotoPickerActivity extends LocaleAwareActivity
                 break;
             case ANDROID_CHOOSE_PHOTO:
                 launchPictureLibrary(multiple);
-                break;
-            case ANDROID_CAPTURE_VIDEO:
-                launchCameraForVideo();
                 break;
             case ANDROID_CHOOSE_VIDEO:
                 launchVideoLibrary(multiple);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1481,10 +1481,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                         mMenuView = null;
                     }
                     break;
-                case WPPermissionUtils.EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE:
-                    mEditorMedia.addNewMediaItemsToEditorAsync(mEditorMedia.getDroppedMediaUris(), false);
-                    mEditorMedia.getDroppedMediaUris().clear();
-                    break;
             }
         }
     }
@@ -3273,11 +3269,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
     public void onMediaDropped(final ArrayList<Uri> mediaUris) {
         mEditorMedia.setDroppedMediaUris(mediaUris);
         ArrayList<Uri> media = new ArrayList<>(mediaUris);
-        if (PermissionUtils
-                .checkAndRequestStoragePermission(this, WPPermissionUtils.EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE)) {
-            mEditorMedia.addNewMediaItemsToEditorAsync(media, false);
-            mEditorMedia.getDroppedMediaUris().clear();
-        }
+        mEditorMedia.addNewMediaItemsToEditorAsync(media, false);
+        mEditorMedia.getDroppedMediaUris().clear();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2909,7 +2909,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     mEditorMedia.addNewMediaItemsToEditorAsync(WPMediaUtils.retrieveMediaUris(data), false);
                     break;
                 case RequestCodes.TAKE_VIDEO:
-                    mEditorMedia.addFreshlyTakenVideoToEditor();
+                    Uri videoUri = data.getData();
+                    mEditorMedia.addNewMediaToEditorAsync(videoUri, true);
+                    mEditorTracker.trackAddMediaFromDevice(mSite, true, true, videoUri);
                     break;
                 case RequestCodes.MEDIA_SETTINGS:
                     if (mEditorFragment instanceof AztecEditorFragment) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2987,20 +2987,19 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     private void addLastTakenPicture() {
         try {
-            // TODO why do we scan the file twice? Also how come it can result in OOM?
             WPMediaUtils.scanMediaFile(this, mMediaCapturePath);
             File f = new File(mMediaCapturePath);
             Uri capturedImageUri = Uri.fromFile(f);
             if (capturedImageUri != null) {
                 mEditorMedia.addNewMediaToEditorAsync(capturedImageUri, true);
-                final Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                scanIntent.setData(capturedImageUri);
-                sendBroadcast(scanIntent);
+                mEditorTracker.trackAddMediaFromDevice(mSite, true, false, capturedImageUri);
             } else {
                 ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
             }
         } catch (RuntimeException | OutOfMemoryError e) {
             AppLog.e(T.EDITOR, e);
+        } finally {
+            mMediaCapturePath = null;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3272,9 +3272,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Override
     public void onMediaDropped(final ArrayList<Uri> mediaUris) {
         mEditorMedia.setDroppedMediaUris(mediaUris);
+        ArrayList<Uri> media = new ArrayList<>(mediaUris);
         if (PermissionUtils
                 .checkAndRequestStoragePermission(this, WPPermissionUtils.EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE)) {
-            mEditorMedia.addNewMediaItemsToEditorAsync(mEditorMedia.getDroppedMediaUris(), false);
+            mEditorMedia.addNewMediaItemsToEditorAsync(media, false);
             mEditorMedia.getDroppedMediaUris().clear();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2907,7 +2907,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 case RequestCodes.TAKE_VIDEO:
                     Uri videoUri = data.getData();
                     mEditorMedia.addNewMediaToEditorAsync(videoUri, true);
-                    mEditorTracker.trackAddMediaFromDevice(mSite, true, true, videoUri);
                     break;
                 case RequestCodes.MEDIA_SETTINGS:
                     if (mEditorFragment instanceof AztecEditorFragment) {
@@ -2988,7 +2987,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
             Uri capturedImageUri = Uri.fromFile(f);
             if (capturedImageUri != null) {
                 mEditorMedia.addNewMediaToEditorAsync(capturedImageUri, true);
-                mEditorTracker.trackAddMediaFromDevice(mSite, true, false, capturedImageUri);
             } else {
                 ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -561,8 +561,7 @@ public class EditPostSettingsFragment extends Fragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (data != null || ((requestCode == RequestCodes.TAKE_PHOTO
-                              || requestCode == RequestCodes.TAKE_VIDEO))) {
+        if (data != null) {
             Bundle extras;
 
             switch (requestCode) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -10,8 +10,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker
-import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.EDITOR_UPLOAD_MEDIA_FAILED
 import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.fluxc.Dispatcher

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -146,11 +146,6 @@ class EditorMedia @Inject constructor(
         }
     }
 
-    fun addFreshlyTakenVideoToEditor() {
-        addNewMediaItemsToEditorAsync(listOf(mediaUtilsWrapper.getLastRecordedVideoUri()), true)
-            .also { AnalyticsTracker.track(Stat.EDITOR_ADDED_VIDEO_NEW) }
-    }
-
     fun onPhotoPickerMediaChosen(uriList: List<Uri>) {
         val onlyVideos = uriList.all { mediaUtilsWrapper.isVideo(it.toString()) }
         if (onlyVideos) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/OptimizeMediaUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/OptimizeMediaUseCase.kt
@@ -44,7 +44,7 @@ class OptimizeMediaUseCase @Inject constructor(
 
     private fun optimizeMedia(mediaUri: Uri, freshlyTaken: Boolean, site: SiteModel, trackEvent: Boolean): Uri? {
         val path = mediaUtilsWrapper.getRealPathFromURI(mediaUri) ?: return null
-        val isVideo = mediaUtilsWrapper.isVideo(mediaUri.toString())
+        val isVideo = mediaUtilsWrapper.isVideo(path)
 
         /**
          * If the user enabled the optimize images feature, the image gets rotated in mediaUtils.getOptimizedMedia.

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFileDownloadManager.kt
@@ -31,7 +31,7 @@ class ReaderFileDownloadManager
             request.addRequestHeader(entry.key, entry.value)
         }
 
-        val fileName = downloadManager.guessUrl(fileUrl)
+        val fileName = downloadManager.guessFileName(fileUrl)
         request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, fileName)
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
         request.setMimeType(downloadManager.getMimeType(fileUrl))

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1709,7 +1709,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         readerTracker.track(AnalyticsTracker.Stat.READER_ARTICLE_FILE_DOWNLOAD_TAPPED)
         return if (activity != null &&
             fileUrl != null &&
-            PermissionUtils.checkAndRequestStoragePermission(
+            PermissionUtils.checkAndRequestFileDownloadPermission(
                 this,
                 READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/DownloadManagerWrapper.kt
@@ -30,7 +30,7 @@ class DownloadManagerWrapper
 
     fun buildQuery() = Query()
 
-    fun guessUrl(fileUrl: String): String = URLUtil.guessUrl(fileUrl)
+    fun guessFileName(fileUrl: String): String = URLUtil.guessFileName(fileUrl, null, null)
 
     fun getMimeType(url: String): String? {
         var type: String? = null

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -26,8 +26,6 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
 
     fun isVideo(mediaUriString: String) = MediaUtils.isVideo(mediaUriString)
 
-    fun getLastRecordedVideoUri(): Uri = MediaUtils.getLastRecordedVideoUri(appContext)
-
     fun getOptimizedMedia(path: String, isVideo: Boolean): Uri? =
         WPMediaUtils.getOptimizedMedia(appContext, path, isVideo)
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 public class WPPermissionUtils {
     // permission request codes - note these are reported to analytics so they shouldn't be changed
+    @Deprecated
+    // This is deprecated to keep to request code taken but media shared to our app does not require permissions
     public static final int SHARE_MEDIA_PERMISSION_REQUEST_CODE = 10;
     public static final int MEDIA_BROWSER_PERMISSION_REQUEST_CODE = 20;
     public static final int MEDIA_PREVIEW_PERMISSION_REQUEST_CODE = 30;
@@ -36,6 +38,8 @@ public class WPPermissionUtils {
     public static final int PHOTO_PICKER_CAMERA_PERMISSION_REQUEST_CODE = 41;
     public static final int EDITOR_LOCATION_PERMISSION_REQUEST_CODE = 50;
     public static final int EDITOR_MEDIA_PERMISSION_REQUEST_CODE = 60;
+    @Deprecated
+    // This is deprecated to keep to request code taken but media dropped to our app does not require permissions
     public static final int EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE = 70;
     public static final int READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE = 80;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -29,18 +29,11 @@ import java.util.Map;
 
 public class WPPermissionUtils {
     // permission request codes - note these are reported to analytics so they shouldn't be changed
-    @Deprecated
-    // This is deprecated to keep to request code taken but media shared to our app does not require permissions
-    public static final int SHARE_MEDIA_PERMISSION_REQUEST_CODE = 10;
     public static final int MEDIA_BROWSER_PERMISSION_REQUEST_CODE = 20;
     public static final int MEDIA_PREVIEW_PERMISSION_REQUEST_CODE = 30;
     public static final int PHOTO_PICKER_MEDIA_PERMISSION_REQUEST_CODE = 40;
     public static final int PHOTO_PICKER_CAMERA_PERMISSION_REQUEST_CODE = 41;
-    public static final int EDITOR_LOCATION_PERMISSION_REQUEST_CODE = 50;
     public static final int EDITOR_MEDIA_PERMISSION_REQUEST_CODE = 60;
-    @Deprecated
-    // This is deprecated to keep to request code taken but media dropped to our app does not require permissions
-    public static final int EDITOR_DRAG_DROP_PERMISSION_REQUEST_CODE = 70;
     public static final int READER_FILE_DOWNLOAD_PERMISSION_REQUEST_CODE = 80;
 
     public static final int NOTIFICATIONS_PERMISSION_REQUEST_CODE = 90;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -157,7 +157,6 @@
     <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>
     <string name="media_error_internal_server_error">Upload error. Try changing Optimize Images in your app\'s settings</string>
     <string name="media_error_timeout">Server took too long to respond</string>
-    <string name="share_media_permission_required">Permissions required in order to share images or videos</string>
     <string name="media_fetching">Fetching media…</string>
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="media_generic_error">Media error occurred</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -377,7 +377,6 @@ class EditorMediaTest : BaseUnitTest() {
 
         fun createMediaUtilsWrapper(
             shouldAdvertiseImageOptimization: Boolean = false,
-            lastRecordedVideoUri: Uri = mock()
         ) =
             mock<MediaUtilsWrapper> {
                 on { shouldAdvertiseImageOptimization() }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/EditorMediaTest.kt
@@ -143,46 +143,6 @@ class EditorMediaTest : BaseUnitTest() {
     }
 
     @Test
-    fun `addFreshlyTakenVideoToEditor invokes addNewMediaToEditorAsync with last recorded video`() =
-        test {
-            // Arrange
-            val lastRecoredVideoUri = mock<Uri>()
-            val mediaUtilsWrapper = createMediaUtilsWrapper(lastRecordedVideoUri = lastRecoredVideoUri)
-            val addLocalMediaToPostUseCase = createAddLocalMediaToPostUseCase()
-
-            // Act
-            createEditorMedia(
-                mediaUtilsWrapper = mediaUtilsWrapper,
-                addLocalMediaToPostUseCase = addLocalMediaToPostUseCase
-            )
-                .addFreshlyTakenVideoToEditor()
-            // Assert
-            verify(addLocalMediaToPostUseCase).addNewMediaToEditorAsync(
-                eq(listOf(lastRecoredVideoUri)),
-                anyOrNull(), anyBoolean(), anyOrNull(), anyBoolean(), anyBoolean()
-            )
-        }
-
-    @Test
-    fun `addFreshlyTakenVideoToEditor does NOT show AdvertiseImageOptimization dialog`() =
-        test {
-            // Arrange
-            val lastRecoredVideoUri = mock<Uri>()
-            val mediaUtilsWrapper = createMediaUtilsWrapper(lastRecordedVideoUri = lastRecoredVideoUri)
-            val editorMediaListener = mock<EditorMediaListener>()
-
-            // Act
-            createEditorMedia(
-                mediaUtilsWrapper = mediaUtilsWrapper,
-                editorMediaListener = editorMediaListener
-            )
-                .addFreshlyTakenVideoToEditor()
-            // Assert
-            verify(editorMediaListener, never()).advertiseImageOptimization(anyOrNull())
-            verify(mediaUtilsWrapper, never()).shouldAdvertiseImageOptimization()
-        }
-
-    @Test
     fun `onPhotoPickerMediaChosen does NOT invoke shouldAdvertiseImageOptimization when only video files`() =
         test {
             // Arrange
@@ -422,7 +382,6 @@ class EditorMediaTest : BaseUnitTest() {
             mock<MediaUtilsWrapper> {
                 on { shouldAdvertiseImageOptimization() }
                     .thenReturn(shouldAdvertiseImageOptimization)
-                on { getLastRecordedVideoUri() }.thenReturn(lastRecordedVideoUri)
                 on { isVideo(VIDEO_URI.toString()) }.thenReturn(true)
                 on { isVideo(IMAGE_URI.toString()) }.thenReturn(false)
             }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderFileDownloadManagerTest.kt
@@ -58,7 +58,7 @@ class ReaderFileDownloadManagerTest {
         val mimeType = "application/pdf"
         whenever(authenticationUtils.getAuthHeaders(url)).thenReturn(mapOf(header to headerValue))
         whenever(downloadManager.buildRequest(url)).thenReturn(request)
-        whenever(downloadManager.guessUrl(url)).thenReturn(fileName)
+        whenever(downloadManager.guessFileName(url)).thenReturn(fileName)
         whenever(downloadManager.getMimeType(url)).thenReturn(mimeType)
 
         readerFileDownloadManager.downloadFile(url)

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '133-0dbd60d9d9ba22e69a14ab9445a1e9d6f73d827a'
+    wordPressUtilsVersion = '3.9.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.8.0'
+    wordPressUtilsVersion = '133-0dbd60d9d9ba22e69a14ab9445a1e9d6f73d827a'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug


### PR DESCRIPTION
Part of #19016
Companion PR: https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/133

Although not directly related to supporting partial media access, this PR cleans up unnecessary storage and media permissions requests. That said, if you use this version on Android 14, giving partial media access will still be broken on flows that need media permissions.

## Notable changes

### Get Video URI from result Intent
Previously we were using `getLastRecordedVideoUri` to get the URI of the video we just requested, instead of relying on the proper way of doing use, which is either setting the `EXTRA_OUTPUT` in the request intent (like we do for images) or using the `data` field from the result `Intent`, which contains the URI for the video, already with proper permissions.

This is also perfect for Android 14 because of the new partial permission grant for videos and images, which makes `getLastRecordedVideoUri` stop working in that scenario since the user would not have given access to the video we just recorded.

Also, this caused the very strange situation of us asking for media permissions when the user selected the Camera as a source, which doesn't make much sense.

Note: Although it should be safe to also remove asking STORAGE permission in older versions, in versions below Android 13 I kept the request for them when asking for the Camera permissions, as it reduces the footprint of changes and is "less dangerous" since there didn't exist such a fragmented storage/media permission model in those versions.

### Fix file downloads and remove unneeded permissions
Same as above, for file downloads, in Android 13 and up we were asking for `READ_MEDIA_*` permissions, which again don't make sense as we are writing to the storage. https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/133 made some changes in the storage permissions and now exposes a specific method for checking `FileDownload` permissions, which for Android Q and up are none if we use `DownloadManager`, as we do.

Other than that, the file download functionality was broken, since it was trying to use a valid URL as file name, which doesn't work because of the special characters present in that string. To fix it I replaced the usage of `guessUrl` with `guessFileName` which provides a valid file name based on the String input.

## Remove unneeded storage permission for media-sharing flows
We support media sharing from other apps via intent filters and we were checking/asking for `READ_MEDIA` or `STORAGE` permissions when apps shared media with us, but in those scenarios, we don't actually need any permissions, as the app providing the media URI already grants access to it. Because of that, I removed the code that asked for those storage permissions.

## Fix the drag-and-drop feature in Aztec
The code implementing the drag-and-drop of media files while in Split Screen was not working correctly, since it was doing some asynchronous processing with a shared array reference but cleaning that array before it could be processed.

To fix it I am making a copy of the array to pass to the async job instead of passing the shared reference.

### Permission clean-ups
Overall clean up code related to permission, media, and Camera. For instance, the deprecated `PhotoPickerActivity` was using `launchCameraForVideo` but that code was never even reached.

## To test
Login to the Jetpack/WordPress app.

### File Download
On Web:
1. Create a post with a File block and upload a PDF (or other non-media file) to it
2. Like that post (on Reader) so you can easily find it on the mobile app Reader

On Jetpack app:
1. In the Reader, find the above post
2. Click the download link (note: currently the Reader shows an extra `Download` text after the file name)
3. (below Android 10) **Verify** storage permission is requested and grant it
4. **Verify** the file is downloaded and opened

Ideally, test this in several Android versions.

### Media Sharing
Make sure Jetpack/WordPress apps DO NOT have any storage nor media permission.

On Gallery/Photos/Files app:
1. Choose a photo/video
2. Share it to Jetpack/WordPress app

On Jetpack/WordPress app:
1. Choose a site and an option (sharing to the media library or to a new post)
2. **Verify** no permission is asked
3. **Verify** the media was properly shared based on the chosen option

### Drag-and-drop media in Aztec Editor
On Web (create a post that forces Aztec on the app):
1. Create a post
2. Go to the Code Editor
3. Add some text to the post body
4. Save as draft

On Jetpack/WordPress app:
1. Put the app in split-screen mode with a gallery/file explorer app
2. Open the above draft post

On Gallery/Photos/Files app:
1. Select a picture/video
2. Drag and drop the media to the Aztec Editor
3. **Verify** no permission is requested
4. **Verify** the media is properly added to the post and uploaded

### Adding Video from camera:
There are several flows to test. Before each of them, make sure to remove all permissions from the app.

1. Create video Story post
   1. (Android 13 and up) **Verify** it doesn't ask for storage/media permissions when requesting the Camera permission
   2. (Below Android 13) **Verify** it still asks for storage permissions when requesting Camera permission
   3. **Verify** it works properly in all versions
2. (Gutenberg) Add Video blocks and choose "Take a Video" as the source
   1. (Android 13 and up) **Verify** it doesn't ask for storage/media permissions when requesting the Camera permission
   2. (Below Android 13) **Verify** it still asks for storage permissions when requesting Camera permission
   3. **Verify** it works properly in all versions
3. (Aztec) Add Video and choose "Take Video" as the source
   1. (Android 13 and up) **Verify** it doesn't ask for storage/media permissions when requesting the Camera permission
   2. (Below Android 13) **Verify** it still asks for storage permissions when requesting Camera permission
   3. **Verify** it works properly in all versions

## Regression Notes
1. Potential unintended areas of impact
Breakage of any flows using Storage or Camera.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

8. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
Likely not needed, since there weren't UI changes.

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)