### PR TITLE
[Reader Improvements] Use sans-serif font in bookmark removed card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -250,7 +250,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 postView = LayoutInflater.from(context).inflate(R.layout.reader_cardview_xpost, parent, false);
                 return new ReaderXPostViewHolder(postView);
             case VIEW_TYPE_REMOVED_POST:
-                postView = LayoutInflater.from(context).inflate(R.layout.reader_cardview_removed_post, parent, false);
+                LayoutInflater inflater = LayoutInflater.from(context);
+                postView = mReaderImprovementsFeatureConfig.isEnabled()
+                        ? inflater.inflate(R.layout.reader_cardview_removed_post_new, parent, false)
+                        : inflater.inflate(R.layout.reader_cardview_removed_post, parent, false);
                 return new ReaderRemovedPostViewHolder(postView);
             default:
                 return mReaderImprovementsFeatureConfig.isEnabled()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -250,10 +250,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 postView = LayoutInflater.from(context).inflate(R.layout.reader_cardview_xpost, parent, false);
                 return new ReaderXPostViewHolder(postView);
             case VIEW_TYPE_REMOVED_POST:
-                LayoutInflater inflater = LayoutInflater.from(context);
-                postView = mReaderImprovementsFeatureConfig.isEnabled()
-                        ? inflater.inflate(R.layout.reader_cardview_removed_post_new, parent, false)
-                        : inflater.inflate(R.layout.reader_cardview_removed_post, parent, false);
+                final int layoutResId = mReaderImprovementsFeatureConfig.isEnabled()
+                        ? R.layout.reader_cardview_removed_post_new : R.layout.reader_cardview_removed_post;
+                postView = LayoutInflater.from(context).inflate(layoutResId, parent, false);
                 return new ReaderRemovedPostViewHolder(postView);
             default:
                 return mReaderImprovementsFeatureConfig.isEnabled()

--- a/WordPress/src/main/res/layout/reader_cardview_removed_post_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_removed_post_new.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/ReaderCardView"
+    android:id="@+id/post_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/removed_item_container"
+        android:layout_width="match_parent"
+        android:layout_height="?android:attr/listPreferredItemHeight"
+        android:gravity="center_vertical"
+        android:paddingStart="@dimen/reader_card_content_padding"
+        android:paddingEnd="@dimen/reader_card_content_padding">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/removed_post_title"
+            style="@style/ReaderTextView.Post.New.Removed.Title"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginEnd="@dimen/margin_large"
+            android:layout_toStartOf="@id/undo_remove"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/undo_remove"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="Removed Best post ever" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/undo_remove"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:drawablePadding="@dimen/margin_small"
+            android:text="@string/undo"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:textColor="?attr/colorPrimary"
+            android:gravity="center_vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -508,4 +508,12 @@
         <item name="android:ellipsize">end</item>
     </style>
 
+    <style name="ReaderTextView.Post.New.Removed.Title" parent="ReaderTextView">
+        <item name="android:ellipsize">marquee</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:textAppearance">@style/TextAppearance.Material3.TitleMedium</item>
+        <item name="android:alpha">@dimen/material_emphasis_high_type</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
 </resources>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -509,7 +509,7 @@
     </style>
 
     <style name="ReaderTextView.Post.New.Removed.Title" parent="ReaderTextView">
-        <item name="android:ellipsize">marquee</item>
+        <item name="android:ellipsize">end</item>
         <item name="android:singleLine">true</item>
         <item name="android:textAppearance">@style/TextAppearance.Material3.TitleMedium</item>
         <item name="android:alpha">@dimen/material_emphasis_high_type</item>


### PR DESCRIPTION
Part of #19082 

This sets the font in the "bookmark removed - undo" card to sans-serif (in the Saved tab of the Reader). This change is behind the `ReaderImprovementsFeatureConfig`.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/b2a792ef-9da0-4948-8c7d-10602b0d1980

To test:
1. Install and log in to Jetpack app
2. Make sure the `ReaderImprovementsFeatureConfig` is disabled in debug settings
3. Go to the Reader and bookmark a post
4. Go to the "Saved" tab of the reader and remove the bookmark
5. **Verify** the "bookmark removed" card looks like in previous versions (serif font)
6. Enable the `ReaderImprovementsFeatureConfig` in debug settings
7. Go to the Reader and bookmark a post
8. Go to the "Saved" tab of the reader and remove the bookmark
9. **Verify** the "bookmark removed" card now uses a sans-serif font, matching new designs

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A just minor UI changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A minor UI changes (font family change) that should not have any impact here.

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
