### PR TITLE
[Reader Improvements] Implement new design for "Sites to follow" section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommen
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderWelcomeBannerCardUiState
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderInterestsCardViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderPostViewHolder
+import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogsCardNewViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogsCardViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.WelcomeBannerViewHolder
@@ -33,9 +34,16 @@ class ReaderDiscoverAdapter(
             welcomeBannerViewType -> WelcomeBannerViewHolder(parent)
             postViewType -> ReaderPostViewHolder(uiHelpers, imageManager, readerTracker, parent)
             interestViewType -> ReaderInterestsCardViewHolder(uiHelpers, parent)
-            recommendedBlogsViewType -> ReaderRecommendedBlogsCardViewHolder(
-                parent, imageManager, uiHelpers, isReaderImprovementsEnabled
-            )
+            recommendedBlogsViewType ->
+                if (isReaderImprovementsEnabled) {
+                    ReaderRecommendedBlogsCardNewViewHolder(
+                        parent, imageManager
+                    )
+                } else {
+                    ReaderRecommendedBlogsCardViewHolder(
+                        parent, imageManager, uiHelpers
+                    )
+                }
             else -> throw NotImplementedError("Unknown ViewType")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderRecommendedBlogsNewAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderRecommendedBlogsNewAdapter.kt
@@ -4,19 +4,17 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
-import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogViewHolder
-import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogNewViewHolder
 import org.wordpress.android.util.image.ImageManager
 
-class ReaderRecommendedBlogsAdapter(
+class ReaderRecommendedBlogsNewAdapter(
     private val imageManager: ImageManager,
-    private val uiHelpers: UiHelpers,
-) : ListAdapter<ReaderRecommendedBlogUiState, ReaderRecommendedBlogViewHolder>(RecommendedBlogsDiffUtil()) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderRecommendedBlogViewHolder {
-        return ReaderRecommendedBlogViewHolder(parent, imageManager, uiHelpers)
+) : ListAdapter<ReaderRecommendedBlogUiState, ReaderRecommendedBlogNewViewHolder>(RecommendedBlogsDiffUtil()) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderRecommendedBlogNewViewHolder {
+        return ReaderRecommendedBlogNewViewHolder(parent, imageManager)
     }
 
-    override fun onBindViewHolder(holder: ReaderRecommendedBlogViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ReaderRecommendedBlogNewViewHolder, position: Int) {
         holder.onBind(getItem(position))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
@@ -1,13 +1,9 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.databinding.ReaderRecommendedBlogItemNewBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
-import org.wordpress.android.ui.reader.views.ReaderFollowButton
 import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
@@ -15,30 +11,25 @@ import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
 class ReaderRecommendedBlogNewViewHolder(
     parent: ViewGroup,
     private val imageManager: ImageManager,
-    private val binding: ReaderRecommendedBlogBinding =
-        with(parent.viewBinding(ReaderRecommendedBlogItemNewBinding::inflate)) {
-            ReaderRecommendedBlogBinding(
-                root = root,
-                siteName = siteName,
-                siteUrl = siteUrl,
-                siteIcon = siteIcon,
-                siteFollowIcon = siteFollowIcon,
-            )
-        },
+    private val binding: ReaderRecommendedBlogItemNewBinding =
+        parent.viewBinding(ReaderRecommendedBlogItemNewBinding::inflate)
 ) : RecyclerView.ViewHolder(binding.root) {
     fun onBind(uiState: ReaderRecommendedBlogUiState) =
         with(binding) {
             siteName.text = uiState.name
             siteUrl.text = uiState.url
-            updateSiteFollowIcon(uiState, this)
+            updateSiteFollowButton(uiState, this)
             updateBlogImage(uiState.iconUrl)
             root.setOnClickListener {
                 uiState.onItemClicked(uiState.blogId, uiState.feedId, uiState.isFollowed)
             }
         }
 
-    private fun updateSiteFollowIcon(uiState: ReaderRecommendedBlogUiState, binding: ReaderRecommendedBlogBinding) {
-        with(binding.siteFollowIcon) {
+    private fun updateSiteFollowButton(
+        uiState: ReaderRecommendedBlogUiState,
+        binding: ReaderRecommendedBlogItemNewBinding
+    ) {
+        with(binding.siteFollowButton) {
             setIsFollowed(uiState.isFollowed)
             contentDescription = context.getString(uiState.followContentDescription.stringRes)
             setOnClickListener {
@@ -58,12 +49,4 @@ class ReaderRecommendedBlogNewViewHolder(
             imageManager.cancelRequestAndClearImageView(siteIcon)
         }
     }
-
-    data class ReaderRecommendedBlogBinding(
-        val root: View,
-        val siteName: TextView,
-        val siteUrl: TextView,
-        val siteIcon: ImageView,
-        val siteFollowIcon: ReaderFollowButton,
-    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.reader.discover.viewholders
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.databinding.ReaderRecommendedBlogItemNewBinding
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
+import org.wordpress.android.ui.reader.views.ReaderFollowButton
+import org.wordpress.android.util.extensions.viewBinding
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType.BLAVATAR_CIRCULAR
+
+class ReaderRecommendedBlogNewViewHolder(
+    parent: ViewGroup,
+    private val imageManager: ImageManager,
+    private val binding: ReaderRecommendedBlogBinding =
+        with(parent.viewBinding(ReaderRecommendedBlogItemNewBinding::inflate)) {
+            ReaderRecommendedBlogBinding(
+                root = root,
+                siteName = siteName,
+                siteUrl = siteUrl,
+                siteIcon = siteIcon,
+                siteFollowIcon = siteFollowIcon,
+            )
+        },
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(uiState: ReaderRecommendedBlogUiState) =
+        with(binding) {
+            siteName.text = uiState.name
+            siteUrl.text = uiState.url
+            updateSiteFollowIcon(uiState, this)
+            updateBlogImage(uiState.iconUrl)
+            root.setOnClickListener {
+                uiState.onItemClicked(uiState.blogId, uiState.feedId, uiState.isFollowed)
+            }
+        }
+
+    private fun updateSiteFollowIcon(uiState: ReaderRecommendedBlogUiState, binding: ReaderRecommendedBlogBinding) {
+        with(binding.siteFollowIcon) {
+            setIsFollowed(uiState.isFollowed)
+            contentDescription = context.getString(uiState.followContentDescription.stringRes)
+            setOnClickListener {
+                uiState.onFollowClicked(uiState)
+            }
+        }
+    }
+
+    private fun updateBlogImage(iconUrl: String?) = with(binding) {
+        if (iconUrl != null) {
+            imageManager.loadIntoCircle(
+                imageView = siteIcon,
+                imageType = BLAVATAR_CIRCULAR,
+                imgUrl = iconUrl
+            )
+        } else {
+            imageManager.cancelRequestAndClearImageView(siteIcon)
+        }
+    }
+
+    data class ReaderRecommendedBlogBinding(
+        val root: View,
+        val siteName: TextView,
+        val siteUrl: TextView,
+        val siteIcon: ImageView,
+        val siteFollowIcon: ReaderFollowButton,
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
@@ -21,7 +21,7 @@ class ReaderRecommendedBlogViewHolder(
             siteName.text = name
             siteUrl.text = url
             uiHelpers.setTextOrHide(siteDescription, description)
-            siteFollowIcon.apply {
+            siteFollowButton.apply {
                 setIsFollowed(isFollowed)
                 contentDescription = context.getString(followContentDescription.stringRes)
                 setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogViewHolder.kt
@@ -1,14 +1,9 @@
 package org.wordpress.android.ui.reader.discover.viewholders
 
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.databinding.ReaderRecommendedBlogItemBinding
-import org.wordpress.android.databinding.ReaderRecommendedBlogItemNewBinding
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState.ReaderRecommendedBlogUiState
-import org.wordpress.android.ui.reader.views.ReaderFollowButton
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
@@ -18,49 +13,24 @@ class ReaderRecommendedBlogViewHolder(
     parent: ViewGroup,
     private val imageManager: ImageManager,
     private val uiHelpers: UiHelpers,
-    private val isReaderImprovementsEnabled: Boolean,
-    private val binding: ReaderRecommendedBlogBinding = if(isReaderImprovementsEnabled) {
-        with(parent.viewBinding(ReaderRecommendedBlogItemNewBinding::inflate)) {
-            ReaderRecommendedBlogBinding(
-                root = root,
-                siteName = siteName,
-                siteUrl = siteUrl,
-                siteDescription = siteDescription,
-                siteIcon = siteIcon,
-                siteFollowButton = siteFollowIcon,
-            )
-        }
-    } else {
-        with(parent.viewBinding(ReaderRecommendedBlogItemBinding::inflate)) {
-            ReaderRecommendedBlogBinding(
-                root = root,
-                siteName = siteName,
-                siteUrl = siteUrl,
-                siteDescription = siteDescription,
-                siteIcon = siteIcon,
-                siteFollowButton = siteFollowIcon,
-            )
-        }
-    },
+    private val binding: ReaderRecommendedBlogItemBinding =
+        parent.viewBinding(ReaderRecommendedBlogItemBinding::inflate)
 ) : RecyclerView.ViewHolder(binding.root) {
-    fun onBind(uiState: ReaderRecommendedBlogUiState) =
-        with(binding) {
-            siteName.text = uiState.name
-            siteUrl.text = uiState.url
-            uiHelpers.setTextOrHide(siteDescription, uiState.description)
-            updateSiteFollowIcon(uiState, this)
-            updateBlogImage(uiState.iconUrl)
-            root.setOnClickListener {
-                uiState.onItemClicked(uiState.blogId, uiState.feedId, uiState.isFollowed)
+    fun onBind(uiState: ReaderRecommendedBlogUiState) = with(binding) {
+        with(uiState) {
+            siteName.text = name
+            siteUrl.text = url
+            uiHelpers.setTextOrHide(siteDescription, description)
+            siteFollowIcon.apply {
+                setIsFollowed(isFollowed)
+                contentDescription = context.getString(followContentDescription.stringRes)
+                setOnClickListener {
+                    onFollowClicked(uiState)
+                }
             }
-        }
-
-    private fun updateSiteFollowIcon(uiState: ReaderRecommendedBlogUiState, binding: ReaderRecommendedBlogBinding) {
-        with(binding.siteFollowButton) {
-            setIsFollowed(uiState.isFollowed)
-            contentDescription = context.getString(uiState.followContentDescription.stringRes)
-            setOnClickListener {
-                uiState.onFollowClicked(uiState)
+            updateBlogImage(iconUrl)
+            root.setOnClickListener {
+                onItemClicked(blogId, feedId, isFollowed)
             }
         }
     }
@@ -76,13 +46,4 @@ class ReaderRecommendedBlogViewHolder(
             imageManager.cancelRequestAndClearImageView(siteIcon)
         }
     }
-
-    data class ReaderRecommendedBlogBinding(
-        val root: View,
-        val siteName: TextView,
-        val siteUrl: TextView,
-        val siteDescription: TextView,
-        val siteIcon: ImageView,
-        val siteFollowButton: ReaderFollowButton,
-    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardNewViewHolder.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.reader.discover.viewholders
+
+import android.view.ViewGroup
+import org.wordpress.android.databinding.ReaderRecommendedBlogsCardNewBinding
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState
+import org.wordpress.android.ui.reader.discover.ReaderRecommendedBlogsNewAdapter
+import org.wordpress.android.util.extensions.viewBinding
+import org.wordpress.android.util.image.ImageManager
+
+class ReaderRecommendedBlogsCardNewViewHolder(
+    parentView: ViewGroup,
+    imageManager: ImageManager,
+) : ReaderViewHolder<ReaderRecommendedBlogsCardNewBinding>(
+    parentView.viewBinding(ReaderRecommendedBlogsCardNewBinding::inflate)
+) {
+    private val recommendedBlogsAdapter =
+        ReaderRecommendedBlogsNewAdapter(imageManager)
+
+    init {
+        with(binding) {
+            recommendedBlogs.adapter = recommendedBlogsAdapter
+        }
+    }
+
+    override fun onBind(uiState: ReaderCardUiState) {
+        uiState as ReaderRecommendedBlogsCardUiState
+        recommendedBlogsAdapter.submitList(uiState.blogs)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogsCardViewHolder.kt
@@ -16,12 +16,11 @@ class ReaderRecommendedBlogsCardViewHolder(
     parentView: ViewGroup,
     imageManager: ImageManager,
     uiHelpers: UiHelpers,
-    isReaderImprovementsEnabled: Boolean,
 ) : ReaderViewHolder<ReaderRecommendedBlogsCardBinding>(
     parentView.viewBinding(ReaderRecommendedBlogsCardBinding::inflate)
 ) {
     private val recommendedBlogsAdapter =
-        ReaderRecommendedBlogsAdapter(imageManager, uiHelpers, isReaderImprovementsEnabled)
+        ReaderRecommendedBlogsAdapter(imageManager, uiHelpers)
 
     init {
         with(binding) {

--- a/WordPress/src/main/res/color/black_default_light_grey_selected_selector.xml
+++ b/WordPress/src/main/res/color/black_default_light_grey_selected_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/reader_follow_button_following_state_color" android:state_selected="true" />
+    <item android:color="@color/reader_improvements_follow_button_following_state" android:state_selected="true" />
     <item android:color="@color/black" />
 </selector>

--- a/WordPress/src/main/res/color/white_default_light_grey_selected_selector.xml
+++ b/WordPress/src/main/res/color/white_default_light_grey_selected_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/reader_follow_button_following_state_color" android:state_selected="true" />
+    <item android:color="@color/reader_improvements_follow_button_following_state" android:state_selected="true" />
     <item android:color="@color/white"/>
 </selector>

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
@@ -15,6 +15,7 @@
         android:contentDescription="@null"
         android:importantForAccessibility="no"
         android:src="@drawable/bg_oval_placeholder_globe_32dp"
+        app:layout_constraintBottom_toTopOf="@+id/site_description"
         app:layout_constraintStart_toStartOf="@id/guideline_start"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1" />

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item.xml
@@ -57,7 +57,7 @@
         android:includeFontPadding="false"
         android:textAppearance="?attr/textAppearanceSubtitle1"
         app:layout_constraintBottom_toTopOf="@+id/site_url"
-        app:layout_constraintEnd_toStartOf="@id/site_follow_icon"
+        app:layout_constraintEnd_toStartOf="@id/site_follow_button"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@id/site_icon"
         app:layout_constraintTop_toTopOf="@id/site_icon"
@@ -91,7 +91,7 @@
         tools:text="@tools:sample/lorem/random" />
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/site_follow_icon"
+        android:id="@+id/site_follow_button"
         style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -4,92 +4,49 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground">
+    android:background="?attr/selectableItemBackground"
+    android:paddingBottom="@dimen/margin_medium"
+    android:paddingTop="@dimen/margin_medium">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/site_icon"
         style="@style/ReaderImageView.Avatar"
         android:layout_marginEnd="@dimen/reader_site_header_avatar_margin_end"
-        android:layout_marginTop="@dimen/margin_extra_large"
         android:background="@drawable/bg_oval_placeholder"
         android:contentDescription="@null"
         android:importantForAccessibility="no"
         android:src="@drawable/bg_oval_placeholder_globe_32dp"
-        app:layout_constraintBottom_toTopOf="@+id/site_description"
-        app:layout_constraintStart_toStartOf="@id/guideline_start"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="@dimen/margin_extra_large" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_top"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="@dimen/margin_extra_large" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_bottom"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_end="@dimen/margin_extra_large" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_start"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="@dimen/margin_extra_large" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/site_name"
-        style="@style/ReaderTextView.Label.Medium"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_medium"
         android:layout_marginStart="@dimen/margin_medium"
-        android:includeFontPadding="false"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textAppearance="?attr/textAppearanceLabelLarge"
+        android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toTopOf="@+id/site_url"
         app:layout_constraintEnd_toStartOf="@id/site_follow_icon"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@id/site_icon"
-        app:layout_constraintTop_toTopOf="@id/site_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
         tools:text="Legal Nomads" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/site_url"
-        style="@style/ReaderTextView.Site.Header.Caption.Url"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_small"
-        android:includeFontPadding="false"
-        app:layout_constraintBottom_toBottomOf="@id/site_icon"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="@color/black_translucent_60"
+        android:textSize="@dimen/text_sz_small"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/site_name"
-        app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="@id/site_name"
         app:layout_constraintTop_toBottomOf="@+id/site_name"
         tools:text="legalnomads.com" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/site_description"
-        style="@style/ReaderTextView.Site.Description"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:includeFontPadding="false"
-        app:layout_constraintBottom_toBottomOf="@id/guideline_bottom"
-        app:layout_constraintEnd_toEndOf="@id/guideline_end"
-        app:layout_constraintStart_toStartOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@+id/site_icon"
-        tools:text="@tools:sample/lorem/random" />
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/site_follow_icon"
@@ -97,8 +54,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@string/reader_btn_follow"
-        app:layout_constraintBottom_toBottomOf="@id/site_url"
-        app:layout_constraintEnd_toEndOf="@id/guideline_end"
-        app:layout_constraintTop_toTopOf="@id/site_name" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -28,7 +28,7 @@
         android:textAppearance="?attr/textAppearanceLabelLarge"
         android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toTopOf="@+id/site_url"
-        app:layout_constraintEnd_toStartOf="@id/site_follow_icon"
+        app:layout_constraintEnd_toStartOf="@id/site_follow_button"
         app:layout_constraintStart_toEndOf="@id/site_icon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -48,7 +48,7 @@
         tools:text="legalnomads.com" />
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
-        android:id="@+id/site_follow_icon"
+        android:id="@+id/site_follow_button"
         style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -10,7 +10,6 @@
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/site_icon"
         style="@style/ReaderImageView.Avatar"
-        android:layout_marginEnd="@dimen/reader_site_header_avatar_margin_end"
         android:background="@drawable/bg_oval_placeholder"
         android:contentDescription="@null"
         android:importantForAccessibility="no"
@@ -23,8 +22,8 @@
         android:id="@+id/site_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_medium"
-        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:layout_marginStart="@dimen/margin_large"
         android:textAppearance="?attr/textAppearanceLabelLarge"
         android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toTopOf="@+id/site_url"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -5,7 +5,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
-    android:padding="@dimen/margin_medium">
+    android:paddingBottom="@dimen/margin_medium_large"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_extra_large"
+    android:paddingTop="@dimen/margin_medium_large">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/site_icon"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -27,27 +27,33 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/margin_large"
         android:layout_marginStart="@dimen/margin_large"
+        android:ellipsize="end"
+        android:fontFamily="sans-serif-medium"
+        android:maxLines="1"
         android:textAppearance="?attr/textAppearanceLabelLarge"
+        android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/text_sz_medium"
         app:layout_constraintBottom_toTopOf="@+id/site_url"
         app:layout_constraintEnd_toStartOf="@id/site_follow_button"
         app:layout_constraintStart_toEndOf="@id/site_icon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
-        tools:text="Legal Nomads" />
+        tools:text="Site site Site site Site site Site site Site site Site site Site site " />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/site_url"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
         android:textAppearance="?attr/textAppearanceBodyMedium"
-        android:textColor="@color/black_translucent_60"
+        android:textColor="@color/reader_improvements_recommended_section_text"
         android:textSize="@dimen/text_sz_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/site_name"
         app:layout_constraintStart_toStartOf="@id/site_name"
         app:layout_constraintTop_toBottomOf="@+id/site_name"
-        tools:text="legalnomads.com" />
+        tools:text="site.com site.com site.com site.com site.com site.com site.com site.com " />
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/site_follow_button"

--- a/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blog_item_new.xml
@@ -5,8 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
-    android:paddingBottom="@dimen/margin_medium"
-    android:paddingTop="@dimen/margin_medium">
+    android:padding="@dimen/margin_medium">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/site_icon"

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -13,7 +13,8 @@
         android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/margin_medium">
+        android:paddingBottom="@dimen/margin_medium"
+        android:paddingTop="@dimen/margin_medium">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recommended_blogs"
@@ -31,6 +32,8 @@
             android:id="@+id/recommended_blogs_header"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
             android:text="@string/reader_discover_recommended_blogs_header"
             android:textAppearance="?attr/textAppearanceBody2"
             android:textSize="@dimen/text_sz_medium"

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -1,44 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/margin_medium"
-    app:cardBackgroundColor="@color/neutral_0"
-    app:cardCornerRadius="@dimen/margin_medium">
+    android:background="?android:colorBackground">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/root_layout"
+    <com.google.android.material.card.MaterialCardView
+        style="@style/ReaderCardView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingTop="@dimen/margin_medium">
+        android:layout_margin="@dimen/margin_large"
+        app:cardBackgroundColor="@color/neutral_0"
+        app:cardCornerRadius="@dimen/margin_medium">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recommended_blogs"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/root_layout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/recommended_blogs_header"
-            tools:itemCount="3"
-            tools:listitem="@layout/reader_recommended_blog_item_new" />
+            android:paddingBottom="@dimen/margin_extra_large"
+            android:paddingTop="@dimen/margin_extra_large">
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/recommended_blogs_header"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_medium"
-            android:layout_marginStart="@dimen/margin_medium"
-            android:text="@string/reader_discover_recommended_header_new"
-            android:textAppearance="?attr/textAppearanceBody2"
-            android:textSize="@dimen/text_sz_medium"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.material.card.MaterialCardView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recommended_blogs"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/recommended_blogs_header"
+                tools:itemCount="3"
+                tools:listitem="@layout/reader_recommended_blog_item_new" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/recommended_blogs_header"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:text="@string/reader_discover_recommended_header_new"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="@color/reader_improvements_recommended_section_title"
+                android:textSize="@dimen/text_sz_medium"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -34,7 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/margin_medium"
             android:layout_marginStart="@dimen/margin_medium"
-            android:text="@string/reader_discover_recommended_blogs_header"
+            android:text="@string/reader_discover_recommended_header_new"
             android:textAppearance="?attr/textAppearanceBody2"
             android:textSize="@dimen/text_sz_medium"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/ReaderCardView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/margin_medium"
+    app:cardBackgroundColor="@color/neutral_0"
+    app:cardCornerRadius="@dimen/margin_medium">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/root_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/margin_medium">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recommended_blogs"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/recommended_blogs_header"
+            tools:itemCount="3"
+            tools:listitem="@layout/reader_recommended_blog_item_new" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/recommended_blogs_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/reader_discover_recommended_blogs_header"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textSize="@dimen/text_sz_medium"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_large"
-        app:cardBackgroundColor="@color/neutral_0"
+        app:cardBackgroundColor="@color/reader_you_might_like_background"
         app:cardCornerRadius="@dimen/margin_medium">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -41,7 +41,7 @@
                 android:layout_marginStart="@dimen/margin_extra_large"
                 android:text="@string/reader_discover_recommended_header_new"
                 android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="@color/reader_improvements_recommended_section_title"
+                android:textColor="@color/reader_improvements_recommended_section_text"
                 android:textSize="@dimen/text_sz_medium"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_large"
+        app:cardElevation="0dp"
         app:cardBackgroundColor="@color/reader_you_might_like_background"
         app:cardCornerRadius="@dimen/margin_medium">
 

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -96,4 +96,8 @@
     <!-- Partial Media Access -->
     <color name="partial_media_access_prompt_background">#444444</color>
 
+    <!-- Reader Improvements -->
+    <color name="reader_you_might_like_background">#1FFFFFFF</color>
+    <color name="reader_improvements_recommended_section_text">#99FFFFFF</color>
+
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -98,8 +98,9 @@
     <color name="reader_topics_you_might_like_chip_orange_font">@color/orange_50</color>
     <color name="reader_topics_you_might_like_chip_orange_fill">@color/orange_0</color>
 
-    <!-- Reader follow button -->
-    <color name="reader_follow_button_following_state_color">#F4F4F4</color>
+    <!-- Reader Improvements -->
+    <color name="reader_improvements_follow_button_following_state">#F4F4F4</color>
+    <color name="reader_improvements_recommended_section_title">#3C3C43</color>
 
     <!-- These colors were removed from the login library and moved here as they are still being
     used by some old layouts. They should be replaced here as well, whenever possible. -->

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -100,7 +100,8 @@
 
     <!-- Reader Improvements -->
     <color name="reader_improvements_follow_button_following_state">#F4F4F4</color>
-    <color name="reader_improvements_recommended_section_title">#3C3C43</color>
+    <color name="reader_improvements_recommended_section_text">#99000000</color>
+    <color name="reader_you_might_like_background">@color/neutral_0</color>
 
     <!-- These colors were removed from the login library and moved here as they are still being
     used by some old layouts. They should be replaced here as well, whenever possible. -->

--- a/WordPress/src/main/res/values/colors_translucent.xml
+++ b/WordPress/src/main/res/values/colors_translucent.xml
@@ -3,6 +3,7 @@
     <color name="black_translucent_20">#33000000</color>
     <color name="black_translucent_40">#66000000</color>
     <color name="black_translucent_50">#80000000</color>
+    <color name="black_translucent_60">#99000000</color>
 
     <color name="white_translucent_20">#33ffffff</color>
     <color name="white_translucent_40">#66ffffff</color>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1641,6 +1641,7 @@
     <string name="reader_expandable_tags_view_overflow_indicator_collapse_title">Hide</string>
     <string name="reader_discover_interests_header">You might like</string>
     <string name="reader_discover_recommended_blogs_header">Sites to follow</string>
+    <string name="reader_discover_recommended_header_new">You might like</string>
     <string name="reader_post_details_header_by_author_name">By</string>
     <string name="show_n_hidden_items_desc">%1$s more items</string>
     <string name="reader_discover_empty_title">Welcome!</string>


### PR DESCRIPTION
### Do not merge
Should only be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/19249

Part of #19083 

This PR updates the follow/unfollow button design from the "Sites to follow" view and also creates a new layout file to be used when the new design is implemented on "Sites to follow".

Design specs: zQnohyMpLzBzQ5jzMMKni3-fi

To test:
1 - Run JP and sign in;
2 - Open debug settings and enable `ReaderImprovementsFeatureConfig` FF;
3 - Open reader;
4 - Select "Discover" tab;
5 - Scroll until you find the "Sites to follow" section;
6 - Verify the layout: the section should have the new design. Make sure that the follow/unfollow action still works as expected;
7 - Repeat step 2 but this time disable the FF;
8 - Repeat steps 3-5 and verify the layout: the section layout should appear like it currently does in prod;

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Changes were only made to views

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
