### PR TITLE
[Tool] Configure Dependabot to Ignore `ExoPlayer` Dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       - dependency-name: "com.android.tools.build:gradle"
       - dependency-name: "com.android.application"
       - dependency-name: "com.android.library"
+      # Bumping 2.13.3 to the newest version requires lots of changes, including changes to
+      # Gutenberg. As such, and as agreed, any update is paused. For more details, see
+      # https://github.com/wordpress-mobile/WordPress-Android/pull/17936#issuecomment-1553227875
+      - dependency-name: "com.google.android.exoplayer:exoplayer"
       # Bumping 2.26.3 to 2.27.2 will break the mocks. For more details, see
       # https://github.com/wiremock/wiremock/issues/1345#issuecomment-656060968
       - dependency-name: "com.github.tomakehurst:wiremock"


### PR DESCRIPTION
This PR disables `Dependabot` alerts for the `ExoPlayer` dependency. Bumping `2.13.3` to the newest version requires lots of changes, including changes to Gutenberg. As such, and as agreed, any update is paused.

For more info see: https://github.com/wordpress-mobile/WordPress-Android/pull/17936#issuecomment-1553227875

-----

## To test:

No need to explicitly test this change (like done [here](https://github.com/wordpress-mobile/WordPress-Android/pull/18335) and [here](https://github.com/wordpress-mobile/WordPress-Android/pull/18543)), verifying that no [such](https://github.com/wordpress-mobile/WordPress-Android/pull/19204) `Dependabot` PR will end-up being opened in the future would be enough for now.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A
-----

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)