### PR TITLE
[Reader Improvements] Udate follow button design on "Manage Topics & Sites" screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -6,7 +6,6 @@ import android.os.AsyncTask;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -21,12 +20,11 @@ import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderTagActions;
-import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.ui.reader.views.ReaderFollowButton;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 
 import java.lang.ref.WeakReference;
 
@@ -99,12 +97,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     public void onBindViewHolder(TagViewHolder holder, int position) {
         final ReaderTag tag = mTags.get(position);
         holder.mTxtTagName.setText(tag.getLabel());
-        holder.mBtnRemove.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                performDeleteTag(tag);
-            }
-        });
+        holder.mRemoveFollowButton.setOnClickListener(v -> performDeleteTag(tag));
     }
 
     private void performDeleteTag(@NonNull ReaderTag tag) {
@@ -138,14 +131,13 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
 
     class TagViewHolder extends RecyclerView.ViewHolder {
         private final TextView mTxtTagName;
-        private final ImageButton mBtnRemove;
+        private final ReaderFollowButton mRemoveFollowButton;
 
         TagViewHolder(View view) {
             super(view);
             mTxtTagName = (TextView) view.findViewById(R.id.text_topic);
-            mBtnRemove = (ImageButton) view.findViewById(R.id.btn_remove);
-            ReaderUtils.setBackgroundToRoundRipple(mBtnRemove);
-            ViewExtensionsKt.expandTouchTargetArea(mBtnRemove, R.dimen.reader_remove_button_extra_padding, false);
+            mRemoveFollowButton = (ReaderFollowButton) view.findViewById(R.id.remove_button);
+            mRemoveFollowButton.setIsFollowed(true);
         }
     }
 

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -60,10 +60,8 @@
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton
         android:id="@+id/follow_button"
-        style="@style/Reader.Follow.Button.Icon"
+        style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_medium"
-        android:layout_marginEnd="@dimen/margin_medium"/>
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -27,14 +27,10 @@
         android:textAppearance="?attr/textAppearanceSubtitle1"
         tools:text="text_topic" />
 
-    <ImageButton
-        android:id="@+id/btn_remove"
+    <org.wordpress.android.ui.reader.views.ReaderFollowButton
+        android:id="@+id/remove_button"
+        style="@style/Reader.Follow.Button.New"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:background="?attr/selectableItemBackground"
-        android:contentDescription="@string/remove"
-        android:padding="@dimen/margin_small"
-        android:src="@drawable/ic_reader_following_white_24dp"
-        app:tint="?attr/wpColorOnSurfaceMedium" />
+        android:contentDescription="@string/remove" />
 </LinearLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -238,7 +238,6 @@
 
     <!-- Increased touch targets to make views more accessible -->
     <dimen name="reader_discover_layout_extra_padding">16dp</dimen>
-    <dimen name="reader_remove_button_extra_padding">12dp</dimen>
     <dimen name="reader_more_image_extra_padding">12dp</dimen>
 
     <dimen name="reader_chip_radius">8dp</dimen>


### PR DESCRIPTION
Fixes #19326 

This PR updates the follow/unfollow button design on "Manage Topics & Sites" screen. We've decided to keep the follow/unfollow button changes out of the feature flag, which means the new design will be shown regardless of the FF status.

To test:
1 - Run JP and sign in;
2 - Open reader;
3 - Tap the follow action on the toolbar to open the "Manage Topics & Sites" screen:
<img width="300" alt="Screenshot 2023-10-06 at 6 02 51 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/a9f2d939-0775-463a-a48c-006e07134896">
4 - Check both tabs ("Followed Topics" and "Followed Sites") to verify if the follow/unfollow button matches the design. Tap the buttons to make sure the follow/unfollow action is still working as expected;

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Changes were only made to views

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)