### PR TITLE
[JP Social] Connect to Mastodon via web

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -144,6 +144,7 @@ android {
         buildConfigField "boolean", "WP_INDIVIDUAL_PLUGIN_OVERLAY", "false"
         buildConfigField "boolean", "SITE_EDITOR_MVP", "false"
         buildConfigField "boolean", "JETPACK_SOCIAL", "false"
+        buildConfigField "boolean", "JP_SOCIAL_MASTODON_CONNECT_VIA_WEB", "true"
         buildConfigField "boolean", "CONTACT_SUPPORT_CHATBOT", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -7,6 +7,7 @@ public class PublicizeConstants {
 
     public static final String GOOGLE_PLUS_ID = "google_plus";
     public static final String FACEBOOK_ID = "facebook";
+    public static final String MASTODON_ID = "mastodon";
     public static final String TWITTER_ID = "twitter";
     public static final String LINKEDIN_ID = "linkedin";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -37,6 +37,7 @@ import org.wordpress.android.util.JetpackBrandingUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
+import org.wordpress.android.util.config.JPSocialMastodonConnectViaWebFeatureConfig;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
@@ -61,6 +62,8 @@ public class PublicizeListActivity extends LocaleAwareActivity
 
     @Inject SiteStore mSiteStore;
     @Inject JetpackBrandingUtils mJetpackBrandingUtils;
+
+    @Inject JPSocialMastodonConnectViaWebFeatureConfig mJPSocialMastodonConnectViaWebFeatureConfig;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -277,8 +280,10 @@ public class PublicizeListActivity extends LocaleAwareActivity
      */
     private boolean shouldConnectViaWeb(PublicizeService service) {
         String serviceId = service.getId();
-        return serviceId.equals(PublicizeConstants.FACEBOOK_ID)
-                || serviceId.equals(PublicizeConstants.MASTODON_ID);
+        boolean showForFacebook = serviceId.equals(PublicizeConstants.FACEBOOK_ID);
+        boolean showForMastodon = serviceId.equals(PublicizeConstants.MASTODON_ID)
+                             && mJPSocialMastodonConnectViaWebFeatureConfig.isEnabled();
+        return showForFacebook || showForMastodon;
     }
 
     private String getConnectionsUrl(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/JPSocialMastodonConnectViaWebFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/JPSocialMastodonConnectViaWebFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val JP_SOCIAL_MASTODON_CONNECT_VIA_WEB = "jp_social_mastodon_connect_via_web"
+
+@Feature(JP_SOCIAL_MASTODON_CONNECT_VIA_WEB, defaultValue = true)
+class JPSocialMastodonConnectViaWebFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.JP_SOCIAL_MASTODON_CONNECT_VIA_WEB,
+    JP_SOCIAL_MASTODON_CONNECT_VIA_WEB,
+)

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -630,7 +630,7 @@ Language: ar
     <string name="gutenberg_native_tiled_gallery_settings">إعدادات المعرض المتجانب</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">ينتقل إلى شاشة اختيار التخطيط</string>
     <string name="gutenberg_native_gallery_style">نمط المعرض</string>
-    <string name="sharing_facebook_warning_positive_button">الانتقال إلى الويب</string>
+    <string name="sharing_connect_via_web_warning_positive_button">الانتقال إلى الويب</string>
     <string name="sharing_facebook_warning_message">يمكنك ربط حسابك على فيسبوك على موقع ووردبريس.كوم على الويب. عند الانتهاء، ارجع إلى تطبيق ووردبريس لتغيير إعدادات المشاركة الخاصة بك.</string>
     <string name="about_automattic_app_icon_description">أيقونة التطبيق</string>
     <string name="about_automattic_back_icon_description">أيقونة الرجوع</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -472,7 +472,7 @@ Language: cs_CZ
     <string name="gutenberg_native_tiled_gallery_settings">Nastavení dlaždicové galerie</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Přejde na obrazovku výběru rozvržení</string>
     <string name="gutenberg_native_gallery_style">Styl galerie</string>
-    <string name="sharing_facebook_warning_positive_button">Zpět na web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Zpět na web</string>
     <string name="sharing_facebook_warning_message">Svůj účet na Facebooku si můžete propojit na webu WordPress.com. Až budete hotovi, vraťte se do aplikace WordPress a změňte nastavení sdílení.</string>
     <string name="about_automattic_app_icon_description">Ikona aplikace</string>
     <string name="about_automattic_back_icon_description">Ikona zpět</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -633,7 +633,7 @@ Language: de
     <string name="gutenberg_native_tiled_gallery_settings">Einstellungen für gekachelte Galerien</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navigiert zum Layout-Auswahlbildschirm</string>
     <string name="gutenberg_native_gallery_style">Galerie-Stil</string>
-    <string name="sharing_facebook_warning_positive_button">Internet öffnen</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Internet öffnen</string>
     <string name="sharing_facebook_warning_message">Du kannst dein Facebook-Konto auf der WordPress.com-Website verbinden. Wenn du fertig bist, kehre zur WordPress-App zurück, um deine Teilen-Einstellungen zu ändern.</string>
     <string name="about_automattic_app_icon_description">App-Icon</string>
     <string name="about_automattic_back_icon_description">Zurück-Icon</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -389,7 +389,7 @@ Language: en_CA
     <string name="gutenberg_native_tiled_gallery_settings">Tiled gallery settings</string>
     <string name="gutenberg_native_gallery_style">Gallery style</string>
     <string name="sharing_facebook_warning_message">You can connect your Facebook account on the WordPress.com website. When you\'re done, return to the WordPress app to change your Sharing settings.</string>
-    <string name="sharing_facebook_warning_positive_button">Go to web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Go to web</string>
     <string name="about_automattic_app_icon_description">App icon</string>
     <string name="about_automattic_back_icon_description">Back icon</string>
     <string name="about_automattic_logo_description">Automattic logo</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -547,7 +547,7 @@ Language: en_GB
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navigates to layout selection screen</string>
     <string name="gutenberg_native_tiled_gallery_settings">Tiled gallery settings</string>
     <string name="sharing_facebook_warning_message">You can connect your Facebook account on the WordPress.com website. When you\'re done, return to the WordPress app to change your Sharing settings.</string>
-    <string name="sharing_facebook_warning_positive_button">Go to web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Go to web</string>
     <string name="gutenberg_native_gallery_style">Gallery style</string>
     <string name="about_automattic_wordpress">WordPress</string>
     <string name="about_automattic_logo_description">Automattic logo</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -238,7 +238,7 @@ Language: es_CO
     <string name="gutenberg_native_tiled_gallery_settings">Ajustes de la galería de mosaico</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navega a la pantalla de selección del diseño</string>
     <string name="gutenberg_native_gallery_style">Estilo de la galería</string>
-    <string name="sharing_facebook_warning_positive_button">Ir a la web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ir a la web</string>
     <string name="sharing_facebook_warning_message">Puedes conectar tu cuenta de Facebook en la web de WordPress.com. Cuando lo hayas hecho, vuelve a la aplicación de WordPress para cambiar tus ajustes para compartir.</string>
     <string name="about_automattic_app_icon_description">Icono de la aplicación</string>
     <string name="about_automattic_back_icon_description">Icono de volver</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -257,7 +257,7 @@ Language: es_VE
     <string name="gutenberg_native_tiled_gallery_settings">Ajustes de la galería de mosaico</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navega a la pantalla de selección del diseño</string>
     <string name="gutenberg_native_gallery_style">Estilo de la galería</string>
-    <string name="sharing_facebook_warning_positive_button">Ir a la web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ir a la web</string>
     <string name="sharing_facebook_warning_message">Puedes conectar tu cuenta de Facebook en la web de WordPress.com. Cuando lo hayas hecho, vuelve a la aplicación de WordPress para cambiar tus ajustes para compartir.</string>
     <string name="about_automattic_app_icon_description">Icono de la aplicación</string>
     <string name="about_automattic_back_icon_description">Icono de volver</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -633,7 +633,7 @@ Language: es
     <string name="gutenberg_native_tiled_gallery_settings">Ajustes de la galería de mosaico</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navega a la pantalla de selección del diseño</string>
     <string name="gutenberg_native_gallery_style">Estilo de la galería</string>
-    <string name="sharing_facebook_warning_positive_button">Ir a la web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ir a la web</string>
     <string name="sharing_facebook_warning_message">Puedes conectar tu cuenta de Facebook en la web de WordPress.com. Cuando lo hayas hecho, vuelve a la aplicación de WordPress para cambiar tus ajustes para compartir.</string>
     <string name="about_automattic_app_icon_description">Icono de la aplicación</string>
     <string name="about_automattic_back_icon_description">Icono de volver</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -632,7 +632,7 @@ Language: fr
     <string name="gutenberg_native_tiled_gallery_settings">Réglages de la mosaïque d’images</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Ouvrir l’écran de sélection de la mise en page</string>
     <string name="gutenberg_native_gallery_style">Style de la galerie</string>
-    <string name="sharing_facebook_warning_positive_button">Aller sur le web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Aller sur le web</string>
     <string name="sharing_facebook_warning_message">Vous pouvez connecter votre compte Facebook sur le site Web de WordPress.com. Lorsque vous avez terminé, revenez à l’application WordPress pour modifier vos paramètres de partage.</string>
     <string name="about_automattic_app_icon_description">Icône de l’application</string>
     <string name="about_automattic_back_icon_description">Icône Retour</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -632,7 +632,7 @@ Language: fr
     <string name="gutenberg_native_tiled_gallery_settings">Réglages de la mosaïque d’images</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Ouvrir l’écran de sélection de la mise en page</string>
     <string name="gutenberg_native_gallery_style">Style de la galerie</string>
-    <string name="sharing_facebook_warning_positive_button">Aller sur le web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Aller sur le web</string>
     <string name="sharing_facebook_warning_message">Vous pouvez connecter votre compte Facebook sur le site Web de WordPress.com. Lorsque vous avez terminé, revenez à l’application WordPress pour modifier vos paramètres de partage.</string>
     <string name="about_automattic_app_icon_description">Icône de l’application</string>
     <string name="about_automattic_back_icon_description">Icône Retour</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -633,7 +633,7 @@ Language: gl_ES
     <string name="gutenberg_native_tiled_gallery_settings">Axustes da galería de mosaico</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navega á pantalla de selección do deseño</string>
     <string name="gutenberg_native_gallery_style">Estilo da galería</string>
-    <string name="sharing_facebook_warning_positive_button">Ir á web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ir á web</string>
     <string name="sharing_facebook_warning_message">Podes conectar a túa conta de Facebook na web de WordPress.com. Cando o teñas feito, volve á aplicación de WordPress para cambiar os teus axustes para compartir.</string>
     <string name="about_automattic_app_icon_description">Icona da aplicación</string>
     <string name="about_automattic_back_icon_description">Icona de volver</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -631,7 +631,7 @@ Language: he_IL
     <string name="gutenberg_native_tiled_gallery_settings">הגדרות גלריה פרושה</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">מנתב למסך של בחירת הפריסה</string>
     <string name="gutenberg_native_gallery_style">סגנון גלריה</string>
-    <string name="sharing_facebook_warning_positive_button">מעבר לאתר בדפדפן</string>
+    <string name="sharing_connect_via_web_warning_positive_button">מעבר לאתר בדפדפן</string>
     <string name="sharing_facebook_warning_message">אפשר לחבר את חשבון הפייסבוק לאתר שלך ב-WordPress.com. בסיום, אפשר לחזור לאפליקציה של WordPress כדי לשנות את הגדרות השיתוף.</string>
     <string name="about_automattic_app_icon_description">סמל האפליקציה</string>
     <string name="about_automattic_back_icon_description">סמל \'חזרה\'</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -630,7 +630,7 @@ Language: id
     <string name="gutenberg_native_tiled_gallery_settings">Pengaturan galeri tampilan kotak</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Buka layar pemilihan tata letak</string>
     <string name="gutenberg_native_gallery_style">Gaya galeri</string>
-    <string name="sharing_facebook_warning_positive_button">Kunjungi situs</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Kunjungi situs</string>
     <string name="sharing_facebook_warning_message">Anda dapat menghubungkan akun Facebook Anda di situs WordPress.com. Setelah selesai, kembali ke aplikasi WordPress untuk mengubah pengaturan fitur Berbagikan.</string>
     <string name="about_automattic_app_icon_description">Ikon Aplikasi</string>
     <string name="about_automattic_back_icon_description">Ikon kembali</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -632,7 +632,7 @@ Language: it
     <string name="gutenberg_native_tiled_gallery_settings">Impostazioni galleria affiancata</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Naviga fino alla schermata di selezione del layout</string>
     <string name="gutenberg_native_gallery_style">Stile della galleria</string>
-    <string name="sharing_facebook_warning_positive_button">Vai al web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Vai al web</string>
     <string name="sharing_facebook_warning_message">Puoi connettere il tuo account Facebook al sito web WordPress.com. Una volta terminato, torna all\'app di WordPress per modificare le impostazioni di Condivisione.</string>
     <string name="about_automattic_app_icon_description">Icona app</string>
     <string name="about_automattic_back_icon_description">Icona Indietro</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -632,7 +632,7 @@ Language: ja_JP
     <string name="gutenberg_native_tiled_gallery_settings">タイルギャラリー設定</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">レイアウト選択画面に移動します</string>
     <string name="gutenberg_native_gallery_style">ギャラリースタイル</string>
-    <string name="sharing_facebook_warning_positive_button">ウェブに移動</string>
+    <string name="sharing_connect_via_web_warning_positive_button">ウェブに移動</string>
     <string name="sharing_facebook_warning_message">WordPress.com サイトでお使いの Facebook アカウントを接続できます。 完了したら WordPress.com アプリに戻り「共有」設定を変更します。</string>
     <string name="about_automattic_app_icon_description">アプリアイコン</string>
     <string name="about_automattic_back_icon_description">「戻る」アイコン</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -633,7 +633,7 @@ Language: ko_KR
     <string name="gutenberg_native_tiled_gallery_settings">바둑판식 갤러리 설정</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">레이아웃 선택 화면으로 이동</string>
     <string name="gutenberg_native_gallery_style">갤러리 스타일</string>
-    <string name="sharing_facebook_warning_positive_button">웹으로 이동</string>
+    <string name="sharing_connect_via_web_warning_positive_button">웹으로 이동</string>
     <string name="sharing_facebook_warning_message">워드프레스닷컴 웹사이트에서 페이스북 계정을 연결할 수 있습니다. 완료하면 워드프레스 앱으로 돌아가서 공유 설정을 변경하세요.</string>
     <string name="about_automattic_app_icon_description">앱 아이콘</string>
     <string name="about_automattic_back_icon_description">뒤로 아이콘</string>

--- a/WordPress/src/main/res/values-lv/strings.xml
+++ b/WordPress/src/main/res/values-lv/strings.xml
@@ -630,7 +630,7 @@ Language: lv
     <string name="gutenberg_native_tiled_gallery_settings">Flīžu galerijas iestatījumi</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Pāriet uz izkārtojuma atlases ekrānu</string>
     <string name="gutenberg_native_gallery_style">Galerijas stils</string>
-    <string name="sharing_facebook_warning_positive_button">Iet uz tīmekļa vietni</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Iet uz tīmekļa vietni</string>
     <string name="sharing_facebook_warning_message">Savu Facebook kontu varat pievienot WordPress.com vietnē. Kad esat pabeidzis, atgriezieties WordPress lietotnē, lai mainītu koplietošanas iestatījumus.</string>
     <string name="about_automattic_app_icon_description">Lietotnes ikona</string>
     <string name="about_automattic_back_icon_description">Atgriešanās ikona</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -609,7 +609,7 @@ Language: nl
     <string name="gutenberg_native_tiled_gallery_settings">Getegelde galerij instellingen</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navigeert naar het lay-out selectiescherm</string>
     <string name="gutenberg_native_gallery_style">Galerij stijl</string>
-    <string name="sharing_facebook_warning_positive_button">Ga naar het web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ga naar het web</string>
     <string name="sharing_facebook_warning_message">Je kunt je Facebook account koppelen op de WordPress.com site. Als je klaar bent, keer je terug naar de WordPress app om je instellingen voor delen te wijzigen.</string>
     <string name="about_automattic_app_icon_description">App pictogram</string>
     <string name="about_automattic_back_icon_description">Terug pictogram</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -276,7 +276,7 @@ Language: pl
     <string name="reader_comment_menu_trash">Przenieś do kosza</string>
     <string name="reader_comment_menu_spam">Oznacz jako spam</string>
     <string name="gutenberg_native_gallery_style">Styl galerii</string>
-    <string name="sharing_facebook_warning_positive_button">Idź do sieci</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Idź do sieci</string>
     <string name="about_automattic_app_icon_description">Ikona aplikacji</string>
     <string name="about_automattic_back_icon_description">Ikona Cofnij/Wstecz</string>
     <string name="about_automattic_wordpress">WordPress</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -526,7 +526,7 @@ Language: pt_BR
     <string name="gutenberg_native_tiled_gallery_settings">Configurações da galeria em mosaico</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Navega para a tela de escolha de layout</string>
     <string name="gutenberg_native_gallery_style">Estilo de galeria</string>
-    <string name="sharing_facebook_warning_positive_button">Ir para a web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Ir para a web</string>
     <string name="sharing_facebook_warning_message">Você pode conectar sua conta do Facebook no site WordPress.com. Ao concluir, volte para o aplicativo WordPress para mudar suas configurações de compartilhamento.</string>
     <string name="about_automattic_app_icon_description">Ícone do aplicativo</string>
     <string name="about_automattic_back_icon_description">Ícone de fundo</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -634,7 +634,7 @@ Language: ro
     <string name="gutenberg_native_tiled_gallery_settings">Setări galerii placate</string>
     <string name="gutenberg_native_gallery_style">Stil galerie</string>
     <string name="sharing_facebook_warning_message">Îți poți conecta contul Facebook la site-ul WordPress.com. Când ai terminat, întoarce-te la aplicația WordPress pentru a modifica setările de partajare.</string>
-    <string name="sharing_facebook_warning_positive_button">Mergi pe web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Mergi pe web</string>
     <string name="about_automattic_wordpress">WordPress</string>
     <string name="about_automattic_back_icon_description">Icon înapoi</string>
     <string name="about_automattic_logo_description">Logo Automattic</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -633,7 +633,7 @@ Language: ru
     <string name="gutenberg_native_tiled_gallery_settings">Настройки плиточной галереи</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Навигация к экрану выбора макета</string>
     <string name="gutenberg_native_gallery_style">Стиль галереи</string>
-    <string name="sharing_facebook_warning_positive_button">Переход на веб-сайт</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Переход на веб-сайт</string>
     <string name="sharing_facebook_warning_message">Вы можете подключить свою учётную запись Facebook на сайте WordPress.com. После этого вернитесь в приложение WordPress, чтобы изменить настройки возможностей поделиться.</string>
     <string name="about_automattic_app_icon_description">Значок приложения</string>
     <string name="about_automattic_back_icon_description">Значок Назад</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -545,7 +545,7 @@ Language: sq_AL
     <string name="gutenberg_native_tiled_gallery_settings">Rregullime galerie mozaik</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Kalohet te skena e përzgjedhjes së skemës</string>
     <string name="gutenberg_native_gallery_style">Stil galerie</string>
-    <string name="sharing_facebook_warning_positive_button">Kaloni në web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Kaloni në web</string>
     <string name="sharing_facebook_warning_message">Mund ta lidhni llogarinë tuaj Facebook në sajtin WordPress.com. Kur të keni mbaruar, kthehuni te aplikacioni WordPress, që të ndryshoni rregullimet tuaja për Ndarje Me të Tjerë.</string>
     <string name="about_automattic_app_icon_description">Ikonë aplikacioni</string>
     <string name="about_automattic_back_icon_description">Ikonë për mbrapsht</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -633,7 +633,7 @@ Language: sv_SE
     <string name="gutenberg_native_tiled_gallery_settings">Mosaikinställningar för galleri</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Går till skärmen för val av layout</string>
     <string name="gutenberg_native_gallery_style">Galleristil</string>
-    <string name="sharing_facebook_warning_positive_button">Gå till webben</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Gå till webben</string>
     <string name="sharing_facebook_warning_message">Du kan ansluta ditt Facebook-konto på WordPress.com-webbplatsen. När du är klar, gå tillbaka till WordPress-appen för att ändra dina delningsinställningar.</string>
     <string name="about_automattic_app_icon_description">App-ikon</string>
     <string name="about_automattic_back_icon_description">Ikon för tillbaka</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -633,7 +633,7 @@ Language: tr
     <string name="gutenberg_native_tiled_gallery_settings">Döşenmiş galeri ayarları</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Yerleşim seçim ekranına ilerler</string>
     <string name="gutenberg_native_gallery_style">Galeri biçimi</string>
-    <string name="sharing_facebook_warning_positive_button">Webe git</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Webe git</string>
     <string name="sharing_facebook_warning_message">Facebook hesabınızı WordPress.com web sitesine bağlayabilirsiniz. Tamamladığınızda WordPress uygulamasına dönüp paylaşım ayarlarını değiştirin.</string>
     <string name="about_automattic_app_icon_description">Uygulama simgesi</string>
     <string name="about_automattic_back_icon_description">Geri simgesi</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -217,7 +217,7 @@ Language: vi_VN
     <string name="gutenberg_native_tiled_gallery_settings">Cài đặt bộ sưu tập dạng ô</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">Chuyển đến chọn màn hình bố cục</string>
     <string name="gutenberg_native_gallery_style">Dạng bộ sưu tập</string>
-    <string name="sharing_facebook_warning_positive_button">Đến trang web</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Đến trang web</string>
     <string name="sharing_facebook_warning_message">Bạn có thể kết nối tài khoản Facebook với WordPress.com. Khi đã kết nối, quay lại app WordPress để thay đổi thiết lập Chia Sẻ.</string>
     <string name="about_automattic_app_icon_description">Biểu tượng app</string>
     <string name="about_automattic_back_icon_description">Biểu tượng trở về</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -631,7 +631,7 @@ Language: zh_CN
     <string name="gutenberg_native_tiled_gallery_settings">平铺图片库设置</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">导航至布局选择界面</string>
     <string name="gutenberg_native_gallery_style">画廊样式</string>
-    <string name="sharing_facebook_warning_positive_button">转到网页</string>
+    <string name="sharing_connect_via_web_warning_positive_button">转到网页</string>
     <string name="sharing_facebook_warning_message">您可以在 WordPress.com 网站上连接您的 Facebook 账户。 完成后，返回 WordPress 应用程序更改您的共享设置。</string>
     <string name="about_automattic_app_icon_description">应用程序图标</string>
     <string name="about_automattic_back_icon_description">返回图标</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -631,7 +631,7 @@ Language: zh_TW
     <string name="gutenberg_native_tiled_gallery_settings">並排圖庫設定</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">導覽至版面配置選取畫面</string>
     <string name="gutenberg_native_gallery_style">圖庫樣式</string>
-    <string name="sharing_facebook_warning_positive_button">前往網頁</string>
+    <string name="sharing_connect_via_web_warning_positive_button">前往網頁</string>
     <string name="sharing_facebook_warning_message">你可以在 WordPress.com 網站連結 Facebook 帳號。 完成設定後，請返回 WordPress 應用程式變更你的「分享」設定。</string>
     <string name="about_automattic_app_icon_description">應用程式圖示</string>
     <string name="about_automattic_back_icon_description">返回圖示</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -631,7 +631,7 @@ Language: zh_TW
     <string name="gutenberg_native_tiled_gallery_settings">並排圖庫設定</string>
     <string name="gutenberg_native_navigates_to_layout_selection_screen">導覽至版面配置選取畫面</string>
     <string name="gutenberg_native_gallery_style">圖庫樣式</string>
-    <string name="sharing_facebook_warning_positive_button">前往網頁</string>
+    <string name="sharing_connect_via_web_warning_positive_button">前往網頁</string>
     <string name="sharing_facebook_warning_message">你可以在 WordPress.com 網站連結 Facebook 帳號。 完成設定後，請返回 WordPress 應用程式變更你的「分享」設定。</string>
     <string name="about_automattic_app_icon_description">應用程式圖示</string>
     <string name="about_automattic_back_icon_description">返回圖示</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2507,12 +2507,15 @@
     <string name="sharing_twitter_message">This will be included in tweets when people share using the Twitter button</string>
     <string name="dialog_title_sharing_facebook_account_must_have_pages">Not Connected</string>
     <string name="sharing_facebook_account_must_have_pages">The Facebook connection cannot find any Pages. Jetpack Social cannot connect to Facebook Profiles, only published Pages.</string>
-    <string name="sharing_facebook_warning_message">You can connect your Facebook account on the WordPress.com website. When you\'re done, return to the WordPress app to change your Sharing settings.</string>
-    <string name="sharing_facebook_warning_positive_button">Go to web</string>
     <string name="sharing_twitter_deprecation_notice_title">Twitter auto-sharing is no longer available</string>
     <string name="sharing_twitter_deprecation_notice_description">Twitter auto-sharing is no longer available due to Twitter\'s changes in terms and pricing.</string>
     <string name="sharing_twitter_deprecation_notice_find_out_more">Find out more</string>
     <string name="social_item_message_title">Message</string>
+
+    <!-- Some JP Social connections can only be connected via web at this time -->
+    <!-- translators: %s is replaced with an external service name, such as "Facebook" or "Mastodon". -->
+    <string name="sharing_connect_via_web_warning_message">You can connect your %s account on the WordPress.com website. When you\'re done, return to the app to change your Sharing settings.</string>
+    <string name="sharing_connect_via_web_warning_positive_button">Go to web</string>
 
     <!--Theme Browser-->
     <string name="current_theme">Current Theme</string>


### PR DESCRIPTION
Show a pop-up when users try to connect to Mastodon via the app, saying they should do it via Web, and opens the connections page in an external browser (requires the user to sign-in in the browser). This is required because currently Mastodon connection URL requires an extra query parameter `instance` containing the Mastodon full user name, which is implemented in the web connections page, but not on the mobile clients.

We already do this for Facebook (because of other reasons) so I just leveraged the same logic.

This also adds a remote feature config (`jp_social_mastodon_connect_via_web`), defaulted to ON as we are investigating how to solve this problem from the web side as well, so we want to be able to remotely disable this "connect via web" fallback.

## Note
This is targeting the `release/23.3` branch as a beta fix.

## Demo

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/859677f0-48c9-4b24-bbd4-cfa308d06f9e

## Test
To test:
1. Install Jetpack and log in
2. Go to the `Menu` > `Social`
3. Tap on Mastodon
4. Tap `Connect`
5. **Verify** a dialog saying the connection needs to be established via web is shown
6. Tap `Go to Web`
7. **Verify** the connections page is opened in an external browser (sign-in might be required)

To test the remote config works:
1. Go to `Debug Settings`
2. Disable the `jp_social_mastodon_connect_via_web` flag
3. Do the steps above again and **verify** that this time a WebView is shown (which currently displays an error regarding `instance` missing)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A. This flow currently has all logic in the `Activity`, which makes it more difficult to add automated tests at the moment.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
