### PR TITLE
Pages Activity Crash on deep link when site is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -325,7 +325,9 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
         setupMlpObservers(activity)
         setupVirtualHomepageObservers(activity)
 
-        val site = requireNotNull(
+        // It is possible that we deep link to pages while we have no sites, at which time using requireNotNull will
+        // cause a crash. We should finish the activity and not throw an exception.
+        val site =
             if (savedInstanceState == null) {
                 val nonNullIntent = checkNotNull(activity.intent)
                 nonNullIntent.getSerializableExtraCompat<SiteModel>(WordPress.SITE)
@@ -333,7 +335,12 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                 restorePreviousSearch = true
                 savedInstanceState.getSerializableCompat<SiteModel>(WordPress.SITE)
             }
-        )
+
+        if (site == null) {
+            showToast(ToastMessageHolder(R.string.pages_no_site_something_went_wrong, Duration.LONG))
+            requireActivity().finish()
+            return
+        }
 
         viewModel.authorUIState.observe(activity) { state ->
             state?.let {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -284,7 +284,9 @@ class PagesViewModel
 
     override fun onCleared() {
         actionPerformer.onCleanup()
-        pageListEventListener.onDestroy()
+        if (::pageListEventListener.isInitialized) {
+            pageListEventListener.onDestroy()
+        }
     }
 
     private fun loadPagesAsync() = launch(defaultDispatcher) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4731,4 +4731,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="my_site_dashboard_no_cards_message_title">All cards are hidden</string>
     <string name="my_site_dashboard_no_cards_message_description">Tap the personalise button to show more cards.</string>
 
+    <string name="pages_no_site_something_went_wrong">Uh oh, something went wrong. Please try again later.</string>
+
 </resources>


### PR DESCRIPTION
Fixes #19258 

This PR fixes a crash that happens when deep linking into pages when the user has no sites.
- The `requireNotNull` check in PagesFragment was changed to a null check when `site` is null. The user will now see a toast error message and the activity will finish. This provides a better user experience than a crash.
- Added a check for a lateinit property in the viewModel before attempting to destroy in `onCleared()`

Note: Targeting trunk because this is an edge case crash with a low occurrence.

**To test:**
**Current behavior**
- Install JP from the play store
- Sign up for a new account
- Do NOT create any sites
- Send the following link to yourself (I used slack) `[ttps://wordpress.com/pages/domain](https://wordpress.com/pages/domain)`
- Tap on the link from within slack while on the device
- ✅ Verify the app crashes

**New behavior**
- Uninstall beta version
- Install the version from this PR
- Navigate to the App settings on the device and allow the app to handle links
- Sign up for a new account
- Do NOT create any sites
- Send the following link to yourself (I used slack) `[ttps://wordpress.com/pages/domain](https://wordpress.com/pages/domain)`
- Tap on the link from within slack while on the device
- ✅ Verify the app no longer crashes and you land on the no sites view

## Regression Notes
1. Potential unintended areas of impact
Pages Fragment deep link

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
