### PR TITLE
Plans in site creation: Add feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -146,6 +146,7 @@ android {
         buildConfigField "boolean", "JETPACK_SOCIAL", "false"
         buildConfigField "boolean", "JP_SOCIAL_MASTODON_CONNECT_VIA_WEB", "true"
         buildConfigField "boolean", "CONTACT_SUPPORT_CHATBOT", "false"
+        buildConfigField "boolean", "PLANS_IN_SITE_CREATION", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/PlansInSiteCreationFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/PlansInSiteCreationFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val PLANS_IN_SITE_CREATION_REMOTE_FIELD = "plans_in_site_creation"
+
+@Feature(PLANS_IN_SITE_CREATION_REMOTE_FIELD, false)
+class PlansInSiteCreationFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.PLANS_IN_SITE_CREATION,
+    PLANS_IN_SITE_CREATION_REMOTE_FIELD
+)


### PR DESCRIPTION
Fixes #19229 

<img width=320 src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/e5d9258b-5f1e-47c9-ba0f-fb839fad0f66" />


To test:
- Launch JP app
- `Go` to Debug settings (Me -> Debug settings)
- `Verify` `plans_in_site_creation` is present as shown above


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
