### PR TITLE
UI - Implement personalization screen for quick links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
@@ -1,0 +1,183 @@
+package org.wordpress.android.ui.mysite.personalization
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.store.BloggingRemindersStore
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+import javax.inject.Named
+
+class DashboardCardPersonalizationViewModelSlice @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val selectedSiteRepository: SelectedSiteRepository,
+    private val bloggingRemindersStore: BloggingRemindersStore,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+) {
+    private val _uiState = MutableLiveData<List<DashboardCardState>>()
+    val uiState: LiveData<List<DashboardCardState>> = _uiState
+
+    lateinit var scope: CoroutineScope
+
+    fun initialize(viewModelScope: CoroutineScope) {
+        this.scope = viewModelScope
+    }
+
+    fun start(siteId: Long) {
+        scope.launch(bgDispatcher) {
+            _uiState.postValue(getCardStates(siteId))
+        }
+    }
+
+    private suspend fun getCardStates(siteId: Long): List<DashboardCardState> {
+        return listOf(
+            DashboardCardState(
+                title = R.string.personalization_screen_stats_card_title,
+                description = R.string.personalization_screen_stats_card_description,
+                enabled = isStatsCardShown(siteId),
+                cardType = CardType.STATS
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_draft_posts_card_title,
+                description = R.string.personalization_screen_draft_posts_card_description,
+                enabled = isDraftPostsCardShown(siteId),
+                cardType = CardType.DRAFT_POSTS
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_scheduled_posts_card_title,
+                description = R.string.personalization_screen_scheduled_posts_card_description,
+                enabled = isScheduledPostsCardShown(siteId),
+                cardType = CardType.SCHEDULED_POSTS
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_pages_card_title,
+                description = R.string.personalization_screen_pages_card_description,
+                enabled = isPagesCardShown(siteId),
+                cardType = CardType.PAGES
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_activity_log_card_title,
+                description = R.string.personalization_screen_activity_log_card_description,
+                enabled = isActivityLogCardShown(siteId),
+                cardType = CardType.ACTIVITY_LOG
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_blaze_card_title,
+                description = R.string.personalization_screen_blaze_card_description,
+                enabled = isBlazeCardShown(siteId),
+                cardType = CardType.BLAZE
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_blogging_prompts_card_title,
+                description = R.string.personalization_screen_blogging_prompts_card_description,
+                enabled = isPromptsSettingEnabled(selectedSiteRepository.getSelectedSiteLocalId()),
+                cardType = CardType.BLOGGING_PROMPTS
+            ),
+            DashboardCardState(
+                title = R.string.personalization_screen_next_steps_card_title,
+                description = R.string.personalization_screen_next_steps_card_description,
+                enabled = isNextStepCardShown(siteId),
+                cardType = CardType.NEXT_STEPS
+            )
+        )
+    }
+
+    fun onCardToggled(cardType: CardType, enabled: Boolean) {
+        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
+        scope.launch(bgDispatcher) {
+            trackCardToggle(cardType, enabled)
+            when (cardType) {
+                CardType.STATS -> appPrefsWrapper.setShouldHideTodaysStatsDashboardCard(siteId, !enabled)
+                CardType.DRAFT_POSTS -> appPrefsWrapper.setShouldHidePostDashboardCard(
+                    siteId,
+                    PostCardType.DRAFT.name,
+                    !enabled
+                )
+
+                CardType.SCHEDULED_POSTS -> appPrefsWrapper.setShouldHidePostDashboardCard(
+                    siteId,
+                    PostCardType.SCHEDULED.name,
+                    !enabled
+                )
+
+                CardType.PAGES -> appPrefsWrapper.setShouldHidePagesDashboardCard(siteId, !enabled)
+                CardType.ACTIVITY_LOG -> appPrefsWrapper.setShouldHideActivityDashboardCard(siteId, !enabled)
+                CardType.BLAZE -> appPrefsWrapper.setShouldHideBlazeCard(siteId, !enabled)
+                CardType.BLOGGING_PROMPTS -> updatePromptsCardEnabled(enabled)
+                CardType.NEXT_STEPS -> appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, !enabled)
+            }
+            // update the ui state
+            updateCardState(cardType, enabled)
+        }
+    }
+
+    private fun trackCardToggle(cardType: CardType, enabled: Boolean) {
+        if (enabled) trackCardShown(cardType)
+        else trackCardHidden(cardType)
+    }
+
+    private fun trackCardHidden(cardType: CardType) {
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.PERSONALIZATION_SCREEN_CARD_HIDE_TAPPED,
+            mapOf(CARD_TYPE_TRACK_PARAM to cardType.trackingName)
+        )
+    }
+
+    private fun trackCardShown(cardType: CardType) {
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.PERSONALIZATION_SCREEN_CARD_SHOW_TAPPED,
+            mapOf(CARD_TYPE_TRACK_PARAM to cardType.trackingName)
+        )
+    }
+
+    private fun updateCardState(cardType: CardType, enabled: Boolean) {
+        val currentCards: MutableList<DashboardCardState> = _uiState.value!!.toMutableList()
+        val updated = currentCards.find { it.cardType == cardType }!!.copy(enabled = enabled)
+        currentCards[cardType.order] = updated
+        _uiState.postValue(currentCards)
+    }
+
+    private fun isStatsCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(siteId)
+
+    private fun isDraftPostsCardShown(siteId: Long) =
+        !appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.DRAFT.name)
+
+    private fun isScheduledPostsCardShown(siteId: Long) =
+        !appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.SCHEDULED.name)
+
+    private fun isPagesCardShown(siteId: Long) = !appPrefsWrapper.getShouldHidePagesDashboardCard(siteId)
+
+    private fun isActivityLogCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideActivityDashboardCard(siteId)
+
+    private fun isBlazeCardShown(siteId: Long) = !appPrefsWrapper.hideBlazeCard(siteId)
+
+    private fun isNextStepCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId)
+
+    private suspend fun isPromptsSettingEnabled(
+        siteId: Int
+    ): Boolean = bloggingRemindersStore
+        .bloggingRemindersModel(siteId)
+        .firstOrNull()
+        ?.isPromptsCardEnabled == true
+
+    private suspend fun updatePromptsCardEnabled(isEnabled: Boolean) {
+        val siteId = selectedSiteRepository.getSelectedSiteLocalId()
+        val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
+        bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
+    }
+
+    fun onCleared() {
+        this.scope.cancel()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -281,7 +282,10 @@ fun ShortcutStateRow(
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .size(24.dp)
-                    .padding(1.dp)
+                    .padding(1.dp),
+                colorFilter = if (state.disableTint) null
+                else ColorFilter.tint(MaterialTheme.colors.onSurface)
+
             )
             Spacer(Modifier.width(8.dp))
             Text(
@@ -302,8 +306,8 @@ fun ShortcutStateRow(
                 val icon = if (state.isActive) R.drawable.ic_personalization_quick_link_remove_circle
                 else R.drawable.ic_personalization_shortcuts_plus_circle
 
-                val iconTint = if (state.isActive) Color(0xFF008710)
-                else Color(0xFFD63638)
+                val iconTint = if (state.isActive) Color(0xFFD63638)
+                else Color(0xFF008710)
 
                 Icon(
                     painter = painterResource(id = icon),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -253,34 +254,41 @@ fun ShortcutStateRow(
     state: ShortcutsState,
     modifier: Modifier = Modifier
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .border(width = 1.dp, color = Color(0xFFE1E2E2), shape = RoundedCornerShape(size = 10.dp))
-            .padding(start = 12.dp, top = 12.dp, end = 16.dp, bottom = 12.dp)
-            .padding(
-                start = 16.dp,
-                end = 16.dp
-            ),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Image(
-            painter = painterResource(id = state.icon),
-            contentDescription = null, // Add appropriate content description
-            contentScale = ContentScale.Fit,
-            modifier = Modifier
-                .size(24.dp)
-                .padding(end = 8.dp)
-        )
-        Text(
-            text = uiStringText(state.label),
-            fontSize = 16.sp,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
-            modifier = Modifier
-                .weight(1f)
-                .padding(end = 8.dp),
-        )
-        Spacer(Modifier.width(8.dp))
+            .padding(start = 16.dp, end = 16.dp, top = 6.dp, bottom = 6.dp)
+    )
+    {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f),
+                    shape = RoundedCornerShape(size = 10.dp)
+                )
+                .padding(start = 12.dp, top = 12.dp, end = 16.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = painterResource(id = state.icon),
+                contentDescription = null, // Add appropriate content description
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(end = 8.dp)
+            )
+            Text(
+                text = uiStringText(state.label),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 8.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -18,10 +18,16 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material3.Tab
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -61,13 +67,42 @@ class PersonalizationActivity : ComponentActivity() {
                 )
             },
             content = {
-                PersonalizationContent(uiState.value ?: emptyList())
+                TabScreen(uiState.value ?: emptyList())
             }
         )
     }
 
     @Composable
-    fun PersonalizationContent(cardStateList: List<DashboardCardState>, modifier: Modifier = Modifier) {
+    fun TabScreen(dashboardCardStates: List<DashboardCardState>) {
+        var tabIndex by remember { mutableStateOf(0) }
+
+        val tabs = listOf(
+            R.string.personalization_screen_cards_tab_title,
+            R.string.personalization_screen_shortcuts_tab_title
+        )
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            TabRow(
+                selectedTabIndex = tabIndex,
+                backgroundColor = MaterialTheme.colors.surface,
+                contentColor = MaterialTheme.colors.onSurface,
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(text = { Text(stringResource(id = title)) },
+                        selected = tabIndex == index,
+                        onClick = { tabIndex = index }
+                    )
+                }
+            }
+            when (tabIndex) {
+                0 -> CardsPersonalizationContent(dashboardCardStates)
+                1 -> CardsPersonalizationContent(dashboardCardStates)
+            }
+        }
+    }
+
+    @Composable
+    fun CardsPersonalizationContent(cardStateList: List<DashboardCardState>, modifier: Modifier = Modifier) {
         Column(
             modifier = modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -117,7 +117,7 @@ class PersonalizationActivity : ComponentActivity() {
                 item {
                     Text(
                         modifier = Modifier.padding(start = 16.dp),
-                        text = stringResource(id = R.string.personalization_screen_description),
+                        text = stringResource(id = R.string.personalization_screen_tab_cards_description),
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
@@ -134,7 +134,7 @@ class PersonalizationActivity : ComponentActivity() {
                 item {
                     Text(
                         modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp),
-                        text = stringResource(id = R.string.personalization_screen_footer_cards),
+                        text = stringResource(id = R.string.personalization_screen_tab_cards_footer_cards),
                         fontSize = 13.sp,
                         fontWeight = FontWeight.Normal,
                         color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -277,8 +277,9 @@ fun ShortcutStateRow(
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .size(24.dp)
-                    .padding(end = 8.dp)
+                    .padding(1.dp)
             )
+            Spacer(Modifier.width(8.dp))
             Text(
                 text = uiStringText(state.label),
                 fontSize = 16.sp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -21,13 +21,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Tab
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -41,6 +42,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,6 +52,7 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.utils.UiString
 
 @AndroidEntryPoint
 class PersonalizationActivity : ComponentActivity() {
@@ -269,7 +272,8 @@ fun ShortcutStateRow(
                     shape = RoundedCornerShape(size = 10.dp)
                 )
                 .padding(start = 12.dp, top = 12.dp, end = 16.dp, bottom = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
         ) {
             Image(
                 painter = painterResource(id = state.icon),
@@ -286,10 +290,44 @@ fun ShortcutStateRow(
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
                 modifier = Modifier
-                    .weight(1f)
                     .padding(end = 8.dp),
             )
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.weight(1f))
+            IconButton(
+                modifier = modifier
+                    .size(24.dp)
+                    .padding(1.dp),
+                onClick = {}
+            ) {
+                val icon = if (state.isActive) R.drawable.ic_personalization_quick_link_remove_circle
+                else R.drawable.ic_personalization_shortcuts_plus_circle
+
+                val iconTint = if (state.isActive) Color(0xFF008710)
+                else Color(0xFFD63638)
+
+                Icon(
+                    painter = painterResource(id = icon),
+                    tint = iconTint,
+                    contentDescription = stringResource(
+                        R.string.personalization_screen_shortcuts_add_or_remove_shortcut_button
+                    ),
+                )
+            }
         }
     }
 }
+
+@Preview
+@Composable
+fun PersonalizationScreenPreview() {
+    AppTheme {
+        ShortcutStateRow(
+            state = ShortcutsState(
+                label = UiString.UiStringRes(R.string.media),
+                icon = R.drawable.media_icon_circle,
+                isActive = true
+            )
+        )
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationShortcutsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationShortcutsViewModelSlice.kt
@@ -1,0 +1,99 @@
+package org.wordpress.android.ui.mysite.personalization
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.blaze.BlazeFeatureUtils
+import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
+import kotlinx.coroutines.launch
+import org.wordpress.android.ui.utils.UiString
+import javax.inject.Inject
+import javax.inject.Named
+
+class PersonalizationShortcutsViewModelSlice @Inject constructor(
+    private val selectedSiteRepository: SelectedSiteRepository,
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val siteItemsBuilder: SiteItemsBuilder,
+    private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
+    private val blazeFeatureUtils: BlazeFeatureUtils
+) {
+    lateinit var scope: CoroutineScope
+
+    fun initialize(scope: CoroutineScope) {
+        this.scope = scope
+    }
+
+    private val _uiState = MutableStateFlow(emptyList<ShortcutsState>())
+
+    val uiState: StateFlow<List<ShortcutsState>> = _uiState
+
+    fun start() {
+        val site = selectedSiteRepository.getSelectedSite()!!
+        buildSiteMenu(site)
+    }
+
+    private fun buildSiteMenu(site: SiteModel) {
+        _uiState.value = convertToShortCutsState(
+            items = siteItemsBuilder.build(
+                MySiteCardAndItemBuilderParams.SiteItemsBuilderParams(
+                    site = site,
+                    activeTask = null,
+                    backupAvailable = false,
+                    scanAvailable = false,
+                    enableFocusPoints = false,
+                    onClick = { },
+                    isBlazeEligible = isSiteBlazeEligible()
+                )
+            )
+        )
+        updateSiteItemsForJetpackCapabilities(site)
+    }
+
+    private fun convertToShortCutsState(items: List<MySiteCardAndItem>): List<ShortcutsState> {
+        return (items.filter { it.type == MySiteCardAndItem.Type.LIST_ITEM } as List<MySiteCardAndItem.Item.ListItem>)
+            .map { listItem ->
+                ShortcutsState(
+                    icon = listItem.primaryIcon,
+                    label = listItem.primaryText as UiString.UiStringRes
+                )
+            }
+    }
+
+    private fun updateSiteItemsForJetpackCapabilities(site: SiteModel) {
+        scope.launch(bgDispatcher) {
+            jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId).collect {
+                _uiState.value = convertToShortCutsState(
+                    items = siteItemsBuilder.build(
+                        MySiteCardAndItemBuilderParams.SiteItemsBuilderParams(
+                            site = site,
+                            activeTask = null,
+                            backupAvailable = it.backup,
+                            scanAvailable = (it.scan && !site.isWPCom && !site.isWPComAtomic),
+                            enableFocusPoints = false,
+                            onClick = { },
+                            isBlazeEligible = isSiteBlazeEligible()
+                        )
+                    )
+                )
+            } // end collect
+        }
+    }
+
+    private fun isSiteBlazeEligible() =
+        blazeFeatureUtils.isSiteBlazeEligible(selectedSiteRepository.getSelectedSite()!!)
+
+    fun onCleared() {
+        this.scope.cancel()
+        jetpackCapabilitiesUseCase.clear()
+    }
+}
+
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -27,21 +27,21 @@ class PersonalizationViewModel @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val bloggingRemindersStore: BloggingRemindersStore,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val personalizationShortcutsViewModelSlice: PersonalizationShortcutsViewModelSlice
+    private val shortcutsPersonalizationViewModelSlice: ShortcutsPersonalizationViewModelSlice
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableLiveData<List<DashboardCardState>>()
     val uiState: LiveData<List<DashboardCardState>> = _uiState
 
-    val shortcutsState = personalizationShortcutsViewModelSlice.uiState
+    val shortcutsState = shortcutsPersonalizationViewModelSlice.uiState
 
     init {
-        personalizationShortcutsViewModelSlice.initialize(viewModelScope)
+        shortcutsPersonalizationViewModelSlice.initialize(viewModelScope)
     }
 
     fun start() {
         val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
         launch(bgDispatcher) { _uiState.postValue(getCardStates(siteId)) }
-        personalizationShortcutsViewModelSlice.start(selectedSiteRepository.getSelectedSite()!!)
+        shortcutsPersonalizationViewModelSlice.start(selectedSiteRepository.getSelectedSite()!!)
     }
 
     private suspend fun getCardStates(siteId: Long): List<DashboardCardState> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.mysite.personalization
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.firstOrNull
@@ -25,14 +26,22 @@ class PersonalizationViewModel @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val bloggingRemindersStore: BloggingRemindersStore,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val personalizationShortcutsViewModelSlice: PersonalizationShortcutsViewModelSlice
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiState = MutableLiveData<List<DashboardCardState>>()
     val uiState: LiveData<List<DashboardCardState>> = _uiState
 
+    val shortcutsState = personalizationShortcutsViewModelSlice.uiState
+
+    init {
+        personalizationShortcutsViewModelSlice.initialize(viewModelScope)
+    }
+
     fun start() {
         val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
         launch(bgDispatcher) { _uiState.postValue(getCardStates(siteId)) }
+        personalizationShortcutsViewModelSlice.start(selectedSiteRepository.getSelectedSite()!!)
     }
 
     private suspend fun getCardStates(siteId: Long): List<DashboardCardState> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -1,19 +1,10 @@
 package org.wordpress.android.ui.mysite.personalization
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.firstOrNull
-import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.fluxc.store.BloggingRemindersStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
-import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
-import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -23,161 +14,31 @@ const val CARD_TYPE_TRACK_PARAM = "type"
 @HiltViewModel
 class PersonalizationViewModel @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val appPrefsWrapper: AppPrefsWrapper,
     private val selectedSiteRepository: SelectedSiteRepository,
-    private val bloggingRemindersStore: BloggingRemindersStore,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
-    private val shortcutsPersonalizationViewModelSlice: ShortcutsPersonalizationViewModelSlice
+    private val shortcutsPersonalizationViewModelSlice: ShortcutsPersonalizationViewModelSlice,
+    private val dashboardCardPersonalizationViewModelSlice: DashboardCardPersonalizationViewModelSlice
 ) : ScopedViewModel(bgDispatcher) {
-    private val _uiState = MutableLiveData<List<DashboardCardState>>()
-    val uiState: LiveData<List<DashboardCardState>> = _uiState
-
+    val uiState = dashboardCardPersonalizationViewModelSlice.uiState
     val shortcutsState = shortcutsPersonalizationViewModelSlice.uiState
 
     init {
         shortcutsPersonalizationViewModelSlice.initialize(viewModelScope)
+        dashboardCardPersonalizationViewModelSlice.initialize(viewModelScope)
     }
 
     fun start() {
         val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
-        launch(bgDispatcher) { _uiState.postValue(getCardStates(siteId)) }
+        dashboardCardPersonalizationViewModelSlice.start(siteId)
         shortcutsPersonalizationViewModelSlice.start(selectedSiteRepository.getSelectedSite()!!)
     }
 
-    private suspend fun getCardStates(siteId: Long): List<DashboardCardState> {
-        return listOf(
-            DashboardCardState(
-                title = R.string.personalization_screen_stats_card_title,
-                description = R.string.personalization_screen_stats_card_description,
-                enabled = isStatsCardShown(siteId),
-                cardType = CardType.STATS
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_draft_posts_card_title,
-                description = R.string.personalization_screen_draft_posts_card_description,
-                enabled = isDraftPostsCardShown(siteId),
-                cardType = CardType.DRAFT_POSTS
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_scheduled_posts_card_title,
-                description = R.string.personalization_screen_scheduled_posts_card_description,
-                enabled = isScheduledPostsCardShown(siteId),
-                cardType = CardType.SCHEDULED_POSTS
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_pages_card_title,
-                description = R.string.personalization_screen_pages_card_description,
-                enabled = isPagesCardShown(siteId),
-                cardType = CardType.PAGES
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_activity_log_card_title,
-                description = R.string.personalization_screen_activity_log_card_description,
-                enabled = isActivityLogCardShown(siteId),
-                cardType = CardType.ACTIVITY_LOG
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_blaze_card_title,
-                description = R.string.personalization_screen_blaze_card_description,
-                enabled = isBlazeCardShown(siteId),
-                cardType = CardType.BLAZE
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_blogging_prompts_card_title,
-                description = R.string.personalization_screen_blogging_prompts_card_description,
-                enabled = isPromptsSettingEnabled(selectedSiteRepository.getSelectedSiteLocalId()),
-                cardType = CardType.BLOGGING_PROMPTS
-            ),
-            DashboardCardState(
-                title = R.string.personalization_screen_next_steps_card_title,
-                description = R.string.personalization_screen_next_steps_card_description,
-                enabled = isNextStepCardShown(siteId),
-                cardType = CardType.NEXT_STEPS
-            )
-        )
-    }
-
     fun onCardToggled(cardType: CardType, enabled: Boolean) {
-        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
-        launch(bgDispatcher) {
-            trackCardToggle(cardType, enabled)
-            when (cardType) {
-                CardType.STATS -> appPrefsWrapper.setShouldHideTodaysStatsDashboardCard(siteId, !enabled)
-                CardType.DRAFT_POSTS -> appPrefsWrapper.setShouldHidePostDashboardCard(
-                    siteId,
-                    PostCardType.DRAFT.name,
-                    !enabled
-                )
-
-                CardType.SCHEDULED_POSTS -> appPrefsWrapper.setShouldHidePostDashboardCard(
-                    siteId,
-                    PostCardType.SCHEDULED.name,
-                    !enabled
-                )
-
-                CardType.PAGES -> appPrefsWrapper.setShouldHidePagesDashboardCard(siteId, !enabled)
-                CardType.ACTIVITY_LOG -> appPrefsWrapper.setShouldHideActivityDashboardCard(siteId, !enabled)
-                CardType.BLAZE -> appPrefsWrapper.setShouldHideBlazeCard(siteId, !enabled)
-                CardType.BLOGGING_PROMPTS -> updatePromptsCardEnabled(enabled)
-                CardType.NEXT_STEPS -> appPrefsWrapper.setShouldHideNextStepsDashboardCard(siteId, !enabled)
-            }
-            // update the ui state
-            updateCardState(cardType, enabled)
-        }
+        dashboardCardPersonalizationViewModelSlice.onCardToggled(cardType, enabled)
     }
 
-    private fun trackCardToggle(cardType: CardType, enabled: Boolean){
-        if(enabled) trackCardShown(cardType)
-        else trackCardHidden(cardType)
-    }
-
-    private fun trackCardHidden(cardType: CardType){
-        analyticsTrackerWrapper.track(
-            Stat.PERSONALIZATION_SCREEN_CARD_HIDE_TAPPED,
-            mapOf(CARD_TYPE_TRACK_PARAM to cardType.trackingName)
-        )
-    }
-
-    private fun trackCardShown(cardType: CardType){
-        analyticsTrackerWrapper.track(
-            Stat.PERSONALIZATION_SCREEN_CARD_SHOW_TAPPED,
-            mapOf(CARD_TYPE_TRACK_PARAM to cardType.trackingName)
-        )
-    }
-
-    private fun updateCardState(cardType: CardType, enabled: Boolean) {
-        val currentCards: MutableList<DashboardCardState> = _uiState.value!!.toMutableList()
-        val updated = currentCards.find { it.cardType == cardType }!!.copy(enabled = enabled)
-        currentCards[cardType.order] = updated
-        _uiState.postValue(currentCards)
-    }
-
-    private fun isStatsCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(siteId)
-
-    private fun isDraftPostsCardShown(siteId: Long) =
-        !appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.DRAFT.name)
-
-    private fun isScheduledPostsCardShown(siteId: Long) =
-        !appPrefsWrapper.getShouldHidePostDashboardCard(siteId, PostCardType.SCHEDULED.name)
-
-    private fun isPagesCardShown(siteId: Long) = !appPrefsWrapper.getShouldHidePagesDashboardCard(siteId)
-
-    private fun isActivityLogCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideActivityDashboardCard(siteId)
-
-    private fun isBlazeCardShown(siteId: Long) = !appPrefsWrapper.hideBlazeCard(siteId)
-
-    private fun isNextStepCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideNextStepsDashboardCard(siteId)
-
-    private suspend fun isPromptsSettingEnabled(
-        siteId: Int
-    ): Boolean = bloggingRemindersStore
-        .bloggingRemindersModel(siteId)
-        .firstOrNull()
-        ?.isPromptsCardEnabled == true
-
-    private suspend fun updatePromptsCardEnabled(isEnabled: Boolean) {
-        val siteId = selectedSiteRepository.getSelectedSiteLocalId()
-        val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
-        bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
+    override fun onCleared() {
+        super.onCleared()
+        shortcutsPersonalizationViewModelSlice.onCleared()
+        dashboardCardPersonalizationViewModelSlice.onCleared()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
@@ -55,7 +55,8 @@ class ShortcutsPersonalizationViewModelSlice @Inject constructor(
         return listItems.map { listItem ->
             ShortcutsState(
                 icon = listItem.primaryIcon,
-                label = listItem.primaryText as UiString.UiStringRes
+                label = listItem.primaryText as UiString.UiStringRes,
+                disableTint = listItem.disablePrimaryIconTint
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
@@ -11,14 +11,13 @@ import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.jetpack.JetpackCapabilitiesUseCase
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
-import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.utils.UiString
 import javax.inject.Inject
 import javax.inject.Named
 
-class PersonalizationShortcutsViewModelSlice @Inject constructor(
+class ShortcutsPersonalizationViewModelSlice @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val siteItemsBuilder: SiteItemsBuilder,
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsState.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.ui.mysite.personalization
+
+import androidx.annotation.DrawableRes
+import org.wordpress.android.ui.utils.UiString
+
+data class ShortcutsState(
+    @DrawableRes val icon: Int,
+    val label: UiString.UiStringRes,
+    val isActive: Boolean = false
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsState.kt
@@ -6,5 +6,6 @@ import org.wordpress.android.ui.utils.UiString
 data class ShortcutsState(
     @DrawableRes val icon: Int,
     val label: UiString.UiStringRes,
-    val isActive: Boolean = false
+    val isActive: Boolean = false,
+    val disableTint : Boolean = false
 )

--- a/WordPress/src/main/res/drawable/ic_personalization_quick_link_remove_circle.xml
+++ b/WordPress/src/main/res/drawable/ic_personalization_quick_link_remove_circle.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,3C7,3 3,7 3,12C3,17 7,21 12,21C17,21 21,17 21,12C21,7 17,3 12,3ZM12,19C8.1,19 5,15.9 5,12C5,8.1 8.1,5 12,5C15.9,5 19,8.1 19,12C19,15.9 15.9,19 12,19ZM12,3C7,3 3,7 3,12C3,17 7,21 12,21C17,21 21,17 21,12C21,7 17,3 12,3ZM12,19C8.1,19 5,15.9 5,12C5,8.1 8.1,5 12,5C15.9,5 19,8.1 19,12C19,15.9 15.9,19 12,19Z"
+      android:fillColor="#D63638"/>
+  <path
+      android:pathData="M8,11h8v2h-8z"
+      android:fillColor="#D63638"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_personalization_shortcuts_plus_circle.xml
+++ b/WordPress/src/main/res/drawable/ic_personalization_shortcuts_plus_circle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,3C7,3 3,7 3,12C3,17 7,21 12,21C17,21 21,17 21,12C21,7 17,3 12,3ZM12,19C8.1,19 5,15.9 5,12C5,8.1 8.1,5 12,5C15.9,5 19,8.1 19,12C19,15.9 15.9,19 12,19ZM13,8H11V11H8V13H11V16H13V13H16V11H13V8ZM12,3C7,3 3,7 3,12C3,17 7,21 12,21C17,21 21,17 21,12C21,7 17,3 12,3ZM12,19C8.1,19 5,15.9 5,12C5,8.1 8.1,5 12,5C15.9,5 19,8.1 19,12C19,15.9 15.9,19 12,19ZM13,8H11V11H8V13H11V16H13V13H16V11H13V8Z"
+      android:fillColor="#008710"/>
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4710,6 +4710,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalization_screen_shortcuts_tab_title">Shortcuts</string>
     <string name="personalization_screen_tab_cards_description">Add or hide Cards</string>
     <string name="personalization_screen_tab_cards_footer_cards">Cards may show different content depending on what\'s happening with your site</string>
+    <string name="personalization_screen_tab_shortcuts_active_shortcuts">Active Shortcuts</string>
+    <string name="personalization_screen_tab_shortcuts_inactive_shortcuts">Inactive Shortcuts</string>
     <string name="personalization_screen_stats_card_title" translatable="false">@string/my_site_todays_stat_card_title</string>
     <string name="personalization_screen_stats_card_description">Views, Visitors and likes</string>
     <string name="personalization_screen_draft_posts_card_title"> Draft posts</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4706,6 +4706,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Personalization Screen -->
     <string name="personalization_screen_title"> Personalize home tab</string>
+    <string name="personalization_screen_cards_tab_title">Cards</string>
+    <string name="personalization_screen_shortcuts_tab_title">Shortcuts</string>
     <string name="personalization_screen_description"> Add or hide Cards</string>
     <string name="personalization_screen_footer_cards"> Cards may show different content depending on what\'s happening with your site</string>
     <string name="personalization_screen_stats_card_title" translatable="false">@string/my_site_todays_stat_card_title</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4728,6 +4728,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalization_screen_activity_log_card_description">Recent actions taken on your site.</string>
     <string name="personalization_screen_next_steps_card_title" translatable="false">@string/quick_start_sites</string>
     <string name="personalization_screen_next_steps_card_description">Learn how to make the most of your site with the app.</string>
+    <string name="personalization_screen_shortcuts_add_or_remove_shortcut_button">Add or Remove shortcuts</string>
 
     <string name="my_site_dashboard_no_cards_message_title">All cards are hidden</string>
     <string name="my_site_dashboard_no_cards_message_description">Tap the personalise button to show more cards.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4708,8 +4708,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="personalization_screen_title"> Personalize home tab</string>
     <string name="personalization_screen_cards_tab_title">Cards</string>
     <string name="personalization_screen_shortcuts_tab_title">Shortcuts</string>
-    <string name="personalization_screen_description"> Add or hide Cards</string>
-    <string name="personalization_screen_footer_cards"> Cards may show different content depending on what\'s happening with your site</string>
+    <string name="personalization_screen_tab_cards_description">Add or hide Cards</string>
+    <string name="personalization_screen_tab_cards_footer_cards">Cards may show different content depending on what\'s happening with your site</string>
     <string name="personalization_screen_stats_card_title" translatable="false">@string/my_site_todays_stat_card_title</string>
     <string name="personalization_screen_stats_card_description">Views, Visitors and likes</string>
     <string name="personalization_screen_draft_posts_card_title"> Draft posts</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
-class PersonalizationViewModelTest : BaseUnitTest() {
+class DashboardCardPersonalizationViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
@@ -36,7 +36,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
-    private lateinit var viewModel: PersonalizationViewModel
+    private lateinit var viewModelSlice: DashboardCardPersonalizationViewModelSlice
 
     private val site = SiteModel().apply { siteId = 123L }
     private val localSiteId = 456
@@ -54,7 +54,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         whenever(bloggingRemindersStore.bloggingRemindersModel(localSiteId))
             .thenReturn(flowOf(userSetBloggingRemindersModel))
 
-        viewModel = PersonalizationViewModel(
+        viewModelSlice = DashboardCardPersonalizationViewModelSlice(
             bgDispatcher = testDispatcher(),
             appPrefsWrapper = appPrefsWrapper,
             selectedSiteRepository = selectedSiteRepository,
@@ -62,9 +62,11 @@ class PersonalizationViewModelTest : BaseUnitTest() {
             analyticsTrackerWrapper = analyticsTrackerWrapper
         )
 
-        viewModel.uiState.observeForever {
+        viewModelSlice.uiState.observeForever {
             uiStateList.add(it)
         }
+
+        viewModelSlice.initialize(testScope())
     }
 
     @Test
@@ -72,7 +74,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         val isStatsCardHidden = false
         whenever(appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(site.siteId)).thenReturn(isStatsCardHidden)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.STATS }
 
         assertTrue(statsCardState!!.enabled)
@@ -82,7 +84,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given draft post card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.getShouldHidePostDashboardCard(123L, PostCardType.DRAFT.name)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.DRAFT_POSTS }
 
         assertTrue(statsCardState!!.enabled)
@@ -92,7 +94,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given scheduled post card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.getShouldHidePostDashboardCard(123L, PostCardType.SCHEDULED.name)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.SCHEDULED_POSTS }
 
         assertTrue(statsCardState!!.enabled)
@@ -102,7 +104,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given pages card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.getShouldHidePagesDashboardCard(123L)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.PAGES }
 
         assertTrue(statsCardState!!.enabled)
@@ -112,7 +114,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given activity log card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.getShouldHideActivityDashboardCard(123L)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.ACTIVITY_LOG }
 
         assertTrue(statsCardState!!.enabled)
@@ -122,7 +124,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given blaze card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.hideBlazeCard(123L)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.BLAZE }
 
         assertTrue(statsCardState!!.enabled)
@@ -133,7 +135,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         whenever(bloggingRemindersStore.bloggingRemindersModel(localSiteId))
             .thenReturn(flowOf(userSetBloggingRemindersModel.copy(isPromptsCardEnabled = false)))
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.BLOGGING_PROMPTS }
 
         assertFalse(statsCardState!!.enabled)
@@ -143,7 +145,7 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given next steps card is not hidden, when cards are fetched, then state is checked`() {
         whenever(appPrefsWrapper.getShouldHideNextStepsDashboardCard(123L)).thenReturn(false)
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardState = uiStateList.last().find { it.cardType == CardType.NEXT_STEPS }
 
         assertTrue(statsCardState!!.enabled)
@@ -155,9 +157,9 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         whenever(appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(site.siteId)).thenReturn(true)
 
 
-        viewModel.start()
+        viewModelSlice.start(123L)
         val statsCardStateBefore = uiStateList.last().find { it.cardType == cardType }
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.onCardToggled(cardType, true)
         val statsCardState = uiStateList.last().find { it.cardType == cardType }
 
         assertFalse(statsCardStateBefore!!.enabled)
@@ -168,8 +170,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when stats card state is toggled, then pref is updated`() {
         val cardType = CardType.STATS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHideTodaysStatsDashboardCard(site.siteId, false)
     }
@@ -178,8 +180,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when draft posts card state is toggled, then pref is updated`() {
         val cardType = CardType.DRAFT_POSTS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHidePostDashboardCard(site.siteId, PostCardType.DRAFT.name, false)
     }
@@ -188,8 +190,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when scheduled posts card state is toggled, then pref is updated`() {
         val cardType = CardType.SCHEDULED_POSTS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHidePostDashboardCard(site.siteId, PostCardType.SCHEDULED.name, false)
     }
@@ -198,8 +200,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when pages card state is toggled, then pref is updated`() {
         val cardType = CardType.PAGES
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHidePagesDashboardCard(site.siteId, false)
     }
@@ -208,8 +210,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when activity log card state is toggled, then pref is updated`() {
         val cardType = CardType.ACTIVITY_LOG
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHideActivityDashboardCard(site.siteId, false)
     }
@@ -218,8 +220,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when blaze card state is toggled, then pref is updated`() {
         val cardType = CardType.BLAZE
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHideBlazeCard(site.siteId, false)
     }
@@ -228,8 +230,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when blogging prompts card state is toggled, then pref is updated`() = test {
         val cardType = CardType.BLOGGING_PROMPTS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(bloggingRemindersStore).updateBloggingReminders(
             userSetBloggingRemindersModel.copy(isPromptsCardEnabled = true)
@@ -240,8 +242,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `when next steps card state is toggled, then pref is updated`() {
         val cardType = CardType.NEXT_STEPS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(appPrefsWrapper).setShouldHideNextStepsDashboardCard(site.siteId, false)
     }
@@ -250,8 +252,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
     fun `given card disabled, when card state is toggled, then event is tracked`() {
         val cardType = CardType.STATS
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, true)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, true)
 
         verify(analyticsTrackerWrapper).track(
             AnalyticsTracker.Stat.PERSONALIZATION_SCREEN_CARD_SHOW_TAPPED,
@@ -264,8 +266,8 @@ class PersonalizationViewModelTest : BaseUnitTest() {
         val cardType = CardType.STATS
         whenever(appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(site.siteId)).thenReturn(false)
 
-        viewModel.start()
-        viewModel.onCardToggled(cardType, false)
+        viewModelSlice.start(123L)
+        viewModelSlice.onCardToggled(cardType, false)
 
         verify(analyticsTrackerWrapper).track(
             AnalyticsTracker.Stat.PERSONALIZATION_SCREEN_CARD_HIDE_TAPPED,


### PR DESCRIPTION
Part of #https://github.com/wordpress-mobile/WordPress-Android/issues/19270

## Description
This PR implements the personalization screen for shortcuts

## 📷  Screenshot
|  Light | Dark   | 
|---|---|
|   ![Screenshot_20230927_185104](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/0c2fd414-33ac-4d14-bac4-21140d226aa7)| ![Screenshot_20230927_185126](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/782217af-de64-4ede-a54b-bf8e065bacc6)  |   


## To test:
1. Go to jetpack  app 
2. Go to dashboard 
3. Click on personalize your home tab
4. Go to shortcuts
5. Verify that all the site items are shown in shortcuts

## Regression Notes
1. Potential unintended areas of impact
Nothing as this is a new screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unit tests

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
