### PR TITLE
[Nullability Annotations to Java Classes] Replace `findViewById` with `ViewBinding` for Reader Comments (`relatively safe`)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -207,11 +207,13 @@ class PostListFragment : ViewPagerFragment() {
         recyclerView?.layoutManager = LinearLayoutManager(context)
         recyclerView?.adapter = postListAdapter
 
-        swipeToRefreshHelper = buildSwipeToRefreshHelper(swipeRefreshLayout) {
-            if (!NetworkUtils.isNetworkAvailable(nonNullActivity)) {
-                swipeRefreshLayout?.isRefreshing = false
-            } else {
-                viewModel.swipeToRefresh()
+        swipeRefreshLayout?.let {
+            swipeToRefreshHelper = buildSwipeToRefreshHelper(it) {
+                if (!NetworkUtils.isNetworkAvailable(nonNullActivity)) {
+                    it.isRefreshing = false
+                } else {
+                    viewModel.swipeToRefresh()
+                }
             }
         }
         return view

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -132,7 +132,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private long mCommentId;
     private int mRestorePosition;
     @Nullable private String mInterceptedUri;
-    private String mSource;
+    @Nullable private String mSource;
 
     @Inject AccountStore mAccountStore;
     @Inject UiHelpers mUiHelpers;
@@ -251,7 +251,9 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         // update the post and its comments upon creation
         mUpdateOnResume = (savedInstanceState == null);
 
-        mReaderTracker.trackPost(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost, mSource);
+        if (mSource != null) {
+            mReaderTracker.trackPost(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTS_OPENED, mPost, mSource);
+        }
 
         if (mBoxBinding != null && mPost != null) {
             mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, mBlogId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -669,6 +669,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         startActivity(Intent.createChooser(shareIntent, getString(R.string.share_link)));
     }
 
+    @SuppressWarnings("deprecation")
     private void setReplyToCommentId(
             @NonNull ReaderActivityCommentListBinding binding,
             @NonNull ReaderIncludeCommentBoxBinding boxBinding,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -117,7 +117,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private long mBlogId;
     @Nullable private ReaderPost mPost;
     @Nullable private ReaderCommentAdapter mCommentAdapter;
-    private SuggestionAdapter mSuggestionAdapter;
+    @Nullable private SuggestionAdapter mSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
     private SwipeToRefreshHelper mSwipeToRefreshHelper;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -551,8 +551,6 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             @NonNull ReaderCommentMenuActionType action
     ) {
         switch (action) {
-            case APPROVE:
-                break;
             case EDIT:
                 SiteModel postSite = mSiteStore.getSiteBySiteId(comment.blogId);
                 if (postSite != null) {
@@ -592,6 +590,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             case SHARE:
                 shareComment(comment.getShortUrl());
                 break;
+            case APPROVE:
             case DIVIDER_NO_ACTION:
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -700,6 +701,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         }
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     private void setupReplyToComment(
             @NonNull ReaderActivityCommentListBinding binding,
             @NonNull ReaderIncludeCommentBoxBinding boxBinding

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -1137,7 +1137,12 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
     private int getCurrentPosition(@NonNull ReaderActivityCommentListBinding binding) {
         if (hasCommentAdapter()) {
-            return ((LinearLayoutManager) binding.recyclerView.getLayoutManager()).findFirstVisibleItemPosition();
+            LinearLayoutManager layoutManager = (LinearLayoutManager) binding.recyclerView.getLayoutManager();
+            if (layoutManager != null) {
+                return layoutManager.findFirstVisibleItemPosition();
+            } else {
+                return 0;
+            }
         } else {
             return 0;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -531,13 +531,11 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
         }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -118,7 +118,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     @Nullable private ReaderPost mPost;
     @Nullable private ReaderCommentAdapter mCommentAdapter;
     @Nullable private SuggestionAdapter mSuggestionAdapter;
-    private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
+    @Nullable private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -310,7 +310,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
     private void initViewModels(
             @NonNull ReaderActivityCommentListBinding binding,
-            Bundle savedInstanceState
+            @Nullable Bundle savedInstanceState
     ) {
         mViewModel = new ViewModelProvider(this, mViewModelFactory).get(ReaderCommentListViewModel.class);
         mViewModel.getScrollTo().observe(this, scrollPositionEvent -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -131,7 +131,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private long mReplyToCommentId;
     private long mCommentId;
     private int mRestorePosition;
-    private String mInterceptedUri;
+    @Nullable private String mInterceptedUri;
     private String mSource;
 
     @Inject AccountStore mAccountStore;
@@ -427,7 +427,9 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
                 return;
             }
 
-            mReaderTracker.trackUri(AnalyticsTracker.Stat.READER_SIGN_IN_INITIATED, mInterceptedUri);
+            if (mInterceptedUri != null) {
+                mReaderTracker.trackUri(AnalyticsTracker.Stat.READER_SIGN_IN_INITIATED, mInterceptedUri);
+            }
             ActivityLauncher.loginWithoutMagicLink(ReaderCommentListActivity.this);
         }
     };

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -120,7 +120,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     @Nullable private SuggestionAdapter mSuggestionAdapter;
     @Nullable private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
-    private SwipeToRefreshHelper mSwipeToRefreshHelper;
+    @Nullable private SwipeToRefreshHelper mSwipeToRefreshHelper;
 
     private boolean mIsUpdatingComments;
     private boolean mHasUpdatedComments;
@@ -1155,7 +1155,9 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
     @SuppressWarnings("SameParameterValue")
     private void setRefreshing(boolean refreshing) {
-        mSwipeToRefreshHelper.setRefreshing(refreshing);
+        if (mSwipeToRefreshHelper != null) {
+            mSwipeToRefreshHelper.setRefreshing(refreshing);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -199,15 +199,15 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
             mBoxBinding.editComment.addTextChangedListener(new TextWatcher() {
                 @Override
-                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
                 }
 
                 @Override
-                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
                 }
 
                 @Override
-                public void afterTextChanged(Editable s) {
+                public void afterTextChanged(@NonNull Editable s) {
                     mBoxBinding.btnSubmitReply.setEnabled(!TextUtils.isEmpty(s.toString().trim()));
                 }
             });
@@ -421,7 +421,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
     private final View.OnClickListener mSignInClickListener = new View.OnClickListener() {
         @Override
-        public void onClick(View v) {
+        public void onClick(@NonNull View v) {
             if (isFinishing()) {
                 return;
             }
@@ -618,7 +618,8 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         ).setAction(R.string.undo, view -> getCommentAdapter(binding, boxBinding).refreshComments());
 
         snackbar.addCallback(new BaseCallback<Snackbar>() {
-            @Override public void onDismissed(Snackbar transientBottomBar, int event) {
+            @Override
+            public void onDismissed(@Nullable Snackbar transientBottomBar, int event) {
                 super.onDismissed(transientBottomBar, event);
 
                 if (event == DISMISS_EVENT_ACTION) {
@@ -1138,7 +1139,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         // if user is returning from login, make sure to update the post and its comments

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -116,7 +116,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private long mPostId;
     private long mBlogId;
     @Nullable private ReaderPost mPost;
-    private ReaderCommentAdapter mCommentAdapter;
+    @Nullable private ReaderCommentAdapter mCommentAdapter;
     private SuggestionAdapter mSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
@@ -869,11 +869,13 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         if (mDirectOperation != null) {
             switch (mDirectOperation) {
                 case COMMENT_JUMP:
-                    mCommentAdapter.setHighlightCommentId(mCommentId, false);
+                    if (mCommentAdapter != null) {
+                        mCommentAdapter.setHighlightCommentId(mCommentId, false);
 
-                    // clear up the direct operation vars. Only performing it once.
-                    mDirectOperation = null;
-                    mCommentId = 0;
+                        // clear up the direct operation vars. Only performing it once.
+                        mDirectOperation = null;
+                        mCommentId = 0;
+                    }
                     break;
                 case COMMENT_REPLY:
                     setReplyToCommentId(binding, boxBinding, mCommentId, mAccountStore.hasAccessToken());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -1136,6 +1136,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         }
     }
 
+    @SuppressWarnings("SameParameterValue")
     private void setRefreshing(boolean refreshing) {
         mSwipeToRefreshHelper.setRefreshing(refreshing);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -547,14 +547,17 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private void performCommentAction(
             @NonNull ReaderActivityCommentListBinding binding,
             @NonNull ReaderIncludeCommentBoxBinding boxBinding,
-            ReaderComment comment,
-            ReaderCommentMenuActionType action
+            @NonNull ReaderComment comment,
+            @NonNull ReaderCommentMenuActionType action
     ) {
         switch (action) {
             case APPROVE:
                 break;
             case EDIT:
-                openCommentEditor(comment);
+                SiteModel postSite = mSiteStore.getSiteBySiteId(comment.blogId);
+                if (postSite != null) {
+                    openCommentEditor(comment, postSite);
+                }
                 break;
             case UNAPPROVE:
                 moderateComment(
@@ -594,10 +597,15 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         }
     }
 
-    private void openCommentEditor(ReaderComment comment) {
-        SiteModel postSite = mSiteStore.getSiteBySiteId(comment.blogId);
-        final Intent intent = UnifiedCommentsEditActivity.createIntent(this,
-                new ReaderCommentIdentifier(comment.blogId, comment.postId, comment.commentId), postSite);
+    private void openCommentEditor(
+            @NonNull ReaderComment comment,
+            @NonNull SiteModel postSite
+    ) {
+        final Intent intent = UnifiedCommentsEditActivity.createIntent(
+                this,
+                new ReaderCommentIdentifier(comment.blogId, comment.postId, comment.commentId),
+                postSite
+        );
         startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -140,7 +140,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     @Inject ReaderTracker mReaderTracker;
     @Inject SiteStore mSiteStore;
 
-    private ReaderCommentListViewModel mViewModel;
+    @Nullable private ReaderCommentListViewModel mViewModel;
     private ConversationNotificationsViewModel mConversationViewModel;
 
     @Nullable private ReaderActivityCommentListBinding mBinding = null;
@@ -177,9 +177,8 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             }
         }
 
-        initViewModel();
         if (mBinding != null) {
-            initObservers(mBinding, savedInstanceState);
+            initViewModels(mBinding, savedInstanceState);
         }
 
         if (mBinding != null && mBoxBinding != null) {
@@ -309,17 +308,11 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
         }
     }
 
-    private void initViewModel() {
-        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(ReaderCommentListViewModel.class);
-        mConversationViewModel = new ViewModelProvider(this, mViewModelFactory).get(
-                ConversationNotificationsViewModel.class
-        );
-    }
-
-    private void initObservers(
+    private void initViewModels(
             @NonNull ReaderActivityCommentListBinding binding,
             Bundle savedInstanceState
     ) {
+        mViewModel = new ViewModelProvider(this, mViewModelFactory).get(ReaderCommentListViewModel.class);
         mViewModel.getScrollTo().observe(this, scrollPositionEvent -> {
             ScrollPosition content = scrollPositionEvent.getContentIfNotHandled();
             LayoutManager layoutManager = binding.recyclerView.getLayoutManager();
@@ -339,6 +332,9 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             }
         });
 
+        mConversationViewModel = new ViewModelProvider(this, mViewModelFactory).get(
+                ConversationNotificationsViewModel.class
+        );
         mConversationViewModel.getSnackbarEvents().observe(this, snackbarMessageHolderEvent -> {
             FragmentManager fm = getSupportFragmentManager();
             CommentNotificationsBottomSheetFragment bottomSheet =
@@ -847,7 +843,9 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
 
                         doDirectOperation(binding, boxBinding);
                     } else if (mRestorePosition > 0) {
-                        mViewModel.scrollToPosition(mRestorePosition, false);
+                        if (mViewModel != null) {
+                            mViewModel.scrollToPosition(mRestorePosition, false);
+                        }
                     }
                     mRestorePosition = 0;
                     checkEmptyView(binding, boxBinding);
@@ -1043,7 +1041,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             long commentId
     ) {
         int position = getCommentAdapter(binding, boxBinding).positionOfCommentId(commentId);
-        if (position > -1) {
+        if (mViewModel != null && position > -1) {
             mViewModel.scrollToPosition(position, false);
         }
     }
@@ -1057,7 +1055,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
             long commentId
     ) {
         int position = getCommentAdapter(binding, boxBinding).positionOfCommentId(commentId);
-        if (position > -1) {
+        if (mViewModel != null && position > -1) {
             mViewModel.scrollToPosition(position, true);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -127,7 +127,7 @@ public class ReaderCommentListActivity extends LocaleAwareActivity implements On
     private boolean mIsSubmittingComment;
     private boolean mUpdateOnResume;
 
-    private DirectOperation mDirectOperation;
+    @Nullable private DirectOperation mDirectOperation;
     private long mReplyToCommentId;
     private long mCommentId;
     private int mRestorePosition;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.reader.actions;
 
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
@@ -39,7 +41,7 @@ public class ReaderCommentActions {
      * add the passed comment text to the passed post - caller must pass a unique "fake" comment id
      * to give the comment that's generated locally
      */
-    public static ReaderComment submitPostComment(final ReaderPost post,
+    public static ReaderComment submitPostComment(final @Nullable ReaderPost post,
                                                   final long fakeCommentId,
                                                   final String commentText,
                                                   final long replyToCommentId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -141,7 +141,7 @@ public class ReaderPostActions {
      * get the latest version of this post - note that the post is only considered changed if the
      * like/comment count has changed, or if the current user's like/follow status has changed
      */
-    public static void updatePost(final ReaderPost localPost,
+    public static void updatePost(@NonNull final ReaderPost localPost,
                                   final UpdateResultListener resultListener) {
         String path = "read/sites/" + localPost.blogId + "/posts/" + localPost.postId + "/?meta=site,likes";
 
@@ -164,7 +164,7 @@ public class ReaderPostActions {
         WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
     }
 
-    private static void handleUpdatePostResponse(final ReaderPost localPost,
+    private static void handleUpdatePostResponse(@NonNull final ReaderPost localPost,
                                                  final JSONObject jsonObject,
                                                  final UpdateResultListener resultListener) {
         if (jsonObject == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -13,6 +13,7 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.ListPopupWindow;
 import androidx.core.graphics.ColorUtils;
 import androidx.recyclerview.widget.RecyclerView;
@@ -109,7 +110,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
     }
 
     public interface CommentMenuActionListener {
-        void onCommentMenuItemTapped(ReaderComment comment, ReaderCommentMenuActionType actionType);
+        void onCommentMenuItemTapped(@NonNull ReaderComment comment, @NonNull ReaderCommentMenuActionType actionType);
     }
 
     private ReaderCommentList mComments = new ReaderCommentList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -180,7 +180,10 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
     }
 
-    public ReaderCommentAdapter(Context context, ReaderPost post) {
+    public ReaderCommentAdapter(
+            Context context,
+            @NonNull ReaderPost post
+    ) {
         ((WordPress) context.getApplicationContext()).component().inject(this);
         mPost = post;
         mIsPrivatePost = mThreadedCommentsUtils.isPrivatePost(post);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
@@ -3,6 +3,8 @@ package org.wordpress.android.util;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.material.elevation.ElevationOverlayProvider;
 
 import org.wordpress.android.R;
@@ -22,8 +24,10 @@ public class WPSwipeToRefreshHelper {
      *                           via the swipe gesture.
      */
     @SuppressLint("ResourceType")
-    public static SwipeToRefreshHelper buildSwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout,
-                                                                 RefreshListener listener) {
+    public static SwipeToRefreshHelper buildSwipeToRefreshHelper(
+            @NonNull CustomSwipeRefreshLayout swipeRefreshLayout,
+            RefreshListener listener
+    ) {
         Context context = swipeRefreshLayout.getContext();
 
         ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(context);

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -5,10 +5,11 @@
 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/layout_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:visibility="gone"
     tools:visibility="visible">
 


### PR DESCRIPTION
Parent #18906
Similar To #19217

This PR's main focus is to replace `findViewById ` with `ViewBinding` for the [ReaderCommentListActivity.java](https://github.com/wordpress-mobile/WordPress-Android/blob/a4fa6ac15e45c3b616dc86d09529584fdd08c971/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java#L4) class.

Additionally, this PR is also dealing with adding any missing nullability annotations to this activity class, focusing mainly on its fields, and, any effected neighbour classes. But first, all existing warnings on this class are being resolved/suppressed so as to make it easier to deal with any missing nullability checks (with help from the IDE), especially when a `@Nullable` annotation is added.

FYI: This change is `relatively safe`, meaning that although there are compile-time changes associated with this change, and it needs testing, the changes included in this PR are very targeted and specific to one screen, and one screen only. Thus, if this screen is tested appropriately, it should be safe to merge this to `trunk`.

-----

PS: @AjeshRPai I added you as the main reviewer, not so randomly, due to the fact that you've also reviewed #19217, and I wanted you from the Jetpack/WordPress mobile team again to be aware of and sign-off on that change for JP/WPAndroid. Feel free to merge this PR directly yourself if you deem so.

-----

`findViewById ` -> `ViewBinding`

1. [Replace findviewbyid with viewbinding for reader comment list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/351335e39e82d5d31dabf2483220f9a32fb172b9)
2. [Use non-null vb method param for reader comment list (1/2)](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/5811448399dceb1e28c413ca2c4c26861fa4aac0)
3. [Use non-null vb method param for reader comment list (2/2)](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/d9fa586723f99e2622166941eaa27352190f443c)

Nullability Annotation List:

1. [Add missing nullability annotations to sdk override methods](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/2c3f0ab44b4fb7215eae36b4d1a2e9bb29def708)
2. [Add missing nl-a to post field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/896dfc58bb697ce8efc724e2a2d788073b48a1bb)
3. [Add missing nl-a to comment adapter field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/65e6c1c2d598463c7bc58eeda21456a72ae73a26)
4. [Add missing nl-a to suggestion adapter field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/a50d2e1e286280444c631ff6b361f60ca3b250d2)
5. [Add missing nl-a to suggestion service connection mgr field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/ca1a478878fa19ccda72ba5bfa25b0aea573042a)
6. [Add missing nl-a to swipe to refresh helper field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/96894dbe0186da437c5bbec78fbf7125f5c988d9)
7. [Add missing nl-a to direct operation field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/3385b1124b29ceedfb0021fc8691dcea31ac1759)
8. [Add missing nl-a to intercepted uri field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/31636b22a9545763646d328362382d8c40896854)
9. [Add missing nl-a to source field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/823603288dd148cecf9f21d22cab05b8340e82af)
10. [Add missing nl-a to view model field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/b9a8dcfb1ef450fb78a2c3db81f21627893145d9)
11. [Add missing nl-a to conversation view model field](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/8fecb2bd1f79deca7851af609408067094404b38)
12. [Add missing nl-a to saved instance state parameter](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/ce75e86e902723d6bf0485f97d3d0914fc147678)

Warnings Resolution List:

1. [Replace unnecessary switch with if stmt on reader cmnt list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/3aacd9aa1a8501278fd0d38d175f52b77f4cc0e8)
2. [Guard nullable post site variable on reader comment list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/b85afb881e57d82dbc47a9dde84c646305e71eaf)
3. [Guard nullable method invocation on reader comment list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/0d7034ee5a38c06aa3e86ec7437e564a8a3c4309)
4. [Merge divider no action with catch approve on reader cmnt list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/9c199c5714b69613cd1eab03a632483de7df220a)

Warnings Suppression List:

1. [Suppress notify data set changed lint warn on reader cmnt list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/311509ee3ed18525e1317cc9dd399100fe541d10)
2. [Suppress same parameter value warning on reader comment list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/017907cbb68c0fb036b92aeb0e4262e6a501f403)
3. [Suppress deprecation warning on reader comment list](https://github.com/wordpress-mobile/WordPress-Android/pull/19333/commits/f5558913e99ccb3a9f664efe9d5f6777c97a958f)

-----

## To test:

1. Quickly smoke test any reader comments related functionality on the Jetpack app and see if everything is working as expected.
2. In addition to the above smoke test, you can expand the below and follow the inner and more explicit test steps within:

<details>
    <summary>Reader Comments Screen [ReaderCommentListActivity.java]</summary>

ℹ️ This test applies to the `Jetpack` app only.

- Go to `Reader` tab, then its `DISCOVER` sub-tab, and tap on any post.
- Tap on the `Comments` button at the bottom of the post.
- Verify that the `Reader Comments` screen is shown and functioning as expected.
- For example, try (un)following, enabling/disabling in-app notifications, replying to post, and then sharing, replying or liking a specific comment.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

16. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

19. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)