### PR TITLE
Fix visibility condition of the free domain dashboard card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
@@ -36,6 +36,7 @@ class PlansCardUtils @Inject constructor(
     ): Boolean {
         return buildConfigWrapper.isJetpackApp &&
                 !isCardHiddenByUser(siteModel.siteId) &&
+                (siteModel.isWPCom || siteModel.isWPComAtomic) &&
                 siteModel.hasFreePlan &&
                 siteModel.isAdmin &&
                 !siteModel.isWpForTeamsSite


### PR DESCRIPTION
This fixes the visibility condition of the "Free domain with an annual plan" dashboard card.

1176cdb4273d8375ba775f00228c0cc79e1fafcb: This commit removed `hasMappedDomains` condition but it should have not removed `site.isWPCom()` condition. This PR fixes the condition.
Internal discussion: p1697661292953299-slack-C441E3YTS

To test:
#### Self-hosted site
1. Launch the JP app.
2. Log in the app with a self-hosted site.
3. Ensure "Free domain with annual plan" card is not displayed on MySite.

#### Self-hosted site, jetpack-connected site
1. Launch the JP app.
2. Log in the app with a self-hosted and jetpack-connected site.
3. Ensure "Free domain with annual plan" card is not displayed on MySite.

#### WordPress.com site
1. Launch the JP app.
2. Log in the app with a WordPress.com site.
3. Ensure "Free domain with annual plan" card is displayed on MySite.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
It's not a suitable case for an automated test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)