### PR TITLE
Fix: NPE on SiteMode in PluginDetailActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1166,6 +1166,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     // This check should only handle events for already installed plugins - onSitePluginConfigured,
     // onSitePluginUpdated, onSitePluginDeleted
     private boolean shouldHandleFluxCSitePluginEvent(SiteModel eventSite, String eventPluginName) {
+        if (mSite == null) return false;
         return mSite.getId() == eventSite.getId() // correct site
                && mPlugin.isInstalled() // needs plugin to be already installed
                && mPlugin.getName() != null // sanity check for NPE since if plugin is installed it'll have the name


### PR DESCRIPTION
Check if SiteModel is null

Fixes #18652 

To test:

This is hard to reproduce incidence.  Added a null check based on [on Sentry log](https://a8c.sentry.io/issues/3098387072/?project=5731682&referrer=github_integration)

- Launch Jetpack app
- `Navigate` to Menu -> Plugins
- `Select` a Plugin -> Plugin Details
- `Verify` no crash

## Regression Notes
1. Potential unintended areas of impact
Plugin detail may not be available if Site is null

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
