### PR TITLE
[Reader] Update post body link color to blue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -82,10 +82,7 @@ class ReaderResourceVars {
                            + ")";
 
         mTextColor = onSurfaceHighType;
-        mLinkColorStr = HtmlUtils.colorResToHtmlColor(context, ContextExtensionsKt.getColorResIdFromAttribute(
-                context,
-                com.google.android.material.R.attr.colorPrimary
-        ));
+        mLinkColorStr = HtmlUtils.colorResToHtmlColor(context, R.color.reader_post_body_link);
 
         // full-size image width must take margin into account
         mFullSizeImageWidthPx = displayWidthPx - (detailMarginWidthPx * 2);

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -106,5 +106,6 @@
     <color name="reader_following_button_text_color">#99FFFFFF</color>
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_dark</color>
     <color name="reader_blog_section_avatar_internal_border">@color/white_translucent_20</color>
+    <color name="reader_post_body_link">@color/blue_30</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -109,6 +109,7 @@
     <color name="reader_following_button_text_color">#99000000</color>
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_light</color>
     <color name="reader_blog_section_avatar_internal_border">@color/black_translucent_20</color>
+    <color name="reader_post_body_link">@color/blue_50</color>
 
     <!-- These colors were removed from the login library and moved here as they are still being
     used by some old layouts. They should be replaced here as well, whenever possible. -->


### PR DESCRIPTION
Fixes #19448

Refs p1698224643398909-slack-C05N140C8H5

This updates the link color to blue. Here's a preview:

Light | Dark
-|-
![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/ed0e18e5-52e0-4527-b78f-14719d7450b2) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/b9505629-6215-40b8-9c74-9c1c0bd977f1)

## To test

- Launch the Jetpack app.
- Go to Reader and open any post with a link in the body.
- 🔎 Verify that the link color is blue.
- Turn on dark mode from settings.
- Go back to the post.
- 🔎 Verify that the link color is blue.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
