### PR TITLE
Dashboard Personalization: Next Steps More Card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -119,10 +119,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
 
         data class QuickStartCard(
             val title: UiString,
-            val toolbarVisible: Boolean = true,
-            val moreMenuVisible: Boolean = true,
-            val onRemoveMenuItemClick: ListItemInteraction,
-            val taskTypeItems: List<QuickStartTaskTypeItem>
+            val taskTypeItems: List<QuickStartTaskTypeItem>,
+            val moreMenuOptions: MoreMenuOptions,
         ) : Card(QUICK_START_CARD) {
             data class QuickStartTaskTypeItem(
                 val quickStartTaskType: QuickStartTaskType,
@@ -133,6 +131,11 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                 @ColorRes val progressColor: Int,
                 val progress: Int,
                 val onClick: ListItemInteraction
+            )
+
+            data class MoreMenuOptions(
+                val onMoreMenuClick: () -> Unit,
+                val onHideThisMenuItemClick: () -> Unit
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -56,9 +56,14 @@ sealed class MySiteCardAndItemBuilderParams {
 
     data class QuickStartCardBuilderParams(
         val quickStartCategories: List<QuickStartCategory>,
-        val onQuickStartBlockRemoveMenuItemClick: () -> Unit,
-        val onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit
-    ) : MySiteCardAndItemBuilderParams()
+        val onQuickStartTaskTypeItemClick: (type: QuickStartTaskType) -> Unit,
+        val moreMenuClickParams : MoreMenuParams
+    ) : MySiteCardAndItemBuilderParams() {
+        data class MoreMenuParams(
+            val onMoreMenuClick: () -> Unit,
+            val onHideThisMenuItemClick: () -> Unit,
+        )
+    }
 
     data class DashboardCardsBuilderParams(
         val showErrorCard: Boolean = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -916,8 +916,11 @@ class MySiteViewModel @Inject constructor(
     private fun onQuickStartHideThisMenuItemClick() {
         // todo: annmarie - track this
         Log.i(javaClass.simpleName, "***=> onQuickStartHideThisMenuItemClick")
+        selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
+            quickStartRepository.onHideQuickStartCard(selectedSite.siteId)
             refresh()
             clearActiveQuickStartTask()
+        }
     }
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -5,7 +5,6 @@ package org.wordpress.android.ui.mysite
 import android.content.Intent
 import android.net.Uri
 import android.text.TextUtils
-import android.util.Log
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
@@ -909,13 +908,9 @@ class MySiteViewModel @Inject constructor(
         } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
     }
 
-    private fun onQuickStartMoreMenuClick() {
-        // todo: annmarie - track this
-        Log.i(javaClass.simpleName, "***=> onQuickStartMoreMenuClick")
-    }
+    private fun onQuickStartMoreMenuClick() = quickStartTracker.trackMoreMenuClicked()
     private fun onQuickStartHideThisMenuItemClick() {
-        // todo: annmarie - track this
-        Log.i(javaClass.simpleName, "***=> onQuickStartHideThisMenuItemClick")
+        quickStartTracker.trackMoreMenuItemClicked()
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
             quickStartRepository.onHideQuickStartCard(selectedSite.siteId)
             refresh()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -916,6 +916,8 @@ class MySiteViewModel @Inject constructor(
     private fun onQuickStartHideThisMenuItemClick() {
         // todo: annmarie - track this
         Log.i(javaClass.simpleName, "***=> onQuickStartHideThisMenuItemClick")
+            refresh()
+            clearActiveQuickStartTask()
     }
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {
@@ -1135,8 +1137,6 @@ class MySiteViewModel @Inject constructor(
                         )
                     )
                 }
-
-                TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogPositiveButtonClicked()
             }
 
             is Negative -> when (interaction.tag) {
@@ -1151,8 +1151,6 @@ class MySiteViewModel @Inject constructor(
                     quickStartRepository.checkAndShowQuickStartNotice()
                     selectedSiteRepository.updateSiteIconMediaId(0, true)
                 }
-
-                TAG_REMOVE_NEXT_STEPS_DIALOG -> onRemoveNextStepsDialogNegativeButtonClicked()
             }
 
             is Dismissed -> when (interaction.tag) {
@@ -1162,17 +1160,6 @@ class MySiteViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun onRemoveNextStepsDialogPositiveButtonClicked() {
-        quickStartTracker.track(Stat.QUICK_START_REMOVE_DIALOG_POSITIVE_TAPPED)
-        quickStartRepository.skipQuickStart()
-        refresh()
-        clearActiveQuickStartTask()
-    }
-
-    private fun onRemoveNextStepsDialogNegativeButtonClicked() {
-        quickStartTracker.track(Stat.QUICK_START_REMOVE_DIALOG_NEGATIVE_TAPPED)
     }
 
     @Suppress("DEPRECATION")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -5,6 +5,7 @@ package org.wordpress.android.ui.mysite
 import android.content.Intent
 import android.net.Uri
 import android.text.TextUtils
+import android.util.Log
 import androidx.annotation.DimenRes
 import androidx.annotation.StringRes
 import androidx.lifecycle.LiveData
@@ -81,7 +82,6 @@ import org.wordpress.android.ui.mysite.MySiteViewModel.State.SiteSelected
 import org.wordpress.android.ui.mysite.MySiteViewModel.TabsUiState.TabUiState
 import org.wordpress.android.ui.mysite.SiteDialogModel.AddSiteIconDialogModel
 import org.wordpress.android.ui.mysite.SiteDialogModel.ChangeSiteIconDialogModel
-import org.wordpress.android.ui.mysite.SiteDialogModel.ShowRemoveNextStepsDialog
 import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
@@ -568,7 +568,10 @@ class MySiteViewModel @Inject constructor(
             ),
             QuickStartCardBuilderParams(
                 quickStartCategories = quickStartCategories,
-                onQuickStartBlockRemoveMenuItemClick = this::onQuickStartBlockRemoveMenuItemClick,
+                moreMenuClickParams = QuickStartCardBuilderParams.MoreMenuParams(
+                    onMoreMenuClick = this::onQuickStartMoreMenuClick,
+                    onHideThisMenuItemClick = this::onQuickStartHideThisMenuItemClick
+                ),
                 onQuickStartTaskTypeItemClick = this::onQuickStartTaskTypeItemClick
             ),
             DashboardCardsBuilderParams(
@@ -906,8 +909,13 @@ class MySiteViewModel @Inject constructor(
         } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
     }
 
-    private fun onQuickStartBlockRemoveMenuItemClick() {
-        _onBasicDialogShown.value = Event(ShowRemoveNextStepsDialog)
+    private fun onQuickStartMoreMenuClick() {
+        // todo: annmarie - track this
+        Log.i(javaClass.simpleName, "***=> onQuickStartMoreMenuClick")
+    }
+    private fun onQuickStartHideThisMenuItemClick() {
+        // todo: annmarie - track this
+        Log.i(javaClass.simpleName, "***=> onQuickStartHideThisMenuItemClick")
     }
 
     private fun onQuickStartTaskTypeItemClick(type: QuickStartTaskType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteDialogModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteDialogModel.kt
@@ -28,12 +28,4 @@ sealed class SiteDialogModel(
         R.string.my_site_icon_dialog_remove_button,
         R.string.my_site_icon_dialog_cancel_button
     )
-
-    object ShowRemoveNextStepsDialog : SiteDialogModel(
-        MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG,
-        R.string.quick_start_dialog_remove_next_steps_title,
-        R.string.quick_start_dialog_remove_next_steps_message,
-        R.string.remove,
-        R.string.cancel
-    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -17,22 +17,17 @@ import kotlin.math.roundToInt
 class QuickStartCardBuilder @Inject constructor() {
     fun build(params: QuickStartCardBuilderParams) = QuickStartCard(
         title = UiStringRes(R.string.quick_start_sites),
-        toolbarVisible = shouldShowCardToolbar(params.quickStartCategories),
-        onRemoveMenuItemClick = ListItemInteraction.create(params.onQuickStartBlockRemoveMenuItemClick),
         taskTypeItems = params.quickStartCategories.map {
             buildQuickStartTaskTypeItem(
                 it,
                 params.onQuickStartTaskTypeItemClick
             )
-        }
+        },
+        moreMenuOptions = QuickStartCard.MoreMenuOptions(
+            onMoreMenuClick = params.moreMenuClickParams.onMoreMenuClick,
+            onHideThisMenuItemClick = params.moreMenuClickParams.onHideThisMenuItemClick
+        )
     )
-
-    private fun shouldShowCardToolbar(quickStartCategories: List<QuickStartCategory>) =
-        !isNewQuickStartType(quickStartCategories)
-
-    private fun isNewQuickStartType(quickStartCategories: List<QuickStartCategory>): Boolean {
-        return quickStartCategories.any { it.taskType == QuickStartTaskType.GET_TO_KNOW_APP }
-    }
 
     private fun buildQuickStartTaskTypeItem(
         category: QuickStartCategory,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -44,7 +44,11 @@ class QuickStartCardSource @Inject constructor(
                 } else {
                     listOf()
                 }
-            getState(QuickStartUpdate(activeTask, categories))
+            if (selectedSite != null && quickStartRepository.shouldShowQuickStartCard(selectedSite.siteId)) {
+                 getState(QuickStartUpdate(activeTask, categories))
+            } else {
+                getState(QuickStartUpdate(null, listOf()))
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.ProgressBar
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
 import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.MySiteCardToolbarBinding
@@ -22,7 +21,6 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType.GROW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
-import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.extensions.viewBinding
@@ -37,28 +35,25 @@ class QuickStartCardViewHolder(
         mySiteCardToolbar.update(card)
         quickStartCustomize.update(CUSTOMIZE, card.taskTypeItems)
         quickStartGrow.update(GROW, card.taskTypeItems)
-        quickStartGetToKnowApp.update(GET_TO_KNOW_APP, card.taskTypeItems, card.onRemoveMenuItemClick)
+        quickStartGetToKnowApp.update(GET_TO_KNOW_APP, card.taskTypeItems, card.moreMenuOptions)
     }
 
     private fun MySiteCardToolbarBinding.update(card: QuickStartCard) {
-        if (!card.toolbarVisible) {
-            mySiteCardToolbar.visibility = View.GONE
-            return
-        }
         mySiteCardToolbarTitle.text = uiHelpers.getTextOfUiString(itemView.context, card.title)
-        mySiteCardToolbarMore.isVisible = card.moreMenuVisible
+        mySiteCardToolbarMore.visibility = View.VISIBLE
         mySiteCardToolbarMore.setOnClickListener {
             showQuickStartCardMenu(
-                card.onRemoveMenuItemClick,
+                card.moreMenuOptions,
                 mySiteCardToolbarMore
             )
         }
     }
 
-    private fun showQuickStartCardMenu(onRemoveMenuItemClick: ListItemInteraction, anchor: View) {
+    private fun showQuickStartCardMenu(moreMenuOptions: QuickStartCard.MoreMenuOptions, anchor: View) {
+        moreMenuOptions.onMoreMenuClick.invoke()
         val quickStartPopupMenu = PopupMenu(itemView.context, anchor)
         quickStartPopupMenu.setOnMenuItemClickListener {
-            onRemoveMenuItemClick.click()
+            moreMenuOptions.onHideThisMenuItemClick.invoke()
             return@setOnMenuItemClickListener true
         }
         quickStartPopupMenu.inflate(R.menu.quick_start_card_menu)
@@ -86,7 +81,7 @@ class QuickStartCardViewHolder(
     private fun NewQuickStartTaskTypeItemBinding.update(
         taskType: QuickStartTaskType,
         taskTypeItems: List<QuickStartTaskTypeItem>,
-        onRemoveMenuItemClick: ListItemInteraction
+        moreMenuOptions: QuickStartCard.MoreMenuOptions
     ) {
         val hasItemOfTaskType = taskTypeItems.any { it.quickStartTaskType == taskType }
         quickStartItemRoot.setVisible(hasItemOfTaskType)
@@ -102,7 +97,7 @@ class QuickStartCardViewHolder(
         quickStartItemRoot.setOnClickListener { item.onClick.click() }
         quickStartItemMoreIcon.setOnClickListener {
             showQuickStartCardMenu(
-                onRemoveMenuItemClick,
+                moreMenuOptions,
                 quickStartItemMoreIcon
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -290,6 +290,11 @@ class QuickStartRepository
         }
     }
 
+    fun shouldShowQuickStartCard(siteId: Long) = appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId).not()
+
+    fun onHideQuickStartCard(siteId: Long) = appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, true)
+
+
     private fun onQuickStartNoticeButtonAction(task: QuickStartTask) {
         quickStartTracker.track(Stat.QUICK_START_TASK_DIALOG_POSITIVE_TAPPED)
         setActiveTask(task)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -202,7 +202,8 @@ public class AppPrefs {
         SHOULD_HIDE_ACTIVITY_DASHBOARD_CARD,
         SHOULD_HIDE_PAGES_DASHBOARD_CARD,
         SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD,
-        SHOULD_HIDE_POST_DASHBOARD_CARD
+        SHOULD_HIDE_POST_DASHBOARD_CARD,
+        SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD
     }
 
     /**
@@ -1769,5 +1770,17 @@ public class AppPrefs {
 
     public static Boolean getShouldHidePostDashboardCard(final long siteId, final String postType) {
         return prefs().getBoolean(getSiteIdHidePostDashboardCardKey(siteId, postType), false);
+    }
+
+    public static void setShouldHideNextStepsDashboardCard(final long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHideNextStepsDashboardCardKey(siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHideNextStepsDashboardCardKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD.name() + siteId;
+    }
+
+    public static Boolean getShouldHideNextStepsDashboardCard(final long siteId) {
+        return prefs().getBoolean(getSiteIdHideNextStepsDashboardCardKey(siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -403,6 +403,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHidePostDashboardCard(siteId: Long, postCardType: String,): Boolean =
         AppPrefs.getShouldHidePostDashboardCard(siteId, postCardType)
 
+    fun setShouldHideNextStepsDashboardCard(siteId: Long, isHidden: Boolean) =
+        AppPrefs.setShouldHideNextStepsDashboardCard(siteId, isHidden)
+
+    fun getShouldHideNextStepsDashboardCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHideNextStepsDashboardCard(siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_START_CARD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
@@ -64,6 +65,22 @@ class QuickStartTracker @Inject constructor(
         }
     }
 
+    fun trackMoreMenuClicked() {
+        analyticsTrackerWrapper.track(
+            Stat.MY_SITE_DASHBOARD_CONTEXTUAL_MENU_ACCESSED,
+            mapOf(CardsTracker.CARD to QuickStartMenuCard.NEXT_STEPS.label)
+        )
+    }
+
+    fun trackMoreMenuItemClicked() {
+        analyticsTrackerWrapper.track(
+            Stat.MY_SITE_DASHBOARD_CARD_MENU_ITEM_TAPPED,
+            mapOf(
+                CARD to QuickStartMenuCard.NEXT_STEPS.label,
+                ITEM to QuickStartMenuItemType.HIDE_THIS.label
+            )
+        )
+    }
     fun resetShown() {
         cardsShownTracked.clear()
     }
@@ -75,8 +92,17 @@ class QuickStartTracker @Inject constructor(
         } ?: NewSiteQuickStartType
     }
 
+    enum class QuickStartMenuItemType(val label: String) {
+        HIDE_THIS("hide_this")
+    }
+
+    enum class QuickStartMenuCard(val label: String) {
+        NEXT_STEPS("next_steps")
+    }
     companion object {
         private const val SITE_TYPE = "site_type"
         private const val TAB = "tab"
+        private const val CARD = "card"
+        private const val ITEM = "item"
     }
 }

--- a/WordPress/src/main/res/menu/quick_start_card_menu.xml
+++ b/WordPress/src/main/res/menu/quick_start_card_menu.xml
@@ -3,6 +3,6 @@
 
     <item
         android:id="@+id/quick_start_card_menu_remove"
-        android:title="@string/quick_start_remove_next_steps_menu_title"/>
+        android:title="@string/quick_start_hide_next_steps_menu_title"/>
 
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3197,9 +3197,7 @@
     <string name="quick_start_button_negative_short" tools:ignore="UnusedResources">Cancel</string>
     <string name="quick_start_button_positive" tools:ignore="UnusedResources">Go</string>
     <string name="quick_start_task_skip_menu_title">Skip task</string>
-    <string name="quick_start_remove_next_steps_menu_title">Remove this</string>
-    <string name="quick_start_dialog_remove_next_steps_title">Remove Next Steps</string>
-    <string name="quick_start_dialog_remove_next_steps_message">Removing Next Steps will hide all tours on this site. This action cannot be undone.</string>
+    <string name="quick_start_hide_next_steps_menu_title" translatable="false">@string/my_site_dashboard_card_more_menu_hide_card</string>
     <string name="quick_start_dialog_check_stats_message">Keep up to date with your site\'s performance.</string>
     <string name="quick_start_dialog_check_stats_title">Check your site stats</string>
     <string name="quick_start_dialog_enable_sharing_message" tools:ignore="UnusedResources">Automatically share new posts to your social media accounts.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -302,7 +302,6 @@ class CardsBuilderTest {
 
     private fun initQuickStartCard() = QuickStartCard(
         title = UiStringText(""),
-        onRemoveMenuItemClick = mock(),
         taskTypeItems = listOf(
             QuickStartTaskTypeItem(
                 quickStartTaskType = mock(),
@@ -314,7 +313,8 @@ class CardsBuilderTest {
                 progress = 0,
                 onClick = mock()
             )
-        )
+        ),
+        moreMenuOptions = mock()
     )
 
     private fun initDashboardCards() = DashboardCards(cards = mock())

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
@@ -23,7 +23,8 @@ class QuickStartCardBuilderTest : BaseUnitTest() {
     private val completedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE)
     private val uncompletedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.VIEW_SITE_TUTORIAL)
     private val onItemClick: (QuickStartTaskType) -> Unit = {}
-    private val onRemoveMenuItemClick: () -> Unit = {}
+    private val onHideThisMenuItemClick: () -> Unit = {}
+    private val onMoreMenuClick: () -> Unit = {}
 
     @Before
     fun setUp() {
@@ -154,24 +155,6 @@ class QuickStartCardBuilderTest : BaseUnitTest() {
             .isEqualTo(ListItemInteraction.create(taskTypeItem.quickStartTaskType, onItemClick))
     }
 
-    /* MORE MENU */
-
-    @Test
-    fun `when card is built, then more menu is visible`() {
-        val quickStartCard = buildQuickStartCard()
-
-        assertThat(quickStartCard.moreMenuVisible).isTrue
-    }
-
-    /* REMOVE MENU ITEM */
-
-    @Test
-    fun `when card is built, then remove menu item click is set on the card`() {
-        val quickStartCard = buildQuickStartCard()
-
-        assertThat(quickStartCard.onRemoveMenuItemClick).isNotNull
-    }
-
     private fun buildQuickStartCard(
         completedTasks: List<QuickStartTaskDetails>? = null,
         uncompletedTasks: List<QuickStartTaskDetails>? = null
@@ -180,9 +163,12 @@ class QuickStartCardBuilderTest : BaseUnitTest() {
         val growCategory = buildQuickStartCategory(QuickStartTaskType.GROW, completedTasks, uncompletedTasks)
         return builder.build(
             QuickStartCardBuilderParams(
-                listOf(customizeCategory, growCategory),
-                onRemoveMenuItemClick,
-                onItemClick
+                quickStartCategories = listOf(customizeCategory, growCategory),
+                onQuickStartTaskTypeItemClick = onItemClick,
+                moreMenuClickParams = QuickStartCardBuilderParams.MoreMenuParams(
+                    onMoreMenuClick = onMoreMenuClick,
+                    onHideThisMenuItemClick = onHideThisMenuItemClick
+                )
             )
         )
     }


### PR DESCRIPTION
Part of #18955 

This PR is the starter showing the more menu in the Next Steps card. While testing this PR it became apparent that there are two types of quick start cards. (1) Get to know the app (2) Next Steps. This PR focused on combining the toolbar for both cards (which now needs to be adjusted). As such, this PR implements "most" of the base logic which will help the next iteration which will be two separate the two types of cards and manage them separately.

**Merge Instructions**
- Please do not merge yet. Review PR #19107 first verify that things are working as expected. Thanks

**Open/known issues**
- The "Get to know the app" card shows two toolbars

**To test:**
- Install the app
- Login 
- Select a site
- When prompted, select "Show me around"
- ✅ Verify that the "Get to know the app" card is shown in the dashboard
- Tap "Get to know the app" more menu (either will do)
- ✅ Verify the logs contain  🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"next_steps"}
- Tap "Get to know the app" more menu > Hide this
- ✅ Verify the logs contain🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"next_steps","item":"hide_this"}


*New Site - Next Steps*
- Navigate to site selector > Add new site > new wordpress.com site
- Follow through the create site flow
- When prompted in the Managing dialog, select "Show me around"
- ✅ Verify that the "Next Steps" card is shown in the dashboard
- Tap "Next Steps" more menu 
- ✅ Verify the logs contain  🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"next_steps"}
- Tap "Next Steps" more menu > Hide this
- ✅ Verify the logs contain🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"next_steps","item":"hide_this"}


## Regression Notes
1. Potential unintended areas of impact
The cards are not shown on the dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
