### PR TITLE
Fix "no sites" account and settings text showing in my site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -244,6 +244,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         if (state.shouldShowAccountSettings) {
             noSitesView.avatarAccountSettings.visibility = View.VISIBLE
             noSitesView.meDisplayName.text = state.accountName
+            if (state.accountName.isNullOrEmpty()) {
+                noSitesView.meDisplayName.visibility = View.GONE
+            } else {
+                noSitesView.meDisplayName.visibility = View.VISIBLE
+            }
             loadGravatar(state.avatartUrl)
             noSitesView.avatarAccountSettings.setOnClickListener { viewModel.onAvatarPressed() }
         } else noSitesView.avatarAccountSettings.visibility = View.GONE

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -21,14 +21,12 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
-import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.ActivityCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PagesCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.PostsCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.TodaysStatsCardModel
 import org.wordpress.android.fluxc.store.AccountStore
-import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
 import org.wordpress.android.fluxc.store.QuickStartStore.Companion.QUICK_START_CHECK_STATS_LABEL
 import org.wordpress.android.fluxc.store.QuickStartStore.Companion.QUICK_START_UPLOAD_MEDIA_LABEL
@@ -1289,13 +1287,6 @@ class MySiteViewModel @Inject constructor(
                     mySiteSourceManager.refreshBloggingPrompts(true)
                 }
             }
-        }
-    }
-
-    @Subscribe(threadMode = MAIN)
-    fun onAccountChanged(event: OnAccountChanged) {
-        if (event.accountInfosChanged && event.causeOfChange == AccountAction.FETCH_SETTINGS) {
-            refresh()
         }
     }
 

--- a/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment_no_sites_view.xml
@@ -28,10 +28,11 @@
         android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:focusable="true"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -43,7 +44,8 @@
                 android:id="@+id/frame_avatar"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:clickable="false">
+                android:clickable="false"
+                android:layout_centerVertical="true">
 
                 <FrameLayout
                     android:id="@+id/avatar_container"
@@ -89,20 +91,14 @@
                 android:src="@drawable/ic_chevron_right_white_24dp"
                 app:tint="?attr/wpColorOnSurfaceMedium" />
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/me_username"
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/me_display_name"
-                android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_toEndOf="@id/frame_avatar"
-                android:clickable="false"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:text="@string/account_and_settings"
-                android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="?attr/wpColorOnSurfaceMedium"
-                tools:text="@string/account_and_settings" />
+                android:orientation="vertical"
+                android:layout_centerInParent="true"
+                android:layout_toEndOf="@+id/frame_avatar"
+                android:layout_toStartOf="@+id/go_to_settings">
+
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/me_display_name"
@@ -110,15 +106,28 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_extra_large"
-                android:layout_toEndOf="@+id/frame_avatar"
-                android:layout_toStartOf="@+id/go_to_settings"
                 android:clickable="false"
                 android:ellipsize="end"
                 android:maxLines="1"
                 app:autoSizeMaxTextSize="@dimen/my_site_name_label_single_line_text_size"
                 app:autoSizeMinTextSize="@dimen/my_site_name_label_double_line_text_size"
                 app:autoSizeTextType="uniform"
-                tools:text="Full Name" />
+                tools:text="Full Name"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/me_username"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_extra_large"
+                    android:clickable="false"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:text="@string/account_and_settings"
+                    android:textAppearance="?attr/textAppearanceBody2"
+                    android:textColor="?attr/wpColorOnSurfaceMedium"
+                    tools:text="@string/account_and_settings" />
+
+            </LinearLayout>
         </RelativeLayout>
     </RelativeLayout>
 


### PR DESCRIPTION
This PR fixes an issue with No Site views "account settings" view leaking into the My Site view.

| Before  | After   | 
|---|---|
| <img width="250" height="500" alt="before" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/916cd544-8d1a-4d01-a206-44b7b94043f2">  | <img width="250" height="500" alt="after" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/203bdbc5-64ee-4872-a0c6-ebce0bc10ef2">  | 

In addition, this PR also aligns the Account Settings line between the user icon and the navigation icon when the user name is empty or null

<img width="200" height="450" alt="No Sites No Display Name" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/6927dfef-ca58-4398-8105-197a393d43f1">

**To test:**
- Install WP app
- Log in with an account that has sites
- Navigate to My Site
- ✅ Verify that the "account and settings" is not shown at the bottom of the view
- Logout
- Signup for an acct
- Do not add a password when prompted
- ✅ Verify the no sites empty view is shown and account settings view is properly aligned (with or without a display name)



## Regression Notes
1. Potential unintended areas of impact
The account and settings line is still shown in the my site view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual visual test

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
