### PR TITLE
Fix Debug settings visibility for vanila flavor-based debug builds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -112,7 +112,7 @@ class HelpActivity : LocaleAwareActivity() {
                 showContactUs()
             }
 
-            if(BuildConfig.DEBUG) {
+            if(BuildConfig.DEBUG && BuildConfig.ENABLE_DEBUG_SETTINGS) {
                 enableDebugSettings()
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -201,7 +201,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         if (BuildConfig.IS_JETPACK_APP) meAboutIcon.setImageResource(R.drawable.ic_jetpack_logo_white_24dp)
 
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.DEBUG && BuildConfig.ENABLE_DEBUG_SETTINGS) {
             rowDebugSettings.isVisible = true
             debugSettingsDivider.isVisible = true
             rowDebugSettings.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -45,7 +45,6 @@ import org.wordpress.android.fluxc.store.WhatsNewStore.OnWhatsNewFetched;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewAppId;
 import org.wordpress.android.fluxc.store.WhatsNewStore.WhatsNewFetchPayload;
 import org.wordpress.android.models.JetpackPoweredScreen;
-import org.wordpress.android.ui.debug.DebugSettingsActivity;
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
@@ -163,8 +162,6 @@ public class AppSettingsFragment extends PreferenceFragment
                 .setOnPreferenceClickListener(this);
         findPreference(getString(R.string.pref_key_device_settings))
                 .setOnPreferenceClickListener(this);
-        findPreference(getString(R.string.pref_key_debug_settings))
-                .setOnPreferenceClickListener(this);
 
         mOptimizedImage =
                 (WPSwitchPreference) WPPrefUtils
@@ -225,10 +222,6 @@ public class AppSettingsFragment extends PreferenceFragment
 
         if (!BuildConfig.OFFER_GUTENBERG) {
             removeExperimentalCategory();
-        }
-
-        if (!BuildConfig.ENABLE_DEBUG_SETTINGS) {
-            removeDebugSettingsCategory();
         }
 
         if (!mMySiteDashboardTabsFeatureConfig.isEnabled()) {
@@ -312,14 +305,6 @@ public class AppSettingsFragment extends PreferenceFragment
         PreferenceScreen preferenceScreen =
                 (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
         preferenceScreen.removePreference(experimentalPreferenceCategory);
-    }
-
-    private void removeDebugSettingsCategory() {
-        Preference experimentalPreference =
-                findPreference(getString(R.string.pref_key_debug_settings));
-        PreferenceScreen preferenceScreen =
-                (PreferenceScreen) findPreference(getString(R.string.pref_key_app_settings_root));
-        preferenceScreen.removePreference(experimentalPreference);
     }
 
     private void removeWhatsNewPreference() {
@@ -439,8 +424,6 @@ public class AppSettingsFragment extends PreferenceFragment
 
         if (preferenceKey.equals(getString(R.string.pref_key_device_settings))) {
             return handleDevicePreferenceClick();
-        } else if (preferenceKey.equals(getString(R.string.pref_key_debug_settings))) {
-            return handleDebugSettingsPreferenceClick();
         } else if (preference == mPrivacySettings) {
             return handlePrivacyClick();
         } else if (preference == mWhatsNew) {
@@ -563,11 +546,6 @@ public class AppSettingsFragment extends PreferenceFragment
 
         // update Reader tags as they need be localized
         ReaderUpdateServiceStarter.startService(WordPress.getContext(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
-    }
-
-    private boolean handleDebugSettingsPreferenceClick() {
-        startActivity(new Intent(getActivity(), DebugSettingsActivity.class));
-        return true;
     }
 
     private boolean handleDevicePreferenceClick() {

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -13,7 +13,6 @@
     <string name="pref_key_send_usage" translatable="false">wp_pref_send_usage_stats</string>
     <string name="pref_key_send_crash" translatable="false">wp_pref_send_crash_stats</string>
     <string name="pref_key_device_settings" translatable="false">wp_pref_device_settings</string>
-    <string name="pref_key_debug_settings" translatable="false">wp_pref_debug_settings</string>
     <string name="pref_key_experimental_section" translatable="false">wp_pref_app_experimental_section</string>
     <string name="pref_key_language" translatable="false">wp_pref_language</string>
     <string name="pref_key_app_theme" translatable="false">wp_pref_app_theme</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -86,11 +86,6 @@
         android:key="@string/pref_key_whats_new"
         android:title="@string/whats_new_in_version_title" />
 
-    <Preference
-        android:key="@string/pref_key_debug_settings"
-        app:isPreferenceVisible="false"
-        android:title="@string/preference_open_debug_settings" />
-
     <PreferenceCategory
         android:key="@string/pref_key_optimize_media"
         android:title="@string/media">


### PR DESCRIPTION
Fixes #19338

The Debug settings screen (on Me tab) should not be visible for apps built with build variants containing vanilla flavor.

To test:
- [ ] Build `jetpackVanillaDebug` app.
- [ ] Log into your account.
- [ ] Go to `Me` tab.
- [ ] Ensure you cannot see the `Debug settings` option on the list.
- [ ] Build any other non-vanilla debug app and make sure the `Debug settings` option is visible on the `Me` tap.
**Upd:**
- [ ] Go to `Login screen` -> `Help (?)` screen and confirm that `Debug settings` is invisible for `jetpackVanillaDebug`-based app
- [ ] Make sure that none of the existing build types have `Debug settings` option on `Me` -> `App settings` screen.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Changes were only made to views.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
