### PR TITLE
APK Download: Replace `build_code` with `current_version_name` 

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -194,7 +194,7 @@ platform :android do
       download_universal_apk_from_google_play(
           package_name: package_name,
           version_code: build_code,
-          destination: signed_apk_path(app, build_code),
+          destination: signed_apk_path(app, current_version_name),
           json_key: UPLOAD_TO_PLAY_STORE_JSON_KEY
       )
     end


### PR DESCRIPTION
This PR switches the apk destination name from using the `build_code` to the `current_version_name`. See p1697555498972979-slack-C02KLTL3MKM