### PR TITLE
Specify android agent in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,9 @@ common_params:
       files: "buildkite-test-analytics/*.xml"
       format: "junit"
 
+agents:
+  queue: "android"
+
 steps:
   #################
   # Gradle Wrapper Validation
@@ -66,7 +69,7 @@ steps:
     steps:
       - label: "🔬 Unit Test WordPress"
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
-        plugins: 
+        plugins:
           - *ci_toolkit
           - *test_collector :
               <<: *test_collector_common_params
@@ -76,7 +79,7 @@ steps:
 
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
-        plugins: 
+        plugins:
           - *ci_toolkit
           - *test_collector :
               <<: *test_collector_common_params
@@ -86,7 +89,7 @@ steps:
 
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
-        plugins: 
+        plugins:
           - *ci_toolkit
           - *test_collector :
               <<: *test_collector_common_params
@@ -101,7 +104,7 @@ steps:
     steps:
       - label: ":wordpress: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
-        plugins: 
+        plugins:
           - *ci_toolkit
           - *test_collector :
               <<: *test_collector_common_params
@@ -111,7 +114,7 @@ steps:
 
       - label: ":jetpack: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
-        plugins: 
+        plugins:
           - *ci_toolkit
           - *test_collector :
               <<: *test_collector_common_params


### PR DESCRIPTION
We are already using `android` agent for this pipeline, but having it specified in the `.buildkite/pipeline.yml` file will make it easier to programmatically change it.

I am working on a small bash script that will make it easier to test `android-staging` changes such as [this one](https://github.com/wordpress-mobile/WordPress-Android/pull/18773) and this change will help keep that script simple.