### PR TITLE
Fixes: Site icon not shown in editor when launched through Quick press shortcut

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -630,7 +630,6 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mToolbar = findViewById(R.id.toolbar_main);
         setSupportActionBar(mToolbar);
 
-        customizeToolbar();
 
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -820,6 +819,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mStorageUtilsViewModel.start(savedInstanceState == null);
 
         mEditorJetpackSocialViewModel.start(mSite, mEditPostRepository);
+
+        customizeToolbar();
     }
 
     private void customizeToolbar() {


### PR DESCRIPTION
## Fixes 
The site icon not shown in editor when launched through Quick press shortcut


## 📷  Issue
|   |   |
|---|---|
| ![Screenshot_20230925_171541](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/de3bf1b0-45c6-40d6-ab50-b02beada3f19)  |  ![Screenshot_20230925_171830](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/731b01f0-e467-4a3e-b475-aa9e4c1c3c0b) |  

## To test:
1. Login to the jetpack app 
2. From home in Android, Add quick press shortcut 
3. Click on Quick press shortcut 
4. Verify that the editor is shown 
5. Verify that the site icon is shown in editor on nav bar

## Regression Notes
1. Potential unintended areas of impact
Site icon is not shown in nav bar

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
