### PR TITLE
Fix NPE on Uri in MediaUtilsWrapper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -65,23 +65,24 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
     fun isVideoFile(mediaUri: Uri): Boolean =
         isVideo(mediaUri) || isVideoMimeType(getMimeType(mediaUri))
 
-    fun isProhibitedVideoDuration(context: Context, site: SiteModel, uri: Uri): Boolean {
-        if (site == null || uri == null) return false
+    fun isProhibitedVideoDuration(context: Context, site: SiteModel?, uri: Uri?): Boolean {
+        if (site != null && uri != null) {
+            if (isVideoFile(uri) && site.hasFreePlan && !site.isActiveModuleEnabled("videopress")) {
+                val retriever = MediaMetadataRetriever()
 
-        if (isVideoFile(uri) && site.hasFreePlan && !site.isActiveModuleEnabled("videopress")) {
-            val retriever = MediaMetadataRetriever()
+                try {
+                    retriever.setDataSource(context, uri)
+                } catch (e: IllegalArgumentException) {
+                    AppLog.d(T.MEDIA, "Cannot retrieve video file $e")
+                }
 
-            try {
-                retriever.setDataSource(context, uri)
-            } catch (e: IllegalArgumentException) {
-                AppLog.d(T.MEDIA, "Cannot retrieve video file $e")
+                val videoDuration =
+                    retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLong() ?: 0
+                retriever.release()
+
+                val allowedVideoDurationForFreeSites = TimeUnit.MILLISECONDS.convert(DURATION_5_MIN, TimeUnit.MINUTES)
+                return allowedVideoDurationForFreeSites < videoDuration
             }
-
-            val videoDuration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLong() ?: 0
-            retriever.release()
-
-            val allowedVideoDurationForFreeSites = TimeUnit.MILLISECONDS.convert(DURATION_5_MIN, TimeUnit.MINUTES)
-            return allowedVideoDurationForFreeSites < videoDuration
         }
 
         return false

--- a/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/MediaUtilsWrapper.kt
@@ -66,6 +66,8 @@ class MediaUtilsWrapper @Inject constructor(private val appContext: Context) {
         isVideo(mediaUri) || isVideoMimeType(getMimeType(mediaUri))
 
     fun isProhibitedVideoDuration(context: Context, site: SiteModel, uri: Uri): Boolean {
+        if (site == null || uri == null) return false
+
         if (isVideoFile(uri) && site.hasFreePlan && !site.isActiveModuleEnabled("videopress")) {
             val retriever = MediaMetadataRetriever()
 


### PR DESCRIPTION
Sometimes, video Uri seems to be null, this should prevent such a situation.

Fixes #18668 

To test:

This may be hard to produce, [going by the log in Sentry](https://a8c.sentry.io/issues/3979839681/?project=5731682&referrer=github_integration)

- Launch JP app
- `Navigate` to Media 
- `Switch` to Videos
- `Upload` a video with duration over 5 minutes
- `Verify` no crash

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.