### PR TITLE
Dashboard Personalization: Set "hide-this" pref from Quick Start Dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -1308,7 +1308,7 @@ class MySiteViewModel @Inject constructor(
         if (!jetpackFeatureRemovalPhaseHelper.shouldShowQuickStart()) return
         quickStartRepository.checkAndSetQuickStartType(isNewSite = isNewSite)
         shouldMarkUpdateSiteTitleTaskComplete = isSiteTitleTaskCompleted
-        showQuickStartDialog(selectedSiteRepository.getSelectedSite())
+        showQuickStartDialog(selectedSiteRepository.getSelectedSite(), isNewSite)
     }
 
     private fun startQuickStart(siteLocalId: Int, isSiteTitleTaskCompleted: Boolean) {
@@ -1324,7 +1324,7 @@ class MySiteViewModel @Inject constructor(
         }
     }
 
-    private fun showQuickStartDialog(siteModel: SiteModel?) {
+    private fun showQuickStartDialog(siteModel: SiteModel?, isNewSite: Boolean) {
         if (siteModel != null && quickStartUtilsWrapper.isQuickStartAvailableForTheSite(siteModel) &&
             !jetpackFeatureRemovalUtils.shouldHideJetpackFeatures()
         ) {
@@ -1334,7 +1334,8 @@ class MySiteViewModel @Inject constructor(
                         R.string.quick_start_dialog_need_help_manage_site_title,
                         R.string.quick_start_dialog_need_help_manage_site_message,
                         R.string.quick_start_dialog_need_help_manage_site_button_positive,
-                        R.string.quick_start_dialog_need_help_button_negative
+                        R.string.quick_start_dialog_need_help_button_negative,
+                        isNewSite
                     )
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -69,7 +69,8 @@ sealed class SiteNavigationAction {
         @StringRes val title: Int,
         @StringRes val message: Int,
         @StringRes val positiveButtonLabel: Int,
-        @StringRes val negativeButtonLabel: Int
+        @StringRes val negativeButtonLabel: Int,
+        val isNewSite: Boolean
     ) : SiteNavigationAction()
 
     data class OpenQuickStartFullScreenDialog(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartPromptDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartPromptDialogViewModel.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.mysite.cards.quickstart
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import javax.inject.Inject
+
+@HiltViewModel
+class QuickStartPromptDialogViewModel @Inject constructor(
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val appPrefsWrapper: AppPrefsWrapper
+) : ViewModel() {
+    fun onNegativeClicked(isNewSite: Boolean) {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            if (isNewSite) {
+                appPrefsWrapper.setShouldHideNextStepsDashboardCard(site.siteId, true)
+            } else {
+                appPrefsWrapper.setShouldHideGetToKnowTheAppDashboardCard(site.siteId,true)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -420,7 +420,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             action.title,
             action.message,
             action.positiveButtonLabel,
-            action.negativeButtonLabel
+            action.negativeButtonLabel,
+            action.isNewSite
         )
         is SiteNavigationAction.OpenQuickStartFullScreenDialog -> openQuickStartFullScreenDialog(action)
         is SiteNavigationAction.OpenDraftsPosts ->
@@ -672,7 +673,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
         @StringRes title: Int,
         @StringRes message: Int,
         @StringRes positiveButtonLabel: Int,
-        @StringRes negativeButtonLabel: Int
+        @StringRes negativeButtonLabel: Int,
+        isNewSite: Boolean
     ) {
         val tag = TAG_QUICK_START_DIALOG
         val quickStartPromptDialogFragment = QuickStartPromptDialogFragment()
@@ -682,7 +684,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             getString(message),
             getString(positiveButtonLabel),
             R.drawable.img_illustration_site_about_280dp,
-            getString(negativeButtonLabel)
+            getString(negativeButtonLabel),
+            isNewSite
         )
         quickStartPromptDialogFragment.show(parentFragmentManager, tag)
         quickStartTracker.track(AnalyticsTracker.Stat.QUICK_START_REQUEST_VIEWED)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/QuickStartPromptDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/QuickStartPromptDialogFragment.kt
@@ -12,15 +12,19 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartPromptDialogViewModel
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPTextView
 import javax.inject.Inject
 
+@AndroidEntryPoint
 class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
     companion object {
         private const val STATE_KEY_DRAWABLE_RES_ID = "state_key_drawable"
@@ -31,6 +35,7 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
         private const val STATE_KEY_NEGATIVE_BUTTON_LABEL = "state_key_negative_button_label"
         private const val UNDEFINED_RES_ID = -1
         private const val SITE_IMAGE_CORNER_RADIUS_IN_DP = 4
+        private const val STATE_KEY_IS_NEW_SITE = "state_key_is_new_site"
     }
 
     @DrawableRes
@@ -41,6 +46,8 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
     private lateinit var positiveButtonLabel: String
     private lateinit var title: String
     private lateinit var siteRecord: SiteRecord
+    private var isNewSite: Boolean = false
+    private val viewModel: QuickStartPromptDialogViewModel by viewModels()
 
     @Inject
     lateinit var imageManager: ImageManager
@@ -62,7 +69,8 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
         message: String,
         positiveButtonLabel: String,
         @DrawableRes drawableResId: Int = UNDEFINED_RES_ID,
-        negativeButtonLabel: String = ""
+        negativeButtonLabel: String = "",
+        isNewSite: Boolean = false
     ) {
         this.fragmentTag = tag
         this.title = title
@@ -70,6 +78,7 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
         this.positiveButtonLabel = positiveButtonLabel
         this.negativeButtonLabel = negativeButtonLabel
         this.drawableResId = drawableResId
+        this.isNewSite = isNewSite
     }
 
     override fun onAttach(context: Context) {
@@ -91,6 +100,7 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
             positiveButtonLabel = requireNotNull(savedInstanceState.getString(STATE_KEY_POSITIVE_BUTTON_LABEL))
             negativeButtonLabel = requireNotNull(savedInstanceState.getString(STATE_KEY_NEGATIVE_BUTTON_LABEL))
             drawableResId = savedInstanceState.getInt(STATE_KEY_DRAWABLE_RES_ID)
+            isNewSite = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_SITE)
         }
     }
 
@@ -101,6 +111,7 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
         outState.putString(STATE_KEY_POSITIVE_BUTTON_LABEL, positiveButtonLabel)
         outState.putString(STATE_KEY_NEGATIVE_BUTTON_LABEL, negativeButtonLabel)
         outState.putInt(STATE_KEY_DRAWABLE_RES_ID, drawableResId)
+        outState.putBoolean(STATE_KEY_IS_NEW_SITE, isNewSite)
 
         super.onSaveInstanceState(outState)
     }
@@ -169,6 +180,7 @@ class QuickStartPromptDialogFragment : AppCompatDialogFragment() {
             buttonNegative.visibility = View.VISIBLE
             buttonNegative.text = negativeButtonLabel
             buttonNegative.setOnClickListener {
+                viewModel.onNegativeClicked(isNewSite)
                 if (activity is QuickStartPromptClickInterface) {
                     (activity as QuickStartPromptClickInterface).onNegativeClicked(fragmentTag)
                 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1406,7 +1406,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 R.string.quick_start_dialog_need_help_manage_site_title,
                 R.string.quick_start_dialog_need_help_manage_site_message,
                 R.string.quick_start_dialog_need_help_manage_site_button_positive,
-                R.string.quick_start_dialog_need_help_button_negative
+                R.string.quick_start_dialog_need_help_button_negative,
+                true
             )
         )
     }
@@ -1424,7 +1425,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 R.string.quick_start_dialog_need_help_manage_site_title,
                 R.string.quick_start_dialog_need_help_manage_site_message,
                 R.string.quick_start_dialog_need_help_manage_site_button_positive,
-                R.string.quick_start_dialog_need_help_button_negative
+                R.string.quick_start_dialog_need_help_button_negative,
+                false
             )
         )
     }


### PR DESCRIPTION
Closes #18955 

This PR sets the "hide-this" preference for "Get to know the app" or "Next Steps" quick start card upon a negative interaction with the Quick Start Prompt Dialog. 

The approach I took was to introduce `QuickStartPromptDialogViewModel` into QuickStartPromptDialogFragment rather than passing the isNewSite value down the chain via the clickInterface. I chose this because WPMainActivity implements two onNegativeClick listeners and it felt clumsy to adjust both to match the interface.

**To test:** (Best to connect to Android Studio for this)
- Uninstall any debug version of the app on your device
- Install the app
- Open Android Studio > Device Explorer  
- Navigate to data > data > com.jetpack.android.prealpha > shared_prefs
- Double click on `com.jetpack.android.prealpha_preferences.xml`
- ✅ Verify there are no settings for `boolean name="SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD{siteId}" value="true" `  **OR** `boolean name="SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD{siteId}" value="true" `
- Login and select a site
- When prompted with the Quick Start Prompt Dialog, select the Negative Option "No thanks"
- Navigate back to Device Explorer and reload the preferences xml file
-  ✅ Verify there is an entry for `boolean name="SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD{siteId}" value="true" `
- Navigate to Site Selector > More > Create WP.com site
- Follow the instructions to create a site
- When prompted with the Quick Start Prompt Dialog, select the Negative Option "No thanks"
- Navigate back to Device Explorer and reload the preferences xml file
-  ✅ Verify there is an entry for `boolean name="SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD{siteId}" value="true" `

## Regression Notes
1. Potential unintended areas of impact
The hide-this preference is not set

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
