### PR TITLE
[Crash Fix] Move callback initialization behind SDK check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -271,29 +271,6 @@ class AppInitializer @Inject constructor(
         }
     }
 
-    /**
-     * Data access auditing
-     * @link https://developer.android.com/guide/topics/data/audit-access
-     */
-    @RequiresApi(VERSION_CODES.R)
-    val appOpsCallback = object : AppOpsManager.OnOpNotedCallback() {
-        private fun logPrivateDataAccess(opCode: String, trace: String) {
-            AppLog.i(T.MAIN, "Private data accessed. Operation: $opCode\nStack Trace:\n$trace")
-        }
-
-        override fun onNoted(syncNotedAppOp: SyncNotedAppOp) {
-            logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
-        }
-
-        override fun onSelfNoted(syncNotedAppOp: SyncNotedAppOp) {
-            logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
-        }
-
-        override fun onAsyncNoted(asyncNotedAppOp: AsyncNotedAppOp) {
-            logPrivateDataAccess(asyncNotedAppOp.op, asyncNotedAppOp.message)
-        }
-    }
-
     init {
         context = application
         startDate = SystemClock.elapsedRealtime()
@@ -404,9 +381,32 @@ class AppInitializer @Inject constructor(
         initialized = true
     }
 
+    /**
+     * Data access auditing
+     * @link https://developer.android.com/guide/topics/data/audit-access
+     */
     @RequiresApi(VERSION_CODES.R)
     private fun initAppOpsManager() {
         val appOpsManager = context?.getSystemService(AppOpsManager::class.java) as AppOpsManager
+
+        val appOpsCallback = object : AppOpsManager.OnOpNotedCallback() {
+            private fun logPrivateDataAccess(opCode: String, trace: String) {
+                AppLog.i(T.MAIN, "Private data accessed. Operation: $opCode\nStack Trace:\n$trace")
+            }
+
+            override fun onNoted(syncNotedAppOp: SyncNotedAppOp) {
+                logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
+            }
+
+            override fun onSelfNoted(syncNotedAppOp: SyncNotedAppOp) {
+                logPrivateDataAccess(syncNotedAppOp.op, Throwable("Stack Trace: ").stackTrace.toString())
+            }
+
+            override fun onAsyncNoted(asyncNotedAppOp: AsyncNotedAppOp) {
+                logPrivateDataAccess(asyncNotedAppOp.op, asyncNotedAppOp.message)
+            }
+        }
+
         appOpsManager.setOnOpNotedCallback(context?.mainExecutor, appOpsCallback)
     }
 


### PR DESCRIPTION
Fixes a crash happening at initialization for users on Android 10 and below, since an API that only exists on Android 11 (SDK 30) and up is being used as a class `field`, so the code tries initializing it but crashes if the current system version does not have that class.

Crash Stacktrace:
```
Exception java.lang.NoClassDefFoundError:
  at android.app.AppOpsManager$OnOpNotedCallback.<clinit> (AppOpsManager.java)
  at org.wordpress.android.AppInitializer.getAppOpsCallback (AppInitializer.kt:279)
  at org.wordpress.android.AppInitializer.<init> (AppInitializer.kt:279)
  at org.wordpress.android.AppInitializer_Factory.newInstance (AppInitializer_Factory.java:248)
  at org.wordpress.android.DaggerWordPressRelease_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get0 (DaggerWordPressRelease_HiltComponents_SingletonC.java:10702)
  at org.wordpress.android.DaggerWordPressRelease_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get (DaggerWordPressRelease_HiltComponents_SingletonC.java:12020)
  at dagger.internal.DoubleCheck.get (DoubleCheck.java:47)
  at org.wordpress.android.DaggerWordPressRelease_HiltComponents_SingletonC$SingletonCImpl.injectWordPressRelease2 (DaggerWordPressRelease_HiltComponents_SingletonC.java:8991)
  at org.wordpress.android.DaggerWordPressRelease_HiltComponents_SingletonC$SingletonCImpl.injectWordPressRelease (DaggerWordPressRelease_HiltComponents_SingletonC.java:7921)
  at org.wordpress.android.Hilt_WordPressRelease.hiltInternalInject (Hilt_WordPressRelease.java:49)
  at org.wordpress.android.Hilt_WordPressRelease.onCreate (Hilt_WordPressRelease.java:40)
  at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1126)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:6062)
  at android.app.ActivityThread.-wrap1
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1764)
  at android.os.Handler.dispatchMessage (Handler.java:105)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:6942)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
```

To test:
1. Open the apps on a device that has Android 10 or below
2. **Verify** it doesn't crash

## Regression Notes
1. Potential unintended areas of impact
N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
