### PR TITLE
[Reader Improvements] Use same color/elevation as cards for post list toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -15,6 +15,7 @@ import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import androidx.annotation.DrawableRes;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
@@ -29,6 +30,7 @@ import com.google.android.material.appbar.AppBarLayout;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.FilterCriteria;
+import org.wordpress.android.ui.utils.RecyclerViewExtensionsKt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -417,6 +419,12 @@ public class FilteredRecyclerView extends RelativeLayout {
         if (mRecyclerView == null) return;
 
         mRecyclerView.addItemDecoration(decor);
+    }
+
+    public void addItemDivider(@DrawableRes int dividerRes) {
+        if (mRecyclerView == null) return;
+
+        RecyclerViewExtensionsKt.addItemDivider(mRecyclerView, dividerRes);
     }
 
     public void addOnScrollListener(RecyclerView.OnScrollListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -151,6 +151,7 @@ public class FilteredRecyclerView extends RelativeLayout {
     private void init(@NonNull Context context, @Nullable AttributeSet attrs) {
         inflate(getContext(), R.layout.filtered_list_component, this);
 
+        boolean includeDefaultSpacing = true;
         if (attrs != null) {
             TypedArray a = context.getTheme().obtainStyledAttributes(
                     attrs,
@@ -165,16 +166,21 @@ public class FilteredRecyclerView extends RelativeLayout {
 
                 mHideAppBarLayout = a.getBoolean(
                         R.styleable.FilteredRecyclerView_wpHideAppBarLayout, false);
+
+                includeDefaultSpacing = a.getBoolean(R.styleable.FilteredRecyclerView_wpIncludeDefaultSpacing, true);
             } finally {
                 a.recycle();
             }
         }
 
-        int spacingHorizontal = 0;
-        int spacingVertical = DisplayUtils.dpToPx(getContext(), 1);
         mRecyclerView = findViewById(R.id.recycler_view);
         mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-        mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical));
+
+        if (includeDefaultSpacing) {
+            int spacingHorizontal = 0;
+            int spacingVertical = DisplayUtils.dpToPx(getContext(), 1);
+            mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical));
+        }
 
         mToolbar = findViewById(R.id.toolbar_with_spinner);
         mAppBarLayout = findViewById(R.id.app_bar_layout);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1115,6 +1115,13 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
         });
 
+        // set the background color as we have different colors for the new and legacy designs that are not easy to
+        // change via styles, because of the FeatureConfig logic
+        int backgroundColor = mReaderImprovementsFeatureConfig.isEnabled()
+                ? R.color.reader_post_list_background_new
+                : R.color.reader_post_list_background;
+        mRecyclerView.setBackgroundColor(ContextCompat.getColor(requireContext(), backgroundColor));
+
         // add the item decoration (dividers) to the recycler, skipping the first item if the first
         // item is the tag toolbar (shown when viewing posts in followed tags) - this is to avoid
         // having the tag toolbar take up more vertical space than necessary
@@ -1124,6 +1131,11 @@ public class ReaderPostListFragment extends ViewPagerFragment
         int spacingHorizontal = getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
         int spacingVertical = getResources().getDimensionPixelSize(spacingVerticalRes);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical, false));
+
+        // add a proper item divider to the RecyclerView when Reader Improvements are enabled
+        if (mReaderImprovementsFeatureConfig.isEnabled()) {
+            mRecyclerView.addItemDivider(R.drawable.default_list_divider);
+        }
 
         mRecyclerView.setToolbarBackgroundColor(0);
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.ic_dropdown_primary_30_24dp);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlo
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderRecommendedBlogsCardViewHolder
 import org.wordpress.android.ui.reader.discover.viewholders.ReaderViewHolder
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.ui.utils.HideItemDivider
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.image.ImageManager
 
@@ -58,6 +59,16 @@ class ReaderDiscoverAdapter(
     override fun getItemCount(): Int = items.size
 
     override fun onBindViewHolder(holder: ReaderViewHolder<*>, position: Int) {
+        if (isReaderImprovementsEnabled) {
+            // hide the item divider by setting the HideItemDivider object as view tag, which is used by the
+            // DividerItemDecorator to skip drawing the bottom divider for the item. It should be hidden for any
+            // recommendation cards and cards above them.
+            val nextPosition = position + 1
+            val shouldHideDivider = isRecommendationCard(position) ||
+                    (nextPosition < itemCount && isRecommendationCard(nextPosition))
+            holder.itemView.tag = HideItemDivider.takeIf { shouldHideDivider }
+        }
+
         holder.onBind(items[position])
     }
 
@@ -75,6 +86,11 @@ class ReaderDiscoverAdapter(
             is ReaderInterestsCardUiState -> INTEREST_VIEW_TYPE
             is ReaderRecommendedBlogsCardUiState -> RECOMMENDED_BLOGS_VIEW_TYPE
         }
+    }
+
+    private fun isRecommendationCard(position: Int): Boolean {
+        val type = getItemViewType(position)
+        return type in listOf(INTEREST_VIEW_TYPE, RECOMMENDED_BLOGS_VIEW_TYPE)
     }
 
     private class DiscoverDiffUtil(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,6 +45,7 @@ import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostCon
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.addItemDivider
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
 import org.wordpress.android.util.image.ImageManager
@@ -91,6 +93,15 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
                     uiHelpers, imageManager, readerTracker, readerImprovementsFeatureConfig.isEnabled()
                 )
 
+            // set the background color as we have different colors for the new and legacy designs that are not easy to
+            // change via styles, because of the FeatureConfig logic
+            val backgroundColor = if (readerImprovementsFeatureConfig.isEnabled()) {
+                R.color.reader_post_list_background_new
+            } else {
+                R.color.reader_post_list_background
+            }
+            recyclerView.setBackgroundColor(ContextCompat.getColor(requireContext(), backgroundColor))
+
             val spacingVerticalRes = if (readerImprovementsFeatureConfig.isEnabled()) {
                 R.dimen.reader_card_gutters_new
             } else {
@@ -99,6 +110,11 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
             val spacingHorizontal = resources.getDimensionPixelSize(R.dimen.reader_card_margin)
             val spacingVertical = resources.getDimensionPixelSize(spacingVerticalRes)
             recyclerView.addItemDecoration(RecyclerItemDecoration(spacingHorizontal, spacingVertical, false))
+
+            // add a proper item divider to the RecyclerView when Reader Improvements are enabled
+            if (readerImprovementsFeatureConfig.isEnabled()) {
+                recyclerView.addItemDivider(R.drawable.default_list_divider)
+            }
 
             WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(ptrLayout) { viewModel.swipeToRefresh() }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/RecyclerViewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/RecyclerViewExtensions.kt
@@ -3,12 +3,20 @@ package org.wordpress.android.ui.utils
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.view.View
+import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
 fun RecyclerView.addItemDivider(drawable: Drawable) {
     if (layoutManager !is LinearLayoutManager) return
     addItemDecoration(DividerItemDecorator(drawable))
+}
+
+fun RecyclerView.addItemDivider(@DrawableRes drawableRes: Int) {
+    AppCompatResources.getDrawable(context, drawableRes)?.let { drawable ->
+        addItemDivider(drawable)
+    }
 }
 
 class DividerItemDecorator(private val divider: Drawable) : RecyclerView.ItemDecoration() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/RecyclerViewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/RecyclerViewExtensions.kt
@@ -8,6 +8,8 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
+object HideItemDivider
+
 fun RecyclerView.addItemDivider(drawable: Drawable) {
     if (layoutManager !is LinearLayoutManager) return
     addItemDecoration(DividerItemDecorator(drawable))
@@ -26,6 +28,8 @@ class DividerItemDecorator(private val divider: Drawable) : RecyclerView.ItemDec
         val childCount = parent.childCount
         for (i in 0..childCount - 2) {
             val child: View = parent.getChildAt(i)
+            if (child.tag == HideItemDivider) continue
+
             val params = child.layoutParams as RecyclerView.LayoutParams
             val dividerTop: Int = child.bottom + params.bottomMargin
             val dividerBottom = dividerTop + (divider.intrinsicHeight)

--- a/WordPress/src/main/res/layout/reader_activity_post_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_list.xml
@@ -16,6 +16,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|enterAlways"
+            android:background="?attr/colorSurface"
             app:theme="@style/WordPress.ActionBar" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/WordPress/src/main/res/layout/reader_cardview_post_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post_new.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
+    style="@style/ReaderCardViewNew"
     android:id="@+id/post_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/WordPress/src/main/res/layout/reader_cardview_removed_post_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_removed_post_new.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
+    style="@style/ReaderCardViewNew"
     android:id="@+id/post_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/WordPress/src/main/res/layout/reader_cardview_xpost_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_xpost_new.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
+    style="@style/ReaderCardViewNew"
     android:id="@+id/post_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -21,7 +21,8 @@
         android:layout_below="@+id/sub_filter_component_container"
         app:wpSpinnerItemView="@layout/toolbar_main_spinner_item"
         app:wpToolbarDisableScrollGestures="true"
-        app:wpHideAppBarLayout="true" />
+        app:wpHideAppBarLayout="true"
+        app:wpIncludeDefaultSpacing="false" />
 
     <include
         android:id="@+id/empty_custom_view"

--- a/WordPress/src/main/res/layout/reader_interest_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_interest_card_new.xml
@@ -6,7 +6,7 @@
     android:background="?android:colorBackground">
 
     <com.google.android.material.card.MaterialCardView
-        style="@style/ReaderCardView"
+        style="@style/ReaderCardViewNew"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_large"

--- a/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
+++ b/WordPress/src/main/res/layout/reader_recommended_blogs_card_new.xml
@@ -7,7 +7,7 @@
     android:background="?android:colorBackground">
 
     <com.google.android.material.card.MaterialCardView
-        style="@style/ReaderCardView"
+        style="@style/ReaderCardViewNew"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin_large"

--- a/WordPress/src/main/res/layout/reader_site_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view_new.xml
@@ -2,7 +2,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
+    style="@style/ReaderCardViewNew"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view_new.xml
@@ -3,7 +3,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/ReaderCardView"
+    style="@style/ReaderCardViewNew"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -45,6 +45,7 @@
 
     <!-- Reader Post Card -->
     <color name="reader_post_list_background">@color/background_dark</color>
+    <color name="reader_post_list_background_new">@color/background_dark</color>
     <color name="reader_welcome_card_background">@color/background_dark</color>
     <color name="reader_welcome_card_text">@color/white</color>
 

--- a/WordPress/src/main/res/values-night/dimens.xml
+++ b/WordPress/src/main/res/values-night/dimens.xml
@@ -6,6 +6,7 @@
        native reader dimens
    -->
     <dimen name="reader_card_elevation">1dp</dimen>
+    <dimen name="reader_card_elevation_new">0dp</dimen>
     <item name="expandable_chips_view_chip_alpha" format="float" type="dimen">
         @dimen/disabled_alpha
     </item>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -171,6 +171,9 @@
         it's not worth replacing the FilteredRecyclerView with something else now. Therefore we
         opted for a simple flag which hides the filtering options from the FilteredRecyclerView -->
         <attr name="wpHideAppBarLayout" format="boolean"/>
+        <!-- Optional: Default is true. Include a default spacing between items, which can act as
+         a divider in case the RecyclerView background is different than each item's background-->
+        <attr name="wpIncludeDefaultSpacing" format="boolean"/>
     </declare-styleable>
 
     <!--

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -62,6 +62,7 @@
 
     <!--Reader Post Card -->
     <color name="reader_post_list_background">@color/neutral_0</color>
+    <color name="reader_post_list_background_new">@color/white</color>
 
     <!-- Modal Layout Picker -->
     <color name="mlp_categories_button_background">#ffededed</color>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -143,7 +143,7 @@
     <dimen name="reader_a8c_avatar_margin_start_new">18dp</dimen>
 
     <dimen name="reader_card_gutters">6dp</dimen>
-    <dimen name="reader_card_gutters_new">1dp</dimen>
+    <dimen name="reader_card_gutters_new">0dp</dimen>
     <dimen name="reader_card_elevation">0dp</dimen>
     <dimen name="reader_card_elevation_new">0dp</dimen>
     <dimen name="reader_site_header_avatar_margin_end">20dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -145,6 +145,7 @@
     <dimen name="reader_card_gutters">6dp</dimen>
     <dimen name="reader_card_gutters_new">1dp</dimen>
     <dimen name="reader_card_elevation">0dp</dimen>
+    <dimen name="reader_card_elevation_new">0dp</dimen>
     <dimen name="reader_site_header_avatar_margin_end">20dp</dimen>
 
     <dimen name="reader_video_overlay_size">56dp</dimen>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -19,6 +19,11 @@
         <item name="cardCornerRadius">0dp</item>
     </style>
 
+    <style name="ReaderCardViewNew" parent="Widget.MaterialComponents.CardView">
+        <item name="cardElevation">@dimen/reader_card_elevation_new</item>
+        <item name="cardCornerRadius">0dp</item>
+    </style>
+
     <!-- TextViews -->
     <style name="ReaderTextView" parent="android:Widget.TextView">
         <item name="android:textColorLink">?attr/colorPrimary</item>


### PR DESCRIPTION
Fixes #19212

## Demo

Site | Tag
--- | ---
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/268373ff-4cc4-4d3a-90d9-7f53d6947b3b" width="300"/> | <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/6240e248-8f48-4ac2-b7b6-ea08ef3894cf" width="300"/>

## To test
1. Install and log into Jetpack
2. Go to Reader
3. Go to a Site post list
4. **Verify** the top bar background color matches the posts background color in both Light and Dark modes
5. Go to a Tag post list
6. **Verify** the top bar background color matches the posts background color in both Light and Dark modes

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A (UI color change only)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
