### PR TITLE
[Reader Improvements] Fix follow unfollow button responsiveness

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderCardUiState.kt
@@ -163,6 +163,7 @@ sealed class ReaderCardUiState {
             val description: String?,
             val iconUrl: String?,
             val isFollowed: Boolean,
+            val isFollowEnabled: Boolean,
             val onItemClicked: (Long, Long, Boolean) -> Unit,
             val onFollowClicked: (ReaderRecommendedBlogUiState) -> Unit
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -117,7 +117,31 @@ class ReaderDiscoverViewModel @Inject constructor(
         // Get the correct repository
         readerDiscoverDataProvider.start()
 
-        // Listen to changes to the discover feed
+        observeDiscoverFeed()
+        observeFollowStatus()
+
+        // TODO reader improvements: Consider using Channel/Flow
+        readerDiscoverDataProvider.communicationChannel.observeForever(communicationChannelObserver)
+
+        _navigationEvents.addSource(readerPostCardActionsHandler.navigationEvents) { event ->
+            val target = event.peekContent()
+            if (target is ShowSitePickerForResult) {
+                pendingReblogPost = target.post
+            }
+            _navigationEvents.value = event
+        }
+
+        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
+            _snackbarEvents.value = event
+        }
+
+        _preloadPostEvents.addSource(readerPostCardActionsHandler.preloadPostEvents) { event ->
+            _preloadPostEvents.value = event
+        }
+    }
+
+    private fun observeDiscoverFeed() {
+        // listen to changes to the discover feed
         _uiState.addSource(readerDiscoverDataProvider.discoverFeed) { posts ->
             launch {
                 val userTags = getFollowedTagsUseCase.get()
@@ -142,7 +166,9 @@ class ReaderDiscoverViewModel @Inject constructor(
                 }
             }
         }
+    }
 
+    private fun observeFollowStatus() {
         // listen to changes on follow status for updating the reader recommended blogs state immediately
         _uiState.addSource(readerPostCardActionsHandler.followStatusUpdated) { data ->
             val currentUiState: DiscoverUiState.ContentUiState = _uiState.value as? DiscoverUiState.ContentUiState
@@ -172,25 +198,6 @@ class ReaderDiscoverViewModel @Inject constructor(
             if (hasChangedCards) {
                 _uiState.value = currentUiState.copy(cards = mutableCards)
             }
-        }
-
-        // TODO reader improvements: Consider using Channel/Flow
-        readerDiscoverDataProvider.communicationChannel.observeForever(communicationChannelObserver)
-
-        _navigationEvents.addSource(readerPostCardActionsHandler.navigationEvents) { event ->
-            val target = event.peekContent()
-            if (target is ShowSitePickerForResult) {
-                pendingReblogPost = target.post
-            }
-            _navigationEvents.value = event
-        }
-
-        _snackbarEvents.addSource(readerPostCardActionsHandler.snackbarEvents) { event ->
-            _snackbarEvents.value = event
-        }
-
-        _preloadPostEvents.addSource(readerPostCardActionsHandler.preloadPostEvents) { event ->
-            _preloadPostEvents.value = event
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderPostUiStateBuilder.kt
@@ -303,6 +303,7 @@ class ReaderPostUiStateBuilder @Inject constructor(
                     description = it.description.ifEmpty { null },
                     iconUrl = it.imageUrl,
                     isFollowed = it.isFollowing,
+                    isFollowEnabled = true,
                     onFollowClicked = onFollowClicked,
                     onItemClicked = onItemClicked
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderRecommendedBlogNewViewHolder.kt
@@ -30,6 +30,7 @@ class ReaderRecommendedBlogNewViewHolder(
         binding: ReaderRecommendedBlogItemNewBinding
     ) {
         with(binding.siteFollowButton) {
+            isEnabled = uiState.isFollowEnabled
             setIsFollowed(uiState.isFollowed)
             contentDescription = context.getString(uiState.followContentDescription.stringRes)
             setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/usecases/ReaderSiteFollowUseCase.kt
@@ -46,7 +46,7 @@ class ReaderSiteFollowUseCase @Inject constructor(
             val isAskingToFollow = !readerBlogTableWrapper.isSiteFollowed(blogId, feedId)
             val showEnableNotification = !readerUtilsWrapper.isExternalFeed(blogId, feedId) && isAskingToFollow
 
-            emit(FollowStatusChanged(blogId, feedId, isAskingToFollow, showEnableNotification))
+            emit(FollowStatusChanged(blogId, feedId, isAskingToFollow, showEnableNotification, isChangeFinal = false))
             performAction(param, isAskingToFollow, source)
         }
     }
@@ -58,7 +58,7 @@ class ReaderSiteFollowUseCase @Inject constructor(
     ) {
         val succeeded = followSiteAndWaitForResult(param, isAskingToFollow, source)
         if (!succeeded) {
-            emit(FollowStatusChanged(param.blogId, param.feedId, !isAskingToFollow))
+            emit(FollowStatusChanged(param.blogId, param.feedId, !isAskingToFollow, isChangeFinal = true))
             emit(RequestFailed)
         } else {
             val deleteNotificationSubscription = !readerUtilsWrapper.isExternalFeed(param.blogId, param.feedId) &&
@@ -68,7 +68,8 @@ class ReaderSiteFollowUseCase @Inject constructor(
                     param.blogId,
                     param.feedId,
                     isAskingToFollow,
-                    deleteNotificationSubscription = deleteNotificationSubscription
+                    deleteNotificationSubscription = deleteNotificationSubscription,
+                    isChangeFinal = true,
                 )
             )
             emit(Success)
@@ -104,7 +105,8 @@ class ReaderSiteFollowUseCase @Inject constructor(
             val feedId: Long,
             val following: Boolean,
             val showEnableNotification: Boolean = false,
-            val deleteNotificationSubscription: Boolean = false
+            val deleteNotificationSubscription: Boolean = false,
+            val isChangeFinal: Boolean = true,
         ) : FollowSiteState()
 
         object Success : FollowSiteState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -248,7 +248,8 @@ class ReaderPostDetailViewModel @Inject constructor(
                     post.isFollowedByCurrentUser = data.following
                     updateFollowButtonUiState(
                         currentUiState = currentUiState,
-                        isFollowed = post.isFollowedByCurrentUser
+                        isFollowed = post.isFollowedByCurrentUser,
+                        isFollowEnabled = data.isChangeFinal
                     )
                 }
             }
@@ -601,12 +602,13 @@ class ReaderPostDetailViewModel @Inject constructor(
 
     private fun updateFollowButtonUiState(
         currentUiState: ReaderPostDetailsUiState,
-        isFollowed: Boolean
+        isFollowed: Boolean,
+        isFollowEnabled: Boolean,
     ) {
         val updatedFollowButtonUiState = currentUiState
             .headerUiState
             .followButtonUiState
-            .copy(isFollowed = isFollowed)
+            .copy(isFollowed = isFollowed, isEnabled = isFollowEnabled)
 
         val updatedHeaderUiState = currentUiState
             .headerUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -253,6 +253,8 @@ public class ReaderSiteHeaderView extends LinearLayout {
         if (!NetworkUtils.checkConnection(getContext())) {
             return;
         }
+        // disable follow button until API call returns
+        mFollowButton.setEnabled(false);
 
         final boolean isAskingToFollow;
         if (mIsFeed) {
@@ -260,6 +262,8 @@ public class ReaderSiteHeaderView extends LinearLayout {
         } else {
             isAskingToFollow = !ReaderBlogTable.isFollowedBlog(mBlogId);
         }
+
+        mFollowButton.setIsFollowed(isAskingToFollow);
 
         if (mFollowListener != null) {
             if (isAskingToFollow) {
@@ -273,24 +277,19 @@ public class ReaderSiteHeaderView extends LinearLayout {
             }
         }
 
-        ReaderActions.ActionListener listener = new ReaderActions.ActionListener() {
-            @Override
-            public void onActionResult(boolean succeeded) {
-                if (getContext() == null) {
-                    return;
-                }
-                mFollowButton.setEnabled(true);
-                if (!succeeded) {
-                    int errResId = isAskingToFollow ? R.string.reader_toast_err_follow_blog
-                            : R.string.reader_toast_err_unfollow_blog;
-                    ToastUtils.showToast(getContext(), errResId);
-                    mFollowButton.setIsFollowed(!isAskingToFollow);
-                }
+        ReaderActions.ActionListener listener = succeeded -> {
+            if (getContext() == null) {
+                return;
+            }
+            mFollowButton.setEnabled(true);
+            if (!succeeded) {
+                int errResId = isAskingToFollow ? R.string.reader_toast_err_follow_blog
+                        : R.string.reader_toast_err_unfollow_blog;
+                ToastUtils.showToast(getContext(), errResId);
+                mFollowButton.setIsFollowed(!isAskingToFollow);
             }
         };
 
-        // disable follow button until API call returns
-        mFollowButton.setEnabled(false);
 
         boolean result;
         if (mIsFeed) {
@@ -313,8 +312,8 @@ public class ReaderSiteHeaderView extends LinearLayout {
             );
         }
 
-        if (result) {
-            mFollowButton.setIsFollowed(isAskingToFollow);
+        if (!result) {
+            mFollowButton.setIsFollowed(!isAskingToFollow);
         }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.Dis
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.BookmarkPostState.PreLoadPostContent
+import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.FollowStatusChanged
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.reader.views.uistates.ReaderBlogSectionUiState
@@ -140,6 +141,7 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
     private val fakeNavigationFeed = MutableLiveData<Event<ReaderNavigationEvents>>()
     private val fakeSnackBarFeed = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val fakePreloadPostFeed = MutableLiveData<Event<PreLoadPostContent>>()
+    private val fakeFollowStatusChangedFeed = MutableLiveData<FollowStatusChanged>()
 
     private lateinit var viewModel: ReaderDiscoverViewModel
 
@@ -164,6 +166,7 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
         whenever(readerPostCardActionsHandler.navigationEvents).thenReturn(fakeNavigationFeed)
         whenever(readerPostCardActionsHandler.snackbarEvents).thenReturn(fakeSnackBarFeed)
         whenever(readerPostCardActionsHandler.preloadPostEvents).thenReturn(fakePreloadPostFeed)
+        whenever(readerPostCardActionsHandler.followStatusUpdated).thenReturn(fakeFollowStatusChangedFeed)
         whenever(readerUtilsWrapper.getTagFromTagName(anyOrNull(), anyOrNull())).thenReturn(mock())
         whenever(menuUiStateBuilder.buildMoreMenuItems(anyOrNull(), any(), anyOrNull())).thenReturn(mock())
         whenever(
@@ -834,7 +837,8 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
                     feedId = it.feedId,
                     onItemClicked = onItemClicked,
                     onFollowClicked = onFollowClicked,
-                    isFollowed = it.isFollowing
+                    isFollowed = it.isFollowing,
+                    isFollowEnabled = true,
                 )
             }
         )


### PR DESCRIPTION
Fixes #19307 

Make the changes where needed to have the behavior closer to:
1. user taps the button
2. button changes state immediately and becomes disabled
3. request for the action is triggered while button is disabled
4. result from backend is received
5. if success -> button is enabled again and keeps the new state
6. if failure -> button is enabled again and reverts to previous state

To test:
Use the reader and use the follow/unfollow button in the several app areas, such as:
- feed cards (posts and recommended blogs)
- site header
- tag header
- follow/unfollow settings

## Regression Notes
1. Potential unintended areas of impact
Wrong behavior in buttons that didn't have code changed.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

8. What automated tests I added (or what prevented me from doing so)
Updated unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
