### PR TITLE
[Reader Improvements] Post details body content sans-serif

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1523,7 +1523,12 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))
         readerProgressBar.visibility = View.VISIBLE
-        renderer = ReaderPostRenderer(readerWebView, viewModel.post, readerCssProvider)
+        renderer = ReaderPostRenderer(
+            readerWebView,
+            viewModel.post,
+            readerCssProvider,
+            readerImprovementsFeatureConfig.isEnabled()
+        )
 
         // if the post is from private atomic site postpone render until we have a special access cookie
         if (post.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -50,9 +50,11 @@ public class ReaderPostRenderer {
     private String mRenderedHtml;
     private ImageSizeMap mAttachmentSizes;
     private ReaderCssProvider mCssProvider;
+    private boolean mUseSansSerifForContent = false;
 
     @SuppressLint("SetJavaScriptEnabled")
-    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post, ReaderCssProvider cssProvider) {
+    public ReaderPostRenderer(ReaderWebView webView, ReaderPost post, ReaderCssProvider cssProvider,
+                              boolean useSansSerifForContent) {
         if (webView == null) {
             throw new IllegalArgumentException("ReaderPostRenderer requires a webView");
         }
@@ -60,6 +62,7 @@ public class ReaderPostRenderer {
             throw new IllegalArgumentException("ReaderPostRenderer requires a post");
         }
 
+        mUseSansSerifForContent = useSansSerifForContent;
         mPost = post;
         mWeakWebView = new WeakReference<>(webView);
         mResourceVars = new ReaderResourceVars(webView.getContext());
@@ -367,8 +370,13 @@ public class ReaderPostRenderer {
         sbHtml.append("<meta name='viewport' content='width=device-width, initial-scale=1'>")
               .append("<style type='text/css'>");
         appendMappedColors(sbHtml);
+
+        String contentFontFamily = mUseSansSerifForContent ? "sans-serif" : "'Noto Serif', serif";
               // force font style and 1px margin from the right to avoid elements being cut off
-        sbHtml.append(" body.reader-full-post__story-content { font-family: 'Noto Serif', serif; font-weight: 400; ")
+        sbHtml.append(" body.reader-full-post__story-content { font-family: ")
+              .append(contentFontFamily)
+              .append("; ")
+              .append("font-weight: 400; ")
               .append("font-size: 16px; margin: 0px; padding: 0px; margin-right: 1px; }")
               .append(" p, div, li { line-height: 1.6em; font-size: 100%; }")
               .append(" body, p, div { max-width: 100% !important; word-wrap: break-word; }")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostWebViewCachingFragment.java
@@ -18,6 +18,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig;
 
 import javax.inject.Inject;
 
@@ -36,6 +37,8 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
     private long mPostId;
 
     @Inject ReaderCssProvider mReaderCssProvider;
+
+    @Inject ReaderImprovementsFeatureConfig mReaderImprovementsFeatureConfig;
 
     public static ReaderPostWebViewCachingFragment newInstance(long blogId, long postId) {
         ReaderPostWebViewCachingFragment fragment = new ReaderPostWebViewCachingFragment();
@@ -75,8 +78,8 @@ public class ReaderPostWebViewCachingFragment extends Fragment {
                     }
                 });
 
-                ReaderPostRenderer rendered =
-                        new ReaderPostRenderer((ReaderWebView) view, post, mReaderCssProvider);
+                ReaderPostRenderer rendered = new ReaderPostRenderer((ReaderWebView) view, post,
+                        mReaderCssProvider, mReaderImprovementsFeatureConfig.isEnabled());
                 rendered.beginRender(); // rendering will cache post content using native WebView implementation.
             } else {
                 // abort mission if post is not available


### PR DESCRIPTION
Part of #19227

This PR set the font in the post details content to be `sans-serif` if the `ReaderImprovementsFeatureConfig` flag is on.

Config OFF | Config ON
--- | ---
![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/0f2da097-38d0-4216-8c49-0ba36729b4ae) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/ff9213a8-be2f-4383-b9f0-a4cb8e82c8a0)


To test:
1. Install and log in to Jetpack app
2. Turn OFF the `ReaderImprovementsFeatureConfig` flag in Debug settings
3. Go to Reader
4. Open a Post
5. **Verify** the post content uses a `serif` font
6. Turn ON the `ReaderImprovementsFeatureConfig` flag in Debug settings
7. Got to Reader
8. Opern a Post
9. **Verify** the post content uses a `sans-serif` font

## Regression Notes
1. Potential unintended areas of impact
N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

11. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
