### PR TITLE
Plans in site creation: Update domain selection screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -48,7 +48,6 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
-import org.wordpress.android.util.extensions.isOnSale
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
@@ -304,7 +303,9 @@ class SiteCreationDomainsViewModel @Inject constructor(
                 }
             }
 
-            data.forEachIndexed { index, domain ->
+            val sortedDomains = sortDomains(data)
+
+            sortedDomains.forEachIndexed { index, domain ->
                 val itemUiState = createAvailableItemUiState(domain, index)
                 items.add(itemUiState)
             }
@@ -312,15 +313,34 @@ class SiteCreationDomainsViewModel @Inject constructor(
         return items
     }
 
+    /**
+     *  Sort in the order
+     *  First two paid domains, become Recommended, and Best Alternative
+     *  First Free domain listed after above two paid domains
+     *  Then remaining paid domains
+     */
+    private fun sortDomains(domains: List<DomainModel>): List<DomainModel> {
+        val paidDomains = domains.filter { !it.isFree }
+        val freeDomains = domains.filter { it.isFree }
+
+        // Sort paid domains first
+        val sortedPaidDomains = paidDomains.sortedBy { it.productId }
+
+        // Get the first two paid domains
+        val recommendedAndBestAlternative = sortedPaidDomains.take(2)
+
+        // Create a list containing recommended and best alternative domains, and first free domain, then rest
+        return recommendedAndBestAlternative + freeDomains + sortedPaidDomains.drop(2)
+    }
+
+
     private fun createAvailableItemUiState(domain: DomainModel, index: Int): ListItemUiState {
         return when (plansInSiteCreationFeatureConfig.isEnabled()) {
             true -> {
-                val product = products[domain.productId]
                 New.DomainUiState(
                     domain.domainName,
                     cost = when {
                         domain.isFree -> Cost.Free
-                        product.isOnSale() -> Cost.OnSale(product?.combinedSaleCostDisplay.orEmpty(), domain.cost)
                         else -> Cost.Paid(domain.cost)
                     },
                     isSelected = domain.domainName == selectedDomain?.domainName,
@@ -331,7 +351,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
                             1 -> Tag.BestAlternative
                             else -> null
                         },
-                        if (product.isOnSale()) Tag.Sale else null,
                     ),
                 )
             }
@@ -517,8 +536,11 @@ private fun createSearchInputUiState(
                 sealed class Cost(val title: UiString) {
                     object Free : Cost(UiStringRes(R.string.free))
 
-                    data class Paid(private val titleCost: String) : Cost(UiStringText(titleCost)) {
-                        val subtitle = UiStringRes(R.string.site_creation_domain_cost)
+                    data class Paid(private val titleCost: String) : Cost(
+                        UiStringText(titleCost)
+                    ) {
+                        val strikeoutTitle = UiStringText(titleCost)
+                        val subtitle = UiStringRes(R.string.site_creation_domain_free_with_annual_plan)
                     }
 
                     data class OnSale(private val titleCost: String, private val strikeoutTitleCost: String) : Cost(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -314,25 +314,15 @@ class SiteCreationDomainsViewModel @Inject constructor(
     }
 
     /**
-     *  Sort in the order
      *  First two paid domains, become Recommended, and Best Alternative
-     *  First Free domain listed after above two paid domains
+     *  First Free domain listed after two paid domains
      *  Then remaining paid domains
      */
     private fun sortDomains(domains: List<DomainModel>): List<DomainModel> {
-        val paidDomains = domains.filter { !it.isFree }
-        val freeDomains = domains.filter { it.isFree }
-
-        // Sort paid domains first
-        val sortedPaidDomains = paidDomains.sortedBy { it.productId }
-
-        // Get the first two paid domains
-        val recommendedAndBestAlternative = sortedPaidDomains.take(2)
-
-        // Create a list containing recommended and best alternative domains, and first free domain, then rest
-        return recommendedAndBestAlternative + freeDomains + sortedPaidDomains.drop(2)
+        return domains.partition { !it.isFree }.let { (paidDomains, freeDomains) ->
+            paidDomains.take(2) + freeDomains + paidDomains.drop(2)
+        }
     }
-
 
     private fun createAvailableItemUiState(domain: DomainModel, index: Int): ListItemUiState {
         return when (plansInSiteCreationFeatureConfig.isEnabled()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -106,28 +106,24 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                 }
             }
             if (tags.none { it is Unavailable }) {
-                when (cost) {
-                    is Cost.OnSale -> {
-                        SalePrice(
-                            cost.strikeoutTitle.asString() to cost.title.asString(),
-                            cost.subtitle.asString(),
-                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                        )
-                    }
-
-                    is Cost.Paid -> {
-                        Plan(
-                            cost.strikeoutTitle.asString() to cost.title.asString(),
-                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                        )
-                    }
-
-                    else -> {
-                        Price(
-                            cost.title.asString(),
-                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                        )
-                    }
+                if (cost is Cost.OnSale) {
+                    SalePrice(
+                        cost.strikeoutTitle.asString() to cost.title.asString(),
+                        cost.subtitle.asString(),
+                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                    )
+                }
+                else if (cost is Cost.Paid) {
+                    Plan(
+                        cost.strikeoutTitle.asString() to cost.title.asString(),
+                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                    )
+                }
+                else {
+                    Price(
+                        cost.title.asString(),
+                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                    )
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -49,6 +49,7 @@ private val PrimaryFontSize = 17.sp
 private val StartPadding = 40.dp
 
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
     Column(Modifier.background(if (isSelected) HighlightBgColor else Unspecified)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -97,19 +97,37 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                         )
                     }
                 }
+                if (cost is Cost.Paid) {
+                    Text(
+                        text = cost.subtitle.asString(),
+                        color = colors.primary,
+                        fontSize = SecondaryFontSize,
+                    )
+                }
             }
             if (tags.none { it is Unavailable }) {
-                if (cost is Cost.OnSale) {
-                    SalePrince(
-                        cost.strikeoutTitle.asString() to cost.title.asString(),
-                        cost.subtitle.asString(),
-                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                    )
-                } else {
-                    Price(
-                        cost.title.asString(),
-                        modifier = Modifier.padding(start = Margin.ExtraLarge.value)
-                    )
+                when (cost) {
+                    is Cost.OnSale -> {
+                        SalePrice(
+                            cost.strikeoutTitle.asString() to cost.title.asString(),
+                            cost.subtitle.asString(),
+                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                        )
+                    }
+
+                    is Cost.Paid -> {
+                        Plan(
+                            cost.strikeoutTitle.asString() to cost.title.asString(),
+                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                        )
+                    }
+
+                    else -> {
+                        Price(
+                            cost.title.asString(),
+                            modifier = Modifier.padding(start = Margin.ExtraLarge.value)
+                        )
+                    }
                 }
             }
         }
@@ -128,7 +146,7 @@ private fun Price(text: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun SalePrince(title: Pair<String, String>, subtitle: String, modifier: Modifier = Modifier) {
+private fun SalePrice(title: Pair<String, String>, subtitle: String, modifier: Modifier = Modifier) {
     Column(
         modifier,
         horizontalAlignment = Alignment.End,
@@ -153,8 +171,27 @@ private fun SalePrince(title: Pair<String, String>, subtitle: String, modifier: 
             subtitle,
             color = colors.primary,
             fontSize = SecondaryFontSize,
-            modifier = Modifier.padding(top = 4.dp)
         )
+    }
+}
+
+@Composable
+private fun Plan(title: Pair<String, String>, modifier: Modifier = Modifier) {
+    Column(
+        modifier,
+        horizontalAlignment = Alignment.End,
+    ) {
+        title.let { (strikethroughText) ->
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    strikethroughText,
+                    color = SecondaryTextColor,
+                    fontSize = SecondaryFontSize,
+                    textDecoration = TextDecoration.LineThrough,
+                    modifier = Modifier.padding(end = 4.dp)
+                )
+            }
+        }
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -48,6 +48,7 @@ private val SecondaryFontSize = 13.sp
 private val PrimaryFontSize = 17.sp
 private val StartPadding = 40.dp
 
+
 @Composable
 fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
     Column(Modifier.background(if (isSelected) HighlightBgColor else Unspecified)) {
@@ -59,7 +60,11 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                     indication = rememberRipple(color = HighlightBgColor),
                     onClick = onClick::invoke,
                 )
-                .padding(vertical = Margin.ExtraLarge.value)
+                .then(if (cost is Cost.Paid) {
+                    Modifier.padding(top = Margin.ExtraLarge.value)
+                } else {
+                    Modifier.padding(vertical = Margin.ExtraLarge.value)
+                })
                 .padding(end = Margin.ExtraLarge.value)
         ) {
             Box(
@@ -97,13 +102,6 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                         )
                     }
                 }
-                if (cost is Cost.Paid) {
-                    Text(
-                        text = cost.subtitle.asString(),
-                        color = colors.primary,
-                        fontSize = SecondaryFontSize,
-                    )
-                }
             }
             if (tags.none { it is Unavailable }) {
                 if (cost is Cost.OnSale) {
@@ -125,6 +123,15 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                         modifier = Modifier.padding(start = Margin.ExtraLarge.value)
                     )
                 }
+            }
+        }
+        if (cost is Cost.Paid) {
+            Row(modifier = Modifier.padding(bottom = Margin.ExtraLarge.value, start = StartPadding)) {
+                Text(
+                    text = cost.subtitle.asString(),
+                    color = colors.primary,
+                    fontSize = SecondaryFontSize,
+                )
             }
         }
         Divider(thickness = 0.5.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/usecases/FetchDomainsUseCase.kt
@@ -44,7 +44,7 @@ class FetchDomainsUseCase @Inject constructor(
             vendor,
             onlyWordpressCom,
             includeWordpressCom = true,
-            includeDotBlogSubdomain = true
+            includeDotBlogSubdomain = false
         )
 
         return suspendCancellableCoroutine { cont ->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3399,6 +3399,7 @@
     <!-- Site Creation : Domains -->
     <string name="site_creation_domain_cost">per year</string>
     <string name="site_creation_domain_cost_sale">for the first year</string>
+    <string name="site_creation_domain_free_with_annual_plan">Free for the first year with annual paid plans</string>
     <string name="site_creation_domain_tag_best_alternative">Best Alternative</string>
     <string name="site_creation_domain_tag_recommended">Recommended</string>
     <string name="site_creation_domain_tag_sale">Sale</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
@@ -456,7 +457,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         assertThat(uiDomains).filteredOn { it.cost is Cost.Paid }.hasSameSizeAs(apiPaidDomains)
     }
 
-    @Test
+    @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
     fun `verify cost of sale domain results from api is 'OnSale'`() = testWithSuccessResultNewUi { (query) ->
         whenever(productsStore.fetchProducts(any())).thenReturn(OnProductsFetched(SALE_PRODUCTS))
 
@@ -468,7 +469,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
         assertThat(uiDomains).filteredOn { it.cost is Cost.OnSale }.hasSameSizeAs(SALE_PRODUCTS)
     }
 
-    @Test
+    @Test @Ignore("It is removed from UI for now, for being Free with annual plan")
     fun `verify sale domain results from api have tag 'Sale'`() = testWithSuccessResultNewUi { (query) ->
         whenever(productsStore.fetchProducts(any())).thenReturn(OnProductsFetched(SALE_PRODUCTS))
 


### PR DESCRIPTION
Fixes #19264 

<img width=320 src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/0909c453-4a13-461e-a049-8133e3104656" />

To test:

- `Launch` JP app
- `Go` to Me-> Debug settings
- `Switch` to `Remote Feature` tab, find `plans_in_site_creation` and enable it
-  `Switch` to **My Site** tab
- `Tap` the down arrow to the right of the site name on the My Site screen
- `Tap` the + icon at the top right on the Site picker screen
- `Select` ⊕ **Create WordPress.com site** on the modal dialog
- `Tap` Skip at top right on the first step (topic screen)
- `Tap` Skip at top right on the next step (theme screen)
- `Enter` a search query (whatever you want here)
- `Verify` that result domains are as shown in the screenshot above
  - The first two paid domains returned from API
  - The first one free domain returned from API
  -  The remaining items


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [xI have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
