### PR TITLE
[Reader Improvements] Implement new design for tags section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -68,6 +68,7 @@ sealed class ReaderCardUiState {
     data class ReaderInterestsCardUiState(val interest: List<ReaderInterestUiState>) : ReaderCardUiState() {
         data class ReaderInterestUiState(
             val interest: String,
+            val slug: String,
             val onClicked: ((String) -> Unit),
             val chipStyle: ChipStyle
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterest
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderRecommendedBlogsCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderWelcomeBannerCardUiState
+import org.wordpress.android.ui.reader.discover.viewholders.ReaderInterestsCardNewViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderInterestsCardViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderPostViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogsCardNewViewHolder
@@ -33,7 +34,13 @@ class ReaderDiscoverAdapter(
         return when (viewType) {
             welcomeBannerViewType -> WelcomeBannerViewHolder(parent)
             postViewType -> ReaderPostViewHolder(uiHelpers, imageManager, readerTracker, parent)
-            interestViewType -> ReaderInterestsCardViewHolder(uiHelpers, parent)
+            interestViewType -> {
+                if (isReaderImprovementsEnabled) {
+                    ReaderInterestsCardNewViewHolder(uiHelpers, parent)
+                } else {
+                    ReaderInterestsCardViewHolder(uiHelpers, parent)
+                }
+            }
             recommendedBlogsViewType ->
                 if (isReaderImprovementsEnabled) {
                     ReaderRecommendedBlogsCardNewViewHolder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderInterestNewAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderInterestNewAdapter.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.ui.reader.discover
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ReaderInterestUiState
+import org.wordpress.android.ui.reader.discover.viewholders.ReaderInterestNewViewHolder
+import org.wordpress.android.ui.utils.UiHelpers
+
+class ReaderInterestNewAdapter(
+    private val uiHelpers: UiHelpers
+) : Adapter<ReaderInterestNewViewHolder>() {
+    private val items = mutableListOf<ReaderInterestUiState>()
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderInterestNewViewHolder {
+        return ReaderInterestNewViewHolder(uiHelpers, parent)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ReaderInterestNewViewHolder, position: Int) {
+        holder.onBind(items[position])
+    }
+
+    fun update(newItems: List<ReaderInterestUiState>) {
+        val diffResult = DiffUtil.calculateDiff(InterestDiffUtil(items, newItems))
+        items.clear()
+        items.addAll(newItems)
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    class InterestDiffUtil(
+        private val oldList: List<ReaderInterestUiState>,
+        private val newList: List<ReaderInterestUiState>
+    ) : Callback() {
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val newItem = newList[newItemPosition]
+            val oldItem = oldList[oldItemPosition]
+
+            return (oldItem == newItem)
+        }
+
+        override fun getOldListSize(): Int = oldList.size
+
+        override fun getNewListSize(): Int = newList.size
+
+        override fun areContentsTheSame(
+            oldItemPosition: Int,
+            newItemPosition: Int
+        ): Boolean = oldList[oldItemPosition] == newList[newItemPosition]
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -199,6 +199,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
             return@withContext ReaderInterestsCardUiState(interests.take(listSize).map { interest ->
                 ReaderInterestUiState(
                     interest = interest.tagTitle,
+                    slug = interest.tagSlug,
                     onClicked = onClicked,
                     chipStyle = buildChipStyle(interest, interests)
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestNewViewHolder.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.reader.discover.viewholders
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.databinding.ReaderInterestItemNewBinding
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderInterestsCardUiState.ReaderInterestUiState
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.viewBinding
+
+class ReaderInterestNewViewHolder(
+    private val uiHelpers: UiHelpers,
+    parent: ViewGroup,
+    private val binding: ReaderInterestItemNewBinding = parent.viewBinding(ReaderInterestItemNewBinding::inflate)
+) : RecyclerView.ViewHolder(binding.root) {
+    fun onBind(uiState: ReaderInterestUiState) = with(binding) {
+        uiHelpers.setTextOrHide(chip, uiState.interest)
+        chip.setOnClickListener { uiState.onClicked.invoke(uiState.interest) }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardNewViewHolder.kt
@@ -1,0 +1,104 @@
+package org.wordpress.android.ui.reader.discover.viewholders
+
+import android.graphics.Rect
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import org.wordpress.android.R
+import org.wordpress.android.databinding.ReaderInterestCardNewBinding
+import org.wordpress.android.ui.reader.discover.ReaderCardUiState
+import org.wordpress.android.ui.reader.discover.ReaderInterestNewAdapter
+import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.extensions.viewBinding
+import org.wordpress.android.widgets.RecyclerItemDecoration
+
+private const val Y_BUFFER = 10
+
+class ReaderInterestsCardNewViewHolder(
+    uiHelpers: UiHelpers,
+    parentView: ViewGroup
+) : ReaderViewHolder<ReaderInterestCardNewBinding>(parentView.viewBinding(ReaderInterestCardNewBinding::inflate)) {
+    init {
+        with(binding.recommendedTags) {
+            if (adapter == null) {
+                layoutManager = FlexboxLayoutManager(context, FlexDirection.ROW, FlexWrap.WRAP)
+                val readerInterestAdapter = ReaderInterestNewAdapter(uiHelpers)
+                setItemSpacing()
+                adapter = readerInterestAdapter
+            }
+        }
+    }
+
+    private fun RecyclerView.setItemSpacing() {
+        val spacingHorizontal = resources.getDimensionPixelSize(R.dimen.margin_small)
+        addItemDecoration(RecyclerItemDecoration(spacingHorizontal, 0, false))
+        addItemDecoration(object : RecyclerView.ItemDecoration() {
+            override fun getItemOffsets(
+                outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State
+            ) {
+                val spacingVertical = resources.getDimensionPixelSize(R.dimen.margin_medium)
+                if (parent.getChildAdapterPosition(view) == state.itemCount - 1) {
+                    outRect.setEmpty()
+                } else {
+                    outRect.set(0, 0, 0, spacingVertical)
+                }
+            }
+        })
+    }
+
+    override fun onBind(uiState: ReaderCardUiState) = with(binding) {
+        uiState as ReaderCardUiState.ReaderInterestsCardUiState
+        setOnTouchItemListener()
+        (recommendedTags.adapter as ReaderInterestNewAdapter).update(uiState.interest)
+    }
+
+    private fun setOnTouchItemListener() = with(binding) {
+        val gestureDetector = GestureDetector(recommendedTags.context, GestureListener())
+        recommendedTags.addOnItemTouchListener(object : RecyclerView.OnItemTouchListener {
+            override fun onInterceptTouchEvent(recyclerView: RecyclerView, e: MotionEvent): Boolean {
+                return gestureDetector.onTouchEvent(e)
+            }
+
+            override fun onTouchEvent(recyclerView: RecyclerView, e: MotionEvent) {
+                // NO OP
+            }
+
+            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                // NO OP
+            }
+        })
+    }
+
+    private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+        /**
+         * Capture the DOWN as soon as it's detected to prevent the viewPager from intercepting touch events
+         * We need to do this immediately, because if we don't, then the next move event could potentially
+         * trigger the viewPager to switch tabs
+         */
+        override fun onDown(e: MotionEvent): Boolean = with(binding) {
+            recommendedTags.parent.requestDisallowInterceptTouchEvent(true)
+            return super.onDown(e)
+        }
+
+        override fun onScroll(
+            e1: MotionEvent?,
+            e2: MotionEvent,
+            distanceX: Float,
+            distanceY: Float
+        ): Boolean = with(binding) {
+            if (kotlin.math.abs(distanceX) > kotlin.math.abs(distanceY)) {
+                // Detected a horizontal scroll, prevent the viewpager from switching tabs
+                recommendedTags.parent.requestDisallowInterceptTouchEvent(true)
+            } else if (kotlin.math.abs(distanceY) > Y_BUFFER) {
+                // Detected a vertical scroll allow the viewpager to switch tabs
+                recommendedTags.parent.requestDisallowInterceptTouchEvent(false)
+            }
+            return super.onScroll(e1, e2, distanceX, distanceY)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderInterestsCardNewViewHolder.kt
@@ -42,11 +42,7 @@ class ReaderInterestsCardNewViewHolder(
                 outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State
             ) {
                 val spacingVertical = resources.getDimensionPixelSize(R.dimen.margin_medium)
-                if (parent.getChildAdapterPosition(view) == state.itemCount - 1) {
-                    outRect.setEmpty()
-                } else {
-                    outRect.set(0, 0, 0, spacingVertical)
-                }
+                outRect.set(0, 0, 0, spacingVertical)
             }
         })
     }

--- a/WordPress/src/main/res/layout/reader_interest_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_card_new.xml
@@ -18,7 +18,7 @@
             android:id="@+id/root_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/margin_extra_large"
+            android:paddingBottom="@dimen/margin_medium"
             android:paddingTop="@dimen/margin_extra_large">
 
             <androidx.recyclerview.widget.RecyclerView

--- a/WordPress/src/main/res/layout/reader_interest_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_card_new.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:colorBackground">
+
+    <com.google.android.material.card.MaterialCardView
+        style="@style/ReaderCardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_large"
+        app:cardBackgroundColor="@color/reader_you_might_like_background"
+        app:cardCornerRadius="@dimen/margin_medium"
+        app:cardElevation="0dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/root_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/margin_extra_large"
+            android:paddingTop="@dimen/margin_extra_large">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recommended_tags"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/recommended_blogs_header" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/recommended_blogs_header"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_extra_large"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:text="@string/reader_discover_recommended_header_new"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="@color/reader_improvements_recommended_section_text"
+                android:textSize="@dimen/text_sz_medium"
+                app:layout_constraintBottom_toTopOf="@+id/recommended_tags"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/reader_interest_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item_new.xml
@@ -6,6 +6,7 @@
     style="@style/ReaderExpandableTagsViewChipNew"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:textColor="@color/material_on_background_emphasis_high_type"
     android:textSize="@dimen/text_sz_medium"
     app:chipBackgroundColor="@color/reader_you_might_like_background"
     tools:text="A Text in a chip" />

--- a/WordPress/src/main/res/layout/reader_interest_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item_new.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/chip"
+    style="@style/ReaderExpandableTagsViewChipNew"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textSize="@dimen/text_sz_medium"
+    app:chipBackgroundColor="@color/reader_you_might_like_background"
+    tools:text="A Text in a chip" />

--- a/WordPress/src/main/res/layout/reader_interest_item_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_item_new.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/chip"
-    style="@style/ReaderExpandableTagsViewChipNew"
+    style="@style/ReaderExpandableTagsViewChipInterestNew"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textColor="@color/material_on_background_emphasis_high_type"
-    android:textSize="@dimen/text_sz_medium"
-    app:chipBackgroundColor="@color/reader_you_might_like_background"
     tools:text="A Text in a chip" />

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -411,6 +411,12 @@
         <item name="chipStrokeWidth">@dimen/reader_expandable_tags_view_chip_new_border</item>
     </style>
 
+    <style name="ReaderExpandableTagsViewChipInterestNew" parent="@style/ReaderExpandableTagsViewChipNew">
+        <item name="android:textColor">@color/material_on_background_emphasis_high_type</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
+        <item name="chipBackgroundColor">@color/reader_you_might_like_background</item>
+    </style>
+
     <!-- Post Details -->
     <style name="ReaderTextView.PostDetail" />
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -738,7 +738,7 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
     }
 
     private fun createReaderInterestsCardUiState(readerTagList: ReaderTagList) =
-        ReaderInterestsCardUiState(readerTagList.map { ReaderInterestUiState("", mock(), mock()) })
+        ReaderInterestsCardUiState(readerTagList.map { ReaderInterestUiState("", "", mock(), mock()) })
 
     private fun createReaderRecommendedBlogsCardUiState(
         recommendedBlogs: List<ReaderBlog>,


### PR DESCRIPTION
Fixes #19083 

Design specs: zQnohyMpLzBzQ5jzMMKni3-fi

To test:
1 - Run JP and sign in;
2 - Open debug settings and enable `ReaderImprovementsFeatureConfig` FF;
3 - Open reader;
4 - Select "Discover" tab;
5 - Scroll until you find the "You might like" tags section;
6 - Verify the layout for light and dark themes: the tags section should have the new design. Make sure that clicking on tags action still works as expected;
7 - Repeat step 2 but this time disable the FF;
8 - Repeat steps 3-5 and verify the layout: the section layout should appear like it currently does in prod;

## Regression Notes
1. Potential unintended areas of impact
Existing tags section on Reader

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Updated `ReaderDiscoverViewModelTest.kt` but changes were mainly implemented on views.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
