### PR TITLE
[Nullability Annotations to Java Classes] Replace `findViewById` with `ViewBinding` for Site Picker (`relatively safe`)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -421,7 +421,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @SuppressWarnings("unchecked")
-    private void restoreSavedInstanceState(Bundle savedInstanceState) {
+    private void restoreSavedInstanceState(@Nullable Bundle savedInstanceState) {
         boolean isInSearchMode = false;
         String lastSearch = "";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -115,7 +115,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private ActionMode mReblogActionMode;
     @Nullable private MenuItem mMenuEdit;
     @Nullable private MenuItem mMenuAdd;
-    private MenuItem mMenuSearch;
+    @Nullable private MenuItem mMenuSearch;
     private SearchView mSearchView;
     private int mCurrentLocalId;
     private SitePickerMode mSitePickerMode;
@@ -255,9 +255,10 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Override
     public boolean onPrepareOptionsMenu(@NonNull Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        if (mBinding != null) {
+        if (mBinding != null && mMenuSearch != null) {
             updateMenuItemVisibility();
-            setupSearchView(mBinding);
+            mSearchView = getSearchView(mMenuSearch);
+            setupSearchView(mBinding, mMenuSearch, mSearchView);
             return true;
         } else {
             return false;
@@ -581,11 +582,19 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
     }
 
-    private void setupSearchView(@NonNull SitePickerActivityBinding binding) {
-        mSearchView = (SearchView) mMenuSearch.getActionView();
-        mSearchView.setMaxWidth(Integer.MAX_VALUE);
+    @NonNull
+    private SearchView getSearchView(@NonNull MenuItem menuSearch) {
+        SearchView searchView = (SearchView) menuSearch.getActionView();
+        searchView.setMaxWidth(Integer.MAX_VALUE);
+        return searchView;
+    }
 
-        mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+    private void setupSearchView(
+            @NonNull SitePickerActivityBinding binding,
+            @NonNull MenuItem menuSearch,
+            @NonNull SearchView searchView
+    ) {
+        menuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
                 if (!getAdapter().getIsInSearchMode() && mMenuEdit != null && mMenuAdd != null) {
@@ -593,7 +602,7 @@ public class SitePickerActivity extends LocaleAwareActivity
                     mMenuEdit.setVisible(false);
                     mMenuAdd.setVisible(false);
 
-                    mSearchView.setOnQueryTextListener(SitePickerActivity.this);
+                    searchView.setOnQueryTextListener(SitePickerActivity.this);
                 }
 
                 return true;
@@ -602,19 +611,22 @@ public class SitePickerActivity extends LocaleAwareActivity
             @Override
             public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
                 disableSearchMode(binding);
-                mSearchView.setOnQueryTextListener(null);
+                searchView.setOnQueryTextListener(null);
                 return true;
             }
         });
 
-        setQueryIfInSearch();
+        setQueryIfInSearch(menuSearch, searchView);
     }
 
-    private void setQueryIfInSearch() {
+    private void setQueryIfInSearch(
+            @NonNull MenuItem menuSearch,
+            @NonNull SearchView searchView
+    ) {
         if (getAdapter().getIsInSearchMode()) {
-            mMenuSearch.expandActionView();
-            mSearchView.setOnQueryTextListener(SitePickerActivity.this);
-            mSearchView.setQuery(getAdapter().getLastSearch(), true);
+            menuSearch.expandActionView();
+            searchView.setOnQueryTextListener(SitePickerActivity.this);
+            searchView.setQuery(getAdapter().getLastSearch(), true);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -332,16 +332,14 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         // Enable the block editor on sites created on mobile
-        switch (requestCode) {
-            case RequestCodes.CREATE_SITE:
-                if (data != null) {
-                    int newSiteLocalID = data.getIntExtra(
-                            SitePickerActivity.KEY_SITE_LOCAL_ID,
-                            SelectedSiteRepository.UNAVAILABLE
-                    );
-                    SiteUtils.enableBlockEditorOnSiteCreation(mDispatcher, mSiteStore, newSiteLocalID);
-                }
-                break;
+        if (requestCode == RequestCodes.CREATE_SITE) {
+            if (data != null) {
+                int newSiteLocalID = data.getIntExtra(
+                        SitePickerActivity.KEY_SITE_LOCAL_ID,
+                        SelectedSiteRepository.UNAVAILABLE
+                );
+                SiteUtils.enableBlockEditorOnSiteCreation(mDispatcher, mSiteStore, newSiteLocalID);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -114,7 +114,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private ActionMode mActionMode;
     @Nullable private ActionMode mReblogActionMode;
     @Nullable private MenuItem mMenuEdit;
-    private MenuItem mMenuAdd;
+    @Nullable private MenuItem mMenuAdd;
     private MenuItem mMenuSearch;
     private SearchView mSearchView;
     private int mCurrentLocalId;
@@ -588,7 +588,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
-                if (!getAdapter().getIsInSearchMode() && mMenuEdit != null) {
+                if (!getAdapter().getIsInSearchMode() && mMenuEdit != null && mMenuAdd != null) {
                     enableSearchMode(binding);
                     mMenuEdit.setVisible(false);
                     mMenuAdd.setVisible(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -190,7 +190,7 @@ public class SitePickerActivity extends LocaleAwareActivity
                         case CONTINUE_REBLOG_TO:
                             if (!mSitePickerMode.isReblogMode()) break;
                             SiteRecord siteToReblog = ((ContinueReblogTo) action).getSiteForReblog();
-                            selectSiteAndFinish(siteToReblog);
+                            if (siteToReblog != null) selectSiteAndFinish(siteToReblog);
                             break;
                         case ASK_FOR_SITE_SELECTION:
                             if (!mSitePickerMode.isReblogMode()) break;
@@ -687,7 +687,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         binding.progress.setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
-    private void selectSiteAndFinish(SiteRecord siteRecord) {
+    private void selectSiteAndFinish(@NonNull SiteRecord siteRecord) {
         hideSoftKeyboard();
         AppPrefs.addRecentlyPickedSiteId(siteRecord.getLocalId());
         setResult(RESULT_OK, new Intent().putExtra(KEY_SITE_LOCAL_ID, siteRecord.getLocalId()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -119,7 +119,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private SearchView mSearchView;
     private int mCurrentLocalId;
     @Nullable private SitePickerMode mSitePickerMode;
-    private final Debouncer mDebouncer = new Debouncer();
+    @NonNull private final Debouncer mDebouncer = new Debouncer();
     private SitePickerViewModel mViewModel;
 
     private HashSet<Integer> mSelectedPositions = new HashSet<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -511,22 +511,24 @@ public class SitePickerActivity extends LocaleAwareActivity
         List<SiteModel> siteList = new ArrayList<>();
         for (SiteRecord siteRecord : changeSet) {
             SiteModel siteModel = mSiteStore.getSiteByLocalId(siteRecord.getLocalId());
-            if (hiddenSites.contains(siteRecord)) {
-                if (siteRecord.getLocalId() == mCurrentLocalId) {
-                    skippedCurrentSite = true;
-                    currentSiteName = siteRecord.getBlogNameOrHomeURL();
-                    continue;
+            if (siteModel != null) {
+                if (hiddenSites.contains(siteRecord)) {
+                    if (siteRecord.getLocalId() == mCurrentLocalId) {
+                        skippedCurrentSite = true;
+                        currentSiteName = siteRecord.getBlogNameOrHomeURL();
+                        continue;
+                    }
+                    siteModel.setIsVisible(false);
+                    // Remove stats data for hidden sites
+                    mStatsStore.deleteSiteData(siteModel);
+                } else {
+                    siteModel.setIsVisible(true);
                 }
-                siteModel.setIsVisible(false);
-                // Remove stats data for hidden sites
-                mStatsStore.deleteSiteData(siteModel);
-            } else {
-                siteModel.setIsVisible(true);
+                // Save the site
+                mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
+                siteList.add(siteModel);
+                trackVisibility(Long.toString(siteModel.getSiteId()), siteModel.isVisible());
             }
-            // Save the site
-            mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
-            siteList.add(siteModel);
-            trackVisibility(Long.toString(siteModel.getSiteId()), siteModel.isVisible());
         }
 
         updateVisibilityOfSitesOnRemote(siteList);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -58,7 +58,6 @@ import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.config.WPIndividualPluginOverlayFeatureConfig;
 import org.wordpress.android.util.helpers.Debouncer;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.viewmodel.main.SitePickerViewModel;
@@ -110,7 +109,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     private static final String TRACK_PROPERTY_BLOG_ID = "blog_id";
     private static final String TRACK_PROPERTY_VISIBLE = "visible";
 
-    private SitePickerAdapter mAdapter;
+    @Nullable private SitePickerAdapter mAdapter;
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
     private ActionMode mActionMode;
     private ActionMode mReblogActionMode;
@@ -432,7 +431,7 @@ public class SitePickerActivity extends LocaleAwareActivity
             mSitePickerMode = (SitePickerMode) getIntent().getSerializableExtra(KEY_SITE_PICKER_MODE);
         }
 
-        setNewAdapter(lastSearch, isInSearchMode);
+        mAdapter = createNewAdapter(lastSearch, isInSearchMode);
     }
 
     private void setupActionBar(@NonNull SitePickerActivityBinding binding) {
@@ -451,18 +450,20 @@ public class SitePickerActivity extends LocaleAwareActivity
 
     private void setIsInSearchModeAndSetNewAdapter(boolean isInSearchMode) {
         String lastSearch = getAdapter().getLastSearch();
-        setNewAdapter(lastSearch, isInSearchMode);
+        mAdapter = createNewAdapter(lastSearch, isInSearchMode);
     }
 
+    @NonNull
     private SitePickerAdapter getAdapter() {
         if (mAdapter == null) {
-            setNewAdapter("", false);
+            mAdapter = createNewAdapter("", false);
         }
         return mAdapter;
     }
 
-    private void setNewAdapter(String lastSearch, boolean isInSearchMode) {
-        mAdapter = new SitePickerAdapter(
+    @NonNull
+    private SitePickerAdapter createNewAdapter(String lastSearch, boolean isInSearchMode) {
+        SitePickerAdapter adapter = new SitePickerAdapter(
                 this,
                 R.layout.site_picker_listitem,
                 mCurrentLocalId,
@@ -481,8 +482,8 @@ public class SitePickerActivity extends LocaleAwareActivity
                         if (mBinding != null) {
                             showProgress(mBinding, false);
                             if (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && !isInSearchMode) {
-                                mAdapter.findAndSelect(mCurrentLocalId);
-                                int scrollPos = mAdapter.getItemPosByLocalId(mCurrentLocalId);
+                                getAdapter().findAndSelect(mCurrentLocalId);
+                                int scrollPos = getAdapter().getItemPosByLocalId(mCurrentLocalId);
                                 if (scrollPos > -1) {
                                     mBinding.recyclerView.scrollToPosition(scrollPos);
                                 }
@@ -493,8 +494,9 @@ public class SitePickerActivity extends LocaleAwareActivity
                 },
                 mSitePickerMode,
                 mIsInEditMode);
-        mAdapter.setOnSiteClickListener(this);
-        mAdapter.setOnSelectedCountChangedListener(this);
+        adapter.setOnSiteClickListener(this);
+        adapter.setOnSelectedCountChangedListener(this);
+        return adapter;
     }
 
     private void saveSiteVisibility(SiteRecord siteRecord) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -413,6 +413,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         binding.recyclerView.setEmptyView(binding.actionableEmptyView);
     }
 
+    @SuppressWarnings("unchecked")
     private void restoreSavedInstanceState(Bundle savedInstanceState) {
         boolean isInSearchMode = false;
         String lastSearch = "";

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -122,7 +122,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @NonNull private final Debouncer mDebouncer = new Debouncer();
     @Nullable private SitePickerViewModel mViewModel;
 
-    private HashSet<Integer> mSelectedPositions = new HashSet<>();
+    @NonNull private HashSet<Integer> mSelectedPositions = new HashSet<>();
     private boolean mIsInEditMode;
 
     private boolean mShowMenuEnabled = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -225,7 +225,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putInt(KEY_SITE_LOCAL_ID, mCurrentLocalId);
         outState.putBoolean(KEY_IS_IN_SEARCH_MODE, getAdapter().getIsInSearchMode());
         outState.putString(KEY_LAST_SEARCH, getAdapter().getLastSearch());
@@ -307,7 +307,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         switch (requestCode) {
@@ -668,13 +668,13 @@ public class SitePickerActivity extends LocaleAwareActivity
     }
 
     @Override
-    public boolean onQueryTextSubmit(String s) {
+    public boolean onQueryTextSubmit(@NonNull String s) {
         hideSoftKeyboard();
         return true;
     }
 
     @Override
-    public boolean onQueryTextChange(String s) {
+    public boolean onQueryTextChange(@NonNull String s) {
         if (getAdapter().getIsInSearchMode()) {
             AnalyticsTracker.track(Stat.SITE_SWITCHER_SEARCH_PERFORMED);
             getAdapter().setLastSearch(s);
@@ -724,7 +724,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public void onDestroyActionMode(ActionMode mode) {
+        public void onDestroyActionMode(@NonNull ActionMode mode) {
             mViewModel.onReblogActionBackSelected();
             mReblogActionMode = null;
         }
@@ -783,7 +783,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
 
         @Override
-        public void onDestroyActionMode(ActionMode actionMode) {
+        public void onDestroyActionMode(@NonNull ActionMode actionMode) {
             if (mHasChanges) {
                 saveSitesVisibility(mChangeSet);
             }
@@ -828,7 +828,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
         @NonNull
         @Override
-        public Dialog onCreateDialog(Bundle savedInstanceState) {
+        public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
             SiteCreationSource source =
                     SiteCreationSource.fromString(getArguments().getString(ARG_SITE_CREATION_SOURCE));
             CharSequence[] items =

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -116,7 +116,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private MenuItem mMenuEdit;
     @Nullable private MenuItem mMenuAdd;
     @Nullable private MenuItem mMenuSearch;
-    private SearchView mSearchView;
+    @Nullable private SearchView mSearchView;
     private int mCurrentLocalId;
     private SitePickerMode mSitePickerMode;
     private final Debouncer mDebouncer = new Debouncer();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -812,6 +812,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static void showAddSiteDialog(Activity activity, SiteCreationSource source) {
         DialogFragment dialog = new AddSiteDialog();
         Bundle args = new Bundle();
@@ -824,11 +825,13 @@ public class SitePickerActivity extends LocaleAwareActivity
      * dialog which appears after user taps "Add site" - enables choosing whether to create
      * a new wp.com blog or add an existing self-hosted one
      */
+    @SuppressWarnings("deprecation")
     public static class AddSiteDialog extends DialogFragment {
         static final String ADD_SITE_DIALOG_TAG = "add_site_dialog";
 
         @NonNull
         @Override
+        @SuppressWarnings("deprecation")
         public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
             SiteCreationSource source =
                     SiteCreationSource.fromString(getArguments().getString(ARG_SITE_CREATION_SOURCE));

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -120,7 +120,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     private int mCurrentLocalId;
     @Nullable private SitePickerMode mSitePickerMode;
     @NonNull private final Debouncer mDebouncer = new Debouncer();
-    private SitePickerViewModel mViewModel;
+    @Nullable private SitePickerViewModel mViewModel;
 
     private HashSet<Integer> mSelectedPositions = new HashSet<>();
     private boolean mIsInEditMode;
@@ -305,7 +305,7 @@ public class SitePickerActivity extends LocaleAwareActivity
             addSite(this, mAccountStore.hasAccessToken(), SiteCreationSource.MY_SITE);
             return true;
         } else if (itemId == R.id.continue_flow) {
-            mViewModel.onContinueFlowSelected();
+            if (mViewModel != null) mViewModel.onContinueFlowSelected();
         }
         return super.onOptionsItemSelected(item);
     }
@@ -452,7 +452,7 @@ public class SitePickerActivity extends LocaleAwareActivity
             actionBar.setTitle(R.string.site_picker_title);
 
             if (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && mReblogActionMode == null) {
-                mViewModel.onRefreshReblogActionMode();
+                if (mViewModel != null) mViewModel.onRefreshReblogActionMode();
             }
         }
     }
@@ -488,7 +488,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
                     @Override
                     public void onAfterLoad() {
-                        if (mBinding != null) {
+                        if (mBinding != null && mViewModel != null) {
                             showProgress(mBinding, false);
                             if (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && !isInSearchMode) {
                                 getAdapter().findAndSelect(mCurrentLocalId);
@@ -681,7 +681,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
     @Override
     public void onSiteClick(SiteRecord siteRecord) {
-        if (mSitePickerMode != null && mSitePickerMode.isReblogMode()) {
+        if (mSitePickerMode != null && mSitePickerMode.isReblogMode() && mViewModel != null) {
             mCurrentLocalId = siteRecord.getLocalId();
             mViewModel.onSiteForReblogSelected(siteRecord);
         } else if (mActionMode == null) {
@@ -738,7 +738,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
             int itemId = item.getItemId();
 
-            if (itemId == R.id.continue_flow) {
+            if (itemId == R.id.continue_flow && mViewModel != null) {
                 mViewModel.onContinueFlowSelected();
             }
 
@@ -747,7 +747,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
         @Override
         public void onDestroyActionMode(@NonNull ActionMode mode) {
-            mViewModel.onReblogActionBackSelected();
+            if (mViewModel != null) mViewModel.onReblogActionBackSelected();
             mReblogActionMode = null;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -113,7 +113,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private SwipeToRefreshHelper mSwipeToRefreshHelper;
     @Nullable private ActionMode mActionMode;
     @Nullable private ActionMode mReblogActionMode;
-    private MenuItem mMenuEdit;
+    @Nullable private MenuItem mMenuEdit;
     private MenuItem mMenuAdd;
     private MenuItem mMenuSearch;
     private SearchView mSearchView;
@@ -588,7 +588,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         mMenuSearch.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
             public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
-                if (!getAdapter().getIsInSearchMode()) {
+                if (!getAdapter().getIsInSearchMode() && mMenuEdit != null) {
                     enableSearchMode(binding);
                     mMenuEdit.setVisible(false);
                     mMenuAdd.setVisible(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -112,7 +112,7 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Nullable private SitePickerAdapter mAdapter;
     @Nullable private SwipeToRefreshHelper mSwipeToRefreshHelper;
     @Nullable private ActionMode mActionMode;
-    private ActionMode mReblogActionMode;
+    @Nullable private ActionMode mReblogActionMode;
     private MenuItem mMenuEdit;
     private MenuItem mMenuAdd;
     private MenuItem mMenuSearch;
@@ -175,7 +175,7 @@ public class SitePickerActivity extends LocaleAwareActivity
                                     }
 
                                     SiteRecord site = ((NavigateToState) action).getSiteForReblog();
-                                    if (site != null) {
+                                    if (site != null && mReblogActionMode != null) {
                                         mReblogActionMode.setTitle(site.getBlogNameOrHomeURL());
                                     }
                                     break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -111,7 +111,7 @@ public class SitePickerActivity extends LocaleAwareActivity
 
     @Nullable private SitePickerAdapter mAdapter;
     @Nullable private SwipeToRefreshHelper mSwipeToRefreshHelper;
-    private ActionMode mActionMode;
+    @Nullable private ActionMode mActionMode;
     private ActionMode mReblogActionMode;
     private MenuItem mMenuEdit;
     private MenuItem mMenuAdd;
@@ -775,12 +775,12 @@ public class SitePickerActivity extends LocaleAwareActivity
                 Set<SiteRecord> changeSet = getAdapter().setVisibilityForSelectedSites(true);
                 mChangeSet.addAll(changeSet);
                 mHasChanges = true;
-                mActionMode.finish();
+                if (mActionMode != null) mActionMode.finish();
             } else if (itemId == R.id.menu_hide) {
                 Set<SiteRecord> changeSet = getAdapter().setVisibilityForSelectedSites(false);
                 mChangeSet.addAll(changeSet);
                 mHasChanges = true;
-                mActionMode.finish();
+                if (mActionMode != null) mActionMode.finish();
             } else if (itemId == R.id.menu_select_all) {
                 getAdapter().selectAll();
             } else if (itemId == R.id.menu_deselect_all) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -136,7 +136,6 @@ public class SitePickerActivity extends LocaleAwareActivity
     @Inject StatsStore mStatsStore;
     @Inject ViewModelProvider.Factory mViewModelFactory;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
-    @Inject WPIndividualPluginOverlayFeatureConfig mWPIndividualPluginOverlayFeatureConfig;
 
     @Nullable private SitePickerActivityBinding mBinding = null;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -99,7 +99,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final float mDisabledSiteOpacity;
 
     private final LayoutInflater mInflater;
-    private final HashSet<Integer> mSelectedPositions = new HashSet<>();
+    @NonNull private final HashSet<Integer> mSelectedPositions = new HashSet<>();
     @Nullable private final ViewHolderHandler mHeaderHandler;
     @Nullable private final ViewHolderHandler mFooterHandler;
 
@@ -493,7 +493,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     /*
      * called when the user chooses to edit the visibility of wp.com blogs
      */
-    void setEnableEditMode(boolean enable, HashSet<Integer> selectedPositions) {
+    void setEnableEditMode(boolean enable, @NonNull HashSet<Integer> selectedPositions) {
         if (mIsMultiSelectEnabled == enable) {
             return;
         }


### PR DESCRIPTION
Parent #18906

This PR's main focus is to replace `findViewById ` with `ViewBinding` for the [SitePickerActivity.java](https://github.com/wordpress-mobile/WordPress-Android/blob/5b0d3f39c8cfe9c08b4e1547e46bc947f9be6b8f/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java#L86) class.

Additionally, this PR is also dealing with adding any missing nullability annotations to this activity class, focusing mainly on its fields, and, any effected neighbour classes. But first, all existing warnings on this class are being resolved/suppressed so as to make it easier to deal with any missing nullability checks (with help from the IDE), especially when a `@Nullable` annotation is added.

FYI: This change is `relatively safe`, meaning that although there are compile-time changes associated with this change, and it needs testing, the changes included in this PR are very targeted and specific to one screen, and one screen only. Thus, if this screen is tested appropriately, it should be safe to merge this to `trunk`.

-----

PS: @thomashorta I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

`findViewById ` -> `ViewBinding`

1. [Replace findviewbyid with viewbinding for site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/777de0b13c2ebe07f2be8e27ae947bc0116f895e)
2. [Use non-null viewbinding method parameter for site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/f1d3930921a951c1109b87118eb515429485dd7a)

Nullability Annotation List:

1. [Add missing nullability annotations to sdk override methods](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/7aae6bf080716f9ad76d91c7685a3f016e35ec90)
2. [Add missing nl-a to adapter field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/6f90b037f950d09900c6a6bd9390f4d6fab037ee)
3. [Add missing nl-a to str helper field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/5c869868c28b7fc3e84068a2969f91569d90b404)
4. [Add missing nl-a to action mode field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/7b62a772996eb0bda6847fb9f2f406fbba40c22f)
5. [Add missing nl-a to reblog action mode field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/fa981265da2afa9c9b1efaba4348f5629163aba9)
6. [Add missing nl-a to menu edit field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/2e589b703d15447b4e122b230778bbd9d8044e24)
7. [Add missing nl-a to menu add field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/bc370ad8a57eb8c75e4bac8ff5d981cd4dd053a0)
8. [Add missing nl-a to menu search field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/782c843808dd63444a5ffa2cf41e72c510339af6)
9. [Add missing nl-a to search view field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/f37ad70f66832e7db3e01a6d271978b3891d710f)
10. [Add missing nl-a to site picker mode field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/07fb5a51773c64f9347b2363e07150acfcd027e7)
11. [Add missing nn-a to debouncer field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/4d28cdd97247e882777fef23b58daf58a539b75d)
12. [Add missing nl-a to view model field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/0cee0cf27353b9ecf31468d80bbbc1fe71792c64)
13. [Add missing nn-a to selected positions field](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/7b792f30c15c749fa65ca15061fc996560a55c3f)
14. [Add missing nl-a to private restore sis method parameter](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/0431fe300d92ef02b18bc94ae7e93a7810053190)

Warnings Resolution List:

1. [Guard nullable site to reblog variable on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/6886c1678fe63c7e32ac46645a8542ded90b190e)
2. [Replace unnecessary switch with if statement on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/bdf37408ee0be432bb60fc0d9f75b6754e903263)
3. [Guard nullable site model variable on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/51dff5467ff0c9c43f7486d25290ca1f8f66cb47)

Warnings Suppression List:

1. [Suppress unchecked warning on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/fafdf4bdcb142ef65a6731c00853353d0409d8eb)
2. [Suppress deprecation warnings on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/321eb18965c89143f7916e38ee5097307948b299)

Cleanup List:

1. [Remove unnecessary feature config injected field on site picker](https://github.com/wordpress-mobile/WordPress-Android/pull/19209/commits/82e169ee635cc63e321c27d501235a4d7bbc2689)

-----

## To test:

1. Quickly smoke test any site picker related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected.
16. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>Site Picker Screen [SitePickerActivity.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `My Site` tab and tap on the `down-arrow`(`top-right`).
- Verify that the `Site Picker` screen is shown and functioning as expected.
- For example, try switching sites, searching for a site, adding a new site and showing/hiding sites.

</details>

FYI: While I was testing the `Site Picker` screen I noticed a bug. This bug is not caused by any of the changes included in this PR, and, can be easily reproduced on `trunk` as well. For more info see: #19211

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

17. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
