### PR TITLE
[Reader Improvements] Enable ReaderImprovementsFeatureConfig by default

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ReaderViewPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/ReaderViewPage.kt
@@ -18,7 +18,9 @@ class ReaderViewPage {
     private val recyclerView = UiScrollable(UiSelector().resourceId(buildResourceId("recycler_view")))
     private val savePostsForLater = device.findObject(UiSelector().text("Save Posts for Later"))
     private val okButton = device.findObject(UiSelector().text("OK"))
-    private val bookmarkButtonSelector = UiSelector().resourceId(buildResourceId("bookmark"))
+    private val postMoreMenuSelector = UiSelector().resourceId(buildResourceId("more_menu"))
+    private val bookmarkMenuAction = device.findObject(UiSelector().text("Save"))
+    private val removeBookmarkMenuAction = device.findObject(UiSelector().text("Saved"))
 
     private fun buildResourceId(id: String): String {
         val packageName = InstrumentationRegistry.getInstrumentation().targetContext.packageName
@@ -63,7 +65,7 @@ class ReaderViewPage {
     }
 
     fun bookmarkPost(): ReaderViewPage {
-        tapBookmarkButton()
+        tapBookmarkMenuAction()
         // Dismiss save posts locally dialog.
         if (savePostsForLater.exists()) {
             okButton.clickAndWaitForNewWindow()
@@ -72,15 +74,26 @@ class ReaderViewPage {
     }
 
     fun removeBookmarkPost(): ReaderViewPage {
-        tapBookmarkButton()
+        tapRemoveBookmarkMenuAction()
         return this
     }
 
-    private fun tapBookmarkButton() {
-        // Scroll to the bookmark button.
-        recyclerView.scrollIntoView(bookmarkButtonSelector)
+    fun openMoreMenu(): ReaderViewPage {
+        // Scroll to the more menu button.
+        recyclerView.scrollIntoView(postMoreMenuSelector)
+        // Tap the more menu button.
+        device.findObject(postMoreMenuSelector).clickAndWaitForNewWindow()
+        return this
+    }
+
+    private fun tapBookmarkMenuAction() {
         // Tap the bookmark button.
-        device.findObject(bookmarkButtonSelector).clickAndWaitForNewWindow()
+        bookmarkMenuAction.clickAndWaitForNewWindow()
+    }
+
+    private fun tapRemoveBookmarkMenuAction() {
+        // Tap the bookmark button.
+        removeBookmarkMenuAction.clickAndWaitForNewWindow()
     }
 
     fun goBackToReader(): ReaderPage {
@@ -128,7 +141,7 @@ class ReaderViewPage {
     }
 
     fun verifyPostNotBookmarked(): ReaderViewPage {
-        val isBookmarked = device.findObject(bookmarkButtonSelector).isSelected
+        val isBookmarked = bookmarkMenuAction.isSelected
         TestCase.assertFalse("The bookmark button is selected", isBookmarked)
         return this
     }

--- a/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ReaderTests.kt
+++ b/WordPress/src/androidTestJetpack/java/org/wordpress/android/e2e/ReaderTests.kt
@@ -47,9 +47,12 @@ class ReaderTests : BaseTest() {
         ReaderPage()
             .tapFollowingTab()
             .openBlogOrPost(TITLE_LONGREADS_BLOG)
+            .openMoreMenu()
             .bookmarkPost()
             .verifyPostBookmarked()
+            .openMoreMenu()
             .removeBookmarkPost()
+            .openMoreMenu()
             .verifyPostNotBookmarked()
             .goBackToReader()
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ReaderImprovementsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ReaderImprovementsFeatureConfig.kt
@@ -1,13 +1,16 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val READER_IMPROVEMENTS_REMOTE_FIELD = "reader_improvements"
+
+@Feature(remoteField = READER_IMPROVEMENTS_REMOTE_FIELD, defaultValue = true)
 class ReaderImprovementsFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
     appConfig,
     BuildConfig.READER_IMPROVEMENTS,
+    READER_IMPROVEMENTS_REMOTE_FIELD,
 )


### PR DESCRIPTION
Fixes #19370 

Change `ReaderImprovementsFeatureConfig` to be a `Feature` with a remote field called `reader_improvements` and default that flag to `true`, so the feature is enabled by default.

Also fix a broken UI test now that the Reader Improvements UI are shown by default.

To test:
1. Uninstall any previous versions of Jetpack or have a version from `trunk` installed
2. Install and log into Jetpack
3. Go to Reader
4. **Verify** the default UI for everything matches the new specs
5. Go to Debug Settings
6. **Verify** the `reader_improvements` feature config is enabled by default

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
