### PR TITLE
Dashboard Personalization: Remove quick start cards from the personalize view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardState.kt
@@ -17,6 +17,5 @@ enum class CardType(val order: Int, val trackingName:String) {
     PAGES(3, "pages"),
     ACTIVITY_LOG(4, "activity_log"),
     BLAZE(5, "blaze"),
-    BLOGGING_PROMPTS(6, "blogging_prompts"),
-    NEXT_STEPS(7, "next_steps")
+    BLOGGING_PROMPTS(6, "blogging_prompts")
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -78,12 +78,6 @@ class PersonalizationViewModel @Inject constructor(
                 description = R.string.personalization_screen_blogging_prompts_card_description,
                 enabled = isPromptsSettingEnabled(selectedSiteRepository.getSelectedSiteLocalId()),
                 cardType = CardType.BLOGGING_PROMPTS
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_next_steps_card_title,
-                description = R.string.personalization_screen_next_steps_card_description,
-                enabled = isNextStepCardShown(siteId),
-                cardType = CardType.NEXT_STEPS
             )
         )
     }
@@ -110,7 +104,6 @@ class PersonalizationViewModel @Inject constructor(
                 CardType.ACTIVITY_LOG -> appPrefsWrapper.setShouldHideActivityDashboardCard(siteId, !enabled)
                 CardType.BLAZE -> appPrefsWrapper.setShouldHideBlazeCard(siteId, !enabled)
                 CardType.BLOGGING_PROMPTS -> updatePromptsCardEnabled(enabled)
-                CardType.NEXT_STEPS -> appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, !enabled)
             }
             // update the ui state
             updateCardState(cardType, enabled)
@@ -156,8 +149,6 @@ class PersonalizationViewModel @Inject constructor(
     private fun isActivityLogCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideActivityDashboardCard(siteId)
 
     private fun isBlazeCardShown(siteId: Long) = !appPrefsWrapper.hideBlazeCard(siteId)
-
-    private fun isNextStepCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId)
 
     private suspend fun isPromptsSettingEnabled(
         siteId: Int

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModelTest.kt
@@ -140,16 +140,6 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given next steps card is not hidden, when cards are fetched, then state is checked`() {
-        whenever(appPrefsWrapper.getShouldHideNextStepsDashboardCard(123L)).thenReturn(false)
-
-        viewModel.start()
-        val statsCardState = uiStateList.last().find { it.cardType == CardType.NEXT_STEPS }
-
-        assertTrue(statsCardState!!.enabled)
-    }
-
-    @Test
     fun `given card is disabled, when card is toggled, then card is enabled`() {
         val cardType = CardType.STATS
         whenever(appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(site.siteId)).thenReturn(true)
@@ -234,16 +224,6 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         verify(bloggingRemindersStore).updateBloggingReminders(
             userSetBloggingRemindersModel.copy(isPromptsCardEnabled = true)
         )
-    }
-
-    @Test
-    fun `when next steps card state is toggled, then pref is updated`() {
-        val cardType = CardType.NEXT_STEPS
-
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
-
-        verify(appPrefsWrapper).setShouldHideNextStepsDashboardCard(site.siteId, false)
     }
 
     @Test


### PR DESCRIPTION
Fixes #19220 

This PR removes the Quick Start Cards (Next Steps and/or Get to Know the App) from the personalize dashboard view. The app prefs will continue to be set to "do not show" when the user taps the Negative button in the quick start dialog prompts and if the user taps the More > Hide This option from within the cad more menu. All other behavior remains as is.

**To test:**
- Install the app
- Login

Existing Site - Get to know the App 
- Select a site
- When prompted, select "Show me around"
- ✅ Verify that the "Get to know the app" card is shown in the dashboard and has a more menu
- Tap "Get to know the app" more menu > Hide this
- ✅ Verify that the "Get to know the app" card is removed from the dashboard
- Switch to a different site and then return to this site
- ✅ Verify that the "Get to know the app" card is not shown in the dashboard  

New Site - Next Steps
- Create a new site (follow all the prompts)
- After the site is created, when prompted, select "Show me around"
- ✅ Verify that the "Next Steps" card is shown in the dashboard and has a more menu
- Tap on the `Personalize your home tab` card
- ✅ Verify that the "Next Steps" card is not shown in the list
- Tap "Next Steps" more menu > Hide this
- ✅ Verify that the "Next Steps" card is removed from the dashboard
- Switch to a different site and then return to this site
- ✅ Verify that the "Next Steps" card is not shown in the dashboard  

## Regression Notes
1. Potential unintended areas of impact
The Next Steps card is still shown in the personalize dashboard view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A

CC @oguzkocer - This is a bug fix for release 23.3
