### PR TITLE
Skeleton: Dashboard Personalisation: Personalise Home tab 

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1091,6 +1091,11 @@
             android:label="@string/stats"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <activity android:name=".ui.mysite.personalisation.PersonalisationActivity"
+            android:exported="false"
+            android:label="@string/stats"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
 
     </application>

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/DashboardCardState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/DashboardCardState.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.mysite.personalisation
+
+import androidx.annotation.StringRes
+
+data class DashboardCardState(
+    @StringRes val title: Int,
+    @StringRes val description: Int? = null,
+    val enabled: Boolean = false,
+    val cardType: CardType
+)
+
+
+enum class CardType(val order: Int) {
+    STATS(0),
+    DRAFT_POSTS(1),
+    SCHEDULED_POSTS(2),
+    BLAZE(3),
+    BLOGGING_PROMPTS(4),
+    NEXT_STEPS(5),
+    PAGES(6),
+    ACTIVITY_LOG(7)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/DashboardCardState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/DashboardCardState.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 
 data class DashboardCardState(
     @StringRes val title: Int,
-    @StringRes val description: Int? = null,
+    @StringRes val description: Int,
     val enabled: Boolean = false,
     val cardType: CardType
 )
@@ -14,9 +14,9 @@ enum class CardType(val order: Int) {
     STATS(0),
     DRAFT_POSTS(1),
     SCHEDULED_POSTS(2),
-    BLAZE(3),
-    BLOGGING_PROMPTS(4),
-    NEXT_STEPS(5),
-    PAGES(6),
-    ACTIVITY_LOG(7)
+    PAGES(3),
+    ACTIVITY_LOG(4),
+    BLAZE(5),
+    BLOGGING_PROMPTS(6),
+    NEXT_STEPS(7)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.mysite.personalisation
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,46 +15,65 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.LiveData
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 class PersonalisationActivity : ComponentActivity() {
+    private val viewModel:PersonalisationViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                val uiItems =
-                PersonalisationScreen()
+                PersonalisationScreen(viewModel.uiState)
             }
         }
     }
 
     @Composable
-    fun PersonalisationScreen() {
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
+    fun PersonalisationScreen(uiState: LiveData<List<DashboardCardState>>) {
         Scaffold(
             topBar = {
                 MainTopAppBar(
                     title = stringResource(id = R.string.personalisation_screen_title),
                     navigationIcon = NavigationIcons.BackIcon,
-                    onNavigationIconClick = onBackClick,
+                    onNavigationIconClick = onBackPressedDispatcher::onBackPressed,
                 )
+            },
+            content = {
+                PersonalisationContent(uiState)
             }
+        )
+    }
+
+    @Composable
+    fun PersonalisationContent(uiState: LiveData<List<DashboardCardState>>) {
+        val cardStateList = uiState.value ?: emptyList()
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp)
         ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                ) {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentPadding = PaddingValues(bottom = 72.dp),
-                    ) {
-
-
-                    }
+            items(cardStateList.size) { index ->
+                val cardState = cardStateList[index]
+                DashboardCardStateRow(
+                    cardState = cardState,
+                    onToggle = viewModel::onToggle
+                )
             }
         }
     }
+}
+
+@Composable
+fun DashboardCardStateRow(
+    cardState: DashboardCardState,
+    onToggle: (Boolean, CardType) -> Unit,
+){
+    // todo., the logic to show the card state row
 }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,12 +14,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -86,13 +89,12 @@ fun PersonalisationContent(cardStateList: List<DashboardCardState>, modifier: Mo
             items(cardStateList.size) { index ->
                 val cardState = cardStateList[index]
                 DashboardCardStateRow(
-                    modifier = Modifier.padding(),
                     cardState = cardState,
                 )
             }
         }
         Text(
-            modifier = Modifier.padding(start = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp),
             text = stringResource(id = R.string.personalisation_screen_footer_cards),
             fontSize = 13.sp,
             fontWeight = FontWeight.Normal,
@@ -110,9 +112,15 @@ fun DashboardCardStateRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp),
+                .padding(start = 16.dp,
+                    end = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .padding(vertical = 12.dp)
+                    .fillMaxWidth(.9f)
+            ) {
                 Text(
                     text = stringResource(id = cardState.title),
                     fontSize = 16.sp
@@ -123,19 +131,20 @@ fun DashboardCardStateRow(
                     color = Color(0x99000000)
                 )
             }
+            Spacer(Modifier.width(8.dp))
+            Switch(
+                checked = cardState.enabled,
+                onCheckedChange = {},
+                modifier = Modifier
+                    .weight(.1f)
+            )
         }
-        Spacer(Modifier.width(16.dp))
-        Switch(
-            checked = cardState.enabled,
-            onCheckedChange = {},
-            modifier = Modifier.padding(end = 16.dp)
+        Divider(
+            thickness = 0.5.dp,
+            modifier = Modifier
+                .padding()
         )
     }
-    Divider(
-        thickness = 0.5.dp,
-        modifier = Modifier
-            .padding()
-    )
 }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -1,0 +1,61 @@
+package org.wordpress.android.ui.mysite.personalisation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+class PersonalisationActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                val uiItems =
+                PersonalisationScreen()
+            }
+        }
+    }
+
+    @Composable
+    fun PersonalisationScreen() {
+        Scaffold(
+            topBar = {
+                MainTopAppBar(
+                    title = stringResource(id = R.string.personalisation_screen_title),
+                    navigationIcon = NavigationIcons.BackIcon,
+                    onNavigationIconClick = onBackClick,
+                )
+            }
+        ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(bottom = 72.dp),
+                    ) {
+
+
+                    }
+            }
+        }
+    }
+}
+
+
+
+
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -5,12 +5,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
@@ -18,8 +20,12 @@ import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.LiveData
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
@@ -54,51 +60,140 @@ class PersonalisationActivity : ComponentActivity() {
             }
         )
     }
+}
 
-    @Composable
-    fun PersonalisationContent(cardStateList: List<DashboardCardState>) {
-        Row {
-            Text(text = stringResource(id = R.string.personalisation_screen_description))
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(16.dp)
-            ) {
-                items(cardStateList.size) { index ->
-                    val cardState = cardStateList[index]
-                    DashboardCardStateRow(
-                        cardState = cardState,
-                        onToggle = viewModel::onToggle
-                    )
-                }
+
+@Composable
+fun PersonalisationContent(cardStateList: List<DashboardCardState>, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentSize()
+            .padding(vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            modifier = Modifier.padding(start = 16.dp),
+            text = stringResource(id = R.string.personalisation_screen_description),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            color = Color(0x99000000),
+        )
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            items(cardStateList.size) { index ->
+                val cardState = cardStateList[index]
+                DashboardCardStateRow(
+                    modifier = Modifier.padding(),
+                    cardState = cardState,
+                )
             }
-            Text(text = stringResource(id = R.string.personalisation_screen_footer_cards))
         }
+        Text(
+            modifier = Modifier.padding(start = 16.dp),
+            text = stringResource(id = R.string.personalisation_screen_footer_cards),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Normal,
+            color = Color(0xFF666666)
+        )
     }
 }
 
 @Composable
 fun DashboardCardStateRow(
     cardState: DashboardCardState,
-    onToggle: (Boolean, CardType) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Row(modifier = modifier.fillMaxWidth()) {
-        Column(
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(start = 16.dp),
         ) {
-            Row () {
-                Text(text = stringResource(id = cardState.title))
-                cardState.description?.let {  Text(text = stringResource(id = cardState.description)) }
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = stringResource(id = cardState.title),
+                    fontSize = 16.sp
+                )
+                Text(
+                    text = stringResource(id = cardState.description),
+                    fontSize = 13.sp,
+                    color = Color(0x99000000)
+                )
             }
-            Switch(checked = cardState.enabled, onCheckedChange = {
-                onToggle(cardState.enabled, cardState.cardType)
-            })
         }
-        Divider(
-            thickness = 0.5.dp,
-            modifier = Modifier
-                .padding()
+        Spacer(Modifier.width(16.dp))
+        Switch(
+            checked = cardState.enabled,
+            onCheckedChange = {},
+            modifier = Modifier.padding(end = 16.dp)
+        )
+    }
+    Divider(
+        thickness = 0.5.dp,
+        modifier = Modifier
+            .padding()
+    )
+}
+
+
+@Preview
+@Composable
+fun PreviewPersonalizeScreen() {
+    AppTheme {
+        PersonalisationContent(
+            cardStateList = listOf(
+                DashboardCardState(
+                    title = R.string.personalisation_screen_stats_card_title,
+                    description = R.string.personalisation_screen_stats_card_description,
+                    enabled = true,
+                    cardType = CardType.STATS
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_draft_posts_card_title,
+                    description = R.string.personalisation_screen_draft_posts_card_description,
+                    enabled = true,
+                    cardType = CardType.DRAFT_POSTS
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_scheduled_posts_card_title,
+                    description = R.string.personalisation_screen_scheduled_posts_card_description,
+                    enabled = true,
+                    cardType = CardType.SCHEDULED_POSTS
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_pages_card_title,
+                    description = R.string.personalisation_screen_pages_card_description,
+                    enabled = true,
+                    cardType = CardType.PAGES
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_activity_log_card_title,
+                    description = R.string.personalisation_screen_activity_log_card_description,
+                    enabled = true,
+                    cardType = CardType.ACTIVITY_LOG
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_blaze_card_title,
+                    description = R.string.personalisation_screen_blaze_card_description,
+                    enabled = true,
+                    cardType = CardType.BLAZE
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_blogging_prompts_card_title,
+                    description = R.string.personalisation_screen_blogging_prompts_card_description,
+                    enabled = true,
+                    cardType = CardType.BLOGGING_PROMPTS
+                ),
+                DashboardCardState(
+                    title = R.string.personalisation_screen_next_steps_card_title,
+                    description = R.string.personalisation_screen_next_steps_card_description,
+                    enabled = true,
+                    cardType = CardType.NEXT_STEPS
+                ),
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -5,12 +5,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -22,7 +27,7 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 class PersonalisationActivity : ComponentActivity() {
-    private val viewModel:PersonalisationViewModel by viewModels()
+    private val viewModel: PersonalisationViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,25 +50,28 @@ class PersonalisationActivity : ComponentActivity() {
                 )
             },
             content = {
-                PersonalisationContent(uiState)
+                PersonalisationContent(uiState.value ?: emptyList())
             }
         )
     }
 
     @Composable
-    fun PersonalisationContent(uiState: LiveData<List<DashboardCardState>>) {
-        val cardStateList = uiState.value ?: emptyList()
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp)
-        ) {
-            items(cardStateList.size) { index ->
-                val cardState = cardStateList[index]
-                DashboardCardStateRow(
-                    cardState = cardState,
-                    onToggle = viewModel::onToggle
-                )
+    fun PersonalisationContent(cardStateList: List<DashboardCardState>) {
+        Row {
+            Text(text = stringResource(id = R.string.personalisation_screen_description))
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(cardStateList.size) { index ->
+                    val cardState = cardStateList[index]
+                    DashboardCardStateRow(
+                        cardState = cardState,
+                        onToggle = viewModel::onToggle
+                    )
+                }
             }
+            Text(text = stringResource(id = R.string.personalisation_screen_footer_cards))
         }
     }
 }
@@ -72,11 +80,25 @@ class PersonalisationActivity : ComponentActivity() {
 fun DashboardCardStateRow(
     cardState: DashboardCardState,
     onToggle: (Boolean, CardType) -> Unit,
-){
-    // todo., the logic to show the card state row
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Row () {
+                Text(text = stringResource(id = cardState.title))
+                cardState.description?.let {  Text(text = stringResource(id = cardState.description)) }
+            }
+            Switch(checked = cardState.enabled, onCheckedChange = {
+                onToggle(cardState.enabled, cardState.cardType)
+            })
+        }
+        Divider(
+            thickness = 0.5.dp,
+            modifier = Modifier
+                .padding()
+        )
+    }
 }
-
-
-
-
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationActivity.kt
@@ -75,31 +75,36 @@ fun PersonalisationContent(cardStateList: List<DashboardCardState>, modifier: Mo
             .padding(vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Text(
-            modifier = Modifier.padding(start = 16.dp),
-            text = stringResource(id = R.string.personalisation_screen_description),
-            fontSize = 14.sp,
-            fontWeight = FontWeight.Medium,
-            color = Color(0x99000000),
-        )
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
         ) {
+            item {
+                Text(
+                    modifier = Modifier.padding(start = 16.dp),
+                    text = stringResource(id = R.string.personalisation_screen_description),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color(0x99000000),
+                )
+            }
             items(cardStateList.size) { index ->
                 val cardState = cardStateList[index]
                 DashboardCardStateRow(
                     cardState = cardState,
                 )
             }
+
+            item {
+                Text(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+                    text = stringResource(id = R.string.personalisation_screen_footer_cards),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Normal,
+                    color = Color(0xFF666666)
+                )
+            }
         }
-        Text(
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-            text = stringResource(id = R.string.personalisation_screen_footer_cards),
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Normal,
-            color = Color(0xFF666666)
-        )
     }
 }
 
@@ -112,8 +117,10 @@ fun DashboardCardStateRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp,
-                    end = 16.dp),
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp
+                ),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
@@ -4,10 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.R
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -15,33 +13,8 @@ import javax.inject.Named
 
 @HiltViewModel
 class PersonalisationViewModel @Inject constructor(
-    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val appPrefsWrapper: AppPrefsWrapper,
-    private val selectedSiteRepository: SelectedSiteRepository
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableLiveData<List<DashboardCardState>>()
     val uiState: LiveData<List<DashboardCardState>> = _uiState
-
-    fun getCardStateList() {
-        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return
-        val items = mutableListOf<DashboardCardState>()
-        items.add(CardType.STATS.order, getStatsCard(siteId))
-        items.add(CardType.DRAFT_POSTS.order, getDraftPostsCard(siteId))
-    }
-
-    private fun getStatsCard(siteId: Long) = DashboardCardState(
-        title = R.string.my_site_todays_stat_card_title,
-        enabled = appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(siteId),
-        cardType = CardType.STATS
-    )
-
-    private fun getDraftPostsCard(siteId: Long) = DashboardCardState(
-        title = R.string.,
-        enabled = appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.DRAFT.name),
-        cardType = CardType.DRAFT_POSTS
-    )
-
-    fun onToggle(currentState: Boolean, cardType: CardType) {
-        // todo., the logic to toggle the hide or show of the cards
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.ui.mysite.personalisation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.R
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class PersonalisationViewModel @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository
+) : ScopedViewModel(bgDispatcher) {
+    private val _uiState = MutableLiveData<List<DashboardCardState>>()
+    val uiState: LiveData<List<DashboardCardState>> = _uiState
+
+    fun getCardStateList() {
+        val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return
+        val items = mutableListOf<DashboardCardState>()
+        items.add(CardType.STATS.order, getStatsCard(siteId))
+        items.add(CardType.DRAFT_POSTS.order, getDraftPostsCard(siteId))
+    }
+
+    private fun getStatsCard(siteId: Long) = DashboardCardState(
+        title = R.string.my_site_todays_stat_card_title,
+        enabled = appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(siteId),
+        cardType = CardType.STATS
+    )
+
+    private fun getDraftPostsCard(siteId: Long) = DashboardCardState(
+        title = R.string.,
+        enabled = appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.DRAFT.name),
+        cardType = CardType.DRAFT_POSTS
+    )
+
+    fun onToggle(currentState: Boolean, cardType: CardType) {
+        // todo., the logic to toggle the hide or show of the cards
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalisation/PersonalisationViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4697,4 +4697,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="partial_media_access_prompt_text">Only selected photos and videos you’ve given access to are available.</string>
     <string name="partial_media_access_prompt_select_more">Select More</string>
     <string name="partial_media_access_prompt_change_settings">Change Settings</string>
+
+    <!-- Personalisation Screen -->
+    <string name="personalisation_screen_title"> Personalise home tab</string>
+    <string name="personalisation_screen_description"> Add or hide Cards</string>
+    <string name="personalisation_screen_footer_cards"> Cards may show different content depending on what\'s happening with your site</string>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4708,7 +4708,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalisation_screen_draft_posts_card_description">Your recent draft posts.</string>
     <string name="personalisation_screen_scheduled_posts_card_title"> Scheduled posts</string>
     <string name="personalisation_screen_scheduled_posts_card_description">Your upcoming scheduled posts.</string>
-    <string name="personalisation_screen_blaze_card_title" translate="false"> @string/blaze_activity_title</string>
+    <string name="personalisation_screen_blaze_card_title" translatable="false"> @string/blaze_activity_title</string>
     <string name="personalisation_screen_blaze_card_description">Promote a post and see current campaigns.</string>
     <string name="personalisation_screen_blogging_prompts_card_title">Blogging prompts</string>
     <string name="personalisation_screen_blogging_prompts_card_description">Daily ideas for your blog posts.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4702,5 +4702,21 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalisation_screen_title"> Personalise home tab</string>
     <string name="personalisation_screen_description"> Add or hide Cards</string>
     <string name="personalisation_screen_footer_cards"> Cards may show different content depending on what\'s happening with your site</string>
+    <string name="personalisation_screen_stats_card_title" translatable="false">@string/my_site_todays_stat_card_title</string>
+    <string name="personalisation_screen_stats_card_description">Views, Visitors and likes</string>
+    <string name="personalisation_screen_draft_posts_card_title"> Draft posts</string>
+    <string name="personalisation_screen_draft_posts_card_description">Your recent draft posts.</string>
+    <string name="personalisation_screen_scheduled_posts_card_title"> Scheduled posts</string>
+    <string name="personalisation_screen_scheduled_posts_card_description">Your upcoming scheduled posts.</string>
+    <string name="personalisation_screen_blaze_card_title" translate="false"> @string/blaze_activity_title</string>
+    <string name="personalisation_screen_blaze_card_description">Promote a post and see current campaigns.</string>
+    <string name="personalisation_screen_blogging_prompts_card_title">Blogging prompts</string>
+    <string name="personalisation_screen_blogging_prompts_card_description">Daily ideas for your blog posts.</string>
+    <string name="personalisation_screen_pages_card_title" translatable="false">@string/pages</string>
+    <string name="personalisation_screen_pages_card_description">Overview of your site pages.</string>
+    <string name="personalisation_screen_activity_log_card_title" translatable="false">@string/activity_log</string>
+    <string name="personalisation_screen_activity_log_card_description">Recent actions taken on your site.</string>
+    <string name="personalisation_screen_next_steps_card_title" translatable="false">@string/quick_start_sites</string>
+    <string name="personalisation_screen_next_steps_card_description">Learn how to make the most of your site with the app.</string>
 
 </resources>


### PR DESCRIPTION
## Part of
 #18940

## Description
This PR implements the skeleton classes for Personalisation screen 

## To test: 
1. Verify that the CI passes as expected 
2. Run `PreviewPersonalizeScreen` in `PersonalisationActivity` and verify that the UI is as expected 


## Todo
1. The click behavior and the launch of activity will be handled in a future PR

## Regression Notes
1. Potential unintended areas of impact
NA

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
