### PR TITLE
Fixes: Scrolling to the top on Unified Dashboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -886,7 +886,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         private const val KEY_LIST_STATE = "key_list_state"
         private const val KEY_NESTED_LISTS_STATES = "key_nested_lists_states"
         private const val TAG_QUICK_START_DIALOG = "TAG_QUICK_START_DIALOG"
-        private const val ONE_ITEM = 1
         private const val FIRST_ITEM = 0
         fun newInstance(): MySiteFragment {
             return MySiteFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -355,7 +355,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 super.onItemRangeInserted(positionStart, itemCount)
-                if (itemCount == ONE_ITEM && positionStart == FIRST_ITEM) {
+                if (itemCount <= 2 && positionStart == FIRST_ITEM) {
                     recyclerView.smoothScrollToPosition(0)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -355,7 +355,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 super.onItemRangeInserted(positionStart, itemCount)
-                if (itemCount <= 2 && positionStart == FIRST_ITEM) {
+                if (positionStart == FIRST_ITEM) {
                     recyclerView.smoothScrollToPosition(0)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -454,15 +454,7 @@ class MySiteViewModel @Inject constructor(
             jetpackInstallFullPluginCardParams
         )
 
-        val siteItems = siteItemsBuilder.build(
-            siteItemsViewModelSlice.buildItems(
-                shouldEnableFocusPoints = false,
-                site = site,
-                activeTask = activeTask,
-                backupAvailable = backupAvailable,
-                scanAvailable = scanAvailable
-            )
-        )
+        val siteItems = getSiteItems(site, activeTask, backupAvailable, scanAvailable)
 
         val jetpackBadge = buildJetpackBadgeIfEnabled()
 
@@ -489,6 +481,25 @@ class MySiteViewModel @Inject constructor(
                 noCardsMessage?.let { add(noCardsMessage) }
                 personalizeCard?.let { add(personalizeCard) }
             }.toList()
+        )
+    }
+
+    private fun getSiteItems(
+        site: SiteModel,
+        activeTask: QuickStartTask?,
+        backupAvailable: Boolean,
+        scanAvailable: Boolean
+    ): List<MySiteCardAndItem> {
+        val isJetpackApp = buildConfigWrapper.isJetpackApp
+        if (isJetpackApp) return emptyList()
+        return siteItemsBuilder.build(
+            siteItemsViewModelSlice.buildItems(
+                shouldEnableFocusPoints = false,
+                site = site,
+                activeTask = activeTask,
+                backupAvailable = backupAvailable,
+                scanAvailable = scanAvailable
+            )
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinkRibbonViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinkRibbonViewHolder.kt
@@ -34,8 +34,5 @@ class QuickLinkRibbonViewHolder(
 
     fun bind(quickLinksItem: QuickLinksItem) = with(binding) {
         (quickLinksItemList.adapter as QuickLinksItemAdapter).update(quickLinksItem.quickLinkItems)
-        if (quickLinksItem.showMoreFocusPoint) {
-            quickLinksItemList.smoothScrollToPosition(quickLinksItemList.adapter!!.itemCount - 1)
-        }
     }
 }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -1,6 +1,5 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
     android:clipChildren="false"
@@ -26,8 +25,7 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentTop="true"
                     android:layout_centerHorizontal="true"
-                    app:layout_collapseMode="parallax"
-                    app:layout_collapseParallaxMultiplier="1.0" />
+                    app:layout_collapseMode="none" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 


### PR DESCRIPTION
## Fixes 
This PR fixes a scrolling issue in the unified dashboard. This PR also fixes the redundant build logic of the site items in Jetpack app. Site items are only shown in Wordpress app and hence this PR adds a logic to build the site items only if the app is Wordpress. 

### Issue 1 : Scrolling
In the Unified dashboard, the dashboard was always scrolled to the 3rd item(google domain card) or 4th(blaze campaign) item if the first item is quick link. This was because of the fact that that quick link item is created after the domain card or blaze campaign card is created, also the current logic was to only scroll to the top if one item is added to the top. 

I made the scrolling logic - scroll to the item when a new item is added on the top, but this introduces another issue. ie if a user scrolls in MySite and then goes to reader tab, and then comes back to MySite. Then the user is scrolled to the top, since all the cards are added. 

Some discussions regarding the scrolling issue in MySite Dashboard can be seen here - https://github.com/wordpress-mobile/WordPress-Android/pull/17083. The discussions in the PR can make a lot of things clear. Hence pointing it out here. 

### Video capture
|  Before | After |  
|---|---|
| https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/8b86c153-c915-4523-9c5f-5435f26abc5a | https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/c4bf4aa7-5f7a-4b3d-afc5-26e0650def0e |


### Site items are built in Jetpack app
In Jetpack app, the site menu items are not shown in Unified dashboard, but in MySiteViewModel, they are built. This is fixed by adding a check - if the current app is jetpack app or not

## To test:

### Scrolling issue

- Install Jetpack app with and without WP app (so that migration card scenario can also be seen)
- Notice that on the launch of the app, the quick links can be seen
- Scroll to the bottom of the dashboard 
- Go to Reader/Notifications
- Go back to MySite
- ~~Verify that the last scrolling position is still maintained~~

### Site items are not built in Jetpack app
- Install WP app
- Login and go to dashboard
- Verify that the Site items are shown in dashboard
- Go to Jetpack app 
- Verify that the cards are shown in the dashboard

## Regression Notes
1. Potential unintended areas of impact
Unified dashboard is not shown as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
