### PR TITLE
Domain Details Screen as WebView Enhancement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
@@ -29,7 +29,7 @@ class DomainManagementActivity : AppCompatActivity() {
     private fun handleActionEvents(actionEvent: DomainManagementViewModel.ActionEvent) {
         when (actionEvent) {
             is DomainManagementViewModel.ActionEvent.DomainTapped -> {
-                startActivity(DomainManagementDetailsActivity.createIntent(this, actionEvent.domain))
+                startActivity(DomainManagementDetailsActivity.createIntent(this, actionEvent.detailUrl))
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementDetailsActivity.kt
@@ -18,14 +18,11 @@ class DomainManagementDetailsActivity : WPWebViewActivity() {
     }
 
     companion object {
-        private fun getDomainDetailsUrl(domainName: String) =
-            "https://wordpress.com/domains/manage/all/$domainName/edit/$domainName"
-
-        fun createIntent(context: Context, domainName: String): Intent =
+        fun createIntent(context: Context, domainDetailUrl: String): Intent =
             Intent(context, DomainManagementDetailsActivity::class.java).apply {
                 putExtra(USE_GLOBAL_WPCOM_USER, true)
                 putExtra(AUTHENTICATION_URL, WPCOM_LOGIN_URL)
-                putExtra(URL_TO_LOAD, getDomainDetailsUrl(domainName))
+                putExtra(URL_TO_LOAD, domainDetailUrl)
             }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
@@ -101,12 +101,6 @@ sealed class DomainCardUiState {
         }
     }
 }
-private fun AllDomainsDomain.getDomainDetailsUrl(): String? =
-    if (domain.isNullOrEmpty() || siteSlug.isNullOrEmpty()) null else when (type) {
-        "transfer" -> "https://wordpress.com/domains/manage/all/$domain/transfer/in/$siteSlug"
-        "redirect" -> "https://wordpress.com/domains/manage/all/$domain/redirect/$siteSlug"
-        else -> "https://wordpress.com/domains/manage/all/$domain/edit/$siteSlug"
-    }
 
 sealed class StatusRowUiState {
     object Initial: StatusRowUiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
@@ -52,15 +52,15 @@ class DomainManagementViewModel @Inject constructor(
         }
     }
 
-    fun onDomainTapped(domain: String) {
+    fun onDomainTapped(detailUrl: String) {
         analyticsTracker.track(Stat.DOMAIN_MANAGEMENT_MY_DOMAINS_SCREEN_DOMAIN_TAPPED)
         launch {
-            _actionEvents.emit(ActionEvent.DomainTapped(domain))
+            _actionEvents.emit(ActionEvent.DomainTapped(detailUrl))
         }
     }
 
     sealed class ActionEvent {
-        data class DomainTapped(val domain: String): ActionEvent()
+        data class DomainTapped(val detailUrl: String): ActionEvent()
     }
 
     sealed class UiState {
@@ -78,6 +78,7 @@ sealed class DomainCardUiState {
     data class Loaded(
         val domain: String?,
         val title: String?,
+        val detailUrl: String?,
         val statusUiState: StatusRowUiState,
     ): DomainCardUiState()
 
@@ -88,6 +89,7 @@ sealed class DomainCardUiState {
             Loaded(
                 domain = it.domain,
                 title = it.blogName,
+                detailUrl = it.getDomainDetailsUrl(),
                 statusUiState = StatusRowUiState.Loaded(
                     indicatorColor = domainStatus.indicatorColor,
                     statusText = domainStatus.statusText,
@@ -99,6 +101,12 @@ sealed class DomainCardUiState {
         }
     }
 }
+private fun AllDomainsDomain.getDomainDetailsUrl(): String? =
+    if (domain.isNullOrEmpty() || siteSlug.isNullOrEmpty()) null else when (type) {
+        "transfer" -> "https://wordpress.com/domains/manage/all/$domain/transfer/in/$siteSlug"
+        "redirect" -> "https://wordpress.com/domains/manage/all/$domain/redirect/$siteSlug"
+        else -> "https://wordpress.com/domains/manage/all/$domain/edit/$siteSlug"
+    }
 
 sealed class StatusRowUiState {
     object Initial: StatusRowUiState()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainsListCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainsListCard.kt
@@ -46,14 +46,14 @@ import java.util.Date
 @Composable
 fun DomainListCard(
     uiState: DomainCardUiState,
-    onDomainTapped: (domain: String) -> Unit = {},
+    onDomainTapped: (detailUrl: String) -> Unit = {},
     ) {
     OutlinedCard(
         modifier = Modifier.fillMaxWidth(),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         onClick = {
-            if (uiState is DomainCardUiState.Loaded && uiState.domain != null) {
-                onDomainTapped(uiState.domain)
+            if (uiState is DomainCardUiState.Loaded && uiState.detailUrl != null) {
+                onDomainTapped(uiState.detailUrl)
             }
         },
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrl.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.ui.domains.management
+
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
+
+fun AllDomainsDomain.getDomainDetailsUrl(): String? =
+    if (domain.isNullOrEmpty() || siteSlug.isNullOrEmpty()) null else when (type) {
+        "transfer" -> "https://wordpress.com/domains/manage/all/$domain/transfer/in/$siteSlug"
+        "redirect" -> "https://wordpress.com/domains/manage/all/$domain/redirect/$siteSlug"
+        else -> "https://wordpress.com/domains/manage/all/$domain/edit/$siteSlug"
+    }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
@@ -50,7 +50,7 @@ import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiS
 @Composable
 fun MyDomainsScreen(
     uiState: UiState,
-    onDomainTapped: (domain: String) -> Unit,
+    onDomainTapped: (detailUrl: String) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -200,7 +200,7 @@ fun MyDomainsSearchInput(
 fun MyDomainsList(
     listUiState: PopulatedList,
     listState: LazyListState,
-    onDomainTapped: (domain: String) -> Unit,
+    onDomainTapped: (detailUrl: String) -> Unit,
 ) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/DomainManagementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/DomainManagementViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.domains
+package org.wordpress.android.ui.domains.management
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -14,7 +14,6 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_MY_DOMAINS_SCREEN_DOMAIN_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_MY_DOMAINS_SCREEN_SHOWN
-import org.wordpress.android.ui.domains.management.DomainManagementViewModel
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.ActionEvent
 import org.wordpress.android.ui.domains.usecases.AllDomains
 import org.wordpress.android.ui.domains.usecases.FetchAllDomainsUseCase

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrlTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrlTest.kt
@@ -1,0 +1,68 @@
+package org.wordpress.android.ui.domains.management
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
+
+@ExperimentalCoroutinesApi
+class GetDomainDetailsUrlTest : BaseUnitTest() {
+    @Test
+    fun `WHEN a transfer domain is passed THEN a transfer detail url is generated`() {
+        val domain = AllDomainsDomain(
+            domain = "transfer.domain",
+            siteSlug = "transfer.domain.slug",
+            type = "transfer"
+        )
+        val expectedDetailUrl = "https://wordpress.com/domains/manage/all/transfer.domain/transfer/in/transfer.domain.slug"
+        val actualDetailUrl = domain.getDomainDetailsUrl()
+        assertThat(actualDetailUrl).isEqualTo(expectedDetailUrl)
+    }
+
+    @Test
+    fun `WHEN a redirect domain is passed THEN a redirect detail url is generated`() {
+        val domain = AllDomainsDomain(
+            domain = "redirect.domain",
+            siteSlug = "redirect.domain.slug",
+            type = "redirect"
+        )
+        val expectedDetailUrl = "https://wordpress.com/domains/manage/all/redirect.domain/redirect/redirect.domain.slug"
+        val actualDetailUrl = domain.getDomainDetailsUrl()
+        assertThat(actualDetailUrl).isEqualTo(expectedDetailUrl)
+    }
+
+    @Test
+    fun `WHEN a mapping domain is passed THEN the default detail url is generated`() {
+        val domain = AllDomainsDomain(
+            domain = "some.domain",
+            siteSlug = "domain.slug",
+            type = "mapping"
+        )
+        val expectedDetailUrl = "https://wordpress.com/domains/manage/all/some.domain/edit/domain.slug"
+        val actualDetailUrl = domain.getDomainDetailsUrl()
+        assertThat(actualDetailUrl).isEqualTo(expectedDetailUrl)
+    }
+
+    @Test
+    fun `WHEN the domain is null THEN the default detail url is null`() {
+        val domain = AllDomainsDomain(
+            domain = null,
+            siteSlug = "domain.slug",
+            type = "mapping"
+        )
+        val actualDetailUrl = domain.getDomainDetailsUrl()
+        assertThat(actualDetailUrl).isNull()
+    }
+
+    @Test
+    fun `WHEN the slug is null THEN the default detail url is null`() {
+        val domain = AllDomainsDomain(
+            domain = "some.domain",
+            siteSlug = null,
+            type = "mapping"
+        )
+        val actualDetailUrl = domain.getDomainDetailsUrl()
+        assertThat(actualDetailUrl).isNull()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrlTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/GetDomainDetailsUrlTest.kt
@@ -12,10 +12,10 @@ class GetDomainDetailsUrlTest : BaseUnitTest() {
     fun `WHEN a transfer domain is passed THEN a transfer detail url is generated`() {
         val domain = AllDomainsDomain(
             domain = "transfer.domain",
-            siteSlug = "transfer.domain.slug",
+            siteSlug = "transfer.slug",
             type = "transfer"
         )
-        val expectedDetailUrl = "https://wordpress.com/domains/manage/all/transfer.domain/transfer/in/transfer.domain.slug"
+        val expectedDetailUrl = "https://wordpress.com/domains/manage/all/transfer.domain/transfer/in/transfer.slug"
         val actualDetailUrl = domain.getDomainDetailsUrl()
         assertThat(actualDetailUrl).isEqualTo(expectedDetailUrl)
     }


### PR DESCRIPTION
Fixes #19071

## Description
This PR enhances the implementation of https://github.com/wordpress-mobile/WordPress-Android/pull/19429 by creating the domain details url based on the type of domain (ref pc8HXX-1gR-p2).
It also moves the `DomainManagementViewModelTest` in the correct package.

## To test:
1. Enable the Domain Management feature flag (in debug settings)
2. Open the My domains screen: Me -> Domains -> My Domains
3. Tap on each domain
4. Verify that the proper domain details page opens in the webview

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
`GetDomainDetailsUrlTest`

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)