### PR TITLE
Fix NPE: freeDomainUrl-must-not-be-null #15636

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -168,8 +168,7 @@ class SiteListItemBuilder @Inject constructor(
 
     fun buildDomainsItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         return if (
-            buildConfigWrapper.isJetpackApp &&
-            site.hasCapabilityManageOptions
+            buildConfigWrapper.isJetpackApp && (site.isUsingWpComRestApi && site.hasCapabilityManageOptions)
         ) {
             ListItem(
                 R.drawable.ic_domains_white_24dp,


### PR DESCRIPTION
`Domains` menu item is not supposed to be shown for self-hosted sites, hence removing `Domains` menu item for self hosted sites. It should prevent the `freeDomainUrl` being null, and ensuing NPE.

Fixes #15636 

To test:

- Launch JP Android app
- `Switch` to a WPCom site, if not already on one 
- `Go` to `More... ` 
- `Verify` there's `Domains` menu item there
- `Tap` on `Domains`
- `Verify` Domains dashboard is opened
- `Go` back to Home
- `Switch` to a self-hosted site
- `Verify` there's no `Domains` menu item now

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual, and unit tests

3. What automated tests I added (or what prevented me from doing so)
Existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
