### PR TITLE
Fixes: Strings in Personalization Screen 

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4705,16 +4705,16 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalize_card_content_description">Tap to personalize your home tab</string>
 
     <!-- Personalization Screen -->
-    <string name="personalization_screen_title"> Personalize home tab</string>
-    <string name="personalization_screen_description"> Add or hide Cards</string>
-    <string name="personalization_screen_footer_cards"> Cards may show different content depending on what\'s happening with your site</string>
+    <string name="personalization_screen_title">Personalize home tab</string>
+    <string name="personalization_screen_description">Add or hide Cards</string>
+    <string name="personalization_screen_footer_cards">Cards may show different content depending on what\'s happening with your site</string>
     <string name="personalization_screen_stats_card_title" translatable="false">@string/my_site_todays_stat_card_title</string>
     <string name="personalization_screen_stats_card_description">Views, Visitors and likes</string>
-    <string name="personalization_screen_draft_posts_card_title"> Draft posts</string>
+    <string name="personalization_screen_draft_posts_card_title">Draft posts</string>
     <string name="personalization_screen_draft_posts_card_description">Your recent draft posts.</string>
-    <string name="personalization_screen_scheduled_posts_card_title"> Scheduled posts</string>
+    <string name="personalization_screen_scheduled_posts_card_title">Scheduled posts</string>
     <string name="personalization_screen_scheduled_posts_card_description">Your upcoming scheduled posts.</string>
-    <string name="personalization_screen_blaze_card_title" translatable="false"> @string/blaze_activity_title</string>
+    <string name="personalization_screen_blaze_card_title" translatable="false">@string/blaze_activity_title</string>
     <string name="personalization_screen_blaze_card_description">Promote a post and see current campaigns.</string>
     <string name="personalization_screen_blogging_prompts_card_title">Blogging prompts</string>
     <string name="personalization_screen_blogging_prompts_card_description">Daily ideas for your blog posts.</string>


### PR DESCRIPTION
## Fixes 
This PR fixes the space in the strings used in Personalization screen

## To test:
1. Go to Me → Debug Settings 
2. Enabled `dashboard_personalization` flag
3. Click on "Personalize your Home tab"
4. Verify that strings on the Screen are correct

## Regression Notes
1. Potential unintended areas of impact
Unit tests and Manual tests

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unit tests


PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
