### PR TITLE
[Reader Improvements] Update follow/unfollow button on Reader post header

### DIFF
--- a/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view.xml
@@ -47,7 +47,7 @@
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/header_follow_button"
-        style="@style/Reader.Follow.Button.PostDetail"
+        style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view_new.xml
@@ -23,13 +23,12 @@
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/header_follow_button"
-        style="@style/Reader.Follow.Button.PostDetail"
+        style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/layout_blog_section"
-        app:layout_constraintBottom_toBottomOf="@id/layout_blog_section"
+        app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/layout/reader_post_detail_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_post_detail_header_view_new.xml
@@ -28,7 +28,8 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@id/layout_blog_section"
+        app:layout_constraintBottom_toBottomOf="@id/layout_blog_section"
         tools:visibility="visible" />
 
     <com.google.android.material.textview.MaterialTextView

--- a/WordPress/src/main/res/values-w600dp/reader_styles.xml
+++ b/WordPress/src/main/res/values-w600dp/reader_styles.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <style name="Reader.Follow.Button.PostDetail" parent="Reader.Follow.Button.New"/>
-</resources>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -287,8 +287,6 @@
         <item name="android:minHeight">@dimen/reader_follow_button_min_height</item>
     </style>
 
-    <style name="Reader.Follow.Button.PostDetail" parent="Reader.Follow.Button.Icon"/>
-
     <style name="Reader.Follow.Button.Icon" parent="Reader.Follow.Button">
         <item name="iconTint">@color/secondary_on_surface_medium_selector</item>
         <item name="android:minHeight">@dimen/min_touch_target_sz</item>


### PR DESCRIPTION
### Do not merge
Should only be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/19248

Part of #19078 

This PR updates the follow/unfollow button design on the reader post header view.

Design specs: zQnohyMpLzBzQ5jzMMKni3-fi

To test:
1 - Run JP and sign in;
2 - Open debug settings and enable `ReaderImprovementsFeatureConfig` FF;
3 - Open reader;
4 - Tap on any post: see if the follow/unfollow button matches the design. Tap on it to change it's status and make sure the follow action is working as expected;
5 - Disable the FF that was enabled on step 2;
6 - Open reader;
7 - Tap on any post: follow/unfollow button design should be the one we currently have in prod (follow icon instead of the new follow button).

### Post header (FF enabled)
<p float="left">
<img width="300" alt="Screenshot 2023-09-23 at 9 25 18 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/873afcb2-91d9-4bd3-a591-c498efa5e7a5">
<img width="300" alt="Screenshot 2023-09-23 at 9 25 23 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/a63b363d-5701-4324-be03-a9cb184d1375">
<img width="300" alt="Screenshot 2023-09-23 at 9 25 03 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/3128508e-4ed5-41e6-b1ab-8cb591cc9023">
<img width="300" alt="Screenshot 2023-09-23 at 9 25 00 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/faf491b0-46ec-4036-a3df-e1a00e05c536">
</p>

### Post header (FF disabled)
<p float="left">
<img width="436" alt="Screenshot 2023-09-23 at 9 26 04 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/9bed72f1-9482-473a-95bf-139d88468b12">
</p>

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Changes were only made to views

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)