### PR TITLE
Update the `build_bundle` call site parameter names

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -34,7 +34,7 @@ platform :android do
     # Create the file names
     app = get_app_name_option!(options)
     version_name = current_version_name
-    build_bundle(app: app, version: version_name, build_code: current_build_code, flavor: 'Vanilla', buildType: 'Release')
+    build_bundle(app: app, version_name: version_name, build_code: current_build_code, flavor: 'Vanilla', buildType: 'Release')
 
     upload_build_to_play_store(app: app, version: version_name, track: 'production')
 
@@ -106,7 +106,7 @@ platform :android do
     # Create the file names
     app = get_app_name_option!(options)
     version_name = current_version_name
-    build_bundle(app: app, version: version_name, build_code: current_build_code, flavor: 'Vanilla', buildType: 'Release')
+    build_bundle(app: app, version_name: version_name, build_code: current_build_code, flavor: 'Vanilla', buildType: 'Release')
 
     upload_build_to_play_store(app: app, version: version_name, track: 'beta') if options[:upload_to_play_store]
 
@@ -262,7 +262,7 @@ platform :android do
     app = get_app_name_option!(options)
 
     if version_name.nil?
-      UI.message("Version specified for #{app} bundle is nil. Skipping ahead")
+      UI.message("Version name specified for #{app} bundle is nil. Skipping ahead")
       next
     end
 


### PR DESCRIPTION
This PR fixes a bug where the `build_bundle` call site parameter names weren't updated from `version` to `version_name`. It resulted in an error during the code freeze: p1697482511871839-slack-C02KLTL3MKM