### PR TITLE
[Nullability Annotations to Java Classes] Replace `findViewById` with `ViewBinding` for Comments (`relatively safe`)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -200,7 +200,10 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     /*
      * used when called from comment list
      */
-    static CommentDetailFragment newInstance(SiteModel site, CommentModel commentModel) {
+    static CommentDetailFragment newInstance(
+            @NonNull SiteModel site,
+            CommentModel commentModel
+    ) {
         CommentDetailFragment fragment = new CommentDetailFragment();
         Bundle args = new Bundle();
         args.putSerializable(KEY_MODE, CommentSource.SITE_COMMENTS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.comments;
 
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -19,14 +20,16 @@ import org.wordpress.android.util.AppLog;
  */
 @Deprecated
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
-    private final SiteModel mSite;
+    @NonNull private final SiteModel mSite;
     private final OnLoadMoreListener mOnLoadMoreListener;
     private final CommentList mCommentList;
 
-    CommentDetailFragmentAdapter(FragmentManager fm,
-                                 CommentList commentList,
-                                 SiteModel site,
-                                 OnLoadMoreListener onLoadMoreListener) {
+    CommentDetailFragmentAdapter(
+            FragmentManager fm,
+            CommentList commentList,
+            @NonNull SiteModel site,
+            OnLoadMoreListener onLoadMoreListener
+    ) {
         super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         this.mSite = site;
         this.mOnLoadMoreListener = onLoadMoreListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -69,7 +69,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     @Nullable private SiteModel mSite;
     @SuppressWarnings("deprecation")
     @Nullable private CommentDetailFragmentAdapter mAdapter;
-    private ViewPager.OnPageChangeListener mOnPageChangeListener;
+    @Nullable private ViewPager.OnPageChangeListener mOnPageChangeListener;
 
     private boolean mIsLoadingComments;
     private boolean mIsUpdatingComments;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -134,7 +134,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle outState) {
+    protected void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putLong(COMMENT_ID_EXTRA, mCommentId);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putSerializable(COMMENT_STATUS_FILTER_EXTRA, mStatusFilter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -66,7 +66,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
 
     private long mCommentId;
     @Nullable private CommentStatus mStatusFilter;
-    private SiteModel mSite;
+    @Nullable private SiteModel mSite;
     @SuppressWarnings("deprecation")
     private CommentDetailFragmentAdapter mAdapter;
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
@@ -178,7 +178,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
             return;
         }
 
-        if (mStatusFilter != null) {
+        if (mSite != null && mStatusFilter != null) {
             final int offset = mAdapter.getCount();
             mCommentsStoreAdapter.dispatch(CommentActionBuilder.newFetchCommentsAction(
                     new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, offset)));
@@ -246,10 +246,14 @@ public class CommentsDetailActivity extends LocaleAwareActivity
         if (mAdapter != null && mAdapter.isAddingNewComments(commentList)) {
             mAdapter.onNewItems(commentList);
         } else {
-            // If current items change, rebuild the adapter
-            mAdapter = new CommentDetailFragmentAdapter(getSupportFragmentManager(), commentList, mSite,
-                    CommentsDetailActivity.this);
-            binding.viewpager.setAdapter(mAdapter);
+            if (mSite != null) {
+                // If current items change, rebuild the adapter
+                mAdapter = new CommentDetailFragmentAdapter(getSupportFragmentManager(), commentList, mSite,
+                        CommentsDetailActivity.this);
+                binding.viewpager.setAdapter(mAdapter);
+            } else {
+                throw new IllegalStateException("mAdapter cannot be constructed; mSite is null");
+            }
         }
 
         final int commentIndex = mAdapter.commentIndex(mCommentId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -54,17 +54,20 @@ import dagger.hilt.android.AndroidEntryPoint;
  */
 @Deprecated
 @AndroidEntryPoint
+@SuppressWarnings({"deprecation", "DeprecatedIsStillUsed"})
 public class CommentsDetailActivity extends LocaleAwareActivity
         implements OnLoadMoreListener,
         CommentActions.OnCommentActionListener, ScrollableViewInitializedListener {
     public static final String COMMENT_ID_EXTRA = "commentId";
     public static final String COMMENT_STATUS_FILTER_EXTRA = "commentStatusFilter";
 
+    @SuppressWarnings("deprecation")
     @Inject CommentsStoreAdapter mCommentsStoreAdapter;
 
     private long mCommentId;
     private CommentStatus mStatusFilter;
     private SiteModel mSite;
+    @SuppressWarnings("deprecation")
     private CommentDetailFragmentAdapter mAdapter;
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
 
@@ -227,6 +230,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void showCommentList(
             @NonNull CommentsDetailActivityBinding binding,
             CommentList commentList

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -65,7 +65,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     @Inject CommentsStoreAdapter mCommentsStoreAdapter;
 
     private long mCommentId;
-    private CommentStatus mStatusFilter;
+    @Nullable private CommentStatus mStatusFilter;
     private SiteModel mSite;
     @SuppressWarnings("deprecation")
     private CommentDetailFragmentAdapter mAdapter;
@@ -178,11 +178,13 @@ public class CommentsDetailActivity extends LocaleAwareActivity
             return;
         }
 
-        final int offset = mAdapter.getCount();
-        mCommentsStoreAdapter.dispatch(CommentActionBuilder.newFetchCommentsAction(
-                new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, offset)));
-        mIsUpdatingComments = true;
-        setLoadingState(binding, true);
+        if (mStatusFilter != null) {
+            final int offset = mAdapter.getCount();
+            mCommentsStoreAdapter.dispatch(CommentActionBuilder.newFetchCommentsAction(
+                    new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, offset)));
+            mIsUpdatingComments = true;
+            setLoadingState(binding, true);
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -68,7 +68,7 @@ public class CommentsDetailActivity extends LocaleAwareActivity
     @Nullable private CommentStatus mStatusFilter;
     @Nullable private SiteModel mSite;
     @SuppressWarnings("deprecation")
-    private CommentDetailFragmentAdapter mAdapter;
+    @Nullable private CommentDetailFragmentAdapter mAdapter;
     private ViewPager.OnPageChangeListener mOnPageChangeListener;
 
     private boolean mIsLoadingComments;
@@ -178,10 +178,10 @@ public class CommentsDetailActivity extends LocaleAwareActivity
             return;
         }
 
-        if (mSite != null && mStatusFilter != null) {
-            final int offset = mAdapter.getCount();
+        if (mSite != null && mStatusFilter != null && mAdapter != null) {
             mCommentsStoreAdapter.dispatch(CommentActionBuilder.newFetchCommentsAction(
-                    new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, offset)));
+                    new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, mAdapter.getCount()))
+            );
             mIsUpdatingComments = true;
             setLoadingState(binding, true);
         }
@@ -267,12 +267,14 @@ public class CommentsDetailActivity extends LocaleAwareActivity
                 @Override
                 public void onPageSelected(int position) {
                     super.onPageSelected(position);
-                    final CommentModel comment = mAdapter.getCommentAtPosition(position);
-                    if (comment != null) {
-                        mCommentId = comment.getRemoteCommentId();
-                        // track subsequent comment views
-                        AnalyticsUtils.trackCommentActionWithSiteDetails(
-                                Stat.COMMENT_VIEWED, AnalyticsCommentActionSource.SITE_COMMENTS, mSite);
+                    if (mAdapter != null) {
+                        final CommentModel comment = mAdapter.getCommentAtPosition(position);
+                        if (comment != null) {
+                            mCommentId = comment.getRemoteCommentId();
+                            // track subsequent comment views
+                            AnalyticsUtils.trackCommentActionWithSiteDetails(
+                                    Stat.COMMENT_VIEWED, AnalyticsCommentActionSource.SITE_COMMENTS, mSite);
+                        }
                     }
                 }
             };

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
@@ -27,12 +27,12 @@ class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
 
     private final CommentsStoreAdapter mCommentsStoreAdapter;
     @Nullable private final CommentStatus mStatusFilter;
-    private final SiteModel mSite;
+    @Nullable private final SiteModel mSite;
     private final LoadingCallback mLoadingCallback;
 
     LoadCommentsTask(CommentsStoreAdapter commentsStoreAdapter,
                      @Nullable CommentStatus statusFilter,
-                     SiteModel site,
+                     @Nullable SiteModel site,
                      LoadingCallback loadingCallback) {
         this.mCommentsStoreAdapter = commentsStoreAdapter;
         this.mStatusFilter = statusFilter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.comments;
 
 import android.os.AsyncTask;
 
+import androidx.annotation.Nullable;
+
 import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -24,12 +26,12 @@ class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
     }
 
     private final CommentsStoreAdapter mCommentsStoreAdapter;
-    private final CommentStatus mStatusFilter;
+    @Nullable private final CommentStatus mStatusFilter;
     private final SiteModel mSite;
     private final LoadingCallback mLoadingCallback;
 
     LoadCommentsTask(CommentsStoreAdapter commentsStoreAdapter,
-                     CommentStatus statusFilter,
+                     @Nullable CommentStatus statusFilter,
                      SiteModel site,
                      LoadingCallback loadingCallback) {
         this.mCommentsStoreAdapter = commentsStoreAdapter;

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -713,8 +713,11 @@ public class AnalyticsUtils {
         }
     }
 
-    public static void trackCommentActionWithSiteDetails(AnalyticsTracker.Stat stat,
-                                                         AnalyticsCommentActionSource actionSource, SiteModel site) {
+    public static void trackCommentActionWithSiteDetails(
+            AnalyticsTracker.Stat stat,
+            AnalyticsCommentActionSource actionSource,
+            @Nullable SiteModel site
+    ) {
         Map<String, Object> properties = new HashMap<>();
         properties.put(COMMENT_ACTION_SOURCE, actionSource.toString());
 


### PR DESCRIPTION
Parent #18906

This PR's main focus is to replace `findViewById ` with `ViewBinding` for the [CommentsDetailActivity.java](https://github.com/wordpress-mobile/WordPress-Android/blob/0c832be0df4b5f88f99fb8c79aebb24d4f4f40d6/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java#L4) class.

Additionally, this PR is also dealing with adding any missing nullability annotations to this activity class, focusing mainly on its fields, and, any effected neighbour classes. But first, all existing warnings on this class are being resolved/suppressed so as to make it easier to deal with any missing nullability checks (with help from the IDE), especially when a `@Nullable` annotation is added.

FYI: This change is `relatively safe`, meaning that although there are compile-time changes associated with this change, and it needs testing, the changes included in this PR are very targeted and specific to one screen, and one screen only. Thus, if this screen is tested appropriately, it should be safe to merge this to `trunk`.

-----

PS: @AjeshRPai I added you as the main reviewer, randomly so, since I just wanted someone from the Jetpack/WordPress mobile team to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

`findViewById ` -> `ViewBinding`

1. [Replace findviewbyid with viewbinding for comments detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/d375f6a14d11199ca069f39a5627d4781d08f381)
2. [Use non-null viewbinding method parameter for comments detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/74f939d9017acf05d3f8be55cf300d188a569d89)

Nullability Annotation List:

1. [Add missing nullability annotations to sdk override methods](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/011658b014c8e67c5a2f7eff403754cf1f33e434)
2. [Add missing nl-a to status filter field](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/9ca0a3cc7094118bec962fb105b054314bc5fd9f)
3. [Add missing nl-a to site field](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/525ca5851b3f13bac169c709ace89322e4b998a1)
4. [Add missing nl-a to adapter field](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/1b709a086ce29e3fdb85669655e857ed00f79f02)
5. [Add missing nl-a to on page change listener field](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/5953977680afbe1ee0a3bf5debea72e4b796686a)

Warnings Suppression List:

1. [Suppress deprecation warnings on comments detail](https://github.com/wordpress-mobile/WordPress-Android/pull/19217/commits/91eed09bf5411afc7be30df98d2fa6fcabaec0ea)

-----

## To test:

1. Quickly smoke test any comments related functionality on both, the WordPress and Jetpack apps, and see if everything is working as expected.
16. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>Comment Details Screen [CommentsDetailActivity.java]</summary>

ℹ️ This test applies to both, the `Jetpack` and `WordPress` app.

- Go to `Comments` screen and tap on any comment.
- Verify that the `Comment Details` screen is shown and functioning as expected.
- For example, try replying, approving, marking as spam, liking, trashing, editing or copying a comment's link address. Most importantly, make sure to verify that you can swipe left-right to navigate between comments.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

17. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
