### PR TITLE
Fix chatbot layout issues

### DIFF
--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -56,3 +56,7 @@ a.floating-button {
     transform: rotate(45deg);
     width: 26px;
 }
+
+.docsbot-chat-btn-send:disabled {
+    opacity: 0.3;
+}

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -43,6 +43,8 @@ a.floating-button {
 .docsbot-chat-input {
     height: 48px !important;
     font-size: 16px !important;
+    padding-top: 16px;
+    padding-bottom: 16px;
 }
 
 .docsbot-chat-bot-message-support a {

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -54,4 +54,5 @@ a.floating-button {
 
 .docsbot-chat-btn-send-icon {
     transform: rotate(45deg);
+    width: 26px;
 }

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -51,3 +51,7 @@ a.floating-button {
     height: 48px;
     font-size: 16px;
 }
+
+.docsbot-chat-btn-send-icon {
+    transform: rotate(45deg);
+}

--- a/WordPress/src/jetpack/assets/support_chat_widget.css
+++ b/WordPress/src/jetpack/assets/support_chat_widget.css
@@ -53,6 +53,10 @@ a.floating-button {
 }
 
 .docsbot-chat-btn-send-icon {
+    fill: rgb(0, 135, 16);
+}
+
+.docsbot-chat-btn-send-icon {
     transform: rotate(45deg);
     width: 26px;
 }


### PR DESCRIPTION
This fixes the "Fix layout issues" item of #19168 
- The word ‘Send a message’ was set vertically centered in the text box. (If the font size is set to small from accessibility settings, it's still not centered. I couldn't find a better way to center for all cases.)
- The send icon is forwarding to the right now. 
- The size of the send icon was enlarged.
- The send icon color was changed to Jetpack green 50, and the disabled color of the button was set to 30%.

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/6deb7680-2226-4279-b2ea-47fdb86adfdc" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/08c9580c-1a21-4653-8242-093438674bdd" width=300>|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/7e3b6dfe-5988-44b0-9b28-e973aca03aa8" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/410a2cf3-220a-4745-899a-6cefcccfc6d0" width=300>|

To test:
1. Launch JP app
2. Go to Contact support (Me -> Help -> Contact support)
3. Ensure the feature flag is enabled (Me -> Debug settings -> contact_support_chatbot)
4. Verify Support Bot is launched
5. Verify it addresses the layout issues that mentioned in #19168. 

## Regression Notes
1. Potential unintended areas of impact
Different use cases on the chatbot screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested different cases.

3. What automated tests I added (or what prevented me from doing so)
This PR fixes small UI issues, and the change is not worthwhile for automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
