### PR TITLE
Add extra space between my site today's stats and lower optional message

### DIFF
--- a/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
+++ b/WordPress/src/main/res/layout/my_site_todays_stats_card.xml
@@ -116,14 +116,21 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <Space
+            android:id="@+id/card_footer_padding"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/margin_large"
+            app:layout_constraintTop_toBottomOf="@+id/views_layout"/>
+
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/get_more_views_message"
             style="@style/MySiteTodaysStatsCardMessage"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:paddingTop="0dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/views_layout"
+            app:layout_constraintTop_toBottomOf="@+id/card_footer_padding"
             tools:text="@string/my_site_todays_stats_get_more_views_message" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
I noticed that the `Today's Stats` card doesn't contain a bottom padding, which makes the card look ugly. It occurs when the optional `get_more_views_message` message is invisible.

| Before | After |
| -------| ----- |
|<img width="300px" src="https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/881532df-2f50-46ce-85d3-29a3ae13983e" />|<img width="300px" src="https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/8975d565-ec2e-454d-aaed-fde498349229" />|

To test:

- [ ] Go to `My Site` tab and select any site with some statistics
- [ ] Make sure the `Today's Stats` card has proper bottom content padding

## Regression Notes
1. Potential unintended areas of impact
NaN

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NaN

3. What automated tests I added (or what prevented me from doing so)
NaN

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
