### PR TITLE
[Reader Improvements] Reader tag chips style update

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewTreeObserver.OnPreDrawListener
 import androidx.annotation.ColorRes
+import androidx.annotation.LayoutRes
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import org.wordpress.android.R
@@ -167,19 +168,21 @@ class ReaderExpandableTagsView @JvmOverloads constructor(
         })
     }
 
-    private sealed class ChipStyle(val name: String) {
-        abstract val chipLayoutRes: Int
-        abstract val overflowChipLayoutRes: Int
+    private sealed interface ChipStyle {
+        @get:LayoutRes
+        val chipLayoutRes: Int
+        @get:LayoutRes
+        val overflowChipLayoutRes: Int
 
-        abstract fun overflowChipText(resources: Resources, hiddenChipsCount: Int): String
+        fun overflowChipText(resources: Resources, hiddenChipsCount: Int): String
 
         @ColorRes
-        open fun overflowBackgroundColorRes(isCollapsed: Boolean): Int? = null
+        fun overflowBackgroundColorRes(isCollapsed: Boolean): Int? = null
 
         @ColorRes
-        open fun overflowStrokeColorRes(isCollapsed: Boolean): Int? = null
+        fun overflowStrokeColorRes(isCollapsed: Boolean): Int? = null
 
-        object Legacy : ChipStyle("legacy") {
+        object Legacy : ChipStyle {
             override val chipLayoutRes: Int
                 get() = R.layout.reader_expandable_tags_view_chip
             override val overflowChipLayoutRes: Int
@@ -201,7 +204,7 @@ class ReaderExpandableTagsView @JvmOverloads constructor(
             }
         }
 
-        object New : ChipStyle("new") {
+        object New : ChipStyle {
             override val chipLayoutRes: Int
                 get() = R.layout.reader_expandable_tags_view_chip_new
             override val overflowChipLayoutRes: Int

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderExpandableTagsView.kt
@@ -167,7 +167,7 @@ class ReaderExpandableTagsView @JvmOverloads constructor(
         })
     }
 
-    sealed class ChipStyle(val name: String) {
+    private sealed class ChipStyle(val name: String) {
         abstract val chipLayoutRes: Int
         abstract val overflowChipLayoutRes: Int
 

--- a/WordPress/src/main/res/color/reader_chip_stroke_color.xml
+++ b/WordPress/src/main/res/color/reader_chip_stroke_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- This is a special color with different alpha values in light and dark mode
+    for a chip in expandable tags view -->
+    <item android:alpha="@dimen/expandable_chips_chip_stroke_alpha" android:color="?attr/colorOnSurface" />
+</selector>

--- a/WordPress/src/main/res/color/reader_chip_stroke_color.xml
+++ b/WordPress/src/main/res/color/reader_chip_stroke_color.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- This is a special color with different alpha values in light and dark mode
-    for a chip in expandable tags view -->
     <item android:alpha="@dimen/expandable_chips_chip_stroke_alpha" android:color="?attr/colorOnSurface" />
 </selector>

--- a/WordPress/src/main/res/layout/reader_expandable_tags_view_chip_new.xml
+++ b/WordPress/src/main/res/layout/reader_expandable_tags_view_chip_new.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    tools:text="A Text in a chip"
+    style="@style/ReaderExpandableTagsViewChipNew" />

--- a/WordPress/src/main/res/layout/reader_expandable_tags_view_overflow_chip_new.xml
+++ b/WordPress/src/main/res/layout/reader_expandable_tags_view_overflow_chip_new.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:checkable="true"
+    android:text="@string/reader_expandable_tags_view_overflow_indicator_collapse_title"
+    style="@style/ReaderExpandableTagsViewChipNew" />

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -168,6 +168,7 @@
     <item name="expandable_chips_view_chip_alpha" format="float" type="dimen">
         @dimen/emphasis_extra_extra_low
     </item>
+    <item name="expandable_chips_chip_stroke_alpha" format="float" type="dimen">0.225</item>
 
     <dimen name="text_sz_extra_extra_small">7sp</dimen>
     <dimen name="text_sz_extra_small">10sp</dimen>
@@ -238,8 +239,13 @@
     <dimen name="reader_chip_height">44dp</dimen>
     <dimen name="reader_site_header_avatar_padding">2dp</dimen>
     <dimen name="reader_site_header_avatar_padding_new">1dp</dimen>
+
     <dimen name="reader_expandable_tags_view_chip_radius">4dp</dimen>
     <dimen name="reader_expandable_tags_view_chip_height">24dp</dimen>
+
+    <dimen name="reader_expandable_tags_view_chip_new_radius">5dp</dimen>
+    <dimen name="reader_expandable_tags_view_chip_new_border">1dp</dimen>
+    <dimen name="reader_expandable_tags_view_chip_new_height">36dp</dimen>
 
     <dimen name="post_list_more_button_extra_padding">24dp</dimen>
 

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -357,6 +357,14 @@
         <item name="chipCornerRadius">@dimen/reader_chip_radius</item>
     </style>
 
+    <style name="ReaderChipNew" parent="@style/Widget.MaterialComponents.Chip.Filter">
+        <item name="android:textAppearance">@style/TextAppearance.Material3.BodyMedium</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:ellipsize">end</item>
+        <item name="checkedIconVisible">false</item>
+        <item name="chipCornerRadius">@dimen/reader_chip_radius</item>
+    </style>
+
     <style name="ReaderInterestFilterChip" parent="@style/ReaderChip">
         <item name="chipMinHeight">@dimen/reader_chip_height</item>
         <item name="chipStartPadding">@dimen/margin_medium_large</item>
@@ -377,6 +385,21 @@
         <item name="ensureMinTouchTargetSize">false</item>
         <item name="chipCornerRadius">@dimen/reader_expandable_tags_view_chip_radius</item>
         <item name="chipBackgroundColor">@color/on_surface_chip</item>
+    </style>
+
+    <style name="ReaderExpandableTagsViewChipNew" parent="@style/ReaderChipNew">
+        <item name="android:checkable">false</item>
+        <item name="chipMinHeight">@dimen/reader_expandable_tags_view_chip_new_height</item>
+        <item name="chipStartPadding">@dimen/margin_extra_large</item>
+        <item name="chipEndPadding">@dimen/margin_extra_large</item>
+        <item name="textStartPadding">0dp</item>
+        <item name="textEndPadding">0dp</item>
+        <item name="android:textColor">@color/material_on_surface_emphasis_medium</item>
+        <item name="ensureMinTouchTargetSize">false</item>
+        <item name="chipCornerRadius">@dimen/reader_expandable_tags_view_chip_new_radius</item>
+        <item name="chipBackgroundColor">@color/transparent</item>
+        <item name="chipStrokeColor">@color/reader_chip_stroke_color</item>
+        <item name="chipStrokeWidth">@dimen/reader_expandable_tags_view_chip_new_border</item>
     </style>
 
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1637,6 +1637,7 @@
     <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
     <string name="reader_error_request_failed_title">There was a problem handling the request. Please try again later.</string>
     <string name="reader_expandable_tags_view_overflow_indicator_expand_title" translatable="false">%1$s+</string>
+    <string name="reader_expandable_tags_view_overflow_indicator_expand_title_new" translatable="false">+%1$s</string>
     <string name="reader_expandable_tags_view_overflow_indicator_collapse_title">Hide</string>
     <string name="reader_discover_interests_header">You might like</string>
     <string name="reader_discover_recommended_blogs_header">Sites to follow</string>


### PR DESCRIPTION
Part of #19085 

This only makes changes to the reader tag chips and is part of the implementation for the Post Details Header UI updates. It's important to note that right now this also affects the tags in the Discovery cards, to make them consistent (even though the tags on those cards will be removed as part of the Reader Improvements tasks).

The changes are behind the `ReaderImprovementsFeatureConfig` so it's possible to toggle between the old and new styles in the Debug Settings.

Demo

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/21f518de-c6d3-4aac-8d7c-3e703af3629e

To test:
1. Install Jetpack and Login
2. Go to Debug Settings -> Features In Development
3. **Verify** `ReaderImprovementsFeatureConfig` is OFF
4. Go to Reader -> Discovery
5. **Verify** the tags are small with gray background (legacy style)
6. Open a post
7. **Verify** the tags are small with gray background (legacy style)
2. Go to Debug Settings -> Features In Development
3. Turn `ReaderImprovementsFeatureConfig` is ON
4. Go to Reader -> Discovery
5. **Verify** the tags are bigger with transparent background and border (new style)
6. Open a post
7. **Verify** the tags are bigger with transparent background and border (new style)

Feel free to also test dark/light modes and checking the functionality of the tags still work properly (collapse/expand and click).

## Regression Notes
1. Potential unintended areas of impact
Wrong style showing up when feature config is off.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

10. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
