### PR TITLE
Dashboard Personalization: Quick Start cards more menu implementation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.SITE_INFO_CARD
 import org.wordpress.android.ui.mysite.cards.blaze.CampaignStatus
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptAttribution
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 
@@ -120,6 +121,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         data class QuickStartCard(
             val title: UiString,
             val toolbarVisible: Boolean = true,
+            val quickStartCardType: QuickStartCardType,
             val taskTypeItems: List<QuickStartTaskTypeItem>,
             val moreMenuOptions: MoreMenuOptions,
         ) : Card(QUICK_START_CARD) {
@@ -135,8 +137,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             )
 
             data class MoreMenuOptions(
-                val onMoreMenuClick: () -> Unit,
-                val onHideThisMenuItemClick: () -> Unit
+                val onMoreMenuClick: (type: QuickStartCardType) -> Unit,
+                val onHideThisMenuItemClick: (type: QuickStartCardType) -> Unit
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -119,6 +119,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
 
         data class QuickStartCard(
             val title: UiString,
+            val toolbarVisible: Boolean = true,
             val taskTypeItems: List<QuickStartTaskTypeItem>,
             val moreMenuOptions: MoreMenuOptions,
         ) : Card(QUICK_START_CARD) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardContentType
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 
@@ -60,8 +61,8 @@ sealed class MySiteCardAndItemBuilderParams {
         val moreMenuClickParams : MoreMenuParams
     ) : MySiteCardAndItemBuilderParams() {
         data class MoreMenuParams(
-            val onMoreMenuClick: () -> Unit,
-            val onHideThisMenuItemClick: () -> Unit,
+            val onMoreMenuClick: (type: QuickStartCardType) -> Unit,
+            val onHideThisMenuItemClick: (type: QuickStartCardType) -> Unit,
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -908,9 +908,10 @@ class MySiteViewModel @Inject constructor(
         } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
     }
 
-    private fun onQuickStartMoreMenuClick() = quickStartTracker.trackMoreMenuClicked()
+    private fun onQuickStartMoreMenuClick() =
+        quickStartTracker.trackMoreMenuClicked(QuickStartTracker.QuickStartMenuCard.NEXT_STEPS)
     private fun onQuickStartHideThisMenuItemClick() {
-        quickStartTracker.trackMoreMenuItemClicked()
+        quickStartTracker.trackMoreMenuItemClicked(QuickStartTracker.QuickStartMenuCard.NEXT_STEPS)
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
             quickStartRepository.onHideQuickStartCard(selectedSite.siteId)
             refresh()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -96,6 +96,7 @@ import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardSh
 import org.wordpress.android.ui.mysite.cards.jpfullplugininstall.JetpackInstallFullPluginCardBuilder
 import org.wordpress.android.ui.mysite.cards.jpfullplugininstall.JetpackInstallFullPluginShownTracker
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartTabStep
@@ -908,12 +909,19 @@ class MySiteViewModel @Inject constructor(
         } ?: _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiStringRes(R.string.site_cannot_be_loaded))))
     }
 
-    private fun onQuickStartMoreMenuClick() =
-        quickStartTracker.trackMoreMenuClicked(QuickStartTracker.QuickStartMenuCard.NEXT_STEPS)
-    private fun onQuickStartHideThisMenuItemClick() {
-        quickStartTracker.trackMoreMenuItemClicked(QuickStartTracker.QuickStartMenuCard.NEXT_STEPS)
+    private fun onQuickStartMoreMenuClick(quickStartCardType: QuickStartCardType) =
+        quickStartTracker.trackMoreMenuClicked(quickStartCardType)
+    private fun onQuickStartHideThisMenuItemClick(quickStartCardType: QuickStartCardType) {
+        quickStartTracker.trackMoreMenuItemClicked(quickStartCardType)
         selectedSiteRepository.getSelectedSite()?.let { selectedSite ->
-            quickStartRepository.onHideQuickStartCard(selectedSite.siteId)
+            when (quickStartCardType) {
+                QuickStartCardType.GET_TO_KNOW_THE_APP -> {
+                    quickStartRepository.onHideShowGetToKnowTheAppCard(selectedSite.siteId)
+                }
+                QuickStartCardType.NEXT_STEPS -> {
+                    quickStartRepository.onHideNextStepsCard(selectedSite.siteId)
+                }
+            }
             refresh()
             clearActiveQuickStartTask()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -17,6 +17,7 @@ import kotlin.math.roundToInt
 class QuickStartCardBuilder @Inject constructor() {
     fun build(params: QuickStartCardBuilderParams) = QuickStartCard(
         title = UiStringRes(R.string.quick_start_sites),
+        toolbarVisible = shouldShowCardToolbar(params.quickStartCategories),
         taskTypeItems = params.quickStartCategories.map {
             buildQuickStartTaskTypeItem(
                 it,
@@ -96,6 +97,13 @@ class QuickStartCardBuilder @Inject constructor() {
 
     private fun getProgress(countCompleted: Int, totalCount: Int) =
         if (totalCount > 0) ((countCompleted / totalCount.toFloat()) * PERCENT_HUNDRED).roundToInt() else 0
+
+    private fun shouldShowCardToolbar(quickStartCategories: List<QuickStartCategory>) =
+        !isNewQuickStartType(quickStartCategories)
+
+    private fun isNewQuickStartType(quickStartCategories: List<QuickStartCategory>): Boolean {
+        return quickStartCategories.any { it.taskType == QuickStartTaskType.GET_TO_KNOW_APP }
+    }
 
     companion object {
         private const val UNEXPECTED_QUICK_START_TYPE = "Unexpected quick start type"

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilder.kt
@@ -18,6 +18,7 @@ class QuickStartCardBuilder @Inject constructor() {
     fun build(params: QuickStartCardBuilderParams) = QuickStartCard(
         title = UiStringRes(R.string.quick_start_sites),
         toolbarVisible = shouldShowCardToolbar(params.quickStartCategories),
+        quickStartCardType = getQuickStartCardType(params.quickStartCategories),
         taskTypeItems = params.quickStartCategories.map {
             buildQuickStartTaskTypeItem(
                 it,
@@ -78,7 +79,7 @@ class QuickStartCardBuilder @Inject constructor() {
         }
     }
 
-    fun getProgressColor(progress: Int, isNewQuickStartType: Boolean): Int {
+    private fun getProgressColor(progress: Int, isNewQuickStartType: Boolean): Int {
         return if (progress == PERCENT_HUNDRED && isNewQuickStartType) {
             R.color.green_40
         } else {
@@ -101,8 +102,12 @@ class QuickStartCardBuilder @Inject constructor() {
     private fun shouldShowCardToolbar(quickStartCategories: List<QuickStartCategory>) =
         !isNewQuickStartType(quickStartCategories)
 
-    private fun isNewQuickStartType(quickStartCategories: List<QuickStartCategory>): Boolean {
-        return quickStartCategories.any { it.taskType == QuickStartTaskType.GET_TO_KNOW_APP }
+    private fun isNewQuickStartType(quickStartCategories: List<QuickStartCategory>) =
+        quickStartCategories.any { it.taskType == QuickStartTaskType.GET_TO_KNOW_APP }
+
+    private fun getQuickStartCardType(quickStartCategories: List<QuickStartCategory>) = when {
+        isNewQuickStartType(quickStartCategories) -> QuickStartCardType.GET_TO_KNOW_THE_APP
+        else -> QuickStartCardType.NEXT_STEPS
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSource.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.fluxc.model.SiteHomepageSettings.ShowOnFront
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTaskType
 import org.wordpress.android.ui.mysite.MySiteSource.MySiteRefreshSource
@@ -44,12 +45,27 @@ class QuickStartCardSource @Inject constructor(
                 } else {
                     listOf()
                 }
-            if (selectedSite != null && quickStartRepository.shouldShowQuickStartCard(selectedSite.siteId)) {
-                 getState(QuickStartUpdate(activeTask, categories))
+
+            if (shouldShowQuickStartCard(categories, selectedSite)) {
+                getState(QuickStartUpdate(activeTask, categories))
             } else {
                 getState(QuickStartUpdate(null, listOf()))
             }
         }
+    }
+
+    private fun shouldShowQuickStartCard(
+        categories: List<QuickStartRepository.QuickStartCategory>,
+        selectedSite: SiteModel?
+    ) : Boolean {
+        selectedSite?.let { site ->
+            return if (categories.any { it.taskType == QuickStartTaskType.GET_TO_KNOW_APP }) {
+                quickStartRepository.shouldShowGetToKnowTheAppCard(site.siteId)
+            } else {
+                quickStartRepository.shouldShowNextStepsCard(site.siteId)
+            }
+        }
+        return false
     }
 
     private fun isEmptyCategory(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardType.kt
@@ -1,0 +1,6 @@
+package org.wordpress.android.ui.mysite.cards.quickstart
+
+enum class QuickStartCardType {
+    GET_TO_KNOW_THE_APP,
+    NEXT_STEPS
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
@@ -39,6 +39,10 @@ class QuickStartCardViewHolder(
     }
 
     private fun MySiteCardToolbarBinding.update(card: QuickStartCard) {
+        if (!card.toolbarVisible) {
+            mySiteCardToolbar.visibility = View.GONE
+            return
+        }
         mySiteCardToolbarTitle.text = uiHelpers.getTextOfUiString(itemView.context, card.title)
         mySiteCardToolbarMore.visibility = View.VISIBLE
         mySiteCardToolbarMore.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardViewHolder.kt
@@ -35,7 +35,12 @@ class QuickStartCardViewHolder(
         mySiteCardToolbar.update(card)
         quickStartCustomize.update(CUSTOMIZE, card.taskTypeItems)
         quickStartGrow.update(GROW, card.taskTypeItems)
-        quickStartGetToKnowApp.update(GET_TO_KNOW_APP, card.taskTypeItems, card.moreMenuOptions)
+        quickStartGetToKnowApp.update(
+            card.quickStartCardType,
+            GET_TO_KNOW_APP,
+            card.taskTypeItems,
+            card.moreMenuOptions
+        )
     }
 
     private fun MySiteCardToolbarBinding.update(card: QuickStartCard) {
@@ -43,21 +48,27 @@ class QuickStartCardViewHolder(
             mySiteCardToolbar.visibility = View.GONE
             return
         }
+        mySiteCardToolbar.visibility = View.VISIBLE
         mySiteCardToolbarTitle.text = uiHelpers.getTextOfUiString(itemView.context, card.title)
         mySiteCardToolbarMore.visibility = View.VISIBLE
         mySiteCardToolbarMore.setOnClickListener {
             showQuickStartCardMenu(
                 card.moreMenuOptions,
+                card.quickStartCardType,
                 mySiteCardToolbarMore
             )
         }
     }
 
-    private fun showQuickStartCardMenu(moreMenuOptions: QuickStartCard.MoreMenuOptions, anchor: View) {
-        moreMenuOptions.onMoreMenuClick.invoke()
+    private fun showQuickStartCardMenu(
+        moreMenuOptions: QuickStartCard.MoreMenuOptions,
+        cardType: QuickStartCardType,
+        anchor: View
+    ) {
+        moreMenuOptions.onMoreMenuClick.invoke(cardType)
         val quickStartPopupMenu = PopupMenu(itemView.context, anchor)
         quickStartPopupMenu.setOnMenuItemClickListener {
-            moreMenuOptions.onHideThisMenuItemClick.invoke()
+            moreMenuOptions.onHideThisMenuItemClick.invoke(cardType)
             return@setOnMenuItemClickListener true
         }
         quickStartPopupMenu.inflate(R.menu.quick_start_card_menu)
@@ -83,6 +94,7 @@ class QuickStartCardViewHolder(
     }
 
     private fun NewQuickStartTaskTypeItemBinding.update(
+        cardType: QuickStartCardType,
         taskType: QuickStartTaskType,
         taskTypeItems: List<QuickStartTaskTypeItem>,
         moreMenuOptions: QuickStartCard.MoreMenuOptions
@@ -102,6 +114,7 @@ class QuickStartCardViewHolder(
         quickStartItemMoreIcon.setOnClickListener {
             showQuickStartCardMenu(
                 moreMenuOptions,
+                cardType,
                 quickStartItemMoreIcon
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -290,10 +290,15 @@ class QuickStartRepository
         }
     }
 
-    fun shouldShowQuickStartCard(siteId: Long) = appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId).not()
+    fun shouldShowNextStepsCard(siteId: Long) = appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId).not()
 
-    fun onHideQuickStartCard(siteId: Long) = appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, true)
+    fun onHideNextStepsCard(siteId: Long) = appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, true)
 
+    fun shouldShowGetToKnowTheAppCard(siteId: Long) =
+        appPrefsWrapper.getShouldHideGetToKnowTheAppDashboardCard(siteId).not()
+
+    fun onHideShowGetToKnowTheAppCard(siteId: Long) =
+        appPrefsWrapper.setShouldHideGetToKnowTheAppDashboardCard(siteId, true)
 
     private fun onQuickStartNoticeButtonAction(task: QuickStartTask) {
         quickStartTracker.track(Stat.QUICK_START_TASK_DIALOG_POSITIVE_TAPPED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -203,7 +203,8 @@ public class AppPrefs {
         SHOULD_HIDE_PAGES_DASHBOARD_CARD,
         SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD,
         SHOULD_HIDE_POST_DASHBOARD_CARD,
-        SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD
+        SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD,
+        SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD
     }
 
     /**
@@ -1782,5 +1783,17 @@ public class AppPrefs {
 
     public static Boolean getShouldHideNextStepsDashboardCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHideNextStepsDashboardCardKey(siteId), false);
+    }
+
+    public static void setShouldHideGetToKnowTheAppDashboardCard(final long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHideGetToKnowTheAppDashboardCardKey(siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getSiteIdHideGetToKnowTheAppDashboardCardKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD.name() + siteId;
+    }
+
+    public static Boolean getShouldHideGetToKnowTheAppDashboardCard(final long siteId) {
+        return prefs().getBoolean(getSiteIdHideGetToKnowTheAppDashboardCardKey(siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -409,6 +409,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideNextStepsDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideNextStepsDashboardCard(siteId)
 
+    fun setShouldHideGetToKnowTheAppDashboardCard(siteId: Long, isHidden: Boolean) =
+        AppPrefs.setShouldHideGetToKnowTheAppDashboardCard(siteId, isHidden)
+
+    fun getShouldHideGetToKnowTheAppDashboardCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHideGetToKnowTheAppDashboardCard(siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
@@ -65,18 +65,18 @@ class QuickStartTracker @Inject constructor(
         }
     }
 
-    fun trackMoreMenuClicked() {
+    fun trackMoreMenuClicked(card: QuickStartMenuCard) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CONTEXTUAL_MENU_ACCESSED,
-            mapOf(CardsTracker.CARD to QuickStartMenuCard.NEXT_STEPS.label)
+            mapOf(CardsTracker.CARD to card.label)
         )
     }
 
-    fun trackMoreMenuItemClicked() {
+    fun trackMoreMenuItemClicked(card: QuickStartMenuCard) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_MENU_ITEM_TAPPED,
             mapOf(
-                CARD to QuickStartMenuCard.NEXT_STEPS.label,
+                CARD to card.label,
                 ITEM to QuickStartMenuItemType.HIDE_THIS.label
             )
         )
@@ -97,6 +97,7 @@ class QuickStartTracker @Inject constructor(
     }
 
     enum class QuickStartMenuCard(val label: String) {
+        GET_TO_KNOW_THE_APP("get_to_know_the_app"),
         NEXT_STEPS("next_steps")
     }
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartTracker.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.QUICK_START_CARD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.tabs.MySiteTabType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartType.NewSiteQuickStartType
@@ -65,18 +66,18 @@ class QuickStartTracker @Inject constructor(
         }
     }
 
-    fun trackMoreMenuClicked(card: QuickStartMenuCard) {
+    fun trackMoreMenuClicked(card: QuickStartCardType) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CONTEXTUAL_MENU_ACCESSED,
-            mapOf(CardsTracker.CARD to card.label)
+            mapOf(CardsTracker.CARD to card.toQuickStartMenuCard().label)
         )
     }
 
-    fun trackMoreMenuItemClicked(card: QuickStartMenuCard) {
+    fun trackMoreMenuItemClicked(card: QuickStartCardType) {
         analyticsTrackerWrapper.track(
             Stat.MY_SITE_DASHBOARD_CARD_MENU_ITEM_TAPPED,
             mapOf(
-                CARD to card.label,
+                CARD to card.toQuickStartMenuCard().label,
                 ITEM to QuickStartMenuItemType.HIDE_THIS.label
             )
         )
@@ -99,6 +100,13 @@ class QuickStartTracker @Inject constructor(
     enum class QuickStartMenuCard(val label: String) {
         GET_TO_KNOW_THE_APP("get_to_know_the_app"),
         NEXT_STEPS("next_steps")
+    }
+
+    private fun QuickStartCardType.toQuickStartMenuCard(): QuickStartMenuCard {
+        return when (this) {
+            QuickStartCardType.GET_TO_KNOW_THE_APP -> QuickStartMenuCard.GET_TO_KNOW_THE_APP
+            QuickStartCardType.NEXT_STEPS -> QuickStartMenuCard.NEXT_STEPS
+        }
     }
     companion object {
         private const val SITE_TYPE = "site_type"

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -113,6 +113,7 @@ import org.wordpress.android.ui.mysite.cards.jetpackfeature.JetpackFeatureCardSh
 import org.wordpress.android.ui.mysite.cards.jpfullplugininstall.JetpackInstallFullPluginCardBuilder
 import org.wordpress.android.ui.mysite.cards.jpfullplugininstall.JetpackInstallFullPluginShownTracker
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartTabStep
@@ -373,8 +374,8 @@ class MySiteViewModelTest : BaseUnitTest() {
     private val activeTask = MutableLiveData<QuickStartTask>()
     private val quickStartTabStep = MutableLiveData<QuickStartTabStep?>()
 
-    private var quickStartHideThisMenuItemClickAction: (() -> Unit)? = null
-    private var quickStartMoreMenuClickAction: (() -> Unit)? = null
+    private var quickStartHideThisMenuItemClickAction: ((type: QuickStartCardType) -> Unit)? = null
+    private var quickStartMoreMenuClickAction: ((type: QuickStartCardType) -> Unit)? = null
     private var quickStartTaskTypeItemClickAction: ((QuickStartTaskType) -> Unit)? = null
     private var onDashboardErrorRetryClick: (() -> Unit)? = null
     private var onBloggingPromptShareClicked: ((message: String) -> Unit)? = null
@@ -3178,9 +3179,10 @@ class MySiteViewModelTest : BaseUnitTest() {
         return QuickStartCard(
             title = UiStringText(""),
             moreMenuOptions = QuickStartCard.MoreMenuOptions(
-                onMoreMenuClick = { (quickStartMoreMenuClickAction as (() -> Unit)).invoke() },
-                onHideThisMenuItemClick = { (quickStartHideThisMenuItemClickAction as (() -> Unit)).invoke() }
+                onMoreMenuClick = { (quickStartMoreMenuClickAction as ((type: QuickStartCardType) -> Unit)).invoke(QuickStartCardType.NEXT_STEPS) },
+                onHideThisMenuItemClick = { (quickStartHideThisMenuItemClickAction as ((type: QuickStartCardType) -> Unit)).invoke(QuickStartCardType.NEXT_STEPS) }
             ),
+            quickStartCardType = QuickStartCardType.NEXT_STEPS,
             taskTypeItems = listOf(
                 QuickStartTaskTypeItem(
                     quickStartTaskType = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1292,7 +1292,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start full screen dialog is opened`() {
-        initSelectedSite( isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true)
 
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
@@ -1302,7 +1302,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start active task is cleared`() {
-        initSelectedSite( isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true)
 
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
@@ -1340,7 +1340,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when remove next steps dialog negative btn clicked, then QS is not skipped`() {
-        initSelectedSite( isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true)
 
         viewModel.onDialogInteraction(DialogInteraction.Negative(MySiteViewModel.TAG_REMOVE_NEXT_STEPS_DIALOG))
 
@@ -1349,7 +1349,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when QS fullscreen dialog dismiss is triggered, then quick start repository is refreshed`() {
-        initSelectedSite( isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true)
 
         viewModel.onQuickStartFullScreenDialogDismiss()
 
@@ -1359,7 +1359,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `when quick start task is clicked, then task is set as active task`() {
         val task = QuickStartNewSiteTask.VIEW_SITE
-        initSelectedSite( isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true)
 
         viewModel.onQuickStartTaskCardClick(task)
 
@@ -3179,8 +3179,16 @@ class MySiteViewModelTest : BaseUnitTest() {
         return QuickStartCard(
             title = UiStringText(""),
             moreMenuOptions = QuickStartCard.MoreMenuOptions(
-                onMoreMenuClick = { (quickStartMoreMenuClickAction as ((type: QuickStartCardType) -> Unit)).invoke(QuickStartCardType.NEXT_STEPS) },
-                onHideThisMenuItemClick = { (quickStartHideThisMenuItemClickAction as ((type: QuickStartCardType) -> Unit)).invoke(QuickStartCardType.NEXT_STEPS) }
+                onMoreMenuClick = {
+                    (quickStartMoreMenuClickAction as ((type: QuickStartCardType) -> Unit)).invoke(
+                        QuickStartCardType.NEXT_STEPS
+                    )
+                },
+                onHideThisMenuItemClick = {
+                    (quickStartHideThisMenuItemClickAction as ((type: QuickStartCardType) -> Unit)).invoke(
+                        QuickStartCardType.NEXT_STEPS
+                    )
+                }
             ),
             quickStartCardType = QuickStartCardType.NEXT_STEPS,
             taskTypeItems = listOf(
@@ -3208,7 +3216,7 @@ class MySiteViewModelTest : BaseUnitTest() {
                 if (params.showErrorCard) {
                     add(initErrorCard(mockInvocation))
                 } else {
-                //    add(initPostCard(mockInvocation))
+                    //    add(initPostCard(mockInvocation))
                     if (bloggingPromptsFeatureConfig.isEnabled()) add(initBloggingPromptCard(mockInvocation))
                     add(initActivityCard(mockInvocation))
                 }
@@ -3221,6 +3229,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         onDashboardErrorRetryClick = params.onErrorRetryClick
         return ErrorCard(onRetryClick = ListItemInteraction.create { onDashboardErrorRetryClick })
     }
+
     private fun initBloggingPromptCard(mockInvocation: InvocationOnMock): BloggingPromptCardWithData {
         val params = (mockInvocation.arguments.filterIsInstance<DashboardCardsBuilderParams>()).first()
         onBloggingPromptShareClicked = params.bloggingPromptCardBuilderParams.onShareClick

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.mysite.cards.jpfullplugininstall.JetpackInstallF
 import org.wordpress.android.ui.mysite.cards.quickactions.QuickActionsCardBuilder
 import org.wordpress.android.ui.mysite.cards.quicklinksribbon.QuickLinkRibbonBuilder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardBuilder
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.quickstart.QuickStartTaskDetails
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -314,6 +315,7 @@ class CardsBuilderTest {
                 onClick = mock()
             )
         ),
+        quickStartCardType = QuickStartCardType.NEXT_STEPS,
         moreMenuOptions = mock()
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardBuilderTest.kt
@@ -23,8 +23,8 @@ class QuickStartCardBuilderTest : BaseUnitTest() {
     private val completedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.UPDATE_SITE_TITLE)
     private val uncompletedTasks: List<QuickStartTaskDetails> = listOf(QuickStartTaskDetails.VIEW_SITE_TUTORIAL)
     private val onItemClick: (QuickStartTaskType) -> Unit = {}
-    private val onHideThisMenuItemClick: () -> Unit = {}
-    private val onMoreMenuClick: () -> Unit = {}
+    private val onHideThisMenuItemClick: (QuickStartCardType) -> Unit = {}
+    private val onMoreMenuClick: (QuickStartCardType) -> Unit = {}
 
     @Before
     fun setUp() {


### PR DESCRIPTION
Parent #18955 

The PR is a continuation of #19104.
- Reinstated `toolbarVisible` in QuickStartCard because the "card" toolbar should not be shown when the card="Get to know the app"
- Added "QuickStartCardType" to easily identify if the card is "Get to know the app" or "Next Steps". 
- Updated appPreferences to support two different preferences - one for each "Get to know the app" | "Next Steps". 
- Updated cardTracker to track based upon `QuickStartCardType`

**Merge Instructions**
- Review PR #19104 
- Review/test this PR
- Merge PR #19104 
- Verify that the target branch is `feature/dashboard-personalization`
- Remove Not Ready for Merge Label
- Merge as normal


**To test:**
- Install the app
- Login 
- Select a site
- When prompted, select "Show me around"
- ✅ Verify that the "Get to know the app" card is shown in the dashboard and has a more menu
- Tap "Get to know the app" more menu
- ✅ Verify the logs contain  🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"get_to_know_the_app"}
- Tap "Get to know the app" more menu > Hide this
- ✅ Verify the logs contain🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"get_to_know_the_app","item":"hide_this"}


*New Site - Next Steps*
- Navigate to site selector > Add new site > new wordpress.com site
- Follow through the create site flow
- When prompted in the Managing dialog, select "Show me around"
- ✅ Verify that the "Next Steps" card is shown in the dashboard and has a more menu
- Tap "Next Steps" more menu 
- ✅ Verify the logs contain  🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"next_steps"}
- Tap "Next Steps" more menu > Hide this
- ✅ Verify the logs contain🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"next_steps","item":"hide_this"}


## Regression Notes
1. Potential unintended areas of impact
The quick start cards do not show or show when they should not

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
Updated tests

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
