### PR TITLE
Exposes the Domains List Endpoint (all-domains) api call

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.domains.usecases
+
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
+import org.wordpress.android.fluxc.store.SiteStore
+import javax.inject.Inject
+
+class FetchAllDomainsUseCase  @Inject constructor(
+    private val siteStore: SiteStore,
+) {
+    suspend fun execute(): AllDomains {
+        val result = siteStore.fetchAllDomains()
+        return when {
+            result.isError -> AllDomains.Error
+            result.domains.isNullOrEmpty() -> return AllDomains.Empty
+            else -> result.domains?.run {
+                AllDomains.Success(this)
+            } ?: AllDomains.Empty
+        }
+    }
+}
+
+sealed interface AllDomains {
+    data class Success(
+        val domains: List<AllDomainsDomain>,
+    ) : AllDomains
+
+    object Empty : AllDomains
+
+    object Error : AllDomains
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/FetchAllDomainsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/FetchAllDomainsUseCaseTest.kt
@@ -1,0 +1,89 @@
+package org.wordpress.android.ui.domains
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.ui.domains.usecases.AllDomains
+import org.wordpress.android.ui.domains.usecases.FetchAllDomainsUseCase
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class FetchAllDomainsUseCaseTest: BaseUnitTest() {
+    @Mock
+    lateinit var store: SiteStore
+
+    private lateinit var fetchAllDomainsUseCase: FetchAllDomainsUseCase
+
+    @Before
+    fun setUp() {
+        fetchAllDomainsUseCase = FetchAllDomainsUseCase(store)
+    }
+
+    @Test
+    fun `given all-domains call returns results, when the usecase is execute, returns success`() = runTest {
+        whenever(store.fetchAllDomains()).thenReturn(
+            SiteStore.FetchedAllDomainsPayload(
+                listOf(
+                    AllDomainsDomain("test.domain.one"),
+                    AllDomainsDomain("test.domain.two")
+                )
+            )
+        )
+
+        val result = fetchAllDomainsUseCase.execute()
+
+        assertThat(result is AllDomains.Success).isTrue
+        with(result as AllDomains.Success) {
+            assertThat(domains.size).isEqualTo(2)
+            assertThat(domains[0].domain).isEqualTo("test.domain.one")
+            assertThat(domains[1].domain).isEqualTo("test.domain.two")
+        }
+    }
+
+    @Test
+    fun `given the all-domain call returns error, when usecase is execute, returns error`() = runTest {
+        whenever(store.fetchAllDomains()).thenReturn(
+            SiteStore.FetchedAllDomainsPayload(
+                SiteStore.AllDomainsError(
+                    SiteStore.AllDomainsErrorType.GENERIC_ERROR,
+                    null
+                )
+            )
+        )
+
+        val result = fetchAllDomainsUseCase.execute()
+
+        assertThat(result is AllDomains.Error).isTrue
+    }
+
+    @Test
+    fun `given the all-domain call returns empty response, when usecase execute, returns empty`() = runTest {
+        whenever(store.fetchAllDomains()).thenReturn(
+            SiteStore.FetchedAllDomainsPayload(listOf())
+        )
+
+        val result = fetchAllDomainsUseCase.execute()
+
+        assertThat(result is AllDomains.Empty).isTrue
+    }
+
+    @Test
+    fun `given the all-domain call returns null response, when usecase execute, returns empty`() = runTest {
+        whenever(store.fetchAllDomains()).thenReturn(
+            SiteStore.FetchedAllDomainsPayload(null)
+        )
+
+        val result = fetchAllDomainsUseCase.execute()
+
+        assertThat(result is AllDomains.Empty).isTrue
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.105.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = 'trunk-f3ba57a9f1d9be24a4f43f929c6d98bfd8539df2'
+    wordPressFluxCVersion = '2869-329bf4b6184cba90d35b358d2fad1e9083e6fc3c'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.105.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2869-329bf4b6184cba90d35b358d2fad1e9083e6fc3c'
+    wordPressFluxCVersion = 'trunk-21b9cb51949bff38713430b86c31e4620623dcf2'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #19165

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2869

This PR exposes the new all-domains api call implementation through a simple use case.

**Note:** Adding the `Note Ready for Merge` tag till we update the fluxc reference to point to trunk

To test:
- Verify that the tests pass and that the implementation matches the UI needs and specs pc8HXX-1gR-p2

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
`FetchAllDomainsUseCaseTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)