### PR TITLE
Domain transfer card fix crash on more menu tapped

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCardViewHolder.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool
 import org.wordpress.android.databinding.DomainTransferCardBinding
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardCards.DashboardCard.DomainTransferCardModel
@@ -13,12 +14,16 @@ import org.wordpress.android.util.extensions.viewBinding
 class DomainTransferCardViewHolder(parent: ViewGroup) :
     CardViewHolder<DomainTransferCardBinding>(parent.viewBinding(DomainTransferCardBinding::inflate)) {
     fun bind(cardModel: DomainTransferCardModel) = with(binding) {
-        domainTransferCard.setContent {
-            AppTheme {
-                DomainTransferCard(
-                    domainTransferCardModel = cardModel,
-                    modifier = Modifier.fillMaxWidth().wrapContentHeight()
-                )
+        // Dispose of the Composition when the view's LifecycleOwner is destroyed
+        this.domainTransferCard.apply {
+            setViewCompositionStrategy(DisposeOnDetachedFromWindowOrReleasedFromPool)
+            setContent {
+                AppTheme {
+                    DomainTransferCard(
+                        domainTransferCardModel = cardModel,
+                        modifier = Modifier.fillMaxWidth().wrapContentHeight()
+                    )
+                }
             }
         }
     }

--- a/WordPress/src/main/res/layout/domain_transfer_card.xml
+++ b/WordPress/src/main/res/layout/domain_transfer_card.xml
@@ -8,6 +8,7 @@
         android:id="@+id/domain_transfer_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        tools:composableName="org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer.DomainTransferCardKt.DomainTransferCardPreview"
         tools:ignore="RtlSymmetry" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #19128 

See https://a8c.sentry.io/issues/4416036433/events/68cdceeba80c448ba91399279507a691/?project=5731682

| Domain Transfer Card | Domain Transfer Intro |
|--------|--------|
| ![Screenshot_20230802_133138](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/fde5e739-9a94-4319-bae7-c7cb308e2e1e) |![Screenshot_20230729_145335](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/026d3e4a-33f5-4db3-8c76-776c930dbef8) | 

To test:

Launch Jetpack app
`Verify` **domains transfer card** appears as shown above on dashboard
`Tap` on the Learn more or anywhere on the card
`Verify` it launches [domain transfer page](https://wordpress.com/setup/domain-transfer/intro)
`Tap` on overflow (three dots) menu on the card
`Verify` it pops up menu with **Hide this** option
`Tap` on Hide this
`Verify`, the card gets hidden 
`Verify`, **no crash in AS Logcat**

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
