### PR TITLE
Integrate gutenberg-mobile release 1.103.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 23.2
 -----
 * [*] The Zendesk ticket screen will be displayed for error dialogs resulting from account closure. [https://github.com/wordpress-mobile/WordPress-Android/pull/19023]
-* [***] [Jetpack-only] Contact Support: Need assistance? Use Jetpack mobile assistant for immediate help. Create a support ticket for further assistance. [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]
 * [*] Block Editor: Fix crash when using the Search block TextInput in the block inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6090]
 * [**] [Jetpack-only] Block Editor: Add basic support to view, relocate, and remove the Jetpack Paywall block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6076]
 * [*] Block Editor: Columns block - Fix transforming into a Group block crash [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6129]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 * [*] The Zendesk ticket screen will be displayed for error dialogs resulting from account closure. [https://github.com/wordpress-mobile/WordPress-Android/pull/19023]
 * [***] [Jetpack-only] Contact Support: Need assistance? Use Jetpack mobile assistant for immediate help. Create a support ticket for further assistance. [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]
 * [*] Block Editor: Fix crash when using the Search block TextInput in the block inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6090]
-* [**] Block Editor:  Add basic support to view, relocate, and remove the Jetpack Paywall block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6076]
+* [**] [Jetpack-only] Block Editor: Add basic support to view, relocate, and remove the Jetpack Paywall block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6076]
 * [*] Block Editor: Columns block - Fix transforming into a Group block crash [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6129]
 * [**] Block Editor: Add block outline to all Social Link blocks when selected [https://github.com/WordPress/gutenberg/pull/54011]
 * [***] [Jetpack-only] Contact Support: Add a new chat-based support channel where users can get answers from a bot trained to help app users. Users can still create a support ticket to talk to a Happiness Engineer if they don't find the answer they're looking for  [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,10 @@
 -----
 * [*] The Zendesk ticket screen will be displayed for error dialogs resulting from account closure. [https://github.com/wordpress-mobile/WordPress-Android/pull/19023]
 * [***] [Jetpack-only] Contact Support: Need assistance? Use Jetpack mobile assistant for immediate help. Create a support ticket for further assistance. [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]
+* [*] Block Editor: Fix crash when using the Search block TextInput in the block inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6090]
+* [**] Block Editor:  Add basic support to view, relocate, and remove the Jetpack Paywall block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6076]
+* [*] Block Editor: Columns block - Fix transforming into a Group block crash [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6129]
+* [**] Block Editor: Add block outline to all Social Link blocks when selected [https://github.com/WordPress/gutenberg/pull/54011]
 
 23.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.3.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = '6139-3025c34b5015f43884b697cb0cd80826c97138ce'
+    gutenbergMobileVersion = 'v1.103.0'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.3.0'
     automatticTracksVersion = '3.2.0'
-    gutenbergMobileVersion = 'v1.102.0'
+    gutenbergMobileVersion = '6139-3025c34b5015f43884b697cb0cd80826c97138ce'
     wordPressAztecVersion = 'v1.7.0'
     wordPressFluxCVersion = '2.42.0'
     wordPressLoginVersion = '1.5.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.103.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6139

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.