### PR TITLE
Plans in Site Creation: Fix for the free domain name from the Calypso popup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -225,8 +225,8 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.onDomainsScreenFinished(domain)
     }
 
-    override fun onPlanSelected(plan: PlanModel) {
-        mainViewModel.onPlanSelection(plan)
+    override fun onPlanSelected(plan: PlanModel, domainName: String?) {
+        mainViewModel.onPlanSelection(plan, domainName)
     }
 
     override fun onHelpClicked(origin: Origin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -276,6 +276,9 @@ class SiteCreationMainVM @Inject constructor(
 
     fun onPlanSelection(plan: PlanModel, domainName: String?) {
         siteCreationState = siteCreationState.copy(plan = plan)
+        domainName?.let {
+            siteCreationState = siteCreationState.copy(domain = siteCreationState.domain?.copy(domainName = it))
+        }
         wizardManager.showNextStep()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -274,7 +274,7 @@ class SiteCreationMainVM @Inject constructor(
         wizardManager.showNextStep()
     }
 
-    fun onPlanSelection(plan: PlanModel) {
+    fun onPlanSelection(plan: PlanModel, domainName: String?) {
         siteCreationState = siteCreationState.copy(plan = plan)
         wizardManager.showNextStep()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/PlansScreenListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/PlansScreenListener.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 interface PlansScreenListener {
-    fun onPlanSelected(plan: PlanModel)
+    fun onPlanSelected(plan: PlanModel, domainName: String?)
 }
 
 @Parcelize

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/PlansScreenListener.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/PlansScreenListener.kt
@@ -11,7 +11,6 @@ interface PlansScreenListener {
 data class PlanModel(
     val productId: Int?,
     val productSlug: String?,
-    val productName: String?,
     val isCurrentPlan: Boolean,
     val hasDomainCredit: Boolean
 ) : Parcelable

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansFragment.kt
@@ -78,7 +78,7 @@ class SiteCreationPlansFragment : Fragment(), SiteCreationPlansWebViewClientList
     private fun handleActionEvents(actionEvent: SiteCreationPlansActionEvent) {
         when (actionEvent) {
             is SiteCreationPlansActionEvent.CreateSite -> {
-                (requireActivity() as PlansScreenListener).onPlanSelected(actionEvent.planModel)
+                (requireActivity() as PlansScreenListener).onPlanSelected(actionEvent.planModel, actionEvent.domainName)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -170,5 +170,5 @@ class SiteCreationPlansViewModel @Inject constructor(
 }
 
 sealed class SiteCreationPlansActionEvent {
-    data class CreateSite(val planModel: PlanModel) : SiteCreationPlansActionEvent()
+    data class CreateSite(val planModel: PlanModel, val domainName: String?) : SiteCreationPlansActionEvent()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -49,7 +49,6 @@ class SiteCreationPlansViewModel @Inject constructor(
         val planModel = PlanModel(
             productId = planId,
             productSlug = planSlug,
-            productName = domainName.domainName,
             isCurrentPlan = false,
             hasDomainCredit = false
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -45,6 +45,7 @@ class SiteCreationPlansViewModel @Inject constructor(
 
         val planId = uri.getQueryParameter(PLAN_ID_PARAM)?.toInt() ?: 0
         val planSlug = uri.getQueryParameter(PLAN_SLUG_PARAM).orEmpty()
+        val domainNameFromRedirectUrl = uri.getQueryParameter(DOMAIN_NAME)
 
         val planModel = PlanModel(
             productId = planId,
@@ -52,7 +53,7 @@ class SiteCreationPlansViewModel @Inject constructor(
             isCurrentPlan = false,
             hasDomainCredit = false
         )
-        postActionEvent(SiteCreationPlansActionEvent.CreateSite(planModel))
+        postActionEvent(SiteCreationPlansActionEvent.CreateSite(planModel, domainNameFromRedirectUrl))
     }
 
     fun onUrlLoaded() {
@@ -166,6 +167,7 @@ class SiteCreationPlansViewModel @Inject constructor(
         const val PLAN_ID_PARAM = "plan_id"
         const val PLAN_SLUG_PARAM = "plan_slug"
         const val PAID_DOMAIN_NAME = "paid_domain_name"
+        const val DOMAIN_NAME = "domain_name"
     }
 }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationFixtures.kt
@@ -27,8 +27,8 @@ const val URL_CUSTOM = "$SUB_DOMAIN.host.com"
 const val SITE_SLUG = "${SUB_DOMAIN}host0.wordpress.com"
 val FREE_DOMAIN = DomainModel(URL, true, "", 1, false)
 val PAID_DOMAIN = DomainModel(URL_CUSTOM, false, "$1", 2, true)
-val PAID_PLAN = PlanModel(1009, "paid_plan", "Personal", isCurrentPlan = false, hasDomainCredit = false)
-val FREE_PLAN = PlanModel(0, "free_plan", "", isCurrentPlan = false, hasDomainCredit = false)
+val PAID_PLAN = PlanModel(1009, "paid_plan", isCurrentPlan = false, hasDomainCredit = false)
+val FREE_PLAN = PlanModel(0, "free_plan", isCurrentPlan = false, hasDomainCredit = false)
 
 const val SITE_REMOTE_ID = 1L
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -200,7 +200,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     @Test
     fun `on site created updates result`() = test {
         viewModel.onDomainsScreenFinished(FREE_DOMAIN)
-        viewModel.onPlanSelection(FREE_PLAN)
+        viewModel.onPlanSelection(FREE_PLAN, domainName = SITE_SLUG )
         viewModel.onFreeSiteCreated(SITE_MODEL)
         assertThat(currentWizardState(viewModel).result).isEqualTo(RESULT_NOT_IN_LOCAL_DB)
     }
@@ -209,7 +209,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     fun `on site created for free domain shows next step`() {
         viewModel.onDomainsScreenFinished(FREE_DOMAIN).run { clearInvocations(wizardManager) }
         viewModel.onFreeSiteCreated(SITE_MODEL)
-        viewModel.onPlanSelection(FREE_PLAN)
+        viewModel.onPlanSelection(FREE_PLAN, domainName = SITE_SLUG)
         verify(wizardManager).showNextStep()
     }
 


### PR DESCRIPTION
This improves the plans in the site creation flow. If a domain from the plan selection screen was received (via `redirect_url`), it will be used for creating the cart.

> [!IMPORTANT]  
> Before testing and merging this PR, the https://github.com/Automattic/wp-calypso/pull/83045 must be merged.


- fa8a6b4cea8ec8d7ddc36efeb8ec727fc665fc1b: productName was unnecessary, so I removed it.
- 0be3bc1582e7e6e53f899de2c182703d656936e1: Added a `domainName` parameter to `CreateSite` event.
- 43f7f4e5ab28f403fcb53112b744508d3d05c527: `domain_name` from `redirect_url` is passed to the `CreateSite` event. It's null if `redirect_url` does not return any domain. In that case, the domain from the domain selection will be used.

To test:
#### Site creation with a free domain and free plan
1. Launch JP app
2. Go to Me-> Debug settings
3. Switch to the Remote Feature tab, find plans_in_site_creation, and enable it
4. Switch to My Site tab
5. Tap the down arrow to the right of the site name on the My Site screen
6. Tap the + icon at the top right on the Site picker screen
7. Select ⊕ Create WordPress.com site on the modal dialog
8. Tap Skip at the top right on the first step (topic screen)
9. Tap Skip at the top right on the next step (theme screen)
10. Enter a search query (whatever you want here)
11. Select a free domain (should be *.wordpress.com)
12. Verify Plans screen opens with Personal, Premium, Business, and Ecommerce plans
13. Select the free plan
14. Verify it returns to the site setup screen
15. Verify a site is created with the desired domain

Also, test these cases
- Site creation with a paid domain and paid plan
- Site creation with a paid domain and free plan
  - From popup, select the free plan
  - From popup, select the paid plan

## Regression Notes
1. Potential unintended areas of impact
This may break different flow in site creation checkout flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
This only updates the current behavior, no automated test was added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)