### PR TITLE
Unified Dashboard: Quick Start Support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -11,8 +11,10 @@ import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignLis
 import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_FLOW_SOURCE
 import org.wordpress.android.ui.blaze.blazepromote.ARG_BLAZE_SHOULD_SHOW_OVERLAY
 import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity
+import org.wordpress.android.ui.mysite.menu.KEY_QUICK_START_EVENT
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -66,7 +68,15 @@ class ActivityNavigator @Inject constructor() {
         context.startActivity(Intent(context, PersonalizationActivity::class.java))
     }
 
-    fun openUnifiedMySiteMenu(context: Context) {
+    fun openUnifiedMySiteMenu(context: Context, quickStartEvent: QuickStartEvent? = null) {
+        if (quickStartEvent != null) {
+            context.startActivity(
+                Intent(context, MenuActivity::class.java).apply {
+                    putExtra(KEY_QUICK_START_EVENT, quickStartEvent)
+                }
+            )
+            return
+        }
         context.startActivity(Intent(context, MenuActivity::class.java))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -56,6 +56,7 @@ import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
 import org.wordpress.android.util.SnackbarItem;
+import org.wordpress.android.util.SnackbarItem.Info;
 import org.wordpress.android.util.SnackbarSequencer;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
@@ -253,11 +254,9 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                 R.string.quick_start_dialog_upload_media_message_short_plus,
                 R.drawable.ic_plus_white_12dp
         );
-        mSnackbarSequencer.enqueue(
-                new SnackbarItem(
-                        new SnackbarItem.Info(getSnackbarParent(), new UiStringText(title), Snackbar.LENGTH_LONG)
-                )
-        );
+        new Handler().postDelayed(() -> mSnackbarSequencer.enqueue(
+                new SnackbarItem(new Info(getSnackbarParent(), new UiStringText(title), Snackbar.LENGTH_LONG))
+        ), 500L);
     }
 
     private View getSnackbarParent() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -602,8 +602,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         is SiteNavigationAction.OpenThemes -> ActivityLauncher.viewCurrentBlogThemes(activity, action.site)
         is SiteNavigationAction.OpenPlugins -> ActivityLauncher.viewPluginBrowser(activity, action.site)
         is SiteNavigationAction.OpenMedia -> ActivityLauncher.viewCurrentBlogMedia(activity, action.site)
-      //  is SiteNavigationAction.OpenMore -> ActivityLauncher.viewQuickLinkMoreMenu(activity, action.site)
-        is SiteNavigationAction.OpenMore -> activityNavigator.openUnifiedMySiteMenu(requireActivity())
+        is SiteNavigationAction.OpenMore -> activityNavigator.openUnifiedMySiteMenu(
+            requireActivity(),
+            action.quickStartEvent
+        )
         is SiteNavigationAction.OpenUnifiedComments -> ActivityLauncher.viewUnifiedComments(activity, action.site)
         is SiteNavigationAction.OpenStats -> ActivityLauncher.viewBlogStats(activity, action.site)
         is SiteNavigationAction.ConnectJetpackForStats ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.model.SiteModel
@@ -182,11 +181,11 @@ class MySiteViewModel @Inject constructor(
 
     val quickLinks: LiveData<MySiteCardAndItem.Card.QuickLinksItem> = merge(
         quickLinksItemViewModelSlice.uiState,
-        quickStartRepository.activeTask
-    ) { quickLinks, activeTask ->
+        quickStartRepository.quickStartMenuStep
+    ) { quickLinks, quickStartMenuStep ->
         if (quickLinks != null &&
-            activeTask != null) {
-            return@merge quickLinksItemViewModelSlice.updateToShowMoreFocusPointIfNeeded(quickLinks, activeTask)
+            quickStartMenuStep != null) {
+            return@merge quickLinksItemViewModelSlice.updateToShowMoreFocusPointIfNeeded(quickLinks, quickStartMenuStep)
         }
         return@merge quickLinks
     }
@@ -702,7 +701,7 @@ class MySiteViewModel @Inject constructor(
     }
 
     fun handleSuccessfulDomainRegistrationResult(email: String?) {
-        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS)
+        analyticsTrackerWrapper.track(Stat.DOMAIN_CREDIT_REDEMPTION_SUCCESS)
         _onSnackbarMessage.postValue(Event(SnackbarMessageHolder(getEmailValidationMessage(email))))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource
 import org.wordpress.android.util.UriWrapper
 
@@ -39,7 +40,7 @@ sealed class SiteNavigationAction {
     data class OpenThemes(val site: SiteModel) : SiteNavigationAction()
     data class OpenPlugins(val site: SiteModel) : SiteNavigationAction()
     data class OpenMedia(val site: SiteModel) : SiteNavigationAction()
-    data class OpenMore(val site:SiteModel) : SiteNavigationAction()
+    data class OpenMore(val site:SiteModel, val quickStartEvent: QuickStartEvent?) : SiteNavigationAction()
     data class OpenUnifiedComments(val site: SiteModel) : SiteNavigationAction()
     object StartWPComLoginForJetpackStats : SiteNavigationAction()
     data class OpenStats(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignLis
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.quickstart.QuickStartEvent
 import javax.inject.Inject
 
 class ListItemActionHandler @Inject constructor(
@@ -15,7 +16,11 @@ class ListItemActionHandler @Inject constructor(
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
     private val blazeFeatureUtils: BlazeFeatureUtils
 ) {
-    fun handleAction(action: ListItemAction, selectedSite: SiteModel): SiteNavigationAction {
+    fun handleAction(
+        action: ListItemAction,
+        selectedSite: SiteModel,
+        quickStartEvent: QuickStartEvent? = null
+    ): SiteNavigationAction {
         return when (action) {
             ListItemAction.ACTIVITY_LOG -> SiteNavigationAction.OpenActivityLog(selectedSite)
             ListItemAction.BACKUP -> SiteNavigationAction.OpenBackup(selectedSite)
@@ -35,7 +40,7 @@ class ListItemActionHandler @Inject constructor(
             ListItemAction.MEDIA -> SiteNavigationAction.OpenMedia(selectedSite)
             ListItemAction.COMMENTS -> SiteNavigationAction.OpenUnifiedComments(selectedSite)
             ListItemAction.BLAZE -> onBlazeMenuItemClick()
-            ListItemAction.MORE -> SiteNavigationAction.OpenMore(selectedSite)
+            ListItemAction.MORE -> SiteNavigationAction.OpenMore(selectedSite, quickStartEvent)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewModelSlice.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.cards.ListItemActionHandler
+import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
@@ -32,7 +33,7 @@ class QuickLinksItemViewModelSlice @Inject constructor(
     private val jetpackCapabilitiesUseCase: JetpackCapabilitiesUseCase,
     private val listItemActionHandler: ListItemActionHandler,
     private val blazeFeatureUtils: BlazeFeatureUtils,
-    private val appPrefsWrapper: AppPrefsWrapper,
+    private val appPrefsWrapper: AppPrefsWrapper
 ) {
     lateinit var scope: CoroutineScope
 
@@ -159,9 +160,9 @@ class QuickLinksItemViewModelSlice @Inject constructor(
 
     fun updateToShowMoreFocusPointIfNeeded(
         quickLinks: MySiteCardAndItem.Card.QuickLinksItem,
-        activeTask: QuickStartStore.QuickStartTask
+        quickStartMenuStep: QuickStartRepository.QuickStartMenuStep
     ): MySiteCardAndItem.Card.QuickLinksItem {
-        val updatedQuickLinks = if (isActiveTaskInMoreMenu(activeTask)) {
+        val updatedQuickLinks = if (isActiveTaskInMoreMenu(quickStartMenuStep.task)) {
             val quickLinkItems = quickLinks.quickLinkItems.toMutableList()
             val lastItem = quickLinkItems.last().copy(showFocusPoint = true)
             quickLinkItems.removeLast()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -95,6 +95,7 @@ class QuickStartRepository
     fun resetTask() {
         clearActiveTask()
         clearPendingTask()
+        clearMenuStep()
     }
 
     fun clearActiveTask() {
@@ -127,11 +128,12 @@ class QuickStartRepository
         }
     }
 
-    fun setActiveTask(task: QuickStartTask) {
+    fun setActiveTask(task: QuickStartTask, isFromMenu: Boolean = false) {
         _activeTask.postValue(task)
         clearPendingTask()
+        clearMenuStep()
         when {
-            task.isShownInMenu() -> requestMoreStepForTask(task)
+            !isFromMenu && task.isShownInMenu() -> requestMoreStepForTask(task)
             task == QuickStartNewSiteTask.UPDATE_SITE_TITLE -> {
                 val shortQuickStartMessage = resourceProvider.getString(
                     R.string.quick_start_dialog_update_site_title_message_short,
@@ -297,6 +299,12 @@ class QuickStartRepository
             QuickStartNewSiteTask.ENABLE_POST_SHARING -> true
             else -> false
         }
+
+    fun clearMenuStep() {
+        if (_quickStartMenuStep.value != null) {
+            _quickStartMenuStep.value = null
+        }
+    }
 
     data class QuickStartCategory(
         val taskType: QuickStartTaskType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.LocaleManager
 import javax.inject.Inject
 
+const val KEY_QUICK_START_EVENT = "key_quick_start_event"
 @AndroidEntryPoint
 class MenuActivity : AppCompatActivity() {
     @Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.publicize;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.os.Handler;
 import android.text.Spannable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -297,9 +298,9 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
                 requireContext(),
                 R.string.quick_start_dialog_enable_sharing_message_short_connections
         );
-        mSnackbarSequencer.enqueue(
+        new Handler().postDelayed(() -> mSnackbarSequencer.enqueue(
                 new SnackbarItem(new Info(mRecycler, new UiStringText(title), Snackbar.LENGTH_LONG))
-        );
+        ), 500L);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/SnackbarItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/SnackbarItem.kt
@@ -9,8 +9,8 @@ import java.lang.ref.WeakReference
 
 // Taken from com.google.android.material.snackbar.SnackbarManager.java
 // Did not find a way to get them directly from the android framework for now
-private const val SHORT_DURATION_MS = 1500L
-private const val LONG_DURATION_MS = 2750L
+const val SHORT_DURATION_MS = 1500L
+const val LONG_DURATION_MS = 2750L
 
 const val INDEFINITE_SNACKBAR_NOT_ALLOWED = "Snackbar.LENGTH_INDEFINITE not allowed in getSnackbarDurationMs."
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -415,6 +415,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(personalizeCardBuilder.build(any())).thenReturn(mock())
         whenever(bloggingPromptCardViewModelSlice.getBuilderParams(anyOrNull())).thenReturn(mock())
         whenever(quickLinksItemViewModelSlice.uiState).thenReturn(mock())
+        whenever(quickStartRepository.quickStartMenuStep).thenReturn(mock())
 
         viewModel = MySiteViewModel(
             testDispatcher(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartCardSourceTest.kt
@@ -208,8 +208,8 @@ class QuickStartCardSourceTest : BaseUnitTest() {
     fun `requestNextStepOfTask clears current active task`() = test {
         initQuickStartInProgress()
 
-        quickStartRepository.setActiveTask(ENABLE_POST_SHARING)
-        quickStartRepository.requestNextStepOfTask(ENABLE_POST_SHARING)
+        quickStartRepository.setActiveTask(QuickStartStore.QuickStartNewSiteTask.FOLLOW_SITE)
+        quickStartRepository.requestNextStepOfTask(QuickStartStore.QuickStartNewSiteTask.FOLLOW_SITE)
 
         val update = result.last()
         assertThat(update.activeTask).isNull()
@@ -342,6 +342,9 @@ class QuickStartCardSourceTest : BaseUnitTest() {
         whenever(quickStartUtilsWrapper.getNextUncompletedQuickStartTask(quickStartType, siteLocalId.toLong()))
             .thenReturn(nextUncompletedTask)
         whenever(htmlMessageUtils.getHtmlMessageFromStringFormat(anyOrNull())).thenReturn("")
+        whenever(resourceProvider.getString(any())).thenReturn("")
+        whenever(resourceProvider.getString(any(), any())).thenReturn("")
+        whenever(htmlCompat.fromHtml(any(), any())).thenReturn(" ")
         initBuild()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -110,7 +110,7 @@ class QuickStartRepositoryTest : BaseUnitTest() {
             event?.getContentIfNotHandled()?.let { quickStartPrompts.add(it) }
         }
         quickStartRepository.quickStartMenuStep.observeForever { event ->
-            quickStartMenuStep.add(event!!)
+            event?.let { quickStartMenuStep.add(it) }
         }
         site = SiteModel()
         site.id = siteLocalId

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepositoryTest.kt
@@ -166,7 +166,6 @@ class QuickStartRepositoryTest : BaseUnitTest() {
     }
 
     /* QUICK START REQUEST NEXT STEP */
-// todo: annmarie
     @Test
     fun `requestNextStepOfTask emits quick start event`() = test {
         initQuickStartInProgress()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/menu/MenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/menu/MenuViewModelTest.kt
@@ -26,9 +26,11 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
 import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.JetpackMigrationLanguageUtil
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -42,6 +44,8 @@ class MenuViewModelTest : BaseUnitTest() {
     private val selectedSiteRepository: SelectedSiteRepository = mock()
     private val siteItemsBuilder: SiteItemsBuilder = mock()
     private val refreshAppLanguageObserver: Observer<String> = mock()
+    private val contextProvider: ContextProvider = mock()
+    private val uiHelpers: UiHelpers = mock()
 
     private lateinit var viewModel: MenuViewModel
 
@@ -62,6 +66,8 @@ class MenuViewModelTest : BaseUnitTest() {
             quickStartRepository,
             selectedSiteRepository,
             siteItemsBuilder,
+            contextProvider,
+            uiHelpers,
             testDispatcher()
         )
 


### PR DESCRIPTION
Parent https://github.com/wordpress-mobile/WordPress-Android/issues/19270 

This PR refactors quick start to support the more menu

**Main Changes**
- Add QuickStartMenuStep
- Update `QuickStartRepository` to include a new mutableLiveData<QuickStartMenuStep?> which will be observed in `MySiteViewModel` and passed along to `QuickLinksItemViewModelSlice` and used to show the More focus point
- Update to show the "tap more menu" snackbar message
- Show the QS focus pt in the More menu on the correct item
- Update `QuickStartRepository.setActiveTask` to take in a boolean indicating if this is being called from the more menu. This prevents it from looping again through task being set to pending instead of active
- Implement a stop-gap solution to support showing a snackbar message in the More Menu. Added a "compose" callback within `SnackbarSequencer` that will post the snackbar back to listeners. This will be picked up in `MenuActivity`; which will create a lightweight message to be displayed. 
- Include a delay in MediaGridFragment and PublicizeListFragment show snackbar methods to account for the fact that the EventBus message gets there very quickly.


**NOTES**: 
- By the time the callback is invoked within `SnackbarSequencer`, the icon has already been merged with the message and there is no opportunity to pull it out. 
- The quick start next task won't prompt the user when in the more view. It is expected that the user tap the quick start card to continue if they had to leave for the More Menu. Perhaps we can move the order of the tasks, so the More menu taps are last?
- A non-stop gap solution would include completely rewriting the sequencer and the data classes, so that compose and traditional snackbars can be handled properly. Perhaps a `SnackbarManager` interface an two implementations:`ComposeSnackbarManager` and `TraditionalSnackbarManager`. The managers would implement their own logic for creating snackbars, but use the single queue in `SnackbarSequencer`. The type of data class in the queue should change to something more generic so both managers can create the proper snackbar. 
- 

**To test:**
- Install the app (fresh install)
- Login and select a site
- When prompted with the quick start dialog, select "Show me around"
- ✅ Go through the Quick Start Card and make sure the focus points are correct


## Regression Notes
1. Potential unintended areas of impact
Quick Start does not work properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and added new unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
