### PR TITLE
Update chatbot style

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 23.2
 -----
 * [*] The Zendesk ticket screen will be displayed for error dialogs resulting from account closure. [https://github.com/wordpress-mobile/WordPress-Android/pull/19023]
-* [***] [Jetpack-only] Contact Support: Need assistance? Use Jetpack mobile assistant for immediate help. Create a support ticket for further assistance. [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]
+* [***] [Jetpack-only] Contact Support: Add a new chat-based support channel where users can get answers from a bot trained to help app users. Users can still create a support ticket to talk to a Happiness Engineer if they don't find the answer they're looking for  [https://github.com/wordpress-mobile/WordPress-Android/pull/18879]
 
 23.1
 -----

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -23,6 +23,10 @@ a.floating-button {
     font-size: 16px;
 }
 
+.docsbot-user-chat-message {
+    font-size: 16px;
+}
+
 .docsbot-chat-suggested-questions-container span {
     font-size: 16px;
 }

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -33,7 +33,7 @@ a.floating-button {
 }
 
 .docsbot-chat-input {
-    height: 48px;
+    height: 48px !important;
     font-size: 16px !important;
 }
 

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -15,6 +15,10 @@ a.floating-button {
     max-height: none !important;
 }
 
+.docsbot-chat-input-form {
+    margin-bottom: 0px;
+}
+
 .docsbot-chat-bot-message {
     font-size: 16px;
 }


### PR DESCRIPTION
This fixes style issues on the chatbot screen and updates the release notes.
- This removes the gap under the input.
- This fixes the issue that input was shrinking after typing anything.

|before|after|
|-|-|
|![before](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/7d3b01a9-d6a5-407c-ac55-1487038850bc)|![after](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/d8bf382a-5bcd-4b4a-bef9-b45f120e8f0b)|

To test:
1. Launch the app and log in.
2. Navigate to "Me → Debug settings" and ensure `contact_support_chatbot` is enabled.
3. Navigate back.
4. Navigate to "Help → Contact Support".
5. Type a message in the input at the bottom of the screen.
6. Verify that the issues on the before screenshot are fixed and look like the after screenshot.

## Regression Notes
1. Potential unintended areas of impact
Some different cases on chatbot screen

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

8. What automated tests I added (or what prevented me from doing so)
I haven't added any since this only fixes minor UI issues.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
