### PR TITLE
[Reader Improvements] Sow 5 tags in "You might like" discover section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -83,6 +83,7 @@ class ReaderDiscoverLogic @Inject constructor(
         coroutineScope?.launch {
             val params = HashMap<String, String>()
             params["tags"] = getFollowedTagsUseCase.get().joinToString { it.tagSlug }
+            params["tag_recs_per_card"] = RECOMMENDED_TAGS_COUNT
 
             when (taskType) {
                 REQUEST_FIRST_PAGE -> {
@@ -286,5 +287,9 @@ class ReaderDiscoverLogic @Inject constructor(
         }
 
         return blogsToBeDeleted
+    }
+
+    companion object {
+        private const val RECOMMENDED_TAGS_COUNT = "5"
     }
 }


### PR DESCRIPTION
Part of #19083

Instead of using the default 4 tags in "You might like" section, we are now requesting 5. This should avoid, for most people, having a widow tag in a separate line.

To test:
1. Install and log into Jetpack
2. Go to the Reader
3. Go to Discover
4. **Verify** the "You might like" card shows 5 tags.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
