### PR TITLE
[UI Tests] Move JP UI tests to JP directory.

### DIFF
--- a/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ContactUsTests.kt
+++ b/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ContactUsTests.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.e2e.flows.LoginFlow

--- a/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ContactUsTests.kt
+++ b/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ContactUsTests.kt
@@ -14,9 +14,6 @@ import org.wordpress.android.test.BuildConfig
 class ContactUsTests : BaseTest() {
     @Before
     fun setUp() {
-        // We run the class for JP only (so far the class contains
-        // only a test for Domains card, which in not valid for WP)
-        Assume.assumeTrue(BuildConfig.IS_JETPACK_APP)
         ComposeEspressoLink().unregister()
         logoutIfNecessary()
     }

--- a/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -13,9 +13,6 @@ import org.wordpress.android.test.BuildConfig
 class DashboardTests : BaseTest() {
     @Before
     fun setUp() {
-        // We run the class for JP only (so far the class contains
-        // only a test for Domains card, which in not valid for WP)
-        assumeTrue(BuildConfig.IS_JETPACK_APP)
         ComposeEspressoLink().unregister()
         logoutIfNecessary()
         wpLogin()

--- a/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/DashboardTests.kt
+++ b/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/DashboardTests.kt
@@ -1,13 +1,11 @@
 package org.wordpress.android.e2e
 
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.wordpress.android.e2e.pages.MySitesPage
 import org.wordpress.android.support.BaseTest
 import org.wordpress.android.support.ComposeEspressoLink
-import org.wordpress.android.test.BuildConfig
 
 @HiltAndroidTest
 class DashboardTests : BaseTest() {


### PR DESCRIPTION
### What

Continuation of #18922.

There are some tests that are only executed for Jetpack. Before this PR, these tests were skipped for WP by using `Assume.assumeTrue(BuildConfig.IS_JETPACK_APP)` in `setUp`. Now, this is done by keeping such tests in a dedicated `androidTestJetpack` directory.

### Testing Instructions

- For [JP](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/e9cd0950-28ae-4b22-8385-c4c19564f99b/018a64bc-183e-4f1e-b280-41557b6b6f06/018a64bc-4b6f-44cc-89fb-9ea67a1222ef/build/instrumented-tests/2023-09-05_09%3A55%3A46.573631_JwYQ/Pixel2.arm-30-en-portrait/test_result_1.xml?response-content-type=application%2Fxml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LSCGTB76V%2F20230905%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230905T102250Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEIL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQDkJfZ5Hcsxi5%2BkjnrwsxV64S0JBzeLtxKt0X4d8zmUagIgfXZYt0Tc5gGXepimxYS1eBiPF8Jgo1mQaarao%2FnmAjEq8QMIWhAAGgwwMzIzNzk3MDUzMDMiDLnhclra3n%2B4JgFOeyrOAw3tRCZyiYjWi33B2v0fV1gBOJOhPJxhHMZBLhHdZjOs1sVoqzSPxVFXlp8sFKRDrHi6YbDZCRgdlsqw2D4UWvVVlcORQa5QMQD8isXXVvzS%2Fe40PuGZTEFQzWl3PSRZ3BxTqTFzfplWkNZnGh46YJV9%2BoQH25uyElxozpsSlE7gWL4Oh4TYpkBGhINNW3faBR0C5f9MXLMqBfD5sXznBMJcOlIXnySkCd7MsSyG2EuHfuCdFbmDmKhtz8sMqulbWEAlt%2BZ%2BJyHXvux70N3r5faGk%2BwiNJz3hjkjsq6%2BhgUVK5que%2F6oXsOxXmh3a3wRRJXn3fNeSP7it3WQAoU%2FbtOcRqnhKzOrEldrM9qj0jl71kKmfxuSEjP%2BdfkYCOUfVHW7yhSpbTmF0UH0vxQh2W8%2F5WDol%2Fluslz7abOJ8Nd9yxS0j0KN9c48F3ZFpp8nbZFQ%2BpuXit6p5F5H6wDyQmYUGqfFrDy03S3d2Kpemu%2F%2F5DDuOtwwqe2VTTEKIvjed3PIrl00zvR3vYBcCLDCbE%2FtvCGGbMtZ3HH6B855DaDbD1xMMKzULvPiVT94UcduTCeilFfno9lXcrZmxDibnMLCUoYjz0llFsrGuf86kTDd5NunBjqlAaFGnEP6E%2BLfOt0B5IhJL4qOdmamh8H0kmW7Absd6oWyQYbAxfGB8zpyC%2F%2FkbI3YHLACG02XeYVAT1kgCXCw0PLPmHs5GFI0HBcrwMqJwJRlHPhg6wOv2j%2BZb0xAGJUjis2rvSxxtXU41ysf414iGC%2BvI%2B3hUdb3QBE8reE4SPYGbIyK7dAZMHdAaBLIa9UHC2PA90qAsGKmX%2F2WkWIsv7T9u1JFWg%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=9f200eecd34b06ce8716fc1e4529cac45f6712fb833065e1a5aee444b41986d1), the tests from `e2e.ContactUsTests`, `e2e.DashboardTests` and `e2e.ReaderTests` are executed.
- For [WP](https://buildkiteartifacts.com/b26f1746-2f0c-49cc-bbd1-a45a5e24c351/e9cd0950-28ae-4b22-8385-c4c19564f99b/018a64bc-183e-4f1e-b280-41557b6b6f06/018a64bc-4b6b-4f18-a20c-284c2f048b40/build/instrumented-tests/2023-09-05_09%3A56%3A27.201705_HJzm/Pixel2.arm-30-en-portrait/test_result_1.xml?response-content-type=application%2Fxml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7L4OCAP6GP%2F20230905%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230905T102302Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEIL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJIMEYCIQDc9vJ5YAt%2BdkXfPCGuoVLKbh9fSBWN7Obyk6YHNIikowIhAP4fx42OigCh3Fgh4tQPUSIK7gxulC%2Bi%2F1WUI6bLOSpXKvEDCFoQABoMMDMyMzc5NzA1MzAzIgzotOGmXBVLeUvyDEEqzgO0tWfD49KWW8cbS6qFVSfH%2FmKZHnM0x2GIaObGw8ggQUZj%2FIW99qS10na4qFCXMC%2B%2FdCwkv73mG9UWWeYioknBgGg%2FH8fu8orosEUQuDff6trmnYGuuLjTn4pdifRQjxhdvjzbgh54nfRY0Ja1IDhTyktgDml1cckVzIMiCEa2hwV%2FjMwu8z8bsIIBItvF%2BAI7cBVXIQuetmkAPqA%2FtuNrybJMYQvaRCwqrGgMlLnsYrZ6YhxsB9IZVZ0HH26z47Nym2%2B9xXYl6dPdiOnpj8C%2B4qOy7F6Bp5Xew9yPQlO0oUvQs0iVpxJ7tGkzJ8yH0uUGCqDAvgWwz%2FKlJIgH5Btna4tb3PBF%2FqNDlhHHuv0JLXsA8mKU1ixDW0f2EIw%2F7zb%2BUWBYac3W0UzGw8eSwcB3KYqkm8zU3KAsquBEnjELll9U2pRMrX7d%2FJkPluZoZbJuPibyBDOkMXhRpFK%2BvPDTQsCmgUrxvZETxxk1VBxLnlftcyrGCFGUoxaYTTNdjknt2P7QVoovR50uaFqffTpACAaw1CPamXok3tXYpeNX1EiBXc0%2F4TuEuMv4VVRdASsX%2FLpnTaMI2CPr2Fj%2FQcWi%2BkVFR2VgIjswm9WuoIow3OTbpwY6pAFy8L0UG3cu0Eav%2FIndnr4eNosk7AGQX%2BGe3u72R9YUlIBMYjydyxoXks0KQqUAWLLOWozMCBCq4PwrqtjXAe2XPUFV0bgDrLZTRs4KmEfzAObMkVCYIvn39%2B82Zz62xMusQkHPjdo01ya9lbJY0Y8EXrMuOYa8WL73mjIHKHajiVXLHU8xSEbVlmkIDYSWSzgegJk0VCRUGFpmtSPuPUDG2K5z9g%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=137f43cf627377223307776515b45d7f8b384440578fbb6d09746058c9e1ed44), the tests (9 in total) from mentioned classes are _not_ executed.