### PR TITLE
[Nullability Annotations to Java Classes] Replace `findViewById` with `ViewBinding` for History (`relatively safe`)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -202,6 +202,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) requireActivity().getApplication()).component().inject(this);
@@ -217,12 +218,14 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.history_detail, menu);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
         if (mBinding != null) {
@@ -234,6 +237,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.history_load) {
             Intent intent = new Intent();
@@ -346,10 +350,11 @@ public class HistoryDetailContainerFragment extends Fragment {
         mBinding = null;
     }
 
+    @SuppressWarnings("deprecation")
     private class HistoryDetailFragmentAdapter extends FragmentStatePagerAdapter {
         private final ArrayList<Revision> mRevisions;
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "deprecation"})
         HistoryDetailFragmentAdapter(FragmentManager fragmentManager, ArrayList<Revision> revisions) {
             super(fragmentManager);
             mRevisions = (ArrayList<Revision>) revisions.clone();

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -55,7 +55,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 public class HistoryDetailContainerFragment extends Fragment {
-    private OnPageChangeListener mOnPageChangeListener;
+    @Nullable private OnPageChangeListener mOnPageChangeListener;
     private Revision mRevision;
     private int mPosition;
     private boolean mIsChevronClicked = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -55,7 +55,6 @@ import java.util.List;
 import javax.inject.Inject;
 
 public class HistoryDetailContainerFragment extends Fragment {
-    private ArrayList<Revision> mRevisions;
     private OnPageChangeListener mOnPageChangeListener;
     private Revision mRevision;
     private int mPosition;
@@ -100,19 +99,18 @@ public class HistoryDetailContainerFragment extends Fragment {
 
         mIsFragmentRecreated = savedInstanceState != null;
 
-        mapRevisions();
-
-        if (mRevisions != null) {
-            for (final Revision revision : mRevisions) {
+        ArrayList<Revision> revisions = mapRevisions();
+        if (revisions != null) {
+            for (final Revision revision : revisions) {
                 if (revision.getRevisionId() == mRevision.getRevisionId()) {
-                    mPosition = mRevisions.indexOf(revision);
+                    mPosition = revisions.indexOf(revision);
                 }
             }
         } else {
             throw new IllegalArgumentException("Revisions list extra is null in HistoryDetailContainerFragment");
         }
 
-        HistoryDetailFragmentAdapter adapter = new HistoryDetailFragmentAdapter(getChildFragmentManager(), mRevisions);
+        HistoryDetailFragmentAdapter adapter = new HistoryDetailFragmentAdapter(getChildFragmentManager(), revisions);
 
         if (mBinding != null) {
             mBinding.diffPager.setPageTransformer(false, new WPViewPagerTransformer(TransformType.SLIDE_OVER));
@@ -165,7 +163,8 @@ public class HistoryDetailContainerFragment extends Fragment {
         return mBinding.getRoot();
     }
 
-    private void mapRevisions() {
+    @Nullable
+    private ArrayList<Revision> mapRevisions() {
         if (getArguments() != null) {
             mRevision = getArguments().getParcelable(EXTRA_CURRENT_REVISION);
 
@@ -176,7 +175,9 @@ public class HistoryDetailContainerFragment extends Fragment {
             for (final long revisionId : previousRevisionsIds) {
                 revisionModels.add(mPostStore.getRevisionById(revisionId, postId, siteId));
             }
-            mRevisions = mapRevisionModelsToRevisions(revisionModels);
+            return mapRevisionModelsToRevisions(revisionModels);
+        } else {
+            return null;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -351,7 +351,7 @@ public class HistoryDetailContainerFragment extends Fragment {
     }
 
     @SuppressWarnings("deprecation")
-    private class HistoryDetailFragmentAdapter extends FragmentStatePagerAdapter {
+    private static class HistoryDetailFragmentAdapter extends FragmentStatePagerAdapter {
         private final ArrayList<Revision> mRevisions;
 
         @SuppressWarnings({"unchecked", "deprecation"})

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -56,7 +56,6 @@ import javax.inject.Inject;
 
 public class HistoryDetailContainerFragment extends Fragment {
     private ArrayList<Revision> mRevisions;
-    private HistoryDetailFragmentAdapter mAdapter;
     private OnPageChangeListener mOnPageChangeListener;
     private Revision mRevision;
     private int mPosition;
@@ -113,11 +112,11 @@ public class HistoryDetailContainerFragment extends Fragment {
             throw new IllegalArgumentException("Revisions list extra is null in HistoryDetailContainerFragment");
         }
 
-        mAdapter = new HistoryDetailFragmentAdapter(getChildFragmentManager(), mRevisions);
+        HistoryDetailFragmentAdapter adapter = new HistoryDetailFragmentAdapter(getChildFragmentManager(), mRevisions);
 
         if (mBinding != null) {
             mBinding.diffPager.setPageTransformer(false, new WPViewPagerTransformer(TransformType.SLIDE_OVER));
-            mBinding.diffPager.setAdapter(mAdapter);
+            mBinding.diffPager.setAdapter(adapter);
             mBinding.diffPager.setCurrentItem(mPosition);
 
             mBinding.next.setOnClickListener(view -> {
@@ -159,8 +158,8 @@ public class HistoryDetailContainerFragment extends Fragment {
             mBinding.previous.setVisibility(isInVisualPreview ? View.INVISIBLE : View.VISIBLE);
             mBinding.next.setVisibility(isInVisualPreview ? View.INVISIBLE : View.VISIBLE);
 
-            refreshHistoryDetail(mBinding);
-            resetOnPageChangeListener(mBinding);
+            refreshHistoryDetail(mBinding, adapter);
+            resetOnPageChangeListener(mBinding, adapter);
         }
 
         return mBinding.getRoot();
@@ -281,7 +280,10 @@ public class HistoryDetailContainerFragment extends Fragment {
         }
     }
 
-    private void refreshHistoryDetail(@NonNull HistoryDetailContainerFragmentBinding binding) {
+    private void refreshHistoryDetail(
+            @NonNull HistoryDetailContainerFragmentBinding binding,
+            @NonNull HistoryDetailFragmentAdapter adapter
+    ) {
         if (mRevision.getTotalAdditions() > 0) {
             binding.diffAdditions.setText(String.valueOf(mRevision.getTotalAdditions()));
             binding.diffAdditions.setVisibility(View.VISIBLE);
@@ -297,10 +299,13 @@ public class HistoryDetailContainerFragment extends Fragment {
         }
 
         binding.previous.setEnabled(mPosition != 0);
-        binding.next.setEnabled(mPosition != mAdapter.getCount() - 1);
+        binding.next.setEnabled(mPosition != adapter.getCount() - 1);
     }
 
-    private void resetOnPageChangeListener(@NonNull HistoryDetailContainerFragmentBinding binding) {
+    private void resetOnPageChangeListener(
+            @NonNull HistoryDetailContainerFragmentBinding binding,
+            @NonNull HistoryDetailFragmentAdapter adapter
+    ) {
         if (mOnPageChangeListener != null) {
             binding.diffPager.removeOnPageChangeListener(mOnPageChangeListener);
         } else {
@@ -327,8 +332,8 @@ public class HistoryDetailContainerFragment extends Fragment {
                     }
 
                     mPosition = position;
-                    mRevision = mAdapter.getRevisionAtPosition(mPosition);
-                    refreshHistoryDetail(binding);
+                    mRevision = adapter.getRevisionAtPosition(mPosition);
+                    refreshHistoryDetail(binding, adapter);
                     showHistoryTimeStampInToolbar();
                 }
             };

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -158,9 +158,11 @@ public class HistoryDetailContainerFragment extends Fragment {
 
             refreshHistoryDetail(mBinding, adapter, mRevision);
             resetOnPageChangeListener(mBinding, adapter);
-        }
 
-        return mBinding.getRoot();
+            return mBinding.getRoot();
+        } else {
+            throw new IllegalStateException("mBinding or mRevision is null");
+        }
     }
 
     @Nullable

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -268,12 +268,9 @@ public class HistoryDetailContainerFragment extends Fragment {
         final View fadeInView = isInVisualPreview(binding) ? binding.diffPager : binding.visualPreviewContainer;
         final View fadeOutView = isInVisualPreview(binding) ? binding.visualPreviewContainer : binding.diffPager;
         binding.visualPreviewContainer.smoothScrollTo(0, 0);
-        binding.visualPreviewContainer.post(new Runnable() {
-            @Override
-            public void run() {
-                AniUtils.fadeIn(fadeInView, Duration.SHORT);
-                AniUtils.fadeOut(fadeOutView, Duration.SHORT);
-            }
+        binding.visualPreviewContainer.post(() -> {
+            AniUtils.fadeIn(fadeInView, Duration.SHORT);
+            AniUtils.fadeOut(fadeOutView, Duration.SHORT);
         });
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -90,8 +90,13 @@ public class HistoryDetailContainerFragment extends Fragment {
         return fragment;
     }
 
+    @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(
+            @NonNull LayoutInflater inflater,
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState
+    ) {
         mBinding = HistoryDetailContainerFragmentBinding.inflate(inflater, container, false);
 
         mIsFragmentRecreated = savedInstanceState != null;
@@ -350,6 +355,7 @@ public class HistoryDetailContainerFragment extends Fragment {
             mRevisions = (ArrayList<Revision>) revisions.clone();
         }
 
+        @NonNull
         @Override
         public Fragment getItem(int position) {
             return HistoryDetailFragment.Companion.newInstance(mRevisions.get(position));
@@ -361,7 +367,7 @@ public class HistoryDetailContainerFragment extends Fragment {
         }
 
         @Override
-        public void restoreState(Parcelable state, ClassLoader loader) {
+        public void restoreState(@Nullable Parcelable state, @Nullable ClassLoader loader) {
             try {
                 super.restoreState(state, loader);
             } catch (IllegalStateException exception) {
@@ -369,6 +375,7 @@ public class HistoryDetailContainerFragment extends Fragment {
             }
         }
 
+        @Nullable
         @Override
         public Parcelable saveState() {
             Bundle bundle = (Bundle) super.saveState();


### PR DESCRIPTION
Parent #18906

This PR's main focus is to replace `findViewById ` with `ViewBinding` for the [HistoryDetailContainerFragment.java](https://github.com/wordpress-mobile/WordPress-Android/blob/5b0d3f39c8cfe9c08b4e1547e46bc947f9be6b8f/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java#L61) class.

Additionally, this PR is also dealing with adding any missing nullability annotations to this fragment class, focusing mainly on its fields, and, any effected neighbour classes. But first, all existing warnings on this class are being resolved/suppressed so as to make it easier to deal with any missing nullability checks (with help from the IDE), especially when a `@Nullable` annotation is added.

FYI: This change is `relatively safe`, meaning that although there are compile-time changes associated with this change, and it needs testing, the changes included in this PR are very targeted and specific to one screen, and one screen only. Thus, if this screen is tested appropriately, it should be safe to merge this to `trunk`.

-----

PS: @RenanLukas I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

`findViewById ` -> `ViewBinding`

1. [Replace findviewbyid with viewbinding for history detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/85f6586cd0d079ec28b4ab0564fbada8f9d4affd)
2. [Use non-null viewbinding method parameter for history detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/6512ed28f0ab2466de6f3a824258198a98fa680a)

Nullability Annotation List:

1. [Add missing nullability annotations to sdk override methods](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/7c204435590d6aa2250811383f37337d0ba46209)
2. [Remove adapter from field and use it as non-null](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/e28be1d240e52e437756938bbcbcb7709e198c62)
3. [Remove revisions from field and use it as nullable](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/01bb24e9d2976ce67242b397cffaf1c1ec9f2ebc)
4. [Add missing nl-a to on page change listener field](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/e8112617b0b752d423f9e9e5c2ad0f5ecdf10d26)
5. [Add missing nl-a to on revision field](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/102dc63f4b2cec66e7470ee2f5643e8af3e57a78)

Warnings Resolution List:

1. [Make inner history detail fragment adapter class static](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/16d535f411db63703cf30a0a9d4b1b666f8df353)
2. [Replace anonymous class with lambda for history detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/5e643b5347cd6f65a98ee3da3515837a8197a5f5)

Warnings Suppression List:

1. [Suppress deprecation warnings on history detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19172/commits/c508f268f75be002b5a772f55088f2a2dac80aaf)

-----

## To test:

1. Quickly smoke test any history related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected.
8. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>History Details Screen [HistoryDetailContainerFragment.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Posts` screen and tap on any post.
- Find the options menu (`top-right`) and tap on `History` .
- From the `History` screen, tap on any revision.
- Verify that the `History Details` screen is shown and functioning as expected.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

9. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
