### PR TITLE
Implements: Me ui for settings in No sites scenario for a new User

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/AccountDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/AccountDataSource.kt
@@ -27,7 +27,8 @@ class AccountDataSource @Inject constructor(
         when (isRefresh) {
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
-                val name = accountStore.account?.displayName.orEmpty()
+                val name =
+                    accountStore.account?.displayName?.ifEmpty { accountStore.account?.userName.orEmpty() }.orEmpty()
                 setState(AccountData(url,name))
             }
             false -> Unit // Do nothing

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/AccountDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/AccountDataSource.kt
@@ -6,29 +6,29 @@ import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.ui.mysite.MySiteSource.SiteIndependentSource
-import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.AccountData
 import javax.inject.Inject
 
-class CurrentAvatarSource @Inject constructor(
+class AccountDataSource @Inject constructor(
     private val accountStore: AccountStore
-) : SiteIndependentSource<CurrentAvatarUrl> {
+) : SiteIndependentSource<AccountData> {
     override val refresh = MutableLiveData(false)
 
-    override fun build(coroutineScope: CoroutineScope): LiveData<CurrentAvatarUrl> {
-        val result = MediatorLiveData<CurrentAvatarUrl>()
+    override fun build(coroutineScope: CoroutineScope): LiveData<AccountData> {
+        val result = MediatorLiveData<AccountData>()
         result.addSource(refresh) { result.refreshData(refresh.value) }
         refresh()
         return result
     }
 
-    private fun MediatorLiveData<CurrentAvatarUrl>.refreshData(
+    private fun MediatorLiveData<AccountData>.refreshData(
         isRefresh: Boolean? = null
     ) {
         when (isRefresh) {
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
                 val name = accountStore.account?.displayName.orEmpty()
-                setState(CurrentAvatarUrl(url,name))
+                setState(AccountData(url,name))
             }
             false -> Unit // Do nothing
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/CurrentAvatarSource.kt
@@ -27,7 +27,8 @@ class CurrentAvatarSource @Inject constructor(
         when (isRefresh) {
             null, true -> {
                 val url = accountStore.account?.avatarUrl.orEmpty()
-                setState(CurrentAvatarUrl(url))
+                val name = accountStore.account?.displayName.orEmpty()
+                setState(CurrentAvatarUrl(url,name))
             }
             false -> Unit // Do nothing
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -242,11 +242,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun MySiteFragmentBinding.showAvatarSettingsView(state: State.NoSites) {
         if (state.shouldShowAccountSettings) {
-            noSitesView.avatarContainer.visibility = View.VISIBLE
+            noSitesView.avatarAccountSettings.visibility = View.VISIBLE
             noSitesView.meDisplayName.text = state.accountName
             loadGravatar(state.avatartUrl)
             noSitesView.avatarAccountSettings.setOnClickListener { viewModel.onAvatarPressed() }
-        } else noSitesView.avatarContainer.visibility = View.GONE
+        } else noSitesView.avatarAccountSettings.visibility = View.GONE
     }
 
     private fun MySiteFragmentBinding.loadGravatar(avatarUrl: String?) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.databinding.MySiteInfoHeaderCardBinding
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginFragment
 import org.wordpress.android.ui.main.SitePickerActivity
+import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.SiteInfoHeaderCard.IconState
 import org.wordpress.android.ui.mysite.MySiteViewModel.SiteInfoToolbarViewParams
@@ -32,6 +33,7 @@ import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartP
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
 import org.wordpress.android.viewmodel.observeEvent
@@ -45,6 +47,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     @Inject
     lateinit var uiHelpers: UiHelpers
+
+    @Inject
+    lateinit var meGravatarLoader: MeGravatarLoader
 
     @Inject
     lateinit var imageManager: ImageManager
@@ -134,7 +139,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     private fun MySiteFragmentBinding.setupActionableEmptyView() {
-        actionableEmptyView.button.setOnClickListener { viewModel.onAddSitePressed() }
+        noSitesView.actionableEmptyView.button.setOnClickListener { viewModel.onAddSitePressed() }
     }
 
     private fun MySiteFragmentBinding.setupObservers() {
@@ -178,8 +183,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.loadData(state: State.SiteSelected) {
         tabLayout.setVisible(state.tabsUiState.showTabs)
         updateTabs(state.tabsUiState)
-        if (actionableEmptyView.isVisible) {
-            actionableEmptyView.setVisible(false)
+        if (noSitesView.actionableEmptyView.isVisible) {
+            noSitesView.actionableEmptyView.setVisible(false)
             viewModel.onActionableEmptyViewGone()
         }
         if (state.siteInfoHeaderState.hasUpdates || !header.isVisible) {
@@ -224,15 +229,32 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     private fun MySiteFragmentBinding.loadEmptyView(state: State.NoSites) {
         tabLayout.setVisible(state.tabsUiState.showTabs)
-        if (!actionableEmptyView.isVisible) {
-            actionableEmptyView.setVisible(true)
-            actionableEmptyView.image.setVisible(state.shouldShowImage)
+        if (!noSitesView.actionableEmptyView.isVisible) {
+            noSitesView.actionableEmptyView.setVisible(true)
+            noSitesView.actionableEmptyView.image.setVisible(state.shouldShowImage)
             viewModel.onActionableEmptyViewVisible()
+            loadGravatar(state.avatartUrl)
+            noSitesView.meDisplayName.text = state.accountName
+            noSitesView.avatarAccountSettings.setOnClickListener { viewModel.onAvatarPressed() }
         }
         siteTitle = getString(R.string.my_site_section_screen_title)
         updateSiteInfoToolbarView(state.siteInfoToolbarViewParams)
         appbarMain.setExpanded(false, true)
     }
+
+    private fun MySiteFragmentBinding.loadGravatar(avatarUrl: String?) =
+        avatarUrl?.let {
+            noSitesView.meAvatar.let {
+                meGravatarLoader.load(
+                    false,
+                    meGravatarLoader.constructGravatarUrl(avatarUrl),
+                    null,
+                    it,
+                    ImageType.USER,
+                    null
+                )
+            }
+        }
 
     private fun MySiteFragmentBinding.showHeader(visibility: Boolean) {
         header.visibility = if (visibility) View.VISIBLE else View.INVISIBLE

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -233,13 +233,20 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             noSitesView.actionableEmptyView.setVisible(true)
             noSitesView.actionableEmptyView.image.setVisible(state.shouldShowImage)
             viewModel.onActionableEmptyViewVisible()
-            loadGravatar(state.avatartUrl)
-            noSitesView.meDisplayName.text = state.accountName
-            noSitesView.avatarAccountSettings.setOnClickListener { viewModel.onAvatarPressed() }
+            showAvatarSettingsView(state)
         }
         siteTitle = getString(R.string.my_site_section_screen_title)
         updateSiteInfoToolbarView(state.siteInfoToolbarViewParams)
         appbarMain.setExpanded(false, true)
+    }
+
+    private fun MySiteFragmentBinding.showAvatarSettingsView(state: State.NoSites) {
+        if (state.shouldShowAccountSettings) {
+            noSitesView.avatarContainer.visibility = View.VISIBLE
+            noSitesView.meDisplayName.text = state.accountName
+            loadGravatar(state.avatartUrl)
+            noSitesView.avatarAccountSettings.setOnClickListener { viewModel.onAvatarPressed() }
+        } else noSitesView.avatarContainer.visibility = View.GONE
     }
 
     private fun MySiteFragmentBinding.loadGravatar(avatarUrl: String?) =
@@ -353,7 +360,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     }
 
     companion object {
-        @JvmField var TAG: String = MySiteFragment::class.java.simpleName
+        @JvmField
+        var TAG: String = MySiteFragment::class.java.simpleName
         private const val PASS_TO_TAB_FRAGMENT_DELAY = 300L
         private const val MAX_PERCENT = 100
         fun newInstance(): MySiteFragment {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteSourceManager.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardSource
 import javax.inject.Inject
 
 class MySiteSourceManager @Inject constructor(
-    private val currentAvatarSource: CurrentAvatarSource,
+    private val accountDataSource: AccountDataSource,
     private val domainRegistrationSource: DomainRegistrationSource,
     private val quickStartCardSource: QuickStartCardSource,
     private val scanAndBackupSource: ScanAndBackupSource,
@@ -30,7 +30,7 @@ class MySiteSourceManager @Inject constructor(
         selectedSiteSource,
         siteIconProgressSource,
         quickStartCardSource,
-        currentAvatarSource,
+        accountDataSource,
         domainRegistrationSource,
         scanAndBackupSource,
         cardsSource,
@@ -95,7 +95,7 @@ class MySiteSourceManager @Inject constructor(
 
     private fun refreshSubsetOfAllSources() {
         selectedSiteSource.updateSiteSettingsIfNecessary()
-        currentAvatarSource.refresh()
+        accountDataSource.refresh()
         if (selectedSiteRepository.hasSelectedSite()) quickStartCardSource.refresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.Qui
 
 data class MySiteUiState(
     val currentAvatarUrl: String? = null,
+    val avatarName: String? = null,
     val site: SiteModel? = null,
     val showSiteIconProgressBar: Boolean = false,
     val isDomainCreditAvailable: Boolean = false,
@@ -29,7 +30,7 @@ data class MySiteUiState(
     val blazeCardUpdate: PartialState.BlazeCardUpdate? = null,
 ) {
     sealed class PartialState {
-        data class CurrentAvatarUrl(val url: String) : PartialState()
+        data class CurrentAvatarUrl(val url: String, val name:String) : PartialState()
         data class SelectedSite(val site: SiteModel?) : PartialState()
         data class ShowSiteIconProgressBar(val showSiteIconProgressBar: Boolean) : PartialState()
         data class DomainCreditAvailable(val isDomainCreditAvailable: Boolean) : PartialState()
@@ -60,7 +61,7 @@ data class MySiteUiState(
         val uiState = updateSnackbarStatusToShowOnlyOnce(partialState)
 
         return when (partialState) {
-            is CurrentAvatarUrl -> uiState.copy(currentAvatarUrl = partialState.url)
+            is CurrentAvatarUrl -> uiState.copy(currentAvatarUrl = partialState.url, avatarName = partialState.name)
             is SelectedSite -> uiState.copy(site = partialState.site)
             is ShowSiteIconProgressBar -> uiState.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
             is DomainCreditAvailable -> uiState.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteUiState.kt
@@ -5,9 +5,9 @@ import org.wordpress.android.fluxc.model.blaze.BlazeCampaignModel
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.AccountData
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.BloggingPromptUpdate
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
-import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.QuickStartUpdate
@@ -30,7 +30,7 @@ data class MySiteUiState(
     val blazeCardUpdate: PartialState.BlazeCardUpdate? = null,
 ) {
     sealed class PartialState {
-        data class CurrentAvatarUrl(val url: String, val name:String) : PartialState()
+        data class AccountData(val url: String, val name:String) : PartialState()
         data class SelectedSite(val site: SiteModel?) : PartialState()
         data class ShowSiteIconProgressBar(val showSiteIconProgressBar: Boolean) : PartialState()
         data class DomainCreditAvailable(val isDomainCreditAvailable: Boolean) : PartialState()
@@ -61,7 +61,7 @@ data class MySiteUiState(
         val uiState = updateSnackbarStatusToShowOnlyOnce(partialState)
 
         return when (partialState) {
-            is CurrentAvatarUrl -> uiState.copy(currentAvatarUrl = partialState.url, avatarName = partialState.name)
+            is AccountData -> uiState.copy(currentAvatarUrl = partialState.url, avatarName = partialState.name)
             is SelectedSite -> uiState.copy(site = partialState.site)
             is ShowSiteIconProgressBar -> uiState.copy(showSiteIconProgressBar = partialState.showSiteIconProgressBar)
             is DomainCreditAvailable -> uiState.copy(isDomainCreditAvailable = partialState.isDomainCreditAvailable)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -710,7 +710,8 @@ class MySiteViewModel @Inject constructor(
             ),
             shouldShowImage = shouldShowImage,
             avatartUrl = accountUrl,
-            accountName = accountName
+            accountName = accountName,
+            shouldShowAccountSettings = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
 
         )
     }
@@ -1312,7 +1313,8 @@ class MySiteViewModel @Inject constructor(
             override val siteInfoToolbarViewParams: SiteInfoToolbarViewParams,
             val shouldShowImage: Boolean,
             val avatartUrl:String? = null,
-            val accountName:String? = null
+            val accountName:String? = null,
+            val shouldShowAccountSettings: Boolean = false
         ) : State()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -21,12 +21,14 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.ActivityCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.fluxc.store.QuickStartStore.Companion.QUICK_START_CHECK_STATS_LABEL
 import org.wordpress.android.fluxc.store.QuickStartStore.Companion.QUICK_START_UPLOAD_MEDIA_LABEL
@@ -1287,6 +1289,13 @@ class MySiteViewModel @Inject constructor(
                     mySiteSourceManager.refreshBloggingPrompts(true)
                 }
             }
+        }
+    }
+
+    @Subscribe(threadMode = MAIN)
+    fun onAccountChanged(event: OnAccountChanged) {
+        if (event.accountInfosChanged && event.causeOfChange == AccountAction.FETCH_SETTINGS) {
+            refresh()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -699,6 +699,8 @@ class MySiteViewModel @Inject constructor(
         // Hide actionable empty view image when screen height is under specified min height.
         val shouldShowImage = !buildConfigWrapper.isJetpackApp &&
                 displayUtilsWrapper.getWindowPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
+
+        val shouldShowAccountSettings = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
         return NoSites(
             tabsUiState = TabsUiState(showTabs = false, tabUiStates = emptyList()),
             siteInfoToolbarViewParams = SiteInfoToolbarViewParams(
@@ -711,8 +713,7 @@ class MySiteViewModel @Inject constructor(
             shouldShowImage = shouldShowImage,
             avatartUrl = accountUrl,
             accountName = accountName,
-            shouldShowAccountSettings = jetpackFeatureRemovalPhaseHelper.shouldRemoveJetpackFeatures()
-
+            shouldShowAccountSettings = shouldShowAccountSettings
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -339,7 +339,7 @@ class MySiteViewModel @Inject constructor(
 
                 state
             } else {
-                buildNoSiteState()
+                buildNoSiteState(currentAvatarUrl, avatarName)
             }
 
             bloggingPromptCardViewModelSlice.onSiteChanged(site?.id)
@@ -348,7 +348,7 @@ class MySiteViewModel @Inject constructor(
 
             domainTransferCardViewModel.onSiteChanged(site?.id, state as? SiteSelected)
 
-            UiModel(currentAvatarUrl.orEmpty(), state)
+            UiModel(currentAvatarUrl.orEmpty(), avatarName, state)
         }
     }
 
@@ -695,7 +695,7 @@ class MySiteViewModel @Inject constructor(
         MySiteTabType.ALL -> emptyList()
     }
 
-    private fun buildNoSiteState(): NoSites {
+    private fun buildNoSiteState(accountUrl:String?, accountName: String?): NoSites {
         // Hide actionable empty view image when screen height is under specified min height.
         val shouldShowImage = !buildConfigWrapper.isJetpackApp &&
                 displayUtilsWrapper.getWindowPixelHeight() >= MIN_DISPLAY_PX_HEIGHT_NO_SITE_IMAGE
@@ -708,7 +708,10 @@ class MySiteViewModel @Inject constructor(
                 appBarLiftOnScroll = true
 
             ),
-            shouldShowImage = shouldShowImage
+            shouldShowImage = shouldShowImage,
+            avatartUrl = accountUrl,
+            accountName = accountName
+
         )
     }
 
@@ -1287,6 +1290,7 @@ class MySiteViewModel @Inject constructor(
 
     data class UiModel(
         val accountAvatarUrl: String,
+        val accountName: String?,
         val state: State
     )
 
@@ -1306,7 +1310,9 @@ class MySiteViewModel @Inject constructor(
         data class NoSites(
             override val tabsUiState: TabsUiState,
             override val siteInfoToolbarViewParams: SiteInfoToolbarViewParams,
-            val shouldShowImage: Boolean
+            val shouldShowImage: Boolean,
+            val avatartUrl:String? = null,
+            val accountName:String? = null
         ) : State()
     }
 

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -60,16 +60,7 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/actionable_empty_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/toolbar_height"
-        android:visibility="gone"
-        app:aevButton="@string/my_site_add_new_site"
-        app:aevImage="@drawable/img_illustration_site_wordpress_camera_pencils_226dp"
-        app:aevSubtitle="@string/my_site_create_new_site"
-        app:aevTitle="@string/my_site_create_new_site_title"
-        tools:visibility="visible" />
+    <include layout="@layout/my_site_fragment_no_sites_view"
+        android:id="@+id/no_sites_view"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -28,12 +28,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:id="@+id/avatar_account_settings"
-        android:visibility="gone"
-        android:padding="@dimen/margin_large">
+        android:background="@drawable/bg_rectangle_black_60_radius_2dp"
+        android:layout_margin="@dimen/actionable_empty_view_text_margin_horizontal"
+        android:visibility="visible"
+        android:clickable="true"
+        android:padding="@dimen/margin_large"
+        android:focusable="true">
 
         <FrameLayout
             android:id="@+id/frame_avatar"
             android:layout_width="wrap_content"
+            android:clickable="false"
             android:layout_height="wrap_content">
 
             <FrameLayout
@@ -46,19 +51,20 @@
 
                 <ImageView
                     android:id="@+id/me_avatar"
-                    android:layout_width="@dimen/avatar_sz_inner_circle"
-                    android:layout_height="@dimen/avatar_sz_inner_circle"
+                    android:layout_width="@dimen/avatar_sz_small"
+                    android:layout_height="@dimen/avatar_sz_small"
+                    android:clickable="false"
                     android:contentDescription="@string/reader_avatar_desc" />
             </FrameLayout>
 
             <ProgressBar
                 android:id="@+id/avatar_progress"
-                android:layout_width="@dimen/avatar_sz_inner_circle"
-                android:layout_height="@dimen/avatar_sz_inner_circle"
+                android:layout_width="@dimen/avatar_sz_small"
+                android:layout_height="@dimen/avatar_sz_small"
                 android:layout_gravity="center"
                 android:background="@drawable/bg_oval_black_translucent_50"
-                android:clickable="true"
-                android:focusable="true"
+                android:clickable="false"
+                android:focusable="false"
                 android:indeterminate="true"
                 android:padding="@dimen/margin_large"
                 android:visibility="gone"
@@ -73,6 +79,7 @@
             android:layout_marginStart="@dimen/margin_extra_large"
             android:layout_toEndOf="@+id/frame_avatar"
             android:ellipsize="end"
+            android:clickable="false"
             android:maxLines="1"
             app:autoSizeMaxTextSize="@dimen/my_site_name_label_single_line_text_size"
             app:autoSizeMinTextSize="@dimen/my_site_name_label_double_line_text_size"
@@ -84,7 +91,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_marginBottom="@dimen/margin_extra_large"
             android:layout_below="@id/me_display_name"
             android:layout_toEndOf="@id/frame_avatar"
             android:ellipsize="end"
@@ -92,7 +98,24 @@
             android:maxLines="1"
             android:textAppearance="?attr/textAppearanceBody2"
             android:textColor="?attr/wpColorOnSurfaceMedium"
+            android:clickable="false"
             tools:text="@string/account_and_settings" />
+
+        <ImageButton
+            android:id="@+id/switch_site"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_small"
+            android:layout_marginEnd="@dimen/margin_small"
+            android:layout_marginStart="@dimen/margin_small"
+            android:layout_marginTop="@dimen/margin_small"
+            android:layout_alignParentEnd="true"
+            android:background="@drawable/ripple_oval"
+            android:contentDescription="@string/my_site_btn_switch_site"
+            android:padding="@dimen/margin_large"
+            android:clickable="false"
+            android:src="@drawable/ic_chevron_right_white_24dp"
+            app:tint="?attr/wpColorOnSurfaceMedium" />
     </RelativeLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -28,7 +28,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:id="@+id/avatar_account_settings"
-        android:visibility="visible"
+        android:visibility="gone"
         android:padding="@dimen/margin_large">
 
         <FrameLayout

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -1,7 +1,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/coordinator_layout"
+    android:id="@+id/no_sites_constraint_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -30,7 +30,7 @@
         android:id="@+id/avatar_account_settings"
         android:background="@drawable/bg_rectangle_black_60_radius_2dp"
         android:layout_margin="@dimen/actionable_empty_view_text_margin_horizontal"
-        android:visibility="visible"
+        android:visibility="gone"
         android:clickable="true"
         android:padding="@dimen/margin_large"
         android:focusable="true">
@@ -78,6 +78,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_large"
             android:layout_toEndOf="@+id/frame_avatar"
+            android:layout_toStartOf="@+id/go_to_settings"
             android:ellipsize="end"
             android:clickable="false"
             android:maxLines="1"
@@ -102,7 +103,7 @@
             tools:text="@string/account_and_settings" />
 
         <ImageButton
-            android:id="@+id/switch_site"
+            android:id="@+id/go_to_settings"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_small"

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -74,7 +74,7 @@
                     tools:visibility="visible" />
             </FrameLayout>
 
-            <ImageButton
+            <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/go_to_settings"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -1,0 +1,98 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/toolbar_height"
+        android:visibility="gone"
+        app:aevButton="@string/my_site_add_new_site"
+        app:aevImage="@drawable/img_illustration_site_wordpress_camera_pencils_226dp"
+        app:aevSubtitle="@string/my_site_create_new_site"
+        app:aevTitle="@string/my_site_create_new_site_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/avatar_account_settings"
+        tools:visibility="visible" />
+
+    <RelativeLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:id="@+id/avatar_account_settings"
+        android:visibility="visible"
+        android:padding="@dimen/margin_large">
+
+        <FrameLayout
+            android:id="@+id/frame_avatar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <FrameLayout
+                android:id="@+id/avatar_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/me_profile_photo"
+                android:padding="@dimen/margin_small">
+
+                <ImageView
+                    android:id="@+id/me_avatar"
+                    android:layout_width="@dimen/avatar_sz_inner_circle"
+                    android:layout_height="@dimen/avatar_sz_inner_circle"
+                    android:contentDescription="@string/reader_avatar_desc" />
+            </FrameLayout>
+
+            <ProgressBar
+                android:id="@+id/avatar_progress"
+                android:layout_width="@dimen/avatar_sz_inner_circle"
+                android:layout_height="@dimen/avatar_sz_inner_circle"
+                android:layout_gravity="center"
+                android:background="@drawable/bg_oval_black_translucent_50"
+                android:clickable="true"
+                android:focusable="true"
+                android:indeterminate="true"
+                android:padding="@dimen/margin_large"
+                android:visibility="gone"
+                tools:visibility="visible" />
+        </FrameLayout>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/me_display_name"
+            style="@style/MySiteTitleLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_toEndOf="@+id/frame_avatar"
+            android:ellipsize="end"
+            android:maxLines="1"
+            app:autoSizeMaxTextSize="@dimen/my_site_name_label_single_line_text_size"
+            app:autoSizeMinTextSize="@dimen/my_site_name_label_double_line_text_size"
+            app:autoSizeTextType="uniform"
+            tools:text="Full Name" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/me_username"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:layout_below="@id/me_display_name"
+            android:layout_toEndOf="@id/frame_avatar"
+            android:ellipsize="end"
+            android:text="@string/account_and_settings"
+            android:maxLines="1"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="?attr/wpColorOnSurfaceMedium"
+            tools:text="@string/account_and_settings" />
+    </RelativeLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -15,108 +15,112 @@
         app:aevImage="@drawable/img_illustration_site_wordpress_camera_pencils_226dp"
         app:aevSubtitle="@string/my_site_create_new_site"
         app:aevTitle="@string/my_site_create_new_site_title"
+        app:layout_constraintBottom_toTopOf="@+id/avatar_account_settings"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/avatar_account_settings"
         tools:visibility="visible" />
 
     <RelativeLayout
+        android:id="@+id/avatar_account_settings"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toStartOf="parent"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:id="@+id/avatar_account_settings"
-        android:background="@drawable/bg_rectangle_black_60_radius_2dp"
-        android:layout_margin="@dimen/actionable_empty_view_text_margin_horizontal"
-        android:visibility="gone"
-        android:clickable="true"
-        android:padding="@dimen/margin_large"
-        android:focusable="true">
+        app:layout_constraintStart_toStartOf="parent">
 
-        <FrameLayout
-            android:id="@+id/frame_avatar"
-            android:layout_width="wrap_content"
-            android:clickable="false"
-            android:layout_height="wrap_content">
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/margin_large"
+            android:background="@drawable/bg_rectangle_black_60_radius_2dp">
 
             <FrameLayout
-                android:id="@+id/avatar_container"
+                android:id="@+id/frame_avatar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/me_profile_photo"
-                android:padding="@dimen/margin_small">
+                android:clickable="false">
 
-                <ImageView
-                    android:id="@+id/me_avatar"
+                <FrameLayout
+                    android:id="@+id/avatar_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/me_profile_photo"
+                    android:padding="@dimen/margin_small">
+
+                    <ImageView
+                        android:id="@+id/me_avatar"
+                        android:layout_width="@dimen/avatar_sz_small"
+                        android:layout_height="@dimen/avatar_sz_small"
+                        android:clickable="false"
+                        android:contentDescription="@string/reader_avatar_desc" />
+                </FrameLayout>
+
+                <ProgressBar
+                    android:id="@+id/avatar_progress"
                     android:layout_width="@dimen/avatar_sz_small"
                     android:layout_height="@dimen/avatar_sz_small"
+                    android:layout_gravity="center"
+                    android:background="@drawable/bg_oval_black_translucent_50"
                     android:clickable="false"
-                    android:contentDescription="@string/reader_avatar_desc" />
+                    android:focusable="false"
+                    android:indeterminate="true"
+                    android:padding="@dimen/margin_large"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
             </FrameLayout>
 
-            <ProgressBar
-                android:id="@+id/avatar_progress"
-                android:layout_width="@dimen/avatar_sz_small"
-                android:layout_height="@dimen/avatar_sz_small"
-                android:layout_gravity="center"
-                android:background="@drawable/bg_oval_black_translucent_50"
+            <ImageButton
+                android:id="@+id/go_to_settings"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_marginBottom="@dimen/margin_small"
+                android:layout_marginEnd="@dimen/margin_small"
+                android:layout_marginStart="@dimen/margin_small"
+                android:layout_marginTop="@dimen/margin_small"
                 android:clickable="false"
-                android:focusable="false"
-                android:indeterminate="true"
+                android:contentDescription="@string/account_and_settings"
                 android:padding="@dimen/margin_large"
-                android:visibility="gone"
-                tools:visibility="visible" />
-        </FrameLayout>
+                android:src="@drawable/ic_chevron_right_white_24dp"
+                app:tint="?attr/wpColorOnSurfaceMedium" />
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/me_display_name"
-            style="@style/MySiteTitleLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_toEndOf="@+id/frame_avatar"
-            android:layout_toStartOf="@+id/go_to_settings"
-            android:ellipsize="end"
-            android:clickable="false"
-            android:maxLines="1"
-            app:autoSizeMaxTextSize="@dimen/my_site_name_label_single_line_text_size"
-            app:autoSizeMinTextSize="@dimen/my_site_name_label_double_line_text_size"
-            app:autoSizeTextType="uniform"
-            tools:text="Full Name" />
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/me_username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/me_display_name"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_toEndOf="@id/frame_avatar"
+                android:clickable="false"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="@string/account_and_settings"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="?attr/wpColorOnSurfaceMedium"
+                tools:text="@string/account_and_settings" />
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/me_username"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_extra_large"
-            android:layout_below="@id/me_display_name"
-            android:layout_toEndOf="@id/frame_avatar"
-            android:ellipsize="end"
-            android:text="@string/account_and_settings"
-            android:maxLines="1"
-            android:textAppearance="?attr/textAppearanceBody2"
-            android:textColor="?attr/wpColorOnSurfaceMedium"
-            android:clickable="false"
-            tools:text="@string/account_and_settings" />
-
-        <ImageButton
-            android:id="@+id/go_to_settings"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_small"
-            android:layout_marginEnd="@dimen/margin_small"
-            android:layout_marginStart="@dimen/margin_small"
-            android:layout_marginTop="@dimen/margin_small"
-            android:layout_alignParentEnd="true"
-            android:background="@drawable/ripple_oval"
-            android:contentDescription="@string/my_site_btn_switch_site"
-            android:padding="@dimen/margin_large"
-            android:clickable="false"
-            android:src="@drawable/ic_chevron_right_white_24dp"
-            app:tint="?attr/wpColorOnSurfaceMedium" />
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/me_display_name"
+                style="@style/TextAppearance.MaterialComponents.Headline6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_extra_large"
+                android:layout_toEndOf="@+id/frame_avatar"
+                android:layout_toStartOf="@+id/go_to_settings"
+                android:clickable="false"
+                android:ellipsize="end"
+                android:maxLines="1"
+                app:autoSizeMaxTextSize="@dimen/my_site_name_label_single_line_text_size"
+                app:autoSizeMinTextSize="@dimen/my_site_name_label_double_line_text_size"
+                app:autoSizeTextType="uniform"
+                tools:text="Full Name" />
+        </RelativeLayout>
     </RelativeLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4737,5 +4737,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_tap_here_to_show_more_details" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Tap here to show more details.</string>
     <string name="gutenberg_native_ungroup_block" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Ungroup block</string>
     <string name="gutenberg_native_warning_message" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Warning message</string>
+    <string name="account_and_settings">Account and Settings</string>
 
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/AccountDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/AccountDataSourceTest.kt
@@ -9,28 +9,28 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.AccountData
 
 @ExperimentalCoroutinesApi
-class CurrentAvatarSourceTest : BaseUnitTest() {
+class AccountDataSourceTest : BaseUnitTest() {
     @Mock
     lateinit var accountStore: AccountStore
 
     @Mock
     lateinit var accountModel: AccountModel
-    private lateinit var currentAvatarSource: CurrentAvatarSource
+    private lateinit var accountDataSource: AccountDataSource
     private lateinit var isRefreshing: MutableList<Boolean>
 
     @Before
     fun setUp() {
-        currentAvatarSource = CurrentAvatarSource(accountStore)
+        accountDataSource = AccountDataSource(accountStore)
         isRefreshing = mutableListOf()
     }
 
     @Test
     fun `current avatar is empty on start`() = test {
-        var result: CurrentAvatarUrl? = null
-        currentAvatarSource.build(testScope()).observeForever {
+        var result: AccountData? = null
+        accountDataSource.build(testScope()).observeForever {
             it?.let { result = it }
         }
 
@@ -43,30 +43,30 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
         val avatarUrl = "avatar.jpg"
         whenever(accountModel.avatarUrl).thenReturn(avatarUrl)
 
-        var result: CurrentAvatarUrl? = null
-        currentAvatarSource.build(testScope()).observeForever {
+        var result: AccountData? = null
+        accountDataSource.build(testScope()).observeForever {
             it?.let { result = it }
         }
 
-        currentAvatarSource.refresh()
+        accountDataSource.refresh()
 
         assertThat(result!!.url).isEqualTo(avatarUrl)
     }
 
     @Test
     fun `when buildSource is invoked, then refresh is true`() = test {
-        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+        accountDataSource.refresh.observeForever { isRefreshing.add(it) }
 
-        currentAvatarSource.build(testScope())
+        accountDataSource.build(testScope())
 
         assertThat(isRefreshing.last()).isTrue
     }
 
     @Test
     fun `when refresh is invoked, then refresh is true`() = test {
-        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+        accountDataSource.refresh.observeForever { isRefreshing.add(it) }
 
-        currentAvatarSource.refresh()
+        accountDataSource.refresh()
 
         assertThat(isRefreshing.last()).isTrue
     }
@@ -76,10 +76,10 @@ class CurrentAvatarSourceTest : BaseUnitTest() {
         whenever(accountStore.account).thenReturn(accountModel)
         val avatarUrl = "avatar.jpg"
         whenever(accountModel.avatarUrl).thenReturn(avatarUrl)
-        currentAvatarSource.refresh.observeForever { isRefreshing.add(it) }
+        accountDataSource.refresh.observeForever { isRefreshing.add(it) }
 
-        currentAvatarSource.build(testScope()).observeForever { }
-        currentAvatarSource.refresh()
+        accountDataSource.build(testScope()).observeForever { }
+        accountDataSource.refresh()
 
         assertThat(isRefreshing.last()).isFalse
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteSourceManagerTest.kt
@@ -37,7 +37,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     lateinit var scanAndBackupSource: ScanAndBackupSource
 
     @Mock
-    lateinit var currentAvatarSource: CurrentAvatarSource
+    lateinit var accountDataSource: AccountDataSource
 
     @Mock
     lateinit var cardsSource: CardsSource
@@ -82,7 +82,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
         whenever(selectedSiteRepository.hasSelectedSite()).thenReturn(true)
 
         mySiteSourceManager = MySiteSourceManager(
-            currentAvatarSource,
+            accountDataSource,
             domainRegistrationSource,
             quickStartCardSource,
             scanAndBackupSource,
@@ -99,7 +99,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
             selectedSiteSource,
             siteIconProgressSource,
             quickStartCardSource,
-            currentAvatarSource,
+            accountDataSource,
             domainRegistrationSource,
             scanAndBackupSource,
             cardsSource
@@ -109,18 +109,18 @@ class MySiteSourceManagerTest : BaseUnitTest() {
             selectedSiteSource,
             siteIconProgressSource,
             quickStartCardSource,
-            currentAvatarSource,
+            accountDataSource,
             domainRegistrationSource,
             scanAndBackupSource,
         )
 
         siteIndependentMySiteSources = listOf(
-            currentAvatarSource
+            accountDataSource
         )
 
         selectRefreshedMySiteSources = listOf(
             quickStartCardSource,
-            currentAvatarSource
+            accountDataSource
         )
 
         siteDependentMySiteSources = allRefreshedMySiteSources.filterNot(SiteIndependentSource::class.java::isInstance)
@@ -250,7 +250,7 @@ class MySiteSourceManagerTest : BaseUnitTest() {
     fun `given site selected, when on resume, then refresh current avatar`() {
         mySiteSourceManager.onResume(true)
 
-        verify(currentAvatarSource).refresh()
+        verify(accountDataSource).refresh()
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -65,9 +65,9 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.InfoItemBu
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickLinkRibbonBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.QuickStartCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.SiteItemsBuilderParams
+import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.AccountData
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.BloggingPromptUpdate
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
-import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CurrentAvatarUrl
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.DomainCreditAvailable
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.JetpackCapabilities
 import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.QuickStartUpdate
@@ -296,6 +296,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private lateinit var trackWithTabSource: MutableList<MySiteTrackWithTabSource>
     private lateinit var tabNavigation: MutableList<TabNavigation>
     private val avatarUrl = "https://1.gravatar.com/avatar/1000?s=96&d=identicon"
+    private val userName = "Username"
     private val siteLocalId = 1
     private val siteUrl = "http://site.com"
     private val siteIcon = "http://site.com/icon.jpg"
@@ -320,7 +321,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             backupAvailable = false
         )
     )
-    private val currentAvatar = MutableLiveData(CurrentAvatarUrl(""))
+    private val currentAvatar = MutableLiveData(AccountData("",""))
     private val quickStartUpdate = MutableLiveData(QuickStartUpdate())
     private val activeTask = MutableLiveData<QuickStartTask>()
     private val quickStartTabStep = MutableLiveData<QuickStartTabStep?>()
@@ -592,7 +593,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `model is empty with no selected site`() {
         onSiteSelected.value = null
-        currentAvatar.value = CurrentAvatarUrl("")
+        currentAvatar.value = AccountData("","")
 
         assertThat(uiModels.last().state).isInstanceOf(NoSites::class.java)
     }
@@ -678,7 +679,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `account avatar url value is emitted and updated from the source`() {
         initSelectedSite()
 
-        currentAvatar.value = CurrentAvatarUrl(avatarUrl)
+        currentAvatar.value = AccountData(avatarUrl,userName)
 
         assertThat(uiModels.last().accountAvatarUrl).isEqualTo(avatarUrl)
     }


### PR DESCRIPTION
Fixes #18873 

## Description
This PR fixes the scenario in which there is no sites present for a WP app user and the user is in NewUsersPhase or Fourth Phase of Feature removal. The user wont have any way for signing out of the app or change the settings of the app until the user adds a site. 

Note: In Phase 4 and in New users phase, the user cant create a Wordpress site. User can only add a self hosted site

| Before  | After   | 
|---|---|
| <img width="549" alt="Screenshot 2023-10-13 at 10 40 49 PM" src=https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/df8d72f4-e52a-42b6-8e14-f7be9e6aaf79>  | <img width="549" alt="Screenshot 2023-10-13 at 10 40 49 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/3c4e6b6e-4f7f-457d-95fa-453aca671ee0">  | 

This PR implements an account settings layout in the No sites view in WP app. 

## To test:
### Account settings is shown in WP - No sites - Phase 4, Phase New Users
1. Sign up and Login with an account having no sites
2. Notice that No Sites Message is shown 
3. Notice that an account settings layout is shown to navigate to Account settings 

### Account settings is not shown in WP - Static Posters Phase
1. Login to an account having no sites and enable Static Posters Phase
2. Notice that No Sites Message is shown and No account settings layout is present in No Sites View
3. Notice that the bottom nav is shown 

## Regression Notes
1. Potential unintended areas of impact
- Account settings is not shown correctly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Manual testing

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
