### PR TITLE
Improve plans in site creation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationStep.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.sitecreation.SiteCreationStep.PROGRESS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_DESIGNS
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_NAME
 import org.wordpress.android.ui.sitecreation.SiteCreationStep.SITE_PREVIEW
+import org.wordpress.android.util.config.PlansInSiteCreationFeatureConfig
 import org.wordpress.android.util.config.SiteIntentQuestionFeatureConfig
 import org.wordpress.android.util.config.SiteNameFeatureConfig
 import org.wordpress.android.util.wizard.WizardStep
@@ -20,14 +21,17 @@ enum class SiteCreationStep : WizardStep {
 @Singleton
 class SiteCreationStepsProvider @Inject constructor(
     private val siteIntentQuestionFeatureConfig: SiteIntentQuestionFeatureConfig,
-    private val siteNameFeatureConfig: SiteNameFeatureConfig
+    private val siteNameFeatureConfig: SiteNameFeatureConfig,
+    private val plansInSiteCreationFeatureConfig: PlansInSiteCreationFeatureConfig
 ) {
     private val isSiteNameEnabled get() = siteNameFeatureConfig.isEnabled()
     private val isIntentsEnabled get() = siteIntentQuestionFeatureConfig.isEnabled()
+    private val isPlansEnabled get() = plansInSiteCreationFeatureConfig.isEnabled()
 
     fun getSteps(): List<SiteCreationStep> = when {
+        isPlansEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, PLANS, PROGRESS, SITE_PREVIEW)
         isSiteNameEnabled -> listOf(INTENTS, SITE_NAME, SITE_DESIGNS, PROGRESS, SITE_PREVIEW)
-        isIntentsEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, PLANS, PROGRESS, SITE_PREVIEW)
-        else -> listOf(SITE_DESIGNS, DOMAINS, PLANS, PROGRESS, SITE_PREVIEW)
+        isIntentsEnabled -> listOf(INTENTS, SITE_DESIGNS, DOMAINS, PROGRESS, SITE_PREVIEW)
+        else -> listOf(SITE_DESIGNS, DOMAINS, PROGRESS, SITE_PREVIEW)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -89,18 +89,18 @@ class SiteCreationPlansViewModel @Inject constructor(
     }
 
     private fun createURL(): String {
-        val uriBuilder =  Uri.Builder().apply {
+        val uriBuilder = Uri.Builder().apply {
             scheme(SCHEME)
             authority(AUTHORITY)
             appendPath(JETPACK_APP_PATH)
             appendPath(PLANS_PATH)
             appendQueryParameter(PLAN_ID_PARAM, "")
             appendQueryParameter(PLAN_SLUG_PARAM, "")
+            if (!domainName.isFree) {
+                appendQueryParameter(PAID_DOMAIN_NAME, domainName.domainName)
+            }
         }
 
-        if (!domainName.isFree) uriBuilder.apply {
-            appendQueryParameter(PAID_DOMAIN_NAME, domainName.domainName)
-        }
 
         return uriBuilder.build().toString()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -45,12 +45,11 @@ class SiteCreationPlansViewModel @Inject constructor(
 
         val planId = uri.getQueryParameter(PLAN_ID_PARAM)?.toInt() ?: 0
         val planSlug = uri.getQueryParameter(PLAN_SLUG_PARAM).orEmpty()
-        val domainName = uri.getQueryParameter(PAID_DOMAIN_NAME).orEmpty()
 
         val planModel = PlanModel(
             productId = planId,
             productSlug = planSlug,
-            productName = domainName, // using domainName here
+            productName = domainName.domainName,
             isCurrentPlan = false,
             hasDomainCredit = false
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -94,8 +94,6 @@ class SiteCreationPlansViewModel @Inject constructor(
             authority(AUTHORITY)
             appendPath(JETPACK_APP_PATH)
             appendPath(PLANS_PATH)
-            appendQueryParameter(PLAN_ID_PARAM, "")
-            appendQueryParameter(PLAN_SLUG_PARAM, "")
             if (!domainName.isFree) {
                 appendQueryParameter(PAID_DOMAIN_NAME, domainName.domainName)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -108,7 +108,7 @@ class SiteCreationProgressViewModel @Inject constructor(
         }
         this.siteCreationState = siteCreationState
         domain = requireNotNull(siteCreationState.domain) { "domain required to create a site" }
-        plan = requireNotNull(siteCreationState.plan) { "plan purchased to create a site" }
+        plan = requireNotNull(siteCreationState.plan) { "plan required to create a site" }
 
         runLoadingAnimationUi()
         startCreateSiteService()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.sitecreation.domains.DomainModel
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.INTERNET_UNAVAILABLE_ERROR
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationErrorType.UNKNOWN
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationTracker
-import org.wordpress.android.ui.sitecreation.plans.PlanModel
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState.Error.CartError
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState.Error.ConnectionError
 import org.wordpress.android.ui.sitecreation.progress.SiteCreationProgressViewModel.SiteProgressUiState.Error.GenericError
@@ -64,7 +63,6 @@ class SiteCreationProgressViewModel @Inject constructor(
 
     private lateinit var siteCreationState: SiteCreationState
     private lateinit var domain: DomainModel
-    private lateinit var plan: PlanModel
     private lateinit var site: SiteModel
 
     private var lastReceivedServiceState: SiteCreationServiceState? = null
@@ -98,7 +96,7 @@ class SiteCreationProgressViewModel @Inject constructor(
         if (siteCreationState.result is Created) {
             check(siteCreationState.result !is Completed) { "Unexpected state on progress screen." }
             // reuse the previously blog when returning with the same domain
-            if (siteCreationState.domain == domain && siteCreationState.plan == plan) {
+            if (siteCreationState.domain == domain) {
                 site = siteCreationState.result.site
                 if (siteCreationState.result is InCart) {
                     createCart()
@@ -108,7 +106,6 @@ class SiteCreationProgressViewModel @Inject constructor(
         }
         this.siteCreationState = siteCreationState
         domain = requireNotNull(siteCreationState.domain) { "domain required to create a site" }
-        plan = requireNotNull(siteCreationState.plan) { "plan required to create a site" }
 
         runLoadingAnimationUi()
         startCreateSiteService()
@@ -176,7 +173,7 @@ class SiteCreationProgressViewModel @Inject constructor(
             SUCCESS -> {
                 site = mapPayloadToSiteModel(event.payload)
                 _onFreeSiteCreated.postValue(site) // MainVM will navigate forward if the domain is free
-                if (!domain.isFree && plan.productId != 0) {
+                if (!domain.isFree && siteCreationState.plan?.productId != 0) {
                     createCart()
                 }
             }
@@ -210,7 +207,7 @@ class SiteCreationProgressViewModel @Inject constructor(
             domain.domainName,
             domain.supportsPrivacy,
             false,
-            planProductId = plan.productId
+            planProductId = siteCreationState.plan?.productId
         )
 
         if (event.isError) {


### PR DESCRIPTION
This fixes some issues and improves the code from https://github.com/wordpress-mobile/WordPress-Android/pull/19304

- 28e9a697ad8fbf67188dee125eeb2c6ce8c00e27: The plan selection screen was passing the domain from the redirect URL. However, this was incorrect because if a free domain is chosen, there is no `paid_domain_name` parameter in the redirect URL. Therefore, I used the viewmodel's domain name to pass it to the next screen.
- 342ec70e5ed6c8692991ce710bef44d01207353e: Fixed a wrong error message.
- 02bc3a2b53840efd867f8073661cbc854ab67c56: Moved `appendQueryParameter` into already opened `apply` scope.
- 696dd82f94111f1521b90a1f41e89bcd62029858: The `plan_id` and `plan_slug` parameters were unnecessary when loading the plan selection link; they are being used only in redirect URLs.

To test:
#### Site creation with a free domain and free plan
1. Launch JP app
2. Go to Me-> Debug settings
3. Switch to the Remote Feature tab, find plans_in_site_creation, and enable it
4. Switch to My Site tab
5. Tap the down arrow to the right of the site name on the My Site screen
6. Tap the + icon at the top right on the Site picker screen
7. Select ⊕ Create WordPress.com site on the modal dialog
8. Tap Skip at the top right on the first step (topic screen)
9. Tap Skip at the top right on the next step (theme screen)
10. Enter a search query (whatever you want here)
11. Verify that the result domains are as shown in the screenshot above
12. Select a free domain (should be *.wordpress.com)
13. Verify Plans screen opens with Personal, Premium, Business, and Ecommerce plans
14. Select the free plan
15. Verify it returns to the site setup screen
16. Verify a site is created with the desired domain

## Regression Notes
1. Potential unintended areas of impact
This may affect the plan selection screen in the site creation flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
I haven't added any automated test since this is an improvement PR for another PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
