### PR TITLE
Temporarily disable importing en-au translations

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -37,7 +37,9 @@ ALL_LOCALES = [
   { glotpress: 'cy', android: 'cy', promo_config: false },
   { glotpress: 'da', android: 'da', promo_config: false },
   { glotpress: 'el', android: 'el', promo_config: false },
-  { glotpress: 'en-au', android: 'en-rAU', promo_config: false },
+  # Temporarily disable 'en-au' translations to address some issues:
+  # https://wordpress.slack.com/archives/C02RP50LK/p1693431282243939
+  # { glotpress: 'en-au', android: 'en-rAU', promo_config: false },
   { glotpress: 'en-ca', android: 'en-rCA', promo_config: false },
   { glotpress: 'en-gb', android: 'en-rGB', promo_config: false },
   { glotpress: 'es-cl', android: 'es-rCL', promo_config: false },


### PR DESCRIPTION
We have had some translation and linting issues with `en-au` translations [since we got a huge influx of translations for `23.1`](https://github.com/wordpress-mobile/WordPress-Android/pull/19129). I've been working with the contributor and addressing issues to the translations and we are almost done. However, it's been stuck in the last phase for a little while now.

In the meantime, I've been reverting the translations for every release and new beta, which is an extra friction in the release process. I've discussed this with @jkmassel and we decided to temporarily disable importing `en-au` strings from GlotPress. I intend to re-enable it as soon as the issues are resolved.