### PR TITLE
Posts & Pages: Update top tabs indicator 

### DIFF
--- a/WordPress/src/jetpack/res/values-night/colors_base.xml
+++ b/WordPress/src/jetpack/res/values-night/colors_base.xml
@@ -8,4 +8,5 @@
     <color name="colorPrimaryEditor">@color/blue_30</color>
 
     <color name="nav_bar">@color/white</color>
+    <color name="tab_indicator">@color/white</color>
 </resources>

--- a/WordPress/src/jetpack/res/values/colors_base.xml
+++ b/WordPress/src/jetpack/res/values/colors_base.xml
@@ -24,4 +24,5 @@
     <color name="primary_light">@color/jetpack_green_30</color>
 
     <color name="nav_bar">@color/black</color>
+    <color name="tab_indicator">@color/black</color>
 </resources>

--- a/WordPress/src/main/res/values-night/colors_base.xml
+++ b/WordPress/src/main/res/values-night/colors_base.xml
@@ -8,4 +8,5 @@
     <color name="colorPrimaryEditor">@color/primary_30</color>
 
     <color name="nav_bar">@color/colorPrimary</color>
+    <color name="tab_indicator">@color/colorPrimary</color>
 </resources>

--- a/WordPress/src/main/res/values/colors_base.xml
+++ b/WordPress/src/main/res/values/colors_base.xml
@@ -24,4 +24,5 @@
     <color name="primary_light">@color/blue_30</color>
 
     <color name="nav_bar">@color/colorPrimary</color>
+    <color name="tab_indicator">@color/colorPrimary</color>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -371,7 +371,7 @@
         <item name="android:duplicateParentState">true</item>
         <item name="tabTextColor">?attr/wpColorOnSurfaceMedium</item>
         <item name="tabSelectedTextColor">?attr/colorOnSurface</item>
-        <item name="tabIndicatorColor">?attr/colorPrimary</item>
+        <item name="tabIndicatorColor">@color/tab_indicator</item>
         <item name="tabBackground">@drawable/tab_indicator_color</item>
         <item name="android:layout_marginBottom">@dimen/bottom_tabs_divider_size</item>
     </style>


### PR DESCRIPTION
Fixes #19349 

This PR updates the top taps tab indicator color across the JP app to black/white.

WP Dark | WP Light
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/55548be8-343c-4b67-838c-72f7de9f5684"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/2fd07dc5-b838-4993-bb23-1c85b7af94fd">

JP Dark | JP Light
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/231ff1b1-af01-4f1a-aec6-33f6724ecf0e"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/82c7d0c6-abfe-4215-8081-1174f46ecd13">


**To test:**
**WordPress App**
- Install the WP app
- Set to light theme
- Login and select a site
- Navigate to the posts list
- ✅ Verify the tab indicator color is still blue
- Set to dark theme
- Navigate to the posts list
- ✅ Verify the tab indicator color is still blue
- Navigate to other "tab" views as needed
- ✅ Verify the tab indicator color is still blue

**Jetpack App**
- Install the JP app
- Set to light theme
- Login and select a site
- Navigate to the posts list
- ✅ Verify the tab indicator color is black
- Set to dark theme
- Navigate to the posts list
- ✅ Verify the tab indicator color is white
- Navigate to other "tab" views as needed
- ✅ Verify the tab indicator color is correct for the theme


## Regression Notes
1. Potential unintended areas of impact
Some tabs are still showing in primary color in JP

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
