### PR TITLE
Posts: Move author filter to toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -14,10 +14,8 @@ import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import android.widget.Toast
-import androidx.annotation.DrawableRes
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
@@ -57,7 +55,6 @@ import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
@@ -634,16 +631,16 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     // Menu PostListViewLayoutType handling
-
-    private fun updateMenuIcon(@DrawableRes iconRes: Int, menuItem: MenuItem) {
-        ContextCompat.getDrawable(this, iconRes)?.let { drawable ->
-            menuItem.setIcon(drawable)
-        }
-    }
-
-    private fun updateMenuTitle(title: UiString, menuItem: MenuItem): MenuItem? {
-        return menuItem.setTitle(uiHelpers.getTextOfUiString(this@PostsListActivity, title))
-    }
+    // todo: implement the logic to change the author filter icon on selection change
+//    private fun updateMenuIcon(@DrawableRes iconRes: Int, menuItem: MenuItem) {
+//        ContextCompat.getDrawable(this, iconRes)?.let { drawable ->
+//            menuItem.setIcon(drawable)
+//        }
+//    }
+//
+//    private fun updateMenuTitle(title: UiString, menuItem: MenuItem): MenuItem? {
+//        return menuItem.setTitle(uiHelpers.getTextOfUiString(this@PostsListActivity, title))
+//    }
 
     override fun onSubmitButtonClicked(publishPost: PublishPost) {
         viewModel.onBottomSheetPublishButtonClicked()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -2,6 +2,7 @@
 
 package org.wordpress.android.ui.posts
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Context
@@ -15,6 +16,7 @@ import android.view.View
 import android.widget.AdapterView
 import android.widget.Toast
 import androidx.annotation.DrawableRes
+import androidx.appcompat.widget.AppCompatSpinner
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
@@ -141,7 +143,7 @@ class PostsListActivity : LocaleAwareActivity(),
 
     private lateinit var postsPagerAdapter: PostsPagerAdapter
     private lateinit var searchActionButton: MenuItem
-    private lateinit var toggleViewLayoutMenuItem: MenuItem
+    private lateinit var authorFiltertMenuItem: MenuItem
 
     private var restorePreviousSearch = false
 
@@ -228,17 +230,6 @@ class PostsListActivity : LocaleAwareActivity(),
     }
 
     private fun PostListActivityBinding.setupContent() {
-        val authorSelectionAdapter = AuthorSelectionAdapter(this@PostsListActivity)
-        postListAuthorSelection.adapter = authorSelectionAdapter
-
-        postListAuthorSelection.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
-            override fun onNothingSelected(parent: AdapterView<*>) {}
-
-            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                viewModel.updateAuthorFilterSelection(id)
-            }
-        }
-
         // Just a safety measure - there shouldn't by any existing listeners since this method is called just once.
         postPager.clearOnPageChangeListeners()
 
@@ -430,22 +421,6 @@ class PostsListActivity : LocaleAwareActivity(),
         } else {
             fabButton.hide()
         }
-
-        val authorSelectionVisibility = if (state.isAuthorFilterVisible) View.VISIBLE else View.GONE
-        postListAuthorSelection.visibility = authorSelectionVisibility
-        postListTabLayoutFadingEdge.visibility = authorSelectionVisibility
-
-        val tabLayoutPaddingStart =
-            if (state.isAuthorFilterVisible) {
-                resources.getDimensionPixelSize(R.dimen.posts_list_tab_layout_fading_edge_width)
-            } else 0
-        tabLayout.setPaddingRelative(tabLayoutPaddingStart, 0, 0, 0)
-        val authorSelectionAdapter = postListAuthorSelection.adapter as AuthorSelectionAdapter
-        authorSelectionAdapter.updateItems(state.authorFilterItems)
-
-        authorSelectionAdapter.getIndexOfSelection(state.authorFilterSelection)?.let { selectionIndex ->
-            postListAuthorSelection.setSelection(selectionIndex)
-        }
     }
 
     private fun showSnackBar(holder: SnackbarMessageHolder) {
@@ -537,8 +512,8 @@ class PostsListActivity : LocaleAwareActivity(),
         if (item.itemId == AndroidR.id.home) {
             onBackPressedDispatcher.onBackPressed()
             return true
-        } else if (item.itemId == R.id.toggle_post_list_item_layout) {
-            viewModel.toggleViewLayout()
+        } else if (item.itemId == R.id.toggle_post_list_author_filter) {
+            // todo: implement the logic to open/close the author filter
             return true
         }
         return super.onOptionsItemSelected(item)
@@ -547,21 +522,17 @@ class PostsListActivity : LocaleAwareActivity(),
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
         menuInflater.inflate(R.menu.posts_list_toggle_view_layout, menu)
-        toggleViewLayoutMenuItem = menu.findItem(R.id.toggle_post_list_item_layout)
-        viewModel.viewLayoutTypeMenuUiState.observe(this, { menuUiState ->
-            menuUiState?.let {
-                updateMenuIcon(menuUiState.iconRes, toggleViewLayoutMenuItem)
-                updateMenuTitle(menuUiState.title, toggleViewLayoutMenuItem)
-            }
-        })
-
+        authorFiltertMenuItem = menu.findItem(R.id.toggle_post_list_author_filter)
+        // todo: set the author filter icon on selection change
         searchActionButton = menu.findItem(R.id.toggle_post_search)
 
         initSearchFragment()
         binding.initSearchView()
+        initAuthorFilter()
         return true
     }
 
+    @SuppressLint("CommitTransaction")
     private fun initSearchFragment() {
         val searchFragmentTag = "search_fragment"
 
@@ -576,6 +547,9 @@ class PostsListActivity : LocaleAwareActivity(),
         }
     }
 
+    private fun initAuthorFilter() {
+        // todo: Implement the logic for the author filter spinner
+    }
     private fun PostListActivityBinding.initSearchView() {
         searchActionButton.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem): Boolean {
@@ -608,7 +582,7 @@ class PostsListActivity : LocaleAwareActivity(),
         })
 
         viewModel.isSearchExpanded.observe(this@PostsListActivity) { isExpanded ->
-            toggleViewLayoutMenuItem.isVisible = !isExpanded
+            authorFiltertMenuItem.isVisible = !isExpanded
             toggleSearch(isExpanded)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -13,10 +13,8 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MenuItem.OnActionExpandListener
 import android.view.View
-import android.widget.AdapterView
 import android.widget.Toast
 import androidx.annotation.DrawableRes
-import androidx.appcompat.widget.AppCompatSpinner
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
@@ -51,7 +49,6 @@ import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissBy
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
 import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.PostListType.SEARCH
-import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment.Companion.newInstance
 import org.wordpress.android.ui.posts.prepublishing.home.PublishPost
@@ -300,13 +297,13 @@ class PostsListActivity : LocaleAwareActivity(),
         viewModel = ViewModelProvider(this@PostsListActivity, viewModelFactory).get(PostListMainViewModel::class.java)
         viewModel.start(site, initPreviewState, currentBottomSheetPostId, editPostRepository)
 
-        viewModel.viewState.observe(this@PostsListActivity, { state ->
+        viewModel.viewState.observe(this@PostsListActivity) { state ->
             state?.let {
                 loadViewState(state)
             }
-        })
+        }
 
-        viewModel.postListAction.observe(this@PostsListActivity, { postListAction ->
+        viewModel.postListAction.observe(this@PostsListActivity) { postListAction ->
             postListAction?.let { action ->
                 handlePostListAction(
                     this@PostsListActivity,
@@ -317,33 +314,33 @@ class PostsListActivity : LocaleAwareActivity(),
                     blazeFeatureUtils
                 )
             }
-        })
-        viewModel.selectTab.observe(this@PostsListActivity, { tabIndex ->
+        }
+        viewModel.selectTab.observe(this@PostsListActivity) { tabIndex ->
             tabIndex?.let {
                 tabLayout.getTabAt(tabIndex)?.select()
             }
-        })
-        viewModel.scrollToLocalPostId.observe(this@PostsListActivity, { targetLocalPostId ->
+        }
+        viewModel.scrollToLocalPostId.observe(this@PostsListActivity) { targetLocalPostId ->
             targetLocalPostId?.let {
                 postsPagerAdapter.getItemAtPosition(postPager.currentItem)?.scrollToTargetPost(targetLocalPostId)
             }
-        })
-        viewModel.snackBarMessage.observe(this@PostsListActivity, {
+        }
+        viewModel.snackBarMessage.observe(this@PostsListActivity) {
             it?.let { snackBarHolder -> showSnackBar(snackBarHolder) }
-        })
-        viewModel.toastMessage.observe(this@PostsListActivity, {
+        }
+        viewModel.toastMessage.observe(this@PostsListActivity) {
             it?.show(this@PostsListActivity)
-        })
-        viewModel.previewState.observe(this@PostsListActivity, {
+        }
+        viewModel.previewState.observe(this@PostsListActivity) {
             progressDialog = progressDialogHelper.updateProgressDialogState(
                 this@PostsListActivity,
                 progressDialog,
                 it.progressDialogUiState,
                 uiHelpers
             )
-        })
+        }
         setupActions()
-        viewModel.openPrepublishingBottomSheet.observeEvent(this@PostsListActivity, {
+        viewModel.openPrepublishingBottomSheet.observeEvent(this@PostsListActivity) {
             val fragment = supportFragmentManager.findFragmentByTag(PrepublishingBottomSheetFragment.TAG)
             if (fragment == null) {
                 val prepublishingFragment = newInstance(
@@ -353,7 +350,7 @@ class PostsListActivity : LocaleAwareActivity(),
                 )
                 prepublishingFragment.show(supportFragmentManager, PrepublishingBottomSheetFragment.TAG)
             }
-        })
+        }
 
         setupFabEvents()
     }
@@ -367,22 +364,21 @@ class PostsListActivity : LocaleAwareActivity(),
         observeBottomSheet(
             bloggingRemindersViewModel.isBottomSheetShowing,
             this,
-            BLOGGING_REMINDERS_FRAGMENT_TAG,
-            {
-                if (!this.isFinishing) {
-                    this.supportFragmentManager
-                } else {
-                    null
-                }
+            BLOGGING_REMINDERS_FRAGMENT_TAG
+        ) {
+            if (!this.isFinishing) {
+                this.supportFragmentManager
+            } else {
+                null
             }
-        )
+        }
     }
 
     private fun setupActions() {
-        viewModel.dialogAction.observe(this@PostsListActivity, {
+        viewModel.dialogAction.observe(this@PostsListActivity) {
             it?.show(this@PostsListActivity, supportFragmentManager, uiHelpers)
-        })
-        viewModel.postUploadAction.observe(this@PostsListActivity, {
+        }
+        viewModel.postUploadAction.observe(this@PostsListActivity) {
             it?.let { uploadAction ->
                 handleUploadAction(
                     uploadAction,
@@ -394,25 +390,25 @@ class PostsListActivity : LocaleAwareActivity(),
                     bloggingRemindersViewModel.onPublishingPost(site.id, isFirstTimePublishing)
                 }
             }
-        })
+        }
     }
 
     private fun PostListActivityBinding.setupFabEvents() {
-        viewModel.onFabClicked.observeEvent(this@PostsListActivity, {
+        viewModel.onFabClicked.observeEvent(this@PostsListActivity) {
             postListCreateMenuViewModel.onFabClicked()
-        })
+        }
 
-        viewModel.onFabLongPressedForCreateMenu.observeEvent(this@PostsListActivity, {
+        viewModel.onFabLongPressedForCreateMenu.observeEvent(this@PostsListActivity) {
             postListCreateMenuViewModel.onFabLongPressed()
             Toast.makeText(fabButton.context, R.string.create_post_story_fab_tooltip, Toast.LENGTH_SHORT).show()
-        })
+        }
 
-        viewModel.onFabLongPressedForPostList.observe(this@PostsListActivity, {
+        viewModel.onFabLongPressedForPostList.observe(this@PostsListActivity) {
             if (fabButton.isHapticFeedbackEnabled) {
                 fabButton.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             }
             Toast.makeText(fabButton.context, R.string.create_post_fab_tooltip, Toast.LENGTH_SHORT).show()
-        })
+        }
     }
 
     private fun PostListActivityBinding.loadViewState(state: PostListMainViewState) {

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -27,35 +27,19 @@
             android:paddingBottom="@dimen/bottom_tabs_divider_size"
             android:duplicateParentState="true">
 
-            <!--Padding start and end is set programmatically based on if the fading edge is visible-->
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabLayout"
-                android:background="@null"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_alignStart="@+id/post_list_tab_layout_fading_edge"
                 android:layout_gravity="start"
+                android:layout_marginBottom="0dp"
+                android:background="@null"
                 android:clipToPadding="false"
+                android:importantForAccessibility="no"
                 app:tabGravity="fill"
                 app:tabMode="scrollable"
                 tools:paddingEnd="0dp"
-                android:layout_marginBottom="0dp"
-                tools:paddingStart="@dimen/posts_list_tab_layout_fading_edge_width" />
-
-            <org.wordpress.android.widgets.AppBarFadingEdgeView
-                android:id="@+id/post_list_tab_layout_fading_edge"
-                android:layout_width="@dimen/posts_list_tab_layout_fading_edge_width"
-                android:layout_height="match_parent"
-                android:layout_alignEnd="@+id/post_list_author_selection" />
-
-            <androidx.appcompat.widget.AppCompatSpinner
-                android:id="@+id/post_list_author_selection"
-                android:layout_width="@dimen/author_spinner_width"
-                android:contentDescription="@string/post_list_author"
-                android:layout_height="match_parent"
-                android:background="?attr/selectableItemBackground"
-                android:paddingStart="0dp"
-                android:paddingEnd="@dimen/margin_small" />
+                tools:paddingStart="0dp" />
         </RelativeLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
@@ -64,6 +48,7 @@
         android:id="@+id/postPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:importantForAccessibility="no"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <FrameLayout

--- a/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
+++ b/WordPress/src/main/res/menu/posts_list_toggle_view_layout.xml
@@ -3,15 +3,15 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/toggle_post_list_author_filter"
+        android:icon="@drawable/ic_multiple_users_white_24dp"
+        android:title="@string/post_list_toggle_author_filter"
+        app:showAsAction="always"/>
+
+    <item
         android:id="@+id/toggle_post_search"
         android:icon="@drawable/ic_search_white_24dp"
         app:showAsAction="always|collapseActionView"
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         android:title="@string/search"/>
-
-    <item
-        android:id="@+id/toggle_post_list_item_layout"
-        android:icon="@drawable/ic_view_post_compact_white_24dp"
-        android:title="@string/post_list_toggle_item_layout_list_view"
-        app:showAsAction="always"/>
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -280,6 +280,7 @@
     <string name="multiple_status_label_delimiter" translatable="false">\u0020·\u0020</string>
     <string name="post_list_toggle_item_layout_cards_view">Switch to cards view</string>
     <string name="post_list_toggle_item_layout_list_view">Switch to list view</string>
+    <string name="post_list_toggle_author_filter">Filter by author</string>
     <string name="post_waiting_for_connection_publish">We\'ll publish the post when your device is back online.</string>
     <string name="post_waiting_for_connection_pending">We\'ll submit your post for review when your device is back online.</string>
     <string name="post_waiting_for_connection_scheduled">We\'ll schedule your post when your device is back online.</string>


### PR DESCRIPTION
Fixes #19350 

This PR is the first in a series that will address the Post List Author filter
- Removes the standard/compact filter from the Post list toolbar (#19340)
- Moves the Post List author filter from the tab layout to the toolbar
- Cleans up some detekt warnings in PostListActivity

**Note**: No rules have been implemented to suppress the icon from showing and tapping on the icon does nothing. 

Old | New
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/edc0c874-1335-41fd-95b5-1f3fa0b65283"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/614516bd-9afc-4c15-a6c6-eb947ff65315">

**To test:**
- Install and launch the app
- Login and choose a site
- Navigate to Posts 
- ✅ Verify the layout filter is not shown in the toolbar
- ✅ Verify the author selection icon is shown in the toolbar
- ✅ Verify the tabs no longer shows a fading edge

## Regression Notes
1. Potential unintended areas of impact
The author filter menu icon is not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
