### PR TITLE
Audit access to private data

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -289,7 +289,6 @@ class AppInitializer @Inject constructor(
             logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
         }
 
-        @RequiresApi(VERSION_CODES.R)
         override fun onAsyncNoted(asyncNotedAppOp: AsyncNotedAppOp) {
             logPrivateDataAccess(asyncNotedAppOp.op, asyncNotedAppOp.message)
         }

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -398,10 +398,8 @@ class AppInitializer @Inject constructor(
 
         debugCookieManager.sync()
 
-        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
-            if (!initialized) {
-                initAppOpsManager()
-            }
+        if (!initialized && BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
+            initAppOpsManager()
         }
 
         initialized = true

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -399,7 +399,9 @@ class AppInitializer @Inject constructor(
         debugCookieManager.sync()
 
         if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
-            initAppOpsManager()
+            if (!initialized) {
+                initAppOpsManager()
+            }
         }
 
         initialized = true

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -3,9 +3,12 @@
 package org.wordpress.android
 
 import android.annotation.SuppressLint
+import android.app.AppOpsManager
 import android.app.Application
+import android.app.AsyncNotedAppOp
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.SyncNotedAppOp
 import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.Intent
@@ -24,6 +27,7 @@ import android.util.AndroidRuntimeException
 import android.util.Log
 import android.webkit.WebSettings
 import android.webkit.WebView
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -267,6 +271,30 @@ class AppInitializer @Inject constructor(
         }
     }
 
+    /**
+     * Data access auditing
+     * @link https://developer.android.com/guide/topics/data/audit-access
+     */
+    @RequiresApi(VERSION_CODES.R)
+    val appOpsCallback = object : AppOpsManager.OnOpNotedCallback() {
+        private fun logPrivateDataAccess(opCode: String, trace: String) {
+            AppLog.i(T.MAIN, "Private data accessed. Operation: $opCode\nStack Trace:\n$trace")
+        }
+
+        override fun onNoted(syncNotedAppOp: SyncNotedAppOp) {
+            logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
+        }
+
+        override fun onSelfNoted(syncNotedAppOp: SyncNotedAppOp) {
+            logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
+        }
+
+        @RequiresApi(VERSION_CODES.R)
+        override fun onAsyncNoted(asyncNotedAppOp: AsyncNotedAppOp) {
+            logPrivateDataAccess(asyncNotedAppOp.op, asyncNotedAppOp.message)
+        }
+    }
+
     init {
         context = application
         startDate = SystemClock.elapsedRealtime()
@@ -370,7 +398,17 @@ class AppInitializer @Inject constructor(
 
         debugCookieManager.sync()
 
+        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
+            initAppOpsManager()
+        }
+
         initialized = true
+    }
+
+    @RequiresApi(VERSION_CODES.R)
+    private fun initAppOpsManager() {
+        val appOpsManager = context?.getSystemService(AppOpsManager::class.java) as AppOpsManager
+        appOpsManager.setOnOpNotedCallback(context?.mainExecutor, appOpsCallback)
     }
 
     private fun initWorkManager() {


### PR DESCRIPTION
Update AppInitializer to log access to private data

https://developer.android.com/guide/topics/data/audit-access

See p1693866457206239-slack-CC7L49W13

Also #19061, and #19076 

To test:
- Use AS
- Launch JP/WP app on a device, emulator with Android 11 (API level 30) or above
- Observe in **WordPress-MAIN** `Logcat Private data accessed` logs
- Particularly anything related to Contacts data

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.