### PR TITLE
[Nullability Annotations to Java Classes] Add Missing Nullability Annotations to All SDK Override `onMenu(...)` Methods (`relatively safe`)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -15,6 +15,7 @@ import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -70,7 +71,7 @@ public class AddQuickPressShortcutActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -15,6 +15,7 @@ import android.widget.BaseAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -137,7 +138,7 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.app_log_viewer_menu, menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -146,7 +146,7 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui;
 
+import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -146,6 +147,7 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     }
 
     @Override
+    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:

--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewActivity.java
@@ -8,6 +8,7 @@ import android.view.Menu;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.WordPress;
@@ -127,7 +128,7 @@ public class JetpackConnectionWebViewActivity extends WPWebViewActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -863,7 +863,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (mWebView == null) {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -22,6 +22,7 @@ import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -853,7 +854,7 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
 
         MenuInflater inflater = getMenuInflater();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -7,6 +7,7 @@ import android.view.Window;
 import android.webkit.WebView;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -162,7 +163,7 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             cancel();
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -295,7 +295,7 @@ public class LoginActivity extends LocaleAwareActivity implements ConnectionCall
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.ProgressBar;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -153,7 +154,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             finish();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -207,7 +207,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int i = item.getItemId();
         if (i == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -199,7 +199,7 @@ public class EditCommentActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.edit_comment, menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentListActionModeCallback.kt
@@ -82,7 +82,7 @@ class CommentListActionModeCallback(
         }
     }
 
-    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
         return false
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsActivity.kt
@@ -57,7 +57,7 @@ class DebugSettingsActivity : LocaleAwareActivity() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.debug_settings_menu, menu)
         return true
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -227,7 +227,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.history_detail, menu);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -240,7 +240,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.history_load) {
             Intent intent = new Intent();
             intent.putExtra(KEY_REVISION, mRevision);

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -233,7 +233,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         MenuItem viewMode = menu.findItem(R.id.history_toggle_view);
         viewMode.setTitle(isInVisualPreview() ? R.string.history_preview_html : R.string.history_preview_visual);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -241,7 +241,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         getMenuInflater().inflate(R.menu.site_picker, menu);
         mMenuSearch = menu.findItem(R.id.menu_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -704,7 +704,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+        public boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             return true;
         }
 
@@ -741,7 +741,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
+        public boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             MenuItem mnuShow = menu.findItem(R.id.menu_show);
             mnuShow.setEnabled(mShowMenuEnabled);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -697,7 +697,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
     private final class ReblogActionModeCallback implements ActionMode.Callback {
         @Override
-        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+        public boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             mReblogActionMode = mode;
             mode.getMenuInflater().inflate(R.menu.site_picker_reblog_action_mode, menu);
             return true;
@@ -731,12 +731,12 @@ public class SitePickerActivity extends LocaleAwareActivity
         private Set<SiteRecord> mChangeSet;
 
         @Override
-        public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
-            mActionMode = actionMode;
+        public boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
+            mActionMode = mode;
             mHasChanges = false;
             mChangeSet = new HashSet<>();
             updateActionModeTitle();
-            actionMode.getMenuInflater().inflate(R.menu.site_picker_action_mode, menu);
+            mode.getMenuInflater().inflate(R.menu.site_picker_action_mode, menu);
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -279,7 +279,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_DISMISSED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -709,7 +709,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+        public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
             int itemId = item.getItemId();
 
             if (itemId == R.id.continue_flow) {
@@ -758,8 +758,8 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
-            int itemId = menuItem.getItemId();
+        public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
+            int itemId = item.getItemId();
             if (itemId == R.id.menu_show) {
                 Set<SiteRecord> changeSet = getAdapter().setVisibilityForSelectedSites(true);
                 mChangeSet.addAll(changeSet);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -251,7 +251,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
+    public boolean onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         updateMenuItemVisibility();
         setupSearchView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -589,7 +589,7 @@ public class SitePickerActivity extends LocaleAwareActivity
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 disableSearchMode();
                 mSearchView.setOnQueryTextListener(null);
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -576,7 +576,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
         mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 if (!getAdapter().getIsInSearchMode()) {
                     enableSearchMode();
                     mMenuEdit.setVisible(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -681,7 +681,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    public boolean onMenuItemActionCollapse(MenuItem item) {
+    public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
         mMenu.findItem(R.id.menu_new_media).setVisible(true);
         mMediaGridFragment.showActionableEmptyViewButton(true);
         invalidateOptionsMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -635,6 +636,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
+    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -665,7 +665,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    public boolean onMenuItemActionExpand(MenuItem item) {
+    public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
         mMenu.findItem(R.id.menu_new_media).setVisible(false);
         mMediaGridFragment.showActionableEmptyViewButton(false);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -635,7 +635,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -595,7 +595,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         mMenu = menu;
         getMenuInflater().inflate(R.menu.media_browser, menu);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -871,7 +871,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         @Override
-        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+        public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
             if (item.getItemId() == R.id.mnu_confirm_selection) {
                 setResultIdsAndFinish();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -862,7 +862,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         @Override
-        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+        public boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             MenuItem mnuConfirm = menu.findItem(R.id.mnu_confirm_selection);
             mnuConfirm.setVisible(mBrowserType.isPicker());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -850,7 +850,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
-        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+        public boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
             mActionMode = mode;
             int selectCount = getAdapter().getSelectedItemCount();
             MenuInflater inflater = mode.getMenuInflater();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -220,7 +220,7 @@ public class MediaPreviewActivity extends LocaleAwareActivity implements MediaPr
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -555,7 +555,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -532,7 +532,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
+    public boolean onPrepareOptionsMenu(@NonNull Menu menu) {
         boolean showSaveMenu = mSite != null && !mSite.isPrivate() && !isMediaFromEditor();
         boolean showShareMenu = mSite != null && !mSite.isPrivate() && !isMediaFromEditor();
         boolean showTrashMenu = mSite != null && !isMediaFromEditor();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -526,7 +526,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         getMenuInflater().inflate(R.menu.media_settings, menu);
         return super.onCreateOptionsMenu(menu);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActionModeCallback.kt
@@ -70,7 +70,7 @@ class MediaPickerActionModeCallback(private val viewModel: MediaPickerViewModel)
         return true
     }
 
-    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
         return false
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -133,7 +133,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.people_invite, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -139,7 +139,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         menu.getItem(0).setEnabled(!mInviteOperationInProgress); // here pass the index of send menu item
         super.onPrepareOptionsMenu(menu);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -99,7 +99,7 @@ public class PeopleListFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.people_list, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.MenuItem;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -231,7 +232,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -111,7 +111,7 @@ public class PersonDetailFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.person_detail, menu);
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActionModeCallback.kt
@@ -52,7 +52,7 @@ class PhotoPickerActionModeCallback(
         return true
     }
 
-    override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
         return false
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -165,7 +165,7 @@ public class PhotoPickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             setResult(RESULT_CANCELED);
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -236,7 +236,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -216,7 +216,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         getMenuInflater().inflate(R.menu.search, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -335,7 +335,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onMenuItemActionCollapse(MenuItem menuItem) {
+    public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
         mSearchView.setOnQueryTextListener(null);
         hideListFragment();
         mViewModel.setSearchQuery("");

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -328,7 +328,7 @@ public class PluginBrowserActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onMenuItemActionExpand(MenuItem menuItem) {
+    public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
         showListFragment(PluginListType.SEARCH);
         mSearchView.setOnQueryTextListener(this);
         return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -399,7 +399,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
+    public boolean onPrepareOptionsMenu(@NonNull Menu menu) {
         boolean showTrash = canPluginBeDisabledOrRemoved();
         menu.findItem(R.id.menu_trash).setVisible(showTrash);
         return super.onPrepareOptionsMenu(menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -393,7 +393,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         getMenuInflater().inflate(R.menu.plugin_detail, menu);
         return super.onCreateOptionsMenu(menu);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -406,7 +406,7 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             if (isPluginStateChangedSinceLastConfigurationDispatch()) {
                 // It looks like we have some unsaved changes, we need to force a configuration dispatch since the

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -154,7 +154,7 @@ public class PluginListFragment extends Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, @NonNull MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         menu.clear();
         super.onCreateOptionsMenu(menu, inflater);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3865,7 +3865,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Override
-    public boolean onMenuOpened(int featureId, Menu menu) {
+    public boolean onMenuOpened(int featureId, @NonNull Menu menu) {
         // This is a workaround for bag discovered on Chromebooks, where Enter key will not work in the toolbar menu
         // Editor fragments are messing with window focus, which causes keyboard events to get ignored
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1353,7 +1353,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.edit_post, menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1361,7 +1361,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
+    public boolean onPrepareOptionsMenu(@NonNull Menu menu) {
         boolean showMenuItems = true;
         if (mViewPager != null && mViewPager.getCurrentItem() > PAGE_CONTENT) {
             showMenuItems = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1575,7 +1575,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     // Menu actions
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
 
         if (itemId == android.R.id.home) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -470,7 +470,11 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo) {
+    public void onCreateContextMenu(
+            @NonNull ContextMenu menu,
+            @NonNull View v,
+            @Nullable ContextMenu.ContextMenuInfo menuInfo
+    ) {
         if (mFeaturedImageRetryOverlay.getVisibility() == View.VISIBLE) {
             menu.add(0, RETRY_FEATURED_IMAGE_UPLOAD_MENU_ID, 0,
                     getString(R.string.post_settings_retry_featured_image));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -487,7 +487,7 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     @Override
-    public boolean onContextItemSelected(MenuItem item) {
+    public boolean onContextItemSelected(@NonNull MenuItem item) {
         SiteModel site = getSite();
         PostImmutableModel post = getEditPostRepository().getPost();
         if (site == null || post == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -79,7 +79,7 @@ public class PostSettingsTagsActivity extends LocaleAwareActivity implements Tag
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
             saveAndFinish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -229,7 +229,7 @@ public class SelectCategoriesActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == R.id.menu_new_category) {
             if (NetworkUtils.checkConnection(this)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -11,6 +11,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -206,7 +207,7 @@ public class SelectCategoriesActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.categories, menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.prefs;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -31,7 +32,7 @@ public class AccountSettingsActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -524,7 +524,7 @@ public class AppSettingsFragment extends PreferenceFragment
         return true;
     }
 
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 getActivity().finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -4,6 +4,7 @@ import android.app.FragmentManager;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -106,7 +107,7 @@ public class BlogPreferencesActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemID = item.getItemId();
         if (itemID == android.R.id.home) {
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.prefs;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
@@ -38,7 +39,7 @@ public class MyProfileActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2231,8 +2231,8 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
-        public boolean onActionItemClicked(ActionMode actionMode, MenuItem menuItem) {
-            switch (menuItem.getItemId()) {
+        public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
+            switch (item.getItemId()) {
                 case R.id.menu_delete:
                     SparseBooleanArray checkedItems = getAdapter().getItemsSelected();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2265,9 +2265,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         @Override
-        public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {
-            mActionMode = actionMode;
-            MenuInflater inflater = actionMode.getMenuInflater();
+        public boolean onCreateActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
+            mActionMode = mode;
+            MenuInflater inflater = mode.getMenuInflater();
             inflater.inflate(R.menu.list_editor, menu);
 
             // we cant use support version of action mode, since we start it on view

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2289,8 +2289,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         @Override
-        public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {
-            actionMode.setTitle(getString(
+        public boolean onPrepareActionMode(@NonNull ActionMode mode, @NonNull Menu menu) {
+            mode.setTitle(getString(
                     R.string.site_settings_list_editor_action_mode_title,
                     getAdapter().getItemsSelected().size())
             );

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -2231,6 +2232,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
+        @SuppressLint("NonConstantResourceId")
         public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
             switch (item.getItemId()) {
                 case R.id.menu_delete:

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -102,7 +102,7 @@ public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         menu.findItem(R.id.menu_trash).setVisible(!mIsNewTerm);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -108,7 +108,7 @@ public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.menu_trash && mListener != null) {
             mListener.onRequestDeleteTag(mTerm);
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -95,7 +95,7 @@ public class SiteSettingsTagDetailFragment extends android.app.Fragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         menu.clear();
         inflater.inflate(R.menu.tag_detail, menu);
         super.onCreateOptionsMenu(menu, inflater);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -376,7 +376,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onMenuItemActionCollapse(MenuItem item) {
+    public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
         mIsSearching = false;
         showActionableEmptyViewForSearch(false);
         showFabWithConditions();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -214,7 +214,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         getMenuInflater().inflate(R.menu.tag_list, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -234,7 +234,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagListActivity.java
@@ -368,7 +368,7 @@ public class SiteSettingsTagListActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onMenuItemActionExpand(MenuItem item) {
+    public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
         mIsSearching = true;
         showActionableEmptyViewForSearch(true);
         hideFabIfShowing();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -319,7 +319,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 mSearchMenuItemCollapsed = true;
                 configureBlogsSettings(mBlogsCategory, false);
                 configureFollowedBlogsSettings(mFollowedBlogsCategory, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -311,7 +311,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 mSearchMenuItemCollapsed = false;
                 configureBlogsSettings(mBlogsCategory, true);
                 configureFollowedBlogsSettings(mFollowedBlogsCategory, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -279,7 +279,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.notifications_settings, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_notifications_settings_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -217,7 +217,7 @@ public class PublicizeListActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -175,7 +175,7 @@ public class ReaderBlogFragment extends Fragment
      * note this will only be called for followed blogs
      */
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.reader_subs, menu);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -191,7 +191,7 @@ public class ReaderBlogFragment extends Fragment
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 return true;
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -186,7 +186,7 @@ public class ReaderBlogFragment extends Fragment
 
         searchMenu.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 return true;
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -520,7 +520,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -468,57 +468,54 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.threaded_comments_menu, menu);
 
         mConversationViewModel.getUpdateFollowUiState().observe(this, uiState -> {
-                    if (menu != null) {
-                        MenuItem bellItem = menu.findItem(R.id.manage_notifications_item);
-                        MenuItem followItem = menu.findItem(R.id.follow_item);
+            MenuItem bellItem = menu.findItem(R.id.manage_notifications_item);
+            MenuItem followItem = menu.findItem(R.id.follow_item);
 
-                        if (bellItem != null && followItem != null) {
-                            ShimmerFrameLayout shimmerView =
-                                    followItem.getActionView().findViewById(R.id.shimmer_view_container);
-                            TextView followText = followItem.getActionView().findViewById(R.id.follow_button);
+            if (bellItem != null && followItem != null) {
+                ShimmerFrameLayout shimmerView =
+                        followItem.getActionView().findViewById(R.id.shimmer_view_container);
+                TextView followText = followItem.getActionView().findViewById(R.id.follow_button);
 
-                            followItem.getActionView().setOnClickListener(
-                                    uiState.getOnFollowTapped() != null
-                                            ? v -> uiState.getOnFollowTapped().invoke()
-                                            : null
-                            );
+                followItem.getActionView().setOnClickListener(
+                        uiState.getOnFollowTapped() != null
+                                ? v -> uiState.getOnFollowTapped().invoke()
+                                : null
+                );
 
-                            bellItem.setOnMenuItemClickListener(item -> {
-                                uiState.getOnManageNotificationsTapped().invoke();
-                                return true;
-                            });
+                bellItem.setOnMenuItemClickListener(item -> {
+                    uiState.getOnManageNotificationsTapped().invoke();
+                    return true;
+                });
 
-                            followItem.getActionView().setEnabled(uiState.getFlags().isMenuEnabled());
-                            followText.setEnabled(uiState.getFlags().isMenuEnabled());
-                            bellItem.setEnabled(uiState.getFlags().isMenuEnabled());
+                followItem.getActionView().setEnabled(uiState.getFlags().isMenuEnabled());
+                followText.setEnabled(uiState.getFlags().isMenuEnabled());
+                bellItem.setEnabled(uiState.getFlags().isMenuEnabled());
 
-                            if (uiState.getFlags().getShowMenuShimmer()) {
-                                if (!shimmerView.isShimmerVisible()) {
-                                    shimmerView.showShimmer(true);
-                                } else if (!shimmerView.isShimmerStarted()) {
-                                    shimmerView.startShimmer();
-                                }
-                            } else {
-                                shimmerView.hideShimmer();
-                            }
-
-                            followItem.setVisible(uiState.getFlags().isFollowMenuVisible());
-                            bellItem.setVisible(uiState.getFlags().isBellMenuVisible());
-
-                            setResult(RESULT_OK, new Intent().putExtra(
-                                    FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY,
-                                    uiState.getFlags()
-                            ));
-                        }
+                if (uiState.getFlags().getShowMenuShimmer()) {
+                    if (!shimmerView.isShimmerVisible()) {
+                        shimmerView.showShimmer(true);
+                    } else if (!shimmerView.isShimmerStarted()) {
+                        shimmerView.startShimmer();
                     }
+                } else {
+                    shimmerView.hideShimmer();
                 }
-        );
+
+                followItem.setVisible(uiState.getFlags().isFollowMenuVisible());
+                bellItem.setVisible(uiState.getFlags().isBellMenuVisible());
+
+                setResult(RESULT_OK, new Intent().putExtra(
+                        FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY,
+                        uiState.getFlags()
+                ));
+            }
+        });
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -157,7 +157,7 @@ public class ReaderPhotoViewerActivity extends LocaleAwareActivity
     };
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -214,7 +214,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
                 getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
@@ -214,6 +215,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     }
 
     @Override
+    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -205,7 +205,7 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
             getMenuInflater().inflate(R.menu.share, menu);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1215,7 +1215,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
         mSearchMenuItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
-            public boolean onMenuItemActionExpand(MenuItem item) {
+            public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 if (getPostListType() != ReaderPostListType.SEARCH_RESULTS) {
                     mReaderTracker.track(AnalyticsTracker.Stat.READER_SEARCH_LOADED);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1231,7 +1231,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 requireActivity().finish();
                 return false;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -660,7 +660,7 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             finish();
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stockmedia/StockMediaPickerActivity.java
@@ -262,7 +262,7 @@ public class StockMediaPickerActivity extends LocaleAwareActivity implements Sea
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             setResult(RESULT_CANCELED);
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -141,7 +141,7 @@ public class ThemeBrowserActivity extends LocaleAwareActivity implements ThemeBr
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int i = item.getItemId();
         if (i == android.R.id.home) {
             getOnBackPressedDispatcher().onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -223,7 +223,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.menu_search) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_SEARCH, mSite);
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -207,7 +207,7 @@ public class ThemeBrowserFragment extends Fragment
     }
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.search, menu);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -146,7 +146,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.action_activate) {
             Intent returnIntent = new Intent();
             setResult(RESULT_OK, returnIntent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -138,7 +138,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
         if (shouldShowActivateMenuItem()) {
             getMenuInflater().inflate(R.menu.theme_web, menu);
         }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -456,7 +456,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_aztec, menu);
     }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -461,23 +461,20 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
         // TODO: disable undo/redo in media mode
         boolean canRedo = mContent.history.redoValid();
         boolean canUndo = mContent.history.undoValid();
 
-        if (menu != null) {
-            MenuItem redoItem = menu.findItem(R.id.redo);
-            if (redoItem != null) {
-                setUndoRedoAppearance(redoItem, canRedo);
-            }
-
-            MenuItem undoItem = menu.findItem(R.id.undo);
-            if (undoItem != null) {
-                setUndoRedoAppearance(undoItem, canUndo);
-            }
+        MenuItem redoItem = menu.findItem(R.id.redo);
+        if (redoItem != null) {
+            setUndoRedoAppearance(redoItem, canRedo);
         }
 
+        MenuItem undoItem = menu.findItem(R.id.undo);
+        if (undoItem != null) {
+            setUndoRedoAppearance(undoItem, canUndo);
+        }
 
         super.onPrepareOptionsMenu(menu);
     }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -500,7 +500,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.undo) {
             if (mContent.getVisibility() == View.VISIBLE) {
                 mContent.undo();

--- a/libs/editor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -251,7 +251,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
 
         if (id == android.R.id.home) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -23,6 +23,7 @@ import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
@@ -245,10 +246,8 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        if (menu != null) {
-            menu.clear();
-        }
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        menu.clear();
     }
 
     @Override

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1075,7 +1075,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.debugmenu) {
             getGutenbergContainerFragment().showDevOptionsDialog();
             return true;

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1062,7 +1062,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         inflater.inflate(R.menu.menu_gutenberg, menu);
     }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1067,11 +1067,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onPrepareOptionsMenu(Menu menu) {
-        if (menu != null) {
-            MenuItem debugMenuItem = menu.findItem(R.id.debugmenu);
-            debugMenuItem.setVisible(BuildConfig.DEBUG);
-        }
+    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+        MenuItem debugMenuItem = menu.findItem(R.id.debugmenu);
+        debugMenuItem.setVisible(BuildConfig.DEBUG);
 
         super.onPrepareOptionsMenu(menu);
     }


### PR DESCRIPTION
Parent #18909

This PR adds the missing `@Nullable` annotation to all SDK override `onMenu(...)` related method on `Activity`, `Fragment`, `Dialog Fragment` and `Preference Fragment` classes.

The `onMenu(...)` refers to the below 11 menu related set of methods:
1. `onCreateOptionsMenu(...)`
2. `onPrepareOptionsMenu(...)`
3. `onOptionsItemSelected(...)`
4. `onMenuOpened(...)`
5. `onCreateContextMenu(...)`
6. `onContextItemSelected(...)`
7. `onMenuItemActionExpand(...)`
8. `onMenuItemActionCollapse(...)`
9. `onCreateActionMode(...)`
10. `onPrepareActionMode(...)`
11. `onActionItemClicked(...)`

FYI: This change is `relatively safe`, meaning that although there shouldn't be any (major) compile-time changes associated with this change and thus needs little to no testing, there still are some `slightly risky` changes associated with this PR, and those are related to the seemingly unnecessarily nullability checks that got removed from the below classes:
1. `onCreateOptionsMenu(...)`
    1. [ReaderCommentListActivity.java](https://github.com/wordpress-mobile/WordPress-Android/commit/59236761112b317be0277e252486ea0d72225d10#diff-ff7c093c5d970b4ad2b4de45d1d842e1cda035f5f7aa800d6d437a93fcd1e292L477-L518) via 59236761112b317be0277e252486ea0d72225d10
    2. [ImageSettingsDialogFragment.java](https://github.com/wordpress-mobile/WordPress-Android/commit/754f3d6e54fa48f31bbf00f1f2f7e50770862c93#diff-c15e860f40d82c166c3b673a89fe25d9786cbfcf61758975f2edf3c5aaead814L249-L251) via 754f3d6e54fa48f31bbf00f1f2f7e50770862c93
2. `onPrepareOptionsMenu(...)`
    1. [GutenbergEditorFragment.java](https://github.com/wordpress-mobile/WordPress-Android/commit/26120646616c35c8df1978a99a9f1ae668e62119#diff-3d055f27ee69cf53a3055662daab1fc04df6e0eba7deadfd63c3a79df8e96dc5L1071-L1074) via 26120646616c35c8df1978a99a9f1ae668e62119 
    2. [AztecEditorFragment.java](https://github.com/wordpress-mobile/WordPress-Android/commit/26120646616c35c8df1978a99a9f1ae668e62119#diff-38b3f9a52be1f47e524602dde5bbd90abfdb6a72026420e58e6b12f0263caa93L469-L478) via 26120646616c35c8df1978a99a9f1ae668e62119

-----

PS: @ravishanker I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

Nullability Annotation List (`onCreateOptionsMenu(...)`):

1. [Add missing nn-a to all on create options menu for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/59236761112b317be0277e252486ea0d72225d10)
2. [Add missing nn-a to all on create options menu for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/0d7889c6957dcbabe98b5b094602f656cf3d3a5c)
3. [Add missing nn-a to all on create options menu for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/55967518426b86da8497ef01057ba7aa04613c75)
4. [Add missing nn-a to all on create options menu for dfrr (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/754f3d6e54fa48f31bbf00f1f2f7e50770862c93)
5. [Make menu nn-a on the on create options menu fun for kotlin](https://github.com/wordpress-mobile/WordPress-Android/commit/ea56b008f44e1ebda92be7c9c66eaa69dc00ebea)

Nullability Annotation List (`onPrepareOptionsMenu(...)`):

1. [Add missing nn-a to all on prepare options menu for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/82943e70f3162642c5971493d8643860ed14942f)
2. [Add missing nn-a to all on prepare options menu for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/2678bc4e6f1b94a511d3587187602a0ec2f5540b)
3. [Add missing nn-a to all on prepare options menu for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/26120646616c35c8df1978a99a9f1ae668e62119)

Nullability Annotation List (`onOptionsItemSelected(...)`):

1. [Add missing nn-a to all on opts item selected for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/51c70c0f9481eb8eb06dfb12aabf84e16ceb8760)
2. [Add missing nn-a to all on opts item selected for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/8a64c682ea312f17101f5282cb3824facd9ea180)
3. [Add missing nn-a to all on opts item selected for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/e739a90d03afecc5c1d99d12bca87d86995ac923)
4. [Add missing nn-a to all on opts item selected for dfrr (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/e199a6f4d440a308cb95d35de631fd01684dfde5)

Nullability Annotation List (`onMenuOpened(...)`):

1. [Add missing nn-a to all on on menu opened for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/7629de17ce0dfe3838ce0f0b399449e211e479a3)

Nullability Annotation List (`onCreateContextMenu(...)`):

1. [Add missing nn-a to all on create context menu for frr (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/d27f97df6ef3bf9519fd3dfef0238941200f4724)

Nullability Annotation List (`onContextItemSelected(...)`):

1. [Add missing nn-a to all on context item selected for frr (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/834b9d32efb3d82bf84c73114bdc2835c978cd1e)

Nullability Annotation List (`onMenuItemActionExpand(...)`):

1. [Add missing nn-a to all on m-i action expand for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/d8672f8ab7fcf4f14d6ea4528f16707b413182b1)
2. [Add missing nn-a to all on m-i action expand for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/a617ea6a22be2ac5d494c0c5f0da62f19a9b6748)
3. [Add missing nn-a to all on m-i action expand for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/dcabf61561fed5b78051637e843472f53695fde0)

Nullability Annotation List (`onMenuItemActionCollapse(...)`):

1. [Add missing nn-a to all on m-i action collapse for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/bd977ecbb508a4e395588b8a114c91f87c23de79)
2. [Add missing nn-a to all on m-i action collapse for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/9cb22d1278a48fbcfb713be7f070f86900f887c0)
3. [Add missing nn-a to all on m-i action expand for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/a3b39d2e45a943aa564639a93f79137d00dbeb7d)

Nullability Annotation List (`onCreateActionMode(...)`):

1. [Add missing nn-a to all on create action mode for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/fea8cc349e982884abf8ce7b8d199b4e6073538d)
2. [Add missing nn-a to all on create action mode for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/5cedf06d761f844b6d1defaae7e776a75a3dfe20)
3. [Add missing nn-a to all on create action mode for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/df56ab13565ebd17ffe3ac4d88264992831fa3e8)

Nullability Annotation List (`onPrepareActionMode(...)`):

1. [Add missing nn-a to all on prepare action mode for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/5f5489ebf61c6418a651935bd5c18556a8f08885)
2. [Add missing nn-a to all on prepare action mode for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/a5eb03f162ce4fd1780f765f62c292f7570271c2)
3. [Add missing nn-a to all on prepare action mode for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/f4da3f50c42b38c2550255e90ef6d4a6dd93c678)
4. [Make mode & menu nn-a on the on prp action mode fun for kotlin](https://github.com/wordpress-mobile/WordPress-Android/commit/e7909e4422e8beed1b35ea4828c32deaa261d5e5)

Nullability Annotation List (`onActionItemClicked(...)`):

1. [Add missing nn-a to all on action item clicked for acts (1/1)](https://github.com/wordpress-mobile/WordPress-Android/commit/961c211fdc3c2d585b0fa2c3fe4860dabb810da9)
2. [Add missing nn-a to all on action item clicked for frr (1/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/3945bae18fefd620a1805c510d521e6e1009aab2)
3. [Add missing nn-a to all on action item clicked for frr (2/2)](https://github.com/wordpress-mobile/WordPress-Android/commit/a33ee0a41e3a95e63db27a7af75dd505dda45cb7)

Lint Suppression List:

1. [Suppress non constant res id lint warning for activities](https://github.com/wordpress-mobile/WordPress-Android/commit/ae0aefc86ab2e0996728e1b0c09738804aa0bece)
5. [Suppress non constant res id lint warning for site settings](https://github.com/wordpress-mobile/WordPress-Android/commit/446c7d905268accec3ac9a5d0eedccc5119428a5)

-----

## To test:

- There is nothing much to test here, verifying that all the CI checks are successful should be enough.
- However, if you really want to be thorough, which is recommending in this case since this change is `relatively safe`, you could quickly smoke both, the Jetpack and WordPress app, and see if they work as expected, just in case.

-----

## Regression Notes

1. Potential unintended areas of impact

    - See `relatively safe` section above.

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

7. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)