### PR TITLE
Fix the menu buttons bug on the reader post detail screen that occurs on low memory

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -479,9 +479,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
     override fun onResume() {
         super.onResume()
-        if (isVisible) {
-            replaceActivityToolbarWithCollapsingToolbar()
-        }
+        replaceActivityToolbarWithCollapsingToolbar()
     }
 
     private fun replaceActivityToolbarWithCollapsingToolbar() {


### PR DESCRIPTION
This fixes two issues on the action bar of the reader detail screen. The issues only occurs when the device is on low memory.

### 1. Double action bar issue

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/562e9db1-0be6-40da-b714-cc73082ed981

To test:
1. Enable the "Don't keep activities" option in developer settings to simulate a low memory state.
2. Launch the JP app.
3. Open the Notifications tab.
4. Tap on a post item from the list.
5. Tap the 🧭 compass button at the top to view in browser.
6. Navigate back.
7. Ensure there aren't two action bars on the screen.

### 2. Menu buttons are not working when navigated back

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/bedc8681-79be-41e1-be5c-2c0ef25027e8

To test:
1. Enable the "Don't keep activities" option in developer settings to simulate a low memory state.
2. Launch the JP app.
3. Open the Reader tab.
4. Open the FOLLOWING tab.
5. Tap a post.
6. Tap the 🧭 compass button at the top to view in browser.
7. Navigate back.
8. Tap on the menu button on the top and ensure they work as expected.

## Regression Notes
1. Potential unintended areas of impact
Other entry points of ReaderPostDetailFragment screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested some of the other screens manually.

7. What automated tests I added (or what prevented me from doing so)
This fixes a UI case, and I believe it's too specific to add this to automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
