### PR TITLE
[Reader Improvements] Update Tag Header to match i2 design

### DIFF
--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -15,7 +15,7 @@
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_tag"
-            style="@style/ReaderTextView.Site.Header.NewTitle"
+            style="@style/ReaderTextView.Tag.Header.NewTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toTopOf="@+id/follow_container"

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -241,6 +241,17 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
+    <style name="ReaderTextView.Tag.Header.NewTitle" parent="ReaderTextView">
+        <item name="android:textAppearance">@style/TextAppearance.Material3.HeadlineMedium</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:gravity">start</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:maxLines">5</item>
+        <item name="android:textStyle">bold</item>
+        <item name="autoSizeMaxTextSize">@dimen/text_sz_double_extra_large</item>
+        <item name="autoSizeMinTextSize">@dimen/text_sz_larger</item>
+    </style>
+
     <style name="Reader.TextView.Error" parent="Widget.MaterialComponents.TextView">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fixes #19077 

To test:
1 - Open `"Me"` -> Debug settings -> `"Features in development"`;
2 - Enable `ReaderImprovementsFeatureConfig`;
3 - Move back to home and open Reader;
4 - Tap on any tag to open the tag posts list;
5 - You should see the new header layout. Make sure follow/unfollow button is working as expected;
<p float="left">
<img width="300" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/86622a1a-2ea2-4712-96fa-000c63994c85">
<img width="300" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/73d3465e-5671-4a32-b0eb-d8f43b79cea8">
</p>


6 - Repeat step 1 but this time disable `ReaderImprovementsFeatureConfig`;
7 - Repeat steps 3 and 4: you should see the existing header layout. Make sure follow/unfollow button is working as expected.
<p float="left">
<img width="300" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/45849af2-5835-4fc1-8ce4-5f40024c834b">
<img width="300" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/2bd5915b-1ddf-478a-8dbd-4436b6a2cd48">
</p>


## Regression Notes
1. Potential unintended areas of impact
None (implementation behind feature flag)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None (all existing logic is inside a custom view)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
