### PR TITLE
[Reader Improvements] Fix follow buton size on "Manage Topics & Sites" screen

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -89,8 +89,8 @@
             android:layout_alignBottom="@+id/edit_add"
             android:layout_alignParentEnd="true"
             android:contentDescription="@string/add"
-            android:layout_marginStart="@dimen/margin_extra_medium_large"
-            android:layout_marginEnd="@dimen/margin_extra_medium_large"/>
+            android:layout_marginStart="@dimen/margin_extra_small_large"
+            android:layout_marginEnd="@dimen/margin_extra_small_large"/>
 
     </RelativeLayout>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -204,7 +204,7 @@
     <dimen name="reader_button_minimum_height">44dp</dimen>
     <dimen name="reader_count_icon">18dp</dimen>
     <dimen name="reader_more_icon">36dp</dimen>
-    <dimen name="reader_follow_icon">16dp</dimen>
+    <dimen name="reader_follow_icon">24dp</dimen>
     <dimen name="reader_follow_button_min_height">36dp</dimen>
 
     <dimen name="reader_post_card_new_more_icon">24dp</dimen>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -280,6 +280,10 @@
         <item name="android:minHeight">@dimen/min_touch_target_sz</item>
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="wpShowFollowButtonCaption">false</item>
+        <item name="android:paddingStart">0dp</item>
+        <item name="android:paddingEnd">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
     </style>
 
     <style name="Reader.Button.Error" parent="WordPress.Button.Primary">


### PR DESCRIPTION
To test:
- Install JP and sign in;
- Open reader;
- Tap on the top right button in the app bar to open "Manage Topics & Sites" screen;
<img width="351" alt="Screenshot 2023-10-10 at 11 25 21 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/0a8cddfd-1b02-4781-abbd-5d3be55a587f">

- Check the icon button in the bottom right: it should be the same as it is in production.
<img width="351" alt="Screenshot 2023-10-10 at 11 26 05 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/9a8247b3-6d03-43e1-8c4b-2a44f77d10ab">

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Only views were changed

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
