### PR TITLE
Add close button to site creation checkout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -139,9 +139,9 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     @Inject Dispatcher mDispatcher;
     @Inject DisplayUtilsWrapper mDisplayUtilsWrapper;
 
+    protected WPWebViewViewModel mViewModel;
     private ActionableEmptyView mActionableEmptyView;
     private ViewGroup mFullScreenProgressLayout;
-    private WPWebViewViewModel mViewModel;
     private PreviewModeSelectorPopup mPreviewModeSelectorPopup;
     private ElevationOverlayProvider mElevationOverlayProvider;
     private View mNavBarContainer;

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -139,9 +139,9 @@ public class WPWebViewActivity extends WebViewActivity implements ErrorManagedWe
     @Inject Dispatcher mDispatcher;
     @Inject DisplayUtilsWrapper mDisplayUtilsWrapper;
 
-    protected WPWebViewViewModel mViewModel;
     private ActionableEmptyView mActionableEmptyView;
     private ViewGroup mFullScreenProgressLayout;
+    private WPWebViewViewModel mViewModel;
     private PreviewModeSelectorPopup mPreviewModeSelectorPopup;
     private ElevationOverlayProvider mElevationOverlayProvider;
     private View mNavBarContainer;

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -36,7 +36,6 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
     }
 
     private fun cancelCheckout() {
-        mViewModel.track(Stat.WEBVIEW_DISMISSED)
         onCheckoutSuccess()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -8,7 +8,6 @@ import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.widget.Toolbar
 import org.wordpress.android.R
-import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity.OpenCheckout.CheckoutDetails

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -35,7 +35,8 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
     }
 
     private fun cancelCheckout() {
-        onCheckoutSuccess()
+        setResult(RESULT_CANCELED)
+        finish()
     }
 
     private fun setupNavigationButton() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -35,8 +35,7 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
     }
 
     private fun cancelCheckout() {
-        setResult(RESULT_CANCELED)
-        finish()
+        onCheckoutSuccess()
     }
 
     private fun setupNavigationButton() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewActivity.kt
@@ -35,7 +35,8 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
     }
 
     private fun cancelCheckout() {
-        onCheckoutSuccess()
+        setResult(RESULT_CANCELED, intent)
+        finish()
     }
 
     private fun setupNavigationButton() {
@@ -99,10 +100,10 @@ class DomainRegistrationCheckoutWebViewActivity : WPWebViewActivity(), DomainReg
 
         override fun parseResult(resultCode: Int, intent: Intent?): DomainRegistrationCompletedEvent? {
             val data = intent?.takeIf { it.hasExtra(REGISTRATION_DOMAIN_NAME) && it.hasExtra(REGISTRATION_EMAIL) }
-            if (resultCode == RESULT_OK && data != null) {
+            if ((resultCode == RESULT_OK || resultCode == RESULT_CANCELED) && data != null) {
                 val domainName = data.getStringExtra(REGISTRATION_DOMAIN_NAME).orEmpty()
                 val email = data.getStringExtra(REGISTRATION_EMAIL).orEmpty()
-                return DomainRegistrationCompletedEvent(domainName, email)
+                return DomainRegistrationCompletedEvent(domainName, email, resultCode == RESULT_CANCELED)
             }
             return null
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCompletedEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCompletedEvent.kt
@@ -1,3 +1,3 @@
 package org.wordpress.android.ui.domains
 
-data class DomainRegistrationCompletedEvent(val domainName: String, val email: String)
+data class DomainRegistrationCompletedEvent(val domainName: String, val email: String, val canceled: Boolean = false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -308,10 +308,7 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
-        if (event == null) {
-            wizardManager.setCurrentStepIndex(SiteCreationStep.values().size - 2) // plans has six steps
-            return onBackPressed()
-        }
+        if (event == null) return onBackPressed()
         domainsRegistrationTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = true)
         siteCreationState = siteCreationState.run {
             check(result is CreatedButNotFetched.InCart)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -308,8 +308,13 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
-        if (event == null) return onBackPressed()
-        domainsRegistrationTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = true)
+        if (event == null) return
+        if (event.canceled) {
+            // Checkout canceled. A site with free domain will be created. Update the isFree parameter of the domain.
+            siteCreationState = siteCreationState.copy(domain = siteCreationState.domain?.copy(isFree = true))
+        } else {
+            domainsRegistrationTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = true)
+        }
         siteCreationState = siteCreationState.run {
             check(result is CreatedButNotFetched.InCart)
             copy(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -308,7 +308,10 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun onCheckoutResult(event: DomainRegistrationCompletedEvent?) {
-        if (event == null) return onBackPressed()
+        if (event == null) {
+            wizardManager.setCurrentStepIndex(SiteCreationStep.values().size - 2) // plans has six steps
+            return onBackPressed()
+        }
         domainsRegistrationTracker.trackDomainsPurchaseDomainSuccess(isSiteCreation = true)
         siteCreationState = siteCreationState.run {
             check(result is CreatedButNotFetched.InCart)

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -33,10 +33,10 @@ class SiteCreationPlansViewModel @Inject constructor(
     private val _actionEvents = Channel<SiteCreationPlansActionEvent>(Channel.BUFFERED)
     val actionEvents = _actionEvents.receiveAsFlow()
 
-    private lateinit var domainName: DomainModel
+    private lateinit var domain: DomainModel
 
     fun start(siteCreationState: SiteCreationState) {
-        domainName = requireNotNull(siteCreationState.domain)
+        domain = requireNotNull(siteCreationState.domain)
         showPlans()
     }
 
@@ -94,8 +94,8 @@ class SiteCreationPlansViewModel @Inject constructor(
             authority(AUTHORITY)
             appendPath(JETPACK_APP_PATH)
             appendPath(PLANS_PATH)
-            if (!domainName.isFree) {
-                appendQueryParameter(PAID_DOMAIN_NAME, domainName.domainName)
+            if (!domain.isFree) {
+                appendQueryParameter(PAID_DOMAIN_NAME, domain.domainName)
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -45,7 +45,7 @@ class SiteCreationPlansViewModel @Inject constructor(
 
         val planId = uri.getQueryParameter(PLAN_ID_PARAM)?.toInt() ?: 0
         val planSlug = uri.getQueryParameter(PLAN_SLUG_PARAM).orEmpty()
-        val domainNameFromRedirectUrl = uri.getQueryParameter(DOMAIN_NAME)
+        val domainNameFromRedirectUrl = uri.getQueryParameter(DOMAIN_NAME_PARAM)
 
         val planModel = PlanModel(
             productId = planId,
@@ -166,8 +166,8 @@ class SiteCreationPlansViewModel @Inject constructor(
         const val PLANS_PATH = "plans"
         const val PLAN_ID_PARAM = "plan_id"
         const val PLAN_SLUG_PARAM = "plan_slug"
+        const val DOMAIN_NAME_PARAM = "domain_name"
         const val PAID_DOMAIN_NAME = "paid_domain_name"
-        const val DOMAIN_NAME = "domain_name"
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/progress/SiteCreationProgressViewModel.kt
@@ -219,7 +219,7 @@ class SiteCreationProgressViewModel @Inject constructor(
             updateUiStateAsync(CartError)
         } else {
             AppLog.d(T.SITE_CREATION, "Successful cart creation: ${event.cartDetails}")
-            _onCartCreated.postValue(CheckoutDetails(site, domain.domainName))
+            _onCartCreated.postValue(CheckoutDetails(site, domain.domainName, showCloseButton = true))
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -160,14 +160,6 @@ class SiteCreationMainVMTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on checkout result when null shows previous step`() {
-        viewModel.onCheckoutResult(null)
-
-        verify(wizardManager).onBackPressed()
-        verify(onBackPressedObserver).onChanged(anyOrNull())
-    }
-
-    @Test
     fun `on checkout result when not null shows next step`() {
         viewModel.onCartCreated(CHECKOUT_DETAILS)
 


### PR DESCRIPTION
This adds a close button to the checkout page in the site creation flow. If the close button is tapped, the purchase will be canceled, and the site will be created.

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/e7723058-abe2-4366-b1a6-bba6418972bb

To test:

1. Enable Plans in Site Creation feature flag
2. Select Site Picker
3. Create new WordPress.com site
4. Select a domain
5. Select a paid plan
6. Verify there is a close button at the top.
7. Tap the close button.
8. Verify the checkout page is closed, and the site preview page with the free domain is launched.
9. Repeat 2-5. 
10. Tap the system back button.
11. Repeat 8.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing

3. What automated tests I added (or what prevented me from doing so)
This is not a good case for an automated test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
