### PR TITLE
[Reader Improvements] Implement new header for tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -210,6 +210,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, getString(R.string.fragment_tag_reader_post_list))
                 .commit();
+        setTitle("");
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.RelativeLayout
+import androidx.core.view.isGone
 import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ReaderTagHeaderViewBinding
@@ -12,7 +13,6 @@ import org.wordpress.android.ui.reader.views.ReaderTagHeaderViewUiState.ReaderTa
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.LocaleProvider
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
-import org.wordpress.android.util.extensions.gone
 import javax.inject.Inject
 
 /**
@@ -74,7 +74,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     }
 
     fun updateUi(uiState: ReaderTagHeaderUiState) = with(binding) {
-        (binding as? ReaderTagBinding.ImprovementsEnabled)?.textTagFollowCount?.gone()
+        (binding as? ReaderTagBinding.ImprovementsEnabled)?.textTagFollowCount?.isGone = true
         // creative-writing -> Creative Writing
         textTag.text = uiState.title
             .split("-")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -12,7 +12,6 @@ import org.wordpress.android.ui.reader.views.ReaderTagHeaderViewUiState.ReaderTa
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
 import org.wordpress.android.util.extensions.gone
-import org.wordpress.android.util.extensions.visible
 import javax.inject.Inject
 
 /**
@@ -55,8 +54,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
         binding.followButton.setOnClickListener { onFollowBtnClicked?.invoke() }
     }
 
-    abstract class ReaderTagBinding(
-    ) {
+    abstract class ReaderTagBinding {
         abstract val textTag: MaterialTextView
         abstract val followButton: ReaderFollowButton
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.RelativeLayout
+import com.google.android.material.textview.MaterialTextView
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.ReaderTagHeaderViewBinding
+import org.wordpress.android.databinding.ReaderTagHeaderViewNewBinding
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderViewUiState.ReaderTagHeaderUiState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
+import org.wordpress.android.util.extensions.visible
 import javax.inject.Inject
 
 /**
@@ -18,16 +22,54 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : RelativeLayout(context, attrs, defStyleAttr) {
-    private val binding = ReaderTagHeaderViewBinding.inflate(LayoutInflater.from(context), this, true)
+
+    private var binding: ReaderTagBinding
 
     @Inject
     lateinit var uiHelpers: UiHelpers
 
+    @Inject
+    lateinit var readerImprovementsFeatureConfig: ReaderImprovementsFeatureConfig
+
     private var onFollowBtnClicked: (() -> Unit)? = null
 
     init {
+        binding = if (readerImprovementsFeatureConfig.isEnabled()) {
+            val readerTagHeaderViewNewBinding =
+                ReaderTagHeaderViewNewBinding.inflate(LayoutInflater.from(context), this, true)
+            ReaderTagBinding.ImprovementsEnabled(
+                textTag = readerTagHeaderViewNewBinding.textTag,
+                followButton = readerTagHeaderViewNewBinding.followContainer.followButton,
+                textTagFollowCount = readerTagHeaderViewNewBinding.followContainer.textBlogFollowCount,
+            )
+        } else {
+            val readerTagHeaderViewBinding =
+                ReaderTagHeaderViewBinding.inflate(LayoutInflater.from(context), this, true)
+            ReaderTagBinding.ImprovementsDisabled(
+                textTag = readerTagHeaderViewBinding.textTag,
+                followButton = readerTagHeaderViewBinding.followButton,
+            )
+        }
         (context.applicationContext as WordPress).component().inject(this)
+        binding.followButton.visible()
         binding.followButton.setOnClickListener { onFollowBtnClicked?.invoke() }
+    }
+
+    abstract class ReaderTagBinding(
+    ) {
+        abstract val textTag: MaterialTextView
+        abstract val followButton: ReaderFollowButton
+
+        data class ImprovementsDisabled(
+            override val textTag: MaterialTextView,
+            override val followButton: ReaderFollowButton
+        ) : ReaderTagBinding()
+
+        data class ImprovementsEnabled(
+            override val textTag: MaterialTextView,
+            override val followButton: ReaderFollowButton,
+            val textTagFollowCount: MaterialTextView,
+        ) : ReaderTagBinding()
     }
 
     fun updateUi(uiState: ReaderTagHeaderUiState) = with(binding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -34,6 +34,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     private var onFollowBtnClicked: (() -> Unit)? = null
 
     init {
+        (context.applicationContext as WordPress).component().inject(this)
         binding = if (readerImprovementsFeatureConfig.isEnabled()) {
             val readerTagHeaderViewNewBinding =
                 ReaderTagHeaderViewNewBinding.inflate(LayoutInflater.from(context), this, true)
@@ -50,7 +51,6 @@ class ReaderTagHeaderView @JvmOverloads constructor(
                 followButton = readerTagHeaderViewBinding.followButton,
             )
         }
-        (context.applicationContext as WordPress).component().inject(this)
         binding.followButton.visible()
         binding.followButton.setOnClickListener { onFollowBtnClicked?.invoke() }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.databinding.ReaderTagHeaderViewBinding
 import org.wordpress.android.databinding.ReaderTagHeaderViewNewBinding
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderViewUiState.ReaderTagHeaderUiState
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.LocaleProvider
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
 import org.wordpress.android.util.extensions.gone
 import javax.inject.Inject
@@ -29,6 +30,9 @@ class ReaderTagHeaderView @JvmOverloads constructor(
 
     @Inject
     lateinit var readerImprovementsFeatureConfig: ReaderImprovementsFeatureConfig
+
+    @Inject
+    lateinit var localeProvider: LocaleProvider
 
     private var onFollowBtnClicked: (() -> Unit)? = null
 
@@ -71,7 +75,12 @@ class ReaderTagHeaderView @JvmOverloads constructor(
 
     fun updateUi(uiState: ReaderTagHeaderUiState) = with(binding) {
         (binding as? ReaderTagBinding.ImprovementsEnabled)?.textTagFollowCount?.gone()
+        // creative-writing -> Creative Writing
         textTag.text = uiState.title
+            .split("-")
+            .joinToString(separator = " ") {
+                it.replaceFirstChar { it.titlecase(localeProvider.getAppLocale()) }
+            }
         with(uiState.followButtonUiState) {
             followButton.setIsFollowed(isFollowed)
             followButton.isEnabled = isEnabled

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.databinding.ReaderTagHeaderViewNewBinding
 import org.wordpress.android.ui.reader.views.ReaderTagHeaderViewUiState.ReaderTagHeaderUiState
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
+import org.wordpress.android.util.extensions.gone
 import org.wordpress.android.util.extensions.visible
 import javax.inject.Inject
 
@@ -51,7 +52,6 @@ class ReaderTagHeaderView @JvmOverloads constructor(
                 followButton = readerTagHeaderViewBinding.followButton,
             )
         }
-        binding.followButton.visible()
         binding.followButton.setOnClickListener { onFollowBtnClicked?.invoke() }
     }
 
@@ -73,6 +73,7 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     }
 
     fun updateUi(uiState: ReaderTagHeaderUiState) = with(binding) {
+        (binding as? ReaderTagBinding.ImprovementsEnabled)?.textTagFollowCount?.gone()
         textTag.text = uiState.title
         with(uiState.followButtonUiState) {
             followButton.setIsFollowed(isFollowed)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagHeaderView.kt
@@ -22,7 +22,6 @@ class ReaderTagHeaderView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : RelativeLayout(context, attrs, defStyleAttr) {
-
     private var binding: ReaderTagBinding
 
     @Inject

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
@@ -83,3 +83,15 @@ fun RecyclerView.disableAnimation() {
 }
 
 fun View.getString(@StringRes stringRes: Int) = context.getString(stringRes)
+
+fun View.visible() {
+    this.visibility = View.VISIBLE
+}
+
+fun View.gone() {
+    this.visibility = View.GONE
+}
+
+fun View.invisible() {
+    this.visibility = View.INVISIBLE
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
@@ -83,15 +83,3 @@ fun RecyclerView.disableAnimation() {
 }
 
 fun View.getString(@StringRes stringRes: Int) = context.getString(stringRes)
-
-fun View.visible() {
-    this.visibility = View.VISIBLE
-}
-
-fun View.gone() {
-    this.visibility = View.GONE
-}
-
-fun View.invisible() {
-    this.visibility = View.INVISIBLE
-}

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -23,7 +23,6 @@
         style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_medium"
         android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -24,10 +24,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small_medium"
-        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_blog_follow_count"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:alpha="@dimen/material_emphasis_high_type"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="@dimen/text_sz_medium"
+        app:layout_constraintBaseline_toBaselineOf="@+id/follow_button"
+        app:layout_constraintEnd_toStartOf="@+id/follow_button"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="123 posts • 1.2m followers" />
+
+    <org.wordpress.android.ui.reader.views.ReaderFollowButton
+        android:id="@+id/follow_button"
+        style="@style/Reader.Follow.Button.New"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/text_blog_follow_count"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -9,6 +9,7 @@
         android:id="@+id/text_blog_follow_count"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:visibility="invisible"
         android:layout_marginEnd="@dimen/margin_large"
         android:alpha="@dimen/material_emphasis_high_type"
         android:textColor="?attr/colorOnSurface"

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -15,6 +15,7 @@
         app:layout_constraintBottom_toTopOf="@+id/follow_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginBottom="@dimen/margin_medium"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="123 posts • 1.2m followers" />
 
@@ -23,7 +24,6 @@
         style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small_medium"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count" />

--- a/WordPress/src/main/res/layout/reader_header_follow_container.xml
+++ b/WordPress/src/main/res/layout/reader_header_follow_container.xml
@@ -9,14 +9,13 @@
         android:id="@+id/text_blog_follow_count"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:visibility="invisible"
-        android:layout_marginEnd="@dimen/margin_large"
         android:alpha="@dimen/material_emphasis_high_type"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/text_sz_medium"
-        app:layout_constraintBaseline_toBaselineOf="@+id/follow_button"
-        app:layout_constraintEnd_toStartOf="@+id/follow_button"
+        app:layout_constraintBottom_toTopOf="@+id/follow_button"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="123 posts • 1.2m followers" />
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
@@ -24,11 +23,11 @@
         style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small_medium"
         android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/text_blog_follow_count"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_site_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view_new.xml
@@ -66,17 +66,10 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_blog_name"
-            style="@style/ReaderTextView.Site.Header.Title"
+            style="@style/ReaderTextView.Site.Header.NewTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"
-            android:ellipsize="end"
-            android:fontFamily="@font/noto_serif"
-            android:maxLines="5"
-            android:textColor="?attr/colorOnSurface"
-            android:textStyle="bold"
-            app:autoSizeMaxTextSize="@dimen/text_sz_double_extra_large"
-            app:autoSizeMinTextSize="@dimen/text_sz_larger"
             app:layout_constraintBottom_toTopOf="@+id/text_domain"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/layout/reader_site_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view_new.xml
@@ -21,21 +21,7 @@
             android:src="@drawable/bg_oval_placeholder_image_32dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/text_blog_follow_count"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_large"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:alpha="@dimen/material_emphasis_high_type"
-            android:textColor="?attr/colorOnSurface"
-            android:textSize="@dimen/text_sz_medium"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_blog_description"
-            tools:text="123 posts • 1.2m followers" />
-
+        
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_domain"
             android:layout_width="0dp"
@@ -76,16 +62,14 @@
             app:layout_constraintTop_toBottomOf="@+id/image_blavatar"
             tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eget ligula eu lectus lobortis condimentum. Aliquam nonummy auctor massa. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas." />
 
-        <org.wordpress.android.ui.reader.views.ReaderFollowButton
-            android:id="@+id/follow_button"
-            style="@style/Reader.Follow.Button.New"
-            android:layout_width="wrap_content"
+        <include
+            layout="@layout/reader_header_follow_container"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_small_medium"
-            android:visibility="invisible"
+            android:layout_marginTop="@dimen/margin_medium"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/text_blog_follow_count"
-            tools:visibility="visible" />
+            app:layout_constraintTop_toBottomOf="@+id/text_blog_description" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/ReaderCardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_tag_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/reader_tag_header_vertical_padding"
+        android:paddingEnd="@dimen/reader_tag_header_horizontal_padding"
+        android:paddingStart="@dimen/reader_tag_header_horizontal_padding"
+        android:paddingTop="@dimen/reader_tag_header_vertical_padding">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/text_tag"
+            style="@style/ReaderTextView.Site.Header.NewTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            app:layout_constraintBottom_toTopOf="@+id/follow_container"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Lorem ipsum dolor sit amet" />
+
+        <include
+            android:id="@+id/follow_container"
+            layout="@layout/reader_header_follow_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_tag" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -18,7 +18,6 @@
             style="@style/ReaderTextView.Site.Header.NewTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
             app:layout_constraintBottom_toTopOf="@+id/follow_container"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -11,10 +11,7 @@
         android:id="@+id/layout_tag_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_medium">
+        android:padding="@dimen/margin_extra_large">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_tag"

--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -11,10 +11,10 @@
         android:id="@+id/layout_tag_info"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/reader_tag_header_vertical_padding"
-        android:paddingEnd="@dimen/reader_tag_header_horizontal_padding"
-        android:paddingStart="@dimen/reader_tag_header_horizontal_padding"
-        android:paddingTop="@dimen/reader_tag_header_vertical_padding">
+        android:paddingBottom="@dimen/margin_medium"
+        android:paddingEnd="@dimen/margin_extra_large"
+        android:paddingStart="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_medium">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_tag"

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -201,6 +201,18 @@
         <item name="android:fontFamily">serif</item>
     </style>
 
+    <style name="ReaderTextView.Site.Header.NewTitle" parent="ReaderTextView">
+        <item name="android:textAppearance">?attr/textAppearanceHeadline6</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:gravity">start</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:fontFamily">@font/noto_serif</item>
+        <item name="android:maxLines">5</item>
+        <item name="android:textStyle">bold</item>
+        <item name="autoSizeMaxTextSize">@dimen/text_sz_double_extra_large</item>
+        <item name="autoSizeMinTextSize">@dimen/text_sz_larger</item>
+    </style>
+
     <style name="ReaderTextView.Site.Header.Caption" parent="ReaderTextView">
         <item name="android:textAppearance">?attr/textAppearanceCaption</item>
         <item name="textColor">?attr/colorOnSurface</item>


### PR DESCRIPTION
Fixes #19077 

To test:
1 - Open `"Me"` -> Debug settings -> `"Features in development"`;
2 - Enable `ReaderImprovementsFeatureConfig`;
3 - Move back to home and open Reader;
4 - Tap on any tag to open the tag posts list;
5 - You should see the new header layout. Make sure follow/unfollow button is working as expected;
<p float="left">
<img width="300" alt="Screen Shot 2023-09-01 at 2 18 41 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/c5cf2c60-4477-44fe-8131-e536833042c6">
<img width="300" alt="Screen Shot 2023-09-01 at 2 19 02 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/5e42d920-d838-4199-8ca6-9502c6430be9">
</p>


6 - Repeat step 1 but this time disable `ReaderImprovementsFeatureConfig`;
7 - Repeat steps 3 and 4: you should see the existing header layout. Make sure follow/unfollow button is working as expected.
<p float="left">
<img width="300" alt="Screen Shot 2023-08-31 at 3 45 08 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/5e099c3c-7f03-42c8-8805-3e6a4acd965e">
<img width="300" alt="Screen Shot 2023-08-31 at 3 45 15 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/4225fb76-22ce-4b01-84c5-bae8451a48e0">
</p>


## Regression Notes
1. Potential unintended areas of impact
None (implementation behind feature flag)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None (all existing logic is inside a custom view)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
