### PR TITLE
Remove unnecessary logs from the domain screen in the site creation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -122,7 +122,6 @@ class SiteCreationDomainsViewModel @Inject constructor(
                 }
 
                 else -> {
-                    AppLog.d(AppLog.T.DOMAIN_REGISTRATION, result.products.toString())
                     products = result.products.orEmpty().associateBy { it.productId }
                 }
             }


### PR DESCRIPTION
This removes unnecessary and too-long logs from the domain list screen in the site creation flow. This log only appears on debug builds.

To test:
1. Launch the JP app.
2. Ensure "Me → App Settings → Privacy settings → Collect information" is enabled.
3. Enable the `plans_in_site_creation` flag from "Me → Debug settings".
4. Navigate to My Site.
5. Tap on the arrow at the end of the site name to open the site list.
6. Tap on the ＋ button and "Create WordPress.com site".
7. Skip topic and theme selection screens.
8. Navigate back to the "Me → Help → Logs"
9. Verify that there is no log starting with "DOMAIN_REGISTRATION" in recorded logs.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Nothing.

3. What automated tests I added (or what prevented me from doing so)
Nothing since this only removed a debug log.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
