### PR TITLE
Fix wrong menu button behavior on post detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -39,6 +39,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.Factory
 import androidx.recyclerview.widget.DefaultItemAnimator
@@ -495,7 +496,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().addMenuProvider(this, viewLifecycleOwner)
+        requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
         val binding = ReaderFragmentPostDetailBinding.bind(view)
 
         initLikeFacesRecycler(savedInstanceState)


### PR DESCRIPTION
Fixes #18693 

This fixes the behavior of menu buttons on the reader post detail screen.

`ReaderPostDetailFragment` is being used in view pagers. We were adding menu buttons with,
```
requireActivity().addMenuProvider(this, viewLifecycleOwner)
```
But, since there are multiple `ReaderPostDetailFragment`s in the view pager, they are in race to handle menu by adding their menu provider. If we don't specify a lifecycle state when calling `addMenuProvider(...)`, the provider will be [removed](https://developer.android.com/reference/androidx/core/view/MenuHost#addMenuProvider(androidx.core.view.MenuProvider,androidx.lifecycle.LifecycleOwner)) on ON_DESTROY event. But our fragments are alive in view pagers, so they should be removed with onPause event. Now were are calling addMenuProvider by specifying a state:
```
requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
```
Now, the menu provider will be added with `onResume` and be removed with `onPause`.

---
_This PR fixes multiple issues._
### Like notification
Like notification screen shouldn't contain menu buttons. (There aren't menu buttons on iOS as well)
|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/c121528f-95e0-4b86-9bb1-a9e432c62076" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/174f40c6-7746-47c5-90f7-05b439f80b89" width=300>|

To test:
1. Launch the JP app.
2. Open the Notifications tab.
3. Tap on a like notification item.
4. Ensure there are no menu buttons on top, except the back button.

### Reader detail menu buttons
If you scroll the view pager, the menu buttons were working for the previous screen.
**before** ⬇️ (it shows the wrong site in webview, and follows the wrong site)

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/04f7ad56-afdc-4644-a9c7-033d91be477d

To test:
1. Launch the JP app.
2. Open the Reader tab.
3. Open the FOLLOWING tab.
4. Tap a post.
5. Tap the 🧭 compass button at the top to view in browser.
6. Ensure it displays the correct site.
7. Navigate back.
8. Swipe the screen to the left to navigate to the next post.
9. Repeat 5-6-7-8.
10. User other option buttons and ensure they are working for the selected site as expected.
11. Repeat 4-11 for the notification items in the Notifications tab.

## Regression Notes
1. Potential unintended areas of impact
Other entry points of `ReaderPostDetailFragment` screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested other screens manually.

3. What automated tests I added (or what prevented me from doing so)
This fixes a UI case and I think it's too specific to add this to automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
