### PR TITLE
UiModernization: Posts & Pages - Update author filter visibility rule

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -236,7 +236,7 @@ class PostListMainViewModel @Inject constructor(
      * This behavior is consistent with Calypso as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isWPCom && site.hasCapabilityEditOthersPosts
+        site.isWPCom && site.hasCapabilityEditOthersPosts && !site.isSingleUserSite
     }
 
     init {
@@ -291,6 +291,7 @@ class PostListMainViewModel @Inject constructor(
         )
 
         _authorSelectionUpdated.value = authorFilterSelection
+      //  Log.i(javaClass.simpleName, "***=> Is site single user site: ${site.isSingleUserSite}")
         _viewState.value = PostListMainViewState(
             isFabVisible = FAB_VISIBLE_POST_LIST_PAGES.contains(POST_LIST_PAGES.first()) &&
                     isSearchExpanded.value != true,

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.106.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2873-d5837e7e54a0a06e75ac854bc1831c6dfd56f70a'
+    wordPressFluxCVersion = 'trunk-6eee26f191edc73d3934ad5876d4a9b7b1456a9f'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.106.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2.51.0'
+    wordPressFluxCVersion = '2873-d5837e7e54a0a06e75ac854bc1831c6dfd56f70a'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #19396 

This PR updates the posts/pages author filter rules to include a restriction to sites that have more than one user. This is addition to the current rules. This PR fixes the current situation and should be addressed against trunk, not the feature branch.

The FluxC companion PR is here: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2873

### **Merge Instructions**
- Review corresponding FluxC PR
- Merge the FluxC PR to trunk
- Update the FluxC PR in this PR
- Remove Not Ready for Merge label
- Merge this PR

### **To test:**

**Prereqs**
Accounts that have the following types of sites:
- WP.com (one that has a single user and one that has multiple users with edit capability)
- Jetpack
- Self-hosted
- Atomic

**Migration Test**
- The fluxC PR added a new column to SiteModel, it is important to test the migration.
- Install an existing version of JP/WP prealpha, login and select a site
- Install the version of the app from this PR
- Login and select a site
- ✅ Verify the app did not crash
- ✅ Verify the `IS_SINGLE_USER_SITE` column is included (using App Inspector > database inspector > SiteModel table)

**Non migration path test**
- Uninstall all versions of the app
- Install the version of the app from this PR
- Login and select a site
- ✅ Verify the app did not crash

**Shows author filter on pages & posts**
- From either path above
- Navigate to a WP.com site that has more than 1 user
- Navigate to My Site > Posts
- ✅ Verify the author filter is shown
- Navigate to My Site > Pages
- ✅ Verify the author filter is shown

**Does not show author filter on pages & posts**
- From either starting path above
- Navigate to a WP.com site that has a single user
- Navigate to My Site > Posts
- ✅ Verify the author filter is not shown
- Navigate to My Site > Pages
- ✅ Verify the author filter is not shown

**Self-hosted/Jetpack/Atomic sites do not show author filter on pages & posts**
- From either starting path above
- Navigate to a self-hosted site (user count does not matter)
- Navigate to My Site > Posts
- ✅ Verify the author filter is not shown
- Navigate to My Site > Pages
- ✅ Verify the author filter is not shown
Repeat for Jetpack and Atomic site

## Regression Notes
1. Potential unintended areas of impact
The author filter displays as it does today

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and ran existing author filter tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:N/A
