### PR TITLE
Implements: ViewModelSlice for SiteinfoHeaderCard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -252,7 +252,7 @@ class MySiteViewModel @Inject constructor(
     )
     val onQuickStartMySitePrompts = quickStartRepository.onQuickStartMySitePrompts
 
-    val onTextInputDialogShown = siteInfoHeaderCardViewModelSlice.onTechInputDialogShown
+    val onTextInputDialogShown = siteInfoHeaderCardViewModelSlice.onTextInputDialogShown
 
     val onBasicDialogShown = siteInfoHeaderCardViewModelSlice.onBasicDialogShown
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
@@ -1,10 +1,18 @@
+@file:Suppress("DEPRECATION")
 package org.wordpress.android.ui.mysite.cards.siteinfo
 
+import android.net.Uri
+import android.text.TextUtils
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
 import org.wordpress.android.ui.mysite.MySiteViewModel
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -12,19 +20,33 @@ import org.wordpress.android.ui.mysite.SiteDialogModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity
+import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.FluxCUtilsWrapper
+import org.wordpress.android.util.MediaUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.WPMediaUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
+import java.io.File
 import javax.inject.Inject
+import javax.inject.Named
 
 class SiteInfoHeaderCardViewModelSlice @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val quickStartRepository: QuickStartRepository,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
+    private val wpMediaUtilsWrapper: WPMediaUtilsWrapper,
+    private val mediaUtilsWrapper: MediaUtilsWrapper,
+    private val fluxCUtilsWrapper: FluxCUtilsWrapper,
+    private val contextProvider: ContextProvider,
     mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
 ) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
@@ -42,7 +64,16 @@ class SiteInfoHeaderCardViewModelSlice @Inject constructor(
     private val _onTrackWithTabSource = MutableLiveData<Event<MySiteViewModel.MySiteTrackWithTabSource>>()
     val onTrackWithTabSource = _onTrackWithTabSource
 
+    private val _onMediaUpload = MutableLiveData<Event<MediaModel>>()
+    val onMediaUpload = _onMediaUpload
+
+    private lateinit var scope: CoroutineScope
+
     private val isMySiteDashboardTabsEnabled by lazy { mySiteDashboardTabsFeatureConfig.isEnabled() }
+
+    fun initialize(viewModelScope: CoroutineScope) {
+        this.scope = viewModelScope
+    }
 
     fun getParams(
         site: SiteModel,
@@ -131,5 +162,135 @@ class SiteInfoHeaderCardViewModelSlice @Inject constructor(
         } else {
             analyticsTrackerWrapper.track(stat, properties ?: emptyMap())
         }
+    }
+
+    fun onSiteNameChosen(input: String) {
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            _onSnackbarMessage.postValue(
+                Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_update_site_title_network)))
+            )
+        } else {
+            selectedSiteRepository.updateTitle(input)
+        }
+    }
+
+    fun onSiteNameChooserDismissed() {
+        // This callback is called even when the dialog interaction is positive,
+        // otherwise we would need to call 'completeTask' on 'onSiteNameChosen' as well.
+        quickStartRepository.completeTask(QuickStartStore.QuickStartNewSiteTask.UPDATE_SITE_TITLE)
+        quickStartRepository.checkAndShowQuickStartNotice()
+    }
+
+    fun onDialogInteraction(interaction: BasicDialogViewModel.DialogInteraction) {
+        when (interaction) {
+            is BasicDialogViewModel.DialogInteraction.Positive -> when (interaction.tag) {
+                MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG, MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG -> {
+                    quickStartRepository.completeTask(QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+                    _onNavigation.postValue(
+                        Event(
+                            SiteNavigationAction.OpenMediaPicker(
+                                requireNotNull(selectedSiteRepository.getSelectedSite())
+                            )
+                        )
+                    )
+                }
+            }
+
+            is BasicDialogViewModel.DialogInteraction.Negative -> when (interaction.tag) {
+                MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG -> {
+                    quickStartRepository.completeTask(QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+                    quickStartRepository.checkAndShowQuickStartNotice()
+                }
+
+                MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG -> {
+                    analyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ICON_REMOVED)
+                    quickStartRepository.completeTask(QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+                    quickStartRepository.checkAndShowQuickStartNotice()
+                    selectedSiteRepository.updateSiteIconMediaId(0, true)
+                }
+            }
+
+            is BasicDialogViewModel.DialogInteraction.Dismissed -> when (interaction.tag) {
+                MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG, MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG -> {
+                    quickStartRepository.completeTask(QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+                    quickStartRepository.checkAndShowQuickStartNotice()
+                }
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    fun handleTakenSiteIcon(iconUrl: String?, source: PhotoPickerActivity.PhotoPickerMediaSource?) {
+        val stat = if (source == PhotoPickerActivity.PhotoPickerMediaSource.ANDROID_CAMERA) {
+            AnalyticsTracker.Stat.MY_SITE_ICON_SHOT_NEW
+        } else {
+            AnalyticsTracker.Stat.MY_SITE_ICON_GALLERY_PICKED
+        }
+        analyticsTrackerWrapper.track(stat)
+        val imageUri = Uri.parse(iconUrl)?.let { UriWrapper(it) }
+        if (imageUri != null) {
+            scope.launch(bgDispatcher) {
+                val fetchMedia = wpMediaUtilsWrapper.fetchMediaToUriWrapper(imageUri)
+                if (fetchMedia != null) {
+                    _onNavigation.postValue(Event(SiteNavigationAction.OpenCropActivity(fetchMedia)))
+                }
+            }
+        }
+    }
+
+    fun handleSelectedSiteIcon(mediaId: Long) {
+        selectedSiteRepository.updateSiteIconMediaId(mediaId.toInt(), true)
+    }
+
+    fun handleCropResult(croppedUri: Uri?, success: Boolean) {
+        if (success && croppedUri != null) {
+            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ICON_CROPPED)
+            selectedSiteRepository.showSiteIconProgressBar(true)
+            scope.launch(bgDispatcher) {
+                wpMediaUtilsWrapper.fetchMediaToUriWrapper(UriWrapper(croppedUri))?.let { fetchMedia ->
+                    mediaUtilsWrapper.getRealPathFromURI(fetchMedia.uri)
+                }?.let {
+                    startSiteIconUpload(it)
+                }
+            }
+        } else {
+            _onSnackbarMessage.postValue(
+                Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_cropping_image)))
+            )
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun startSiteIconUpload(filePath: String) {
+        if (TextUtils.isEmpty(filePath)) {
+            _onSnackbarMessage.postValue(
+                Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_locating_image)))
+            )
+            return
+        }
+        val file = File(filePath)
+        if (!file.exists()) {
+            _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.file_error_create))))
+            return
+        }
+        val selectedSite = selectedSiteRepository.getSelectedSite()
+        if (selectedSite != null) {
+            val media = buildMediaModel(file, selectedSite)
+            if (media == null) {
+                _onSnackbarMessage.postValue(
+                    Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.file_not_found)))
+                )
+                return
+            }
+            _onMediaUpload.postValue(Event(media))
+        } else {
+            _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_generic))))
+        }
+    }
+
+    private fun buildMediaModel(file: File, site: SiteModel): MediaModel? {
+        val uri = Uri.Builder().path(file.path).build()
+        val mimeType = contextProvider.getContext().contentResolver.getType(uri)
+        return fluxCUtilsWrapper.mediaModelFromLocalUri(uri, mimeType, site.id)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
@@ -52,8 +52,8 @@ class SiteInfoHeaderCardViewModelSlice @Inject constructor(
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     val onSnackbarMessage = _onSnackbarMessage
 
-    private val _onTechInputDialogShown = MutableLiveData<Event<MySiteViewModel.TextInputDialogModel>>()
-    val onTechInputDialogShown = _onTechInputDialogShown
+    private val _onTextInputDialogShown = MutableLiveData<Event<MySiteViewModel.TextInputDialogModel>>()
+    val onTextInputDialogShown = _onTextInputDialogShown
 
     private val _onBasicDialogShown = MutableLiveData<Event<SiteDialogModel>>()
     val onBasicDialogShown = _onBasicDialogShown
@@ -101,7 +101,7 @@ class SiteInfoHeaderCardViewModelSlice @Inject constructor(
                 SnackbarMessageHolder(UiString.UiStringRes(R.string.my_site_title_changer_dialog_not_allowed_hint))
             )
         } else {
-            _onTechInputDialogShown.value = Event(
+            _onTextInputDialogShown.value = Event(
                 MySiteViewModel.TextInputDialogModel(
                     callbackId = MySiteViewModel.SITE_NAME_CHANGE_CALLBACK_ID,
                     title = R.string.my_site_title_changer_dialog_title,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSlice.kt
@@ -1,0 +1,135 @@
+package org.wordpress.android.ui.mysite.cards.siteinfo
+
+import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
+import org.wordpress.android.ui.mysite.MySiteViewModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteDialogModel
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+class SiteInfoHeaderCardViewModelSlice @Inject constructor(
+    private val quickStartRepository: QuickStartRepository,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
+    mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+) {
+    private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
+    val onSnackbarMessage = _onSnackbarMessage
+
+    private val _onTechInputDialogShown = MutableLiveData<Event<MySiteViewModel.TextInputDialogModel>>()
+    val onTechInputDialogShown = _onTechInputDialogShown
+
+    private val _onBasicDialogShown = MutableLiveData<Event<SiteDialogModel>>()
+    val onBasicDialogShown = _onBasicDialogShown
+
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation
+
+    private val _onTrackWithTabSource = MutableLiveData<Event<MySiteViewModel.MySiteTrackWithTabSource>>()
+    val onTrackWithTabSource = _onTrackWithTabSource
+
+    private val isMySiteDashboardTabsEnabled by lazy { mySiteDashboardTabsFeatureConfig.isEnabled() }
+
+    fun getParams(
+        site: SiteModel,
+        activeTask: QuickStartStore.QuickStartTask? = null,
+        showSiteIconProgressBar: Boolean = false
+    ): MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams {
+        return MySiteCardAndItemBuilderParams.SiteInfoCardBuilderParams(
+            site = site,
+            showSiteIconProgressBar = showSiteIconProgressBar,
+            titleClick = this::titleClick,
+            iconClick = this::iconClick,
+            urlClick = this::urlClick,
+            switchSiteClick = this::switchSiteClick,
+            activeTask = activeTask
+        )
+    }
+
+    private fun titleClick() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            _onSnackbarMessage.value =
+                Event(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_network_connection)))
+        } else if (!SiteUtils.isAccessedViaWPComRest(selectedSite) || !selectedSite.hasCapabilityManageOptions) {
+            _onSnackbarMessage.value = Event(
+                SnackbarMessageHolder(UiString.UiStringRes(R.string.my_site_title_changer_dialog_not_allowed_hint))
+            )
+        } else {
+            _onTechInputDialogShown.value = Event(
+                MySiteViewModel.TextInputDialogModel(
+                    callbackId = MySiteViewModel.SITE_NAME_CHANGE_CALLBACK_ID,
+                    title = R.string.my_site_title_changer_dialog_title,
+                    initialText = selectedSite.name,
+                    hint = R.string.my_site_title_changer_dialog_hint,
+                    isMultiline = false,
+                    isInputEnabled = true
+                )
+            )
+        }
+    }
+
+    private fun iconClick() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ICON_TAPPED)
+        val hasIcon = selectedSite.iconUrl != null
+        if (selectedSite.hasCapabilityManageOptions && selectedSite.hasCapabilityUploadFiles) {
+            if (hasIcon) {
+                _onBasicDialogShown.value = Event(SiteDialogModel.ChangeSiteIconDialogModel)
+            } else {
+                _onBasicDialogShown.value = Event(SiteDialogModel.AddSiteIconDialogModel)
+            }
+        } else {
+            val message = when {
+                !selectedSite.isUsingWpComRestApi -> {
+                    R.string.my_site_icon_dialog_change_requires_jetpack_message
+                }
+
+                hasIcon -> {
+                    R.string.my_site_icon_dialog_change_requires_permission_message
+                }
+
+                else -> {
+                    R.string.my_site_icon_dialog_add_requires_permission_message
+                }
+            }
+            _onSnackbarMessage.value = Event(SnackbarMessageHolder(UiString.UiStringRes(message)))
+        }
+    }
+
+    private fun urlClick() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        quickStartRepository.completeTask(
+            quickStartRepository.quickStartType.getTaskFromString(QuickStartStore.QUICK_START_VIEW_SITE_LABEL)
+        )
+        _onNavigation.value = Event(SiteNavigationAction.OpenSite(selectedSite))
+    }
+
+    private fun switchSiteClick() {
+        val selectedSite = requireNotNull(selectedSiteRepository.getSelectedSite())
+        trackWithTabSourceIfNeeded(AnalyticsTracker.Stat.MY_SITE_SITE_SWITCHER_TAPPED)
+        _onNavigation.value = Event(SiteNavigationAction.OpenSitePicker(selectedSite))
+    }
+
+    private fun trackWithTabSourceIfNeeded(stat: AnalyticsTracker.Stat, properties: HashMap<String, *>? = null) {
+        if (isMySiteDashboardTabsEnabled) {
+            _onTrackWithTabSource.postValue(Event(MySiteViewModel.MySiteTrackWithTabSource(stat, properties)))
+        } else {
+            analyticsTrackerWrapper.track(stat, properties ?: emptyMap())
+        }
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewModelSliceTest.kt
@@ -1,0 +1,468 @@
+package org.wordpress.android.ui.mysite.cards.siteinfo
+
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.QuickStartStore
+import org.wordpress.android.ui.mysite.MySiteViewModel
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.SiteDialogModel
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
+import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.posts.BasicDialogViewModel
+import org.wordpress.android.ui.quickstart.QuickStartType
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.FluxCUtilsWrapper
+import org.wordpress.android.util.MediaUtilsWrapper
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.WPMediaUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.MySiteDashboardTabsFeatureConfig
+import org.wordpress.android.viewmodel.ContextProvider
+
+@Suppress("LargeClass")
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class SiteInfoHeaderCardViewModelSliceTest : BaseUnitTest() {
+    @Mock
+    lateinit var wpMediaUtilsWrapper: WPMediaUtilsWrapper
+
+    @Mock
+    lateinit var mediaUtilsWrapper: MediaUtilsWrapper
+
+    @Mock
+    lateinit var fluxCUtilsWrapper: FluxCUtilsWrapper
+
+    @Mock
+    lateinit var contextProvider: ContextProvider
+
+    @Mock
+    lateinit var quickStartRepository: QuickStartRepository
+
+    @Mock
+    lateinit var mySiteDashboardTabsFeatureConfig: MySiteDashboardTabsFeatureConfig
+
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
+    @Mock
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
+    private lateinit var viewModelSlice: SiteInfoHeaderCardViewModelSlice
+
+    private lateinit var site: SiteModel
+
+    private lateinit var snackbars: MutableList<SnackbarMessageHolder>
+    private lateinit var textInputDialogModels: MutableList<MySiteViewModel.TextInputDialogModel>
+    private lateinit var dialogModels: MutableList<SiteDialogModel>
+    private lateinit var navigationActions: MutableList<SiteNavigationAction>
+    private lateinit var trackWithTabSource: MutableList<MySiteViewModel.MySiteTrackWithTabSource>
+    private lateinit var tabNavigation: MutableList<MySiteViewModel.TabNavigation>
+
+    private val siteLocalId = 1
+    private val siteUrl = "http://site.com"
+    private val siteIcon = "http://site.com/icon.jpg"
+    private val siteName = "Site"
+
+    private val activeTask = MutableLiveData<QuickStartStore.QuickStartTask>()
+
+    @Mock
+    lateinit var quickStartType: QuickStartType
+
+    @Before
+    fun setUp() {
+        viewModelSlice = SiteInfoHeaderCardViewModelSlice(
+            testDispatcher(),
+            quickStartRepository,
+            selectedSiteRepository,
+            analyticsTrackerWrapper,
+            networkUtilsWrapper,
+            wpMediaUtilsWrapper,
+            mediaUtilsWrapper,
+            fluxCUtilsWrapper,
+            contextProvider,
+            mySiteDashboardTabsFeatureConfig
+        )
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        snackbars = mutableListOf()
+        textInputDialogModels = mutableListOf()
+        dialogModels = mutableListOf()
+        navigationActions = mutableListOf()
+        trackWithTabSource = mutableListOf()
+        tabNavigation = mutableListOf()
+
+
+        viewModelSlice.onSnackbarMessage.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                snackbars.add(it)
+            }
+        }
+        viewModelSlice.onTextInputDialogShown.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                textInputDialogModels.add(it)
+            }
+        }
+        viewModelSlice.onBasicDialogShown.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                dialogModels.add(it)
+            }
+        }
+        viewModelSlice.onNavigation.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                navigationActions.add(it)
+            }
+        }
+        viewModelSlice.onTrackWithTabSource.observeForever { event ->
+            event?.getContentIfNotHandled()?.let {
+                trackWithTabSource.add(it)
+            }
+        }
+
+        site = SiteModel()
+        site.id = siteLocalId
+        site.url = siteUrl
+        site.name = siteName
+        site.iconUrl = siteIcon
+        site.siteId = siteLocalId.toLong()
+
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(quickStartRepository.quickStartType).thenReturn(quickStartType)
+        whenever(quickStartType.getTaskFromString(QuickStartStore.QUICK_START_VIEW_SITE_LABEL))
+            .thenReturn(QuickStartStore.QuickStartNewSiteTask.VIEW_SITE)
+
+        viewModelSlice.initialize(testScope())
+    }
+
+    /* SITE INFO CARD */
+
+    @Test
+    fun `site info card title click shows snackbar message when network not available`() = test {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.TITLE_CLICK)
+
+        Assertions.assertThat(textInputDialogModels).isEmpty()
+        Assertions.assertThat(snackbars).containsOnly(
+            SnackbarMessageHolder(UiString.UiStringRes(R.string.error_network_connection))
+        )
+    }
+
+    @Test
+    fun `site info card title click shows snackbar message when hasCapabilityManageOptions is false`() = test {
+        site.hasCapabilityManageOptions = false
+        site.origin = SiteModel.ORIGIN_WPCOM_REST
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.TITLE_CLICK)
+
+        Assertions.assertThat(textInputDialogModels).isEmpty()
+        Assertions.assertThat(snackbars).containsOnly(
+            SnackbarMessageHolder(
+                UiString.UiStringRes(R.string.my_site_title_changer_dialog_not_allowed_hint)
+            )
+        )
+    }
+
+    @Test
+    fun `site info card title click shows snackbar message when origin not ORIGIN_WPCOM_REST`() = test {
+        site.hasCapabilityManageOptions = true
+        site.origin = SiteModel.ORIGIN_XMLRPC
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.TITLE_CLICK)
+
+        Assertions.assertThat(textInputDialogModels).isEmpty()
+        Assertions.assertThat(snackbars).containsOnly(
+            SnackbarMessageHolder(UiString.UiStringRes(R.string.my_site_title_changer_dialog_not_allowed_hint))
+        )
+    }
+
+    @Test
+    fun `site info card title click shows input dialog when editing allowed`() = test {
+        site.hasCapabilityManageOptions = true
+        site.origin = SiteModel.ORIGIN_WPCOM_REST
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.TITLE_CLICK)
+
+        Assertions.assertThat(snackbars).isEmpty()
+        Assertions.assertThat(textInputDialogModels.last()).isEqualTo(
+            MySiteViewModel.TextInputDialogModel(
+                callbackId = MySiteViewModel.SITE_NAME_CHANGE_CALLBACK_ID,
+                title = R.string.my_site_title_changer_dialog_title,
+                initialText = siteName,
+                hint = R.string.my_site_title_changer_dialog_hint,
+                isMultiline = false,
+                isInputEnabled = true
+            )
+        )
+    }
+
+    @Test
+    fun `site info card icon click shows change icon dialog when site has icon`() = test {
+        site.hasCapabilityManageOptions = true
+        site.hasCapabilityUploadFiles = true
+        site.iconUrl = siteIcon
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.ICON_CLICK)
+
+        Assertions.assertThat(dialogModels.last()).isEqualTo(SiteDialogModel.ChangeSiteIconDialogModel)
+    }
+
+    @Test
+    fun `site info card icon click shows add icon dialog when site doesn't have icon`() = test {
+        site.hasCapabilityManageOptions = true
+        site.hasCapabilityUploadFiles = true
+        site.iconUrl = null
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.ICON_CLICK)
+
+        Assertions.assertThat(dialogModels.last()).isEqualTo(SiteDialogModel.AddSiteIconDialogModel)
+    }
+
+    @Test
+    fun `site info card icon click shows snackbar when upload files not allowed and site doesn't have Jetpack`() =
+        test {
+            site.hasCapabilityManageOptions = true
+            site.hasCapabilityUploadFiles = false
+            site.setIsWPCom(false)
+
+            invokeSiteInfoCardAction(SiteInfoHeaderCardAction.ICON_CLICK)
+
+            Assertions.assertThat(dialogModels).isEmpty()
+            Assertions.assertThat(snackbars).containsOnly(
+                SnackbarMessageHolder(
+                    UiString.UiStringRes(R.string.my_site_icon_dialog_change_requires_jetpack_message)
+                )
+            )
+        }
+
+    @Test
+    fun `site info card icon click shows snackbar when upload files not allowed and site has icon`() = test {
+        site.hasCapabilityManageOptions = true
+        site.hasCapabilityUploadFiles = false
+        site.setIsWPCom(true)
+        site.iconUrl = siteIcon
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.ICON_CLICK)
+
+        Assertions.assertThat(dialogModels).isEmpty()
+        Assertions.assertThat(snackbars).containsOnly(
+            SnackbarMessageHolder(UiString.UiStringRes(R.string.my_site_icon_dialog_change_requires_permission_message))
+        )
+    }
+
+    @Test
+    fun `site info card icon click shows snackbar when upload files not allowed and site does not have icon`() = test {
+        site.hasCapabilityManageOptions = true
+        site.hasCapabilityUploadFiles = false
+        site.setIsWPCom(true)
+        site.iconUrl = null
+
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.ICON_CLICK)
+
+        Assertions.assertThat(dialogModels).isEmpty()
+        Assertions.assertThat(snackbars).containsOnly(
+            SnackbarMessageHolder(UiString.UiStringRes(R.string.my_site_icon_dialog_add_requires_permission_message))
+        )
+    }
+
+    @Test
+    fun `on site name chosen updates title if network available `() = test {
+        val title = "updated site name"
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+        viewModelSlice.onSiteNameChosen(title)
+
+        verify(selectedSiteRepository).updateTitle(title)
+    }
+
+    @Test
+    fun `on site name chosen shows snackbar if network not available `() = test {
+        val title = "updated site name"
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        viewModelSlice.onSiteNameChosen(title)
+
+        verify(selectedSiteRepository, never()).updateTitle(any())
+        Assertions.assertThat(snackbars)
+            .containsOnly(SnackbarMessageHolder(UiString.UiStringRes(R.string.error_update_site_title_network)))
+    }
+
+    @Test
+    fun `given new site QS View Site task, when site info url clicked, site opened + View Site task completed`() =
+        test {
+            whenever(quickStartType.getTaskFromString(QuickStartStore.QUICK_START_VIEW_SITE_LABEL))
+                .thenReturn(QuickStartStore.QuickStartNewSiteTask.VIEW_SITE)
+            invokeSiteInfoCardAction(SiteInfoHeaderCardAction.URL_CLICK)
+
+            verify(quickStartRepository).completeTask(QuickStartStore.QuickStartNewSiteTask.VIEW_SITE)
+            Assertions.assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenSite(site))
+        }
+
+    @Test
+    fun `given existing site QS View Site task, when site info url clicked, site opened + View Site task completed`() =
+        test {
+            whenever(quickStartType.getTaskFromString(QuickStartStore.QUICK_START_VIEW_SITE_LABEL))
+                .thenReturn(QuickStartStore.QuickStartExistingSiteTask.VIEW_SITE)
+            invokeSiteInfoCardAction(SiteInfoHeaderCardAction.URL_CLICK)
+
+            verify(quickStartRepository).completeTask(QuickStartStore.QuickStartExistingSiteTask.VIEW_SITE)
+            Assertions.assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenSite(site))
+        }
+
+    @Test
+    fun `site info card switch click opens site picker`() = test {
+        invokeSiteInfoCardAction(SiteInfoHeaderCardAction.SWITCH_SITE_CLICK)
+
+        Assertions.assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenSitePicker(site))
+    }
+
+    private suspend fun invokeSiteInfoCardAction(action: SiteInfoHeaderCardAction) {
+        val siteInfoCard = viewModelSlice.getParams(
+            site,
+            activeTask.value,
+            false
+        )
+        when (action) {
+            SiteInfoHeaderCardAction.TITLE_CLICK -> siteInfoCard.titleClick()
+            SiteInfoHeaderCardAction.ICON_CLICK -> siteInfoCard.iconClick()
+            SiteInfoHeaderCardAction.URL_CLICK -> siteInfoCard.urlClick()
+            SiteInfoHeaderCardAction.SWITCH_SITE_CLICK -> siteInfoCard.switchSiteClick()
+        }
+    }
+
+    /* ADD SITE ICON DIALOG */
+
+    @Test
+    fun `when add site icon dialog +ve btn is clicked, then upload site icon task marked complete without refresh`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).completeTask(task = QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+    }
+
+    @Test
+    fun `when change site icon dialog +ve btn clicked, then upload site icon task marked complete without refresh`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Positive(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).completeTask(task = QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+    }
+
+    @Test
+    fun `when add site icon dialog -ve btn is clicked, then upload site icon task marked complete without refresh`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Negative(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).completeTask(task = QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+    }
+
+    @Test
+    fun `when change site icon dialog -ve btn is clicked, then upload site icon task marked complete no refresh`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Negative(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).completeTask(task = QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+    }
+
+    @Test
+    fun `when site icon dialog is dismissed, then upload site icon task is marked complete without refresh`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Dismissed(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).completeTask(task = QuickStartStore.QuickStartNewSiteTask.UPLOAD_SITE_ICON)
+    }
+
+    @Test
+    fun `when add site icon dialog positive button is clicked, then media picker is opened`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Positive(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG)
+        )
+
+        Assertions.assertThat(navigationActions).containsExactly(SiteNavigationAction.OpenMediaPicker(site))
+    }
+
+    @Test
+    fun `when change site icon dialog positive button is clicked, then media picker is opened`() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Positive(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+        )
+
+        Assertions.assertThat(navigationActions).containsExactly(SiteNavigationAction.OpenMediaPicker(site))
+    }
+
+    @Test
+    fun `when add site icon dialog negative button is clicked, then check and show quick start notice`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Negative(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when change site icon dialog negative button is clicked, then check and show quick start notice`() {
+        viewModelSlice.onDialogInteraction(
+                BasicDialogViewModel.DialogInteraction.Negative(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+            )
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when add site icon dialog is dismissed, then check and show quick start notice`() {
+        viewModelSlice.onDialogInteraction(
+            BasicDialogViewModel.DialogInteraction.Dismissed(MySiteViewModel.TAG_ADD_SITE_ICON_DIALOG)
+        )
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when change site icon dialog is dismissed, then check and show quick start notice`() {
+        viewModelSlice
+            .onDialogInteraction(
+                BasicDialogViewModel
+                    .DialogInteraction
+                    .Dismissed(MySiteViewModel.TAG_CHANGE_SITE_ICON_DIALOG)
+            )
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    @Test
+    fun `when site chooser is dismissed, then check and show quick start notice`() {
+        viewModelSlice.onSiteNameChooserDismissed()
+
+        verify(quickStartRepository).checkAndShowQuickStartNotice()
+    }
+
+    private enum class SiteInfoHeaderCardAction {
+        TITLE_CLICK, ICON_CLICK, URL_CLICK, SWITCH_SITE_CLICK
+    }
+}


### PR DESCRIPTION
## Description: 
This PR moves the SiteInfoHeaderCard logic from MySiteViewModel to a seperate viewmodel slice - `SiteInfoHeaderCardViewModelSlice`

Also moves the unit tests for SiteInfoHeader card in `MySiteViewModelTest` to  `SiteInfoHeaderCardViewModelSliceTest` 

## 📷  SiteInfoHeaderCard
![Screenshot_20230922_173731](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/ebd8ae1b-70c9-41cd-91d9-d83498f2bc47)


## To test:
- Go to Jp/Wp app
- Go to dashboard 
- Verify that SiteInfoHeaderCard interactions are working as expected 
- Interactions to test 
   - Click on the Site name and change the name 
   - Click on the Site Icon and change Icon
   - Click on the Site url and verify that the user is navigated to the site in webview
   - Click on the Site Switcher → Select another site 
   - Verify that site switching is working as expected  

## Regression Notes
1. Potential unintended areas of impact
Site Info is not shown as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and Unit testing

3. What automated tests I added (or what prevented me from doing so)
Unit testing

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
