### PR TITLE
Dashboard: unified menu Refactoring

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.mysite.cards.blaze.CampaignStatus
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptAttribution
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 
@@ -396,7 +397,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val secondaryText: UiString? = null,
             val showFocusPoint: Boolean = false,
             val onClick: ListItemInteraction,
-            val disablePrimaryIconTint: Boolean = false
+            val disablePrimaryIconTint: Boolean = false,
+            val listItemAction: ListItemAction
         ) : Item(LIST_ITEM, activeQuickStartItem = showFocusPoint)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -45,19 +45,22 @@ class SiteItemsBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_posts_white_24dp,
                 UiStringRes(R.string.my_site_btn_blog_posts),
-                onClick = ListItemInteraction.create(POSTS, params.onClick)
+                onClick = ListItemInteraction.create(POSTS, params.onClick),
+                listItemAction = POSTS
             ),
             siteListItemBuilder.buildPagesItemIfAvailable(params.site, params.onClick, showPagesFocusPoint),
             ListItem(
                 R.drawable.ic_media_white_24dp,
                 UiStringRes(R.string.media),
                 onClick = ListItemInteraction.create(MEDIA, params.onClick),
-                showFocusPoint = showMediaFocusPoint
+                showFocusPoint = showMediaFocusPoint,
+                listItemAction = MEDIA
             ),
             ListItem(
                 R.drawable.ic_comment_white_24dp,
                 UiStringRes(R.string.my_site_btn_comments),
-                onClick = ListItemInteraction.create(COMMENTS, params.onClick)
+                onClick = ListItemInteraction.create(COMMENTS, params.onClick),
+                listItemAction = COMMENTS
             )
         )
     }
@@ -78,7 +81,8 @@ class SiteItemsBuilder @Inject constructor(
                 R.drawable.ic_stats_alt_white_24dp,
                 UiStringRes(R.string.stats),
                 onClick = ListItemInteraction.create(ListItemAction.STATS, params.onClick),
-                showFocusPoint = showStatsFocusPoint
+                showFocusPoint = showStatsFocusPoint,
+                listItemAction = ListItemAction.STATS
             ),
             siteListItemBuilder.buildBlazeItemIfAvailable(params.isBlazeEligible, params.onClick)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -49,7 +49,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_history_white_24dp,
                 UiStringRes(R.string.activity_log),
-                onClick = ListItemInteraction.create(ACTIVITY_LOG, onClick)
+                onClick = ListItemInteraction.create(ACTIVITY_LOG, onClick),
+                listItemAction = ACTIVITY_LOG
             )
         } else null
     }
@@ -59,7 +60,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_gridicons_cloud_upload_white_24dp,
                 UiStringRes(R.string.backup),
-                onClick = ListItemInteraction.create(BACKUP, onClick)
+                onClick = ListItemInteraction.create(BACKUP, onClick),
+                listItemAction = BACKUP
             )
         } else null
     }
@@ -69,7 +71,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_baseline_security_white_24dp,
                 UiStringRes(R.string.scan),
-                onClick = ListItemInteraction.create(SCAN, onClick)
+                onClick = ListItemInteraction.create(SCAN, onClick),
+                listItemAction = SCAN
             )
         } else null
     }
@@ -91,7 +94,8 @@ class SiteListItemBuilder @Inject constructor(
                 UiStringRes(R.string.plan),
                 secondaryText = UiStringText(planShortName),
                 onClick = ListItemInteraction.create(PLAN, onClick),
-                showFocusPoint = showFocusPoint
+                showFocusPoint = showFocusPoint,
+                listItemAction = PLAN
             )
         } else null
     }
@@ -106,7 +110,8 @@ class SiteListItemBuilder @Inject constructor(
                 R.drawable.ic_pages_white_24dp,
                 UiStringRes(R.string.my_site_btn_site_pages),
                 onClick = ListItemInteraction.create(PAGES, onClick),
-                showFocusPoint = showFocusPoint
+                showFocusPoint = showFocusPoint,
+                listItemAction = PAGES
             )
         } else null
     }
@@ -117,7 +122,8 @@ class SiteListItemBuilder @Inject constructor(
                 R.drawable.ic_wordpress_white_24dp,
                 UiStringRes(R.string.my_site_btn_wp_admin),
                 secondaryIcon = R.drawable.ic_external_white_24dp,
-                onClick = ListItemInteraction.create(ADMIN, onClick)
+                onClick = ListItemInteraction.create(ADMIN, onClick),
+                listItemAction = ADMIN
             )
         } else null
     }
@@ -127,7 +133,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_user_white_24dp,
                 UiStringRes(R.string.people),
-                onClick = ListItemInteraction.create(PEOPLE, onClick)
+                onClick = ListItemInteraction.create(PEOPLE, onClick),
+                listItemAction = PEOPLE
             )
         } else null
     }
@@ -137,7 +144,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_plugins_white_24dp,
                 UiStringRes(R.string.my_site_btn_plugins),
-                onClick = ListItemInteraction.create(PLUGINS, onClick)
+                onClick = ListItemInteraction.create(PLUGINS, onClick),
+                listItemAction = PLUGINS
             )
         } else null
     }
@@ -152,7 +160,8 @@ class SiteListItemBuilder @Inject constructor(
                 R.drawable.ic_share_white_24dp,
                 UiStringRes(R.string.my_site_btn_sharing),
                 showFocusPoint = showFocusPoint,
-                onClick = ListItemInteraction.create(SHARING, onClick)
+                onClick = ListItemInteraction.create(SHARING, onClick),
+                listItemAction = SHARING
             )
         } else null
     }
@@ -165,7 +174,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_domains_white_24dp,
                 UiStringRes(R.string.my_site_btn_domains),
-                onClick = ListItemInteraction.create(DOMAINS, onClick)
+                onClick = ListItemInteraction.create(DOMAINS, onClick),
+                listItemAction = DOMAINS
             )
         } else null
     }
@@ -175,7 +185,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_cog_white_24dp,
                 UiStringRes(R.string.my_site_btn_site_settings),
-                onClick = ListItemInteraction.create(SITE_SETTINGS, onClick)
+                onClick = ListItemInteraction.create(SITE_SETTINGS, onClick),
+                listItemAction = SITE_SETTINGS
             )
         } else null
     }
@@ -192,7 +203,8 @@ class SiteListItemBuilder @Inject constructor(
                 R.drawable.ic_user_primary_white_24,
                 UiStringRes(R.string.me),
                 onClick = ListItemInteraction.create(ListItemAction.ME, onClick),
-                disablePrimaryIconTint = true
+                disablePrimaryIconTint = true,
+                listItemAction = ListItemAction.ME
             )
         } else null
     }
@@ -203,7 +215,8 @@ class SiteListItemBuilder @Inject constructor(
                 R.drawable.ic_promote_with_blaze,
                 UiStringRes(R.string.blaze_menu_item_label),
                 onClick = ListItemInteraction.create(BLAZE, onClick),
-                disablePrimaryIconTint = true
+                disablePrimaryIconTint = true,
+                listItemAction = BLAZE
             )
         } else null
     }
@@ -227,7 +240,8 @@ class SiteListItemBuilder @Inject constructor(
             ListItem(
                 R.drawable.ic_themes_white_24dp,
                 UiStringRes(R.string.themes),
-                onClick = ListItemInteraction.create(THEMES, onClick)
+                onClick = ListItemInteraction.create(THEMES, onClick),
+                listItemAction = THEMES
             )
         } else null
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -48,6 +48,7 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 import javax.inject.Inject
@@ -269,7 +270,8 @@ class MenuActivity : ComponentActivity() {
                 secondaryIcon = null,
                 secondaryText = null,
                 showFocusPoint = false,
-                onClick = ListItemInteraction.create { onClick() })
+                onClick = ListItemInteraction.create { onClick() },
+                listItemAction = ListItemAction.POSTS)
             )
     }
 
@@ -284,7 +286,8 @@ class MenuActivity : ComponentActivity() {
                 secondaryIcon = null,
                 secondaryText = null,
                 showFocusPoint = true,
-                onClick = ListItemInteraction.create { onClick() })
+                onClick = ListItemInteraction.create { onClick() },
+                listItemAction = ListItemAction.POSTS)
         )
     }
 
@@ -299,7 +302,8 @@ class MenuActivity : ComponentActivity() {
                 secondaryIcon = null,
                 secondaryText = UiString.UiStringText("Basic"),
                 showFocusPoint = false,
-                onClick = ListItemInteraction.create { onClick() })
+                onClick = ListItemInteraction.create { onClick() },
+                listItemAction = ListItemAction.PLAN)
         )
     }
 
@@ -314,7 +318,8 @@ class MenuActivity : ComponentActivity() {
                 secondaryIcon = R.drawable.ic_story_icon_24dp,
                 secondaryText = null,
                 showFocusPoint = false,
-                onClick = ListItemInteraction.create { onClick() })
+                onClick = ListItemInteraction.create { onClick() },
+                listItemAction = ListItemAction.PLAN)
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -174,37 +174,48 @@ class PersonalizationActivity : ComponentActivity() {
                 modifier = Modifier
                     .fillMaxWidth()
             ) {
-                item {
-                    Text(
-                        modifier = Modifier.padding(start = 16.dp),
-                        text = stringResource(id = R.string.personalization_screen_tab_shortcuts_active_shortcuts),
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
-                    )
+                val activeShortcuts = state.activeShortCuts
+                if (activeShortcuts.isNotEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier.padding(start = 16.dp),
+                            text = stringResource(id = R.string.personalization_screen_tab_shortcuts_active_shortcuts),
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+                        )
+                    }
+                    items(activeShortcuts.size) { index ->
+                        val cardState = activeShortcuts[index]
+                        ShortcutStateRow(
+                            state = cardState,
+                            actionIcon = R.drawable.ic_personalization_quick_link_remove_circle,
+                            actionIconTint = Color(0xFFD63638)
+                        )
+                    }
                 }
-                items(state.activeShortCuts.size) { index ->
-                    val cardState = state.activeShortCuts[index]
-                    ShortcutStateRow(
-                        state = cardState,
-                    )
-                }
+                val inactiveShortcuts = state.inactiveShortCuts
+                if (inactiveShortcuts.isNotEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp),
+                            text = stringResource(
+                                id = R.string.personalization_screen_tab_shortcuts_inactive_shortcuts
+                            ),
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                        )
+                    }
 
-                item {
-                    Text(
-                        modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp),
-                        text = stringResource(id = R.string.personalization_screen_tab_shortcuts_inactive_shortcuts),
-                        fontSize = 13.sp,
-                        fontWeight = FontWeight.Normal,
-                        color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-                    )
-                }
-
-                items(state.inactiveShortCuts.size) { index ->
-                    val cardState = state.inactiveShortCuts[index]
-                    ShortcutStateRow(
-                        state = cardState,
-                    )
+                    items(inactiveShortcuts.size) { index ->
+                        val cardState = inactiveShortcuts[index]
+                        ShortcutStateRow(
+                            state = cardState,
+                            actionIcon = R.drawable.ic_personalization_shortcuts_plus_circle,
+                            actionIconTint = Color(0xFF008710)
+                        )
+                    }
                 }
             }
         }
@@ -263,6 +274,8 @@ fun DashboardCardStateRow(
 @Composable
 fun ShortcutStateRow(
     state: ShortcutState,
+    actionIcon: Int,
+    actionIconTint: Color,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -310,15 +323,9 @@ fun ShortcutStateRow(
                     .padding(1.dp),
                 onClick = {}
             ) {
-                val icon = if (state.isActive) R.drawable.ic_personalization_quick_link_remove_circle
-                else R.drawable.ic_personalization_shortcuts_plus_circle
-
-                val iconTint = if (state.isActive) Color(0xFFD63638)
-                else Color(0xFF008710)
-
                 Icon(
-                    painter = painterResource(id = icon),
-                    tint = iconTint,
+                    painter = painterResource(id = actionIcon),
+                    tint = actionIconTint,
                     contentDescription = stringResource(
                         R.string.personalization_screen_shortcuts_add_or_remove_shortcut_button
                     ),
@@ -337,7 +344,9 @@ fun PersonalizationScreenPreview() {
                 label = UiString.UiStringRes(R.string.media),
                 icon = R.drawable.media_icon_circle,
                 isActive = true
-            )
+            ),
+            actionIcon = R.drawable.ic_personalization_shortcuts_plus_circle,
+            actionIconTint = Color(0xFF008710)
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -162,7 +162,7 @@ class PersonalizationActivity : ComponentActivity() {
     }
 
     @Composable
-    fun ShortCutsPersonalizationContent(cardStateList: List<ShortcutsState>, modifier: Modifier = Modifier) {
+    fun ShortCutsPersonalizationContent(state: ShortcutsState, modifier: Modifier = Modifier) {
         Column(
             modifier = modifier
                 .fillMaxWidth()
@@ -183,8 +183,8 @@ class PersonalizationActivity : ComponentActivity() {
                         color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
                     )
                 }
-                items(cardStateList.size) { index ->
-                    val cardState = cardStateList[index]
+                items(state.activeShortCuts.size) { index ->
+                    val cardState = state.activeShortCuts[index]
                     ShortcutStateRow(
                         state = cardState,
                     )
@@ -197,6 +197,13 @@ class PersonalizationActivity : ComponentActivity() {
                         fontSize = 13.sp,
                         fontWeight = FontWeight.Normal,
                         color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+                    )
+                }
+
+                items(state.inactiveShortCuts.size) { index ->
+                    val cardState = state.inactiveShortCuts[index]
+                    ShortcutStateRow(
+                        state = cardState,
                     )
                 }
             }
@@ -255,7 +262,7 @@ fun DashboardCardStateRow(
 
 @Composable
 fun ShortcutStateRow(
-    state: ShortcutsState,
+    state: ShortcutState,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -326,7 +333,7 @@ fun ShortcutStateRow(
 fun PersonalizationScreenPreview() {
     AppTheme {
         ShortcutStateRow(
-            state = ShortcutsState(
+            state = ShortcutState(
                 label = UiString.UiStringRes(R.string.media),
                 icon = R.drawable.media_icon_circle,
                 isActive = true

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.UiString
 
 @AndroidEntryPoint
@@ -186,11 +187,12 @@ class PersonalizationActivity : ComponentActivity() {
                         )
                     }
                     items(activeShortcuts.size) { index ->
-                        val cardState = activeShortcuts[index]
+                        val shortcutState = activeShortcuts[index]
                         ShortcutStateRow(
-                            state = cardState,
+                            state = shortcutState,
                             actionIcon = R.drawable.ic_personalization_quick_link_remove_circle,
-                            actionIconTint = Color(0xFFD63638)
+                            actionIconTint = Color(0xFFD63638),
+                            actionButtonClick = { viewModel.removeShortcut(shortcutState)}
                         )
                     }
                 }
@@ -209,11 +211,12 @@ class PersonalizationActivity : ComponentActivity() {
                     }
 
                     items(inactiveShortcuts.size) { index ->
-                        val cardState = inactiveShortcuts[index]
+                        val shortcutState = inactiveShortcuts[index]
                         ShortcutStateRow(
-                            state = cardState,
+                            state = shortcutState,
                             actionIcon = R.drawable.ic_personalization_shortcuts_plus_circle,
-                            actionIconTint = Color(0xFF008710)
+                            actionIconTint = Color(0xFF008710),
+                            actionButtonClick = { viewModel.addShortcut(shortcutState) },
                         )
                     }
                 }
@@ -276,6 +279,7 @@ fun ShortcutStateRow(
     state: ShortcutState,
     actionIcon: Int,
     actionIconTint: Color,
+    actionButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -321,7 +325,7 @@ fun ShortcutStateRow(
                 modifier = modifier
                     .size(24.dp)
                     .padding(1.dp),
-                onClick = {}
+                onClick = { actionButtonClick() }
             ) {
                 Icon(
                     painter = painterResource(id = actionIcon),
@@ -343,10 +347,12 @@ fun PersonalizationScreenPreview() {
             state = ShortcutState(
                 label = UiString.UiStringRes(R.string.media),
                 icon = R.drawable.media_icon_circle,
-                isActive = true
+                isActive = true,
+                listItemAction = ListItemAction.MEDIA
             ),
             actionIcon = R.drawable.ic_personalization_shortcuts_plus_circle,
-            actionIconTint = Color(0xFF008710)
+            actionIconTint = Color(0xFF008710),
+            actionButtonClick = { },
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -41,4 +41,14 @@ class PersonalizationViewModel @Inject constructor(
         shortcutsPersonalizationViewModelSlice.onCleared()
         dashboardCardPersonalizationViewModelSlice.onCleared()
     }
+
+    fun removeShortcut(shortcutState: ShortcutState) {
+        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
+        shortcutsPersonalizationViewModelSlice.removeShortcut(shortcutState,siteId)
+    }
+
+    fun addShortcut(shortcutState: ShortcutState) {
+        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
+        shortcutsPersonalizationViewModelSlice.addShortcut(shortcutState,siteId)
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutState.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.personalization
 
 import androidx.annotation.DrawableRes
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.UiString
 
 data class ShortcutsState(
@@ -12,5 +13,6 @@ data class ShortcutState(
     @DrawableRes val icon: Int,
     val label: UiString.UiStringRes,
     val isActive: Boolean = false,
-    val disableTint : Boolean = false
+    val disableTint : Boolean = false,
+    val listItemAction: ListItemAction
 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutState.kt
@@ -4,6 +4,11 @@ import androidx.annotation.DrawableRes
 import org.wordpress.android.ui.utils.UiString
 
 data class ShortcutsState(
+    val activeShortCuts: List<ShortcutState>,
+    val inactiveShortCuts: List<ShortcutState>,
+)
+
+data class ShortcutState(
     @DrawableRes val icon: Int,
     val label: UiString.UiStringRes,
     val isActive: Boolean = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/ShortcutsPersonalizationViewModelSlice.kt
@@ -32,9 +32,9 @@ class ShortcutsPersonalizationViewModelSlice @Inject constructor(
         this.scope = scope
     }
 
-    private val _uiState = MutableStateFlow(emptyList<ShortcutsState>())
+    private val _uiState = MutableStateFlow(ShortcutsState(emptyList(), emptyList()))
 
-    val uiState: StateFlow<List<ShortcutsState>> = _uiState
+    val uiState: StateFlow<ShortcutsState> = _uiState
 
     fun start(site: SiteModel) {
         _uiState.value = convertToShortCutsState(
@@ -54,16 +54,20 @@ class ShortcutsPersonalizationViewModelSlice @Inject constructor(
         updateSiteItemsForJetpackCapabilities(site)
     }
 
-    private fun convertToShortCutsState(items: List<MySiteCardAndItem>, siteId: Long): List<ShortcutsState> {
+    private fun convertToShortCutsState(items: List<MySiteCardAndItem>, siteId: Long): ShortcutsState {
         val listItems = items.filterIsInstance(MySiteCardAndItem.Item.ListItem::class.java)
-        return listItems.map { listItem ->
-            ShortcutsState(
+        val shortcuts = listItems.map { listItem ->
+            ShortcutState(
                 icon = listItem.primaryIcon,
                 label = listItem.primaryText as UiString.UiStringRes,
                 disableTint = listItem.disablePrimaryIconTint,
                 isActive = isActiveShortcut(listItem.listItemAction, siteId)
             )
         }
+        return ShortcutsState(
+            activeShortCuts = shortcuts.filter { it.isActive },
+            inactiveShortCuts = shortcuts.filter { !it.isActive }
+        )
     }
 
     private fun updateSiteItemsForJetpackCapabilities(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1801,8 +1801,8 @@ public class AppPrefs {
     }
 
     public static void setShouldShowDefaultQuickLink(final String siteItem, final long siteId,
-                                                        final boolean isHidden) {
-        prefs().edit().putBoolean(getShouldShowDefaultQuickLinkKey(siteItem, siteId), isHidden).apply();
+                                                        final boolean shouldShow) {
+        prefs().edit().putBoolean(getShouldShowDefaultQuickLinkKey(siteItem, siteId), shouldShow).apply();
     }
 
     @NonNull private static String getShouldShowDefaultQuickLinkKey(String siteItem, long siteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -203,7 +203,9 @@ public class AppPrefs {
         SHOULD_HIDE_TODAY_STATS_DASHBOARD_CARD,
         SHOULD_HIDE_POST_DASHBOARD_CARD,
         SHOULD_HIDE_NEXT_STEPS_DASHBOARD_CARD,
-        SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD
+        SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD,
+
+        SHOULD_SHOW_SITE_ITEM_AS_QUICK_LINK_IN_DASHBOARD,
     }
 
     /**
@@ -376,7 +378,7 @@ public class AppPrefs {
     }
 
     public static void putLong(final PrefKey key, final long value) {
-        prefs().edit().putLong(key.name(), value) .apply();
+        prefs().edit().putLong(key.name(), value).apply();
     }
 
     private static int getInt(PrefKey key, int def) {
@@ -1782,5 +1784,18 @@ public class AppPrefs {
 
     public static Boolean getShouldHideGetToKnowTheAppDashboardCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHideGetToKnowTheAppDashboardCardKey(siteId), false);
+    }
+
+    public static void setShouldShowSiteItemAsQuickLink(final String siteItem, final long siteId,
+                                                        final boolean isHidden) {
+        prefs().edit().putBoolean(getShouldShowSiteItemAsQuickLinkKey(siteItem, siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getShouldShowSiteItemAsQuickLinkKey(String siteItem, long siteId) {
+        return DeletablePrefKey.SHOULD_SHOW_SITE_ITEM_AS_QUICK_LINK_IN_DASHBOARD.name() + siteItem + siteId;
+    }
+
+    public static Boolean getShouldShowSiteItemAsQuickLink(String siteItem, final long siteId) {
+        return prefs().getBoolean(getShouldShowSiteItemAsQuickLinkKey(siteItem, siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -206,6 +206,7 @@ public class AppPrefs {
         SHOULD_HIDE_GET_TO_KNOW_THE_APP_DASHBOARD_CARD,
 
         SHOULD_SHOW_SITE_ITEM_AS_QUICK_LINK_IN_DASHBOARD,
+        SHOULD_SHOW_DEFAULT_QUICK_LINK_IN_DASHBOARD,
     }
 
     /**
@@ -1797,5 +1798,18 @@ public class AppPrefs {
 
     public static Boolean getShouldShowSiteItemAsQuickLink(String siteItem, final long siteId) {
         return prefs().getBoolean(getShouldShowSiteItemAsQuickLinkKey(siteItem, siteId), false);
+    }
+
+    public static void setShouldShowDefaultQuickLink(final String siteItem, final long siteId,
+                                                        final boolean isHidden) {
+        prefs().edit().putBoolean(getShouldShowDefaultQuickLinkKey(siteItem, siteId), isHidden).apply();
+    }
+
+    @NonNull private static String getShouldShowDefaultQuickLinkKey(String siteItem, long siteId) {
+        return DeletablePrefKey.SHOULD_SHOW_DEFAULT_QUICK_LINK_IN_DASHBOARD.name() + siteItem + siteId;
+    }
+
+    public static Boolean getShouldShowDefaultQuickLink(String siteItem, final long siteId) {
+        return prefs().getBoolean(getShouldShowDefaultQuickLinkKey(siteItem, siteId), true);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -416,10 +416,10 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.getShouldShowSiteItemAsQuickLink(siteItem, siteId)
 
     fun setShouldShowDefaultQuickLink(siteItem: String, siteId: Long, shouldShow: Boolean) =
-        AppPrefs.setShouldShowSiteItemAsQuickLink(siteItem, siteId, shouldShow)
+        AppPrefs.setShouldShowDefaultQuickLink(siteItem, siteId, shouldShow)
 
     fun getShouldShowDefaultQuickLink(siteItem: String, siteId: Long): Boolean =
-        AppPrefs.getShouldShowSiteItemAsQuickLink(siteItem, siteId)
+        AppPrefs.getShouldShowDefaultQuickLink(siteItem, siteId)
 
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -409,6 +409,18 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideGetToKnowTheAppDashboardCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideGetToKnowTheAppDashboardCard(siteId)
 
+    fun setShouldShowSiteItemAsQuickLink(siteItem: String, siteId: Long, shouldShow: Boolean) =
+        AppPrefs.setShouldShowSiteItemAsQuickLink(siteItem, siteId, shouldShow)
+
+    fun getShouldShowSiteItemAsQuickLink(siteItem: String, siteId: Long): Boolean =
+        AppPrefs.getShouldShowSiteItemAsQuickLink(siteItem, siteId)
+
+    fun setShouldShowDefaultQuickLink(siteItem: String, siteId: Long, shouldShow: Boolean) =
+        AppPrefs.setShouldShowSiteItemAsQuickLink(siteItem, siteId, shouldShow)
+
+    fun getShouldShowDefaultQuickLink(siteItem: String, siteId: Long): Boolean =
+        AppPrefs.getShouldShowSiteItemAsQuickLink(siteItem, siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteCardAndItemTest.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard.IconState.Visible
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringText
 
@@ -96,6 +97,7 @@ class MySiteCardAndItemTest {
         secondaryIcon = null,
         secondaryText = null,
         showFocusPoint = showFocusPoint,
-        onClick = interaction
+        onClick = interaction,
+        listItemAction = ListItemAction.PAGES
     )
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -20,82 +20,98 @@ val PLAN_ITEM = ListItem(
     R.drawable.ic_plans_white_24dp,
     UiStringRes(R.string.plan),
     secondaryText = UiStringText(PLAN_NAME),
-    onClick = ListItemInteraction.create(ListItemAction.PLAN, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.PLAN, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.PLAN
 )
 
 val STATS_ITEM = ListItem(
     R.drawable.ic_stats_alt_white_24dp,
     UiStringRes(R.string.stats),
-    onClick = ListItemInteraction.create(ListItemAction.STATS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.STATS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.STATS
 )
 val ACTIVITY_ITEM = ListItem(
     R.drawable.ic_history_white_24dp,
     UiStringRes(R.string.activity_log),
-    onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.ACTIVITY_LOG, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.ACTIVITY_LOG
 )
 val BACKUP_ITEM = ListItem(
     R.drawable.ic_gridicons_cloud_upload_white_24dp,
     UiStringRes(R.string.backup),
-    onClick = ListItemInteraction.create(ListItemAction.BACKUP, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.BACKUP, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.BACKUP
 )
 val SCAN_ITEM = ListItem(
     R.drawable.ic_baseline_security_white_24dp,
     UiStringRes(R.string.scan),
-    onClick = ListItemInteraction.create(ListItemAction.SCAN, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.SCAN, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.SCAN
 )
 val PAGES_ITEM = ListItem(
     R.drawable.ic_pages_white_24dp,
     UiStringRes(R.string.my_site_btn_site_pages),
-    onClick = ListItemInteraction.create(ListItemAction.PAGES, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.PAGES, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.PAGES
 )
 val POSTS_ITEM = ListItem(
     R.drawable.ic_posts_white_24dp,
     UiStringRes(R.string.my_site_btn_blog_posts),
-    onClick = ListItemInteraction.create(ListItemAction.POSTS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.POSTS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.POSTS
 )
 val MEDIA_ITEM = ListItem(
     R.drawable.ic_media_white_24dp,
     UiStringRes(R.string.media),
-    onClick = ListItemInteraction.create(ListItemAction.MEDIA, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.MEDIA, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.MEDIA
 )
 val COMMENTS_ITEM = ListItem(
     R.drawable.ic_comment_white_24dp,
     UiStringRes(R.string.my_site_btn_comments),
-    onClick = ListItemInteraction.create(ListItemAction.COMMENTS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.COMMENTS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.COMMENTS
 )
 val ADMIN_ITEM = ListItem(
     R.drawable.ic_wordpress_white_24dp,
     UiStringRes(R.string.my_site_btn_wp_admin),
     secondaryIcon = R.drawable.ic_external_white_24dp,
-    onClick = ListItemInteraction.create(ListItemAction.ADMIN, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.ADMIN, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.ADMIN
 )
 val PEOPLE_ITEM = ListItem(
     R.drawable.ic_user_white_24dp,
     UiStringRes(R.string.people),
-    onClick = ListItemInteraction.create(ListItemAction.PEOPLE, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.PEOPLE, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.PEOPLE
 )
 val PLUGINS_ITEM = ListItem(
     R.drawable.ic_plugins_white_24dp,
     UiStringRes(R.string.my_site_btn_plugins),
-    onClick = ListItemInteraction.create(ListItemAction.PLUGINS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.PLUGINS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.PLUGINS
 )
 val SHARING_ITEM = ListItem(
     R.drawable.ic_share_white_24dp,
     UiStringRes(R.string.my_site_btn_sharing),
-    onClick = ListItemInteraction.create(ListItemAction.SHARING, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.SHARING, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.SHARING
 )
 val SITE_SETTINGS_ITEM = ListItem(
     R.drawable.ic_cog_white_24dp,
     UiStringRes(R.string.my_site_btn_site_settings),
-    onClick = ListItemInteraction.create(ListItemAction.SITE_SETTINGS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.SITE_SETTINGS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.SITE_SETTINGS
 )
 val THEMES_ITEM = ListItem(
     R.drawable.ic_themes_white_24dp,
     UiStringRes(R.string.themes),
-    onClick = ListItemInteraction.create(ListItemAction.THEMES, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(ListItemAction.THEMES, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.THEMES
 )
 val DOMAINS_ITEM = ListItem(
     R.drawable.ic_domains_white_24dp,
     UiStringRes(R.string.my_site_btn_domains),
-    onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION)
+    onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION),
+    listItemAction = DOMAINS
 )


### PR DESCRIPTION
Parent #19270 

- Add ListItemAction to ListItem
- Add logic to hide/show quick link preferences
- Update ShortCutsState to include ListItemAction
- Handle action button click within the Personalize Shortcuts View

Note: RTL will be handled in a separate PR

To test:
- Install the app
- Navigate to jetpack app
- Navigate to dashboard
- Tap on the personalize your home tab card
- Navigate to the shortcuts tab
- Tap on an "-" icon for an item within the Active Shortcuts list 
- ✅ Verify the item moved to the Inactive Shortcuts list
- Tap on an "+" icon for an item within the Inactive Shortcuts list 
- ✅ Verify the item moved to the Active Shortcuts list


## Regression Notes
1. Potential unintended areas of impact
The item doesn't move between the active/inactive lists

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)