### PR TITLE
Fixes: Dashboard cards shown in Jetpack app for Self hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -525,12 +525,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         siteInfo.loadMySiteDetails(state.siteInfoHeader)
 
         recyclerView.setVisible(true)
-        val cardAndItems = if (state.shouldShowDashboard) {
-            state.dashboardCardsAndItems
-        } else {
-            state.siteMenuCardsAndItems
-        }
-        (recyclerView.adapter as? MySiteAdapter)?.submitList(cardAndItems)
+        (recyclerView.adapter as? MySiteAdapter)?.submitList(state.dashboardData)
 
         if (noSitesView.actionableEmptyView.isVisible) {
             noSitesView.actionableEmptyView.setVisible(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -65,7 +65,6 @@ import org.wordpress.android.ui.utils.TitleSubtitleSnackbarSpannable
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.QuickStartUtilsWrapper
@@ -133,9 +132,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     @Inject
     lateinit var activityNavigator: ActivityNavigator
-
-    @Inject
-    lateinit var buildConfigWrapper: BuildConfigWrapper
 
     private lateinit var viewModel: MySiteViewModel
     private lateinit var dialogViewModel: BasicDialogViewModel
@@ -529,7 +525,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         siteInfo.loadMySiteDetails(state.siteInfoHeader)
 
         recyclerView.setVisible(true)
-        val cardAndItems = if (buildConfigWrapper.isJetpackApp) {
+        val cardAndItems = if (state.shouldShowDashboard) {
             state.dashboardCardsAndItems
         } else {
             state.siteMenuCardsAndItems

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -365,7 +365,8 @@ class MySiteViewModel @Inject constructor(
         return SiteSelected(
             siteInfoHeader = siteInfo,
             siteMenuCardsAndItems = siteItems[MySiteTabType.SITE_MENU]!!,
-            dashboardCardsAndItems = siteItems[MySiteTabType.DASHBOARD]!!
+            dashboardCardsAndItems = siteItems[MySiteTabType.DASHBOARD]!!,
+            shouldShowDashboard = shouldShowDashboard(site)
         )
     }
 
@@ -407,7 +408,7 @@ class MySiteViewModel @Inject constructor(
         )
         val jetpackInstallFullPluginCard = jetpackInstallFullPluginCardBuilder.build(jetpackInstallFullPluginCardParams)
 
-        val cardsResult = if (!jetpackFeatureRemovalPhaseHelper.shouldShowDashboard()) emptyList()
+        val cardsResult = if (!shouldShowDashboard(site)) emptyList()
         else cardsBuilder.build(
             DomainRegistrationCardBuilderParams(
                 isDomainCreditAvailable = isDomainCreditAvailable,
@@ -484,14 +485,17 @@ class MySiteViewModel @Inject constructor(
         )
     }
 
+    private fun shouldShowDashboard(site: SiteModel): Boolean {
+       return buildConfigWrapper.isJetpackApp && site.isUsingWpComRestApi
+    }
+
     private fun getSiteItems(
         site: SiteModel,
         activeTask: QuickStartTask?,
         backupAvailable: Boolean,
         scanAvailable: Boolean
     ): List<MySiteCardAndItem> {
-        val isJetpackApp = buildConfigWrapper.isJetpackApp
-        if (isJetpackApp) return emptyList()
+        if(shouldShowDashboard(site)) return emptyList()
         return siteItemsBuilder.build(
             siteItemsViewModelSlice.buildItems(
                 shouldEnableFocusPoints = false,
@@ -976,7 +980,8 @@ class MySiteViewModel @Inject constructor(
         data class SiteSelected(
             val siteInfoHeader: SiteInfoHeaderCard,
             val siteMenuCardsAndItems: List<MySiteCardAndItem>,
-            val dashboardCardsAndItems: List<MySiteCardAndItem>
+            val dashboardCardsAndItems: List<MySiteCardAndItem>,
+            val shouldShowDashboard: Boolean = false
         ) : State()
 
         data class NoSites(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -453,8 +453,7 @@ class MySiteViewModel @Inject constructor(
         )
         val jetpackInstallFullPluginCard = jetpackInstallFullPluginCardBuilder.build(jetpackInstallFullPluginCardParams)
 
-        val cardsResult = if (!shouldShowDashboard(site)) emptyList()
-        else cardsBuilder.build(
+        val cardsResult = cardsBuilder.build(
             DomainRegistrationCardBuilderParams(
                 isDomainCreditAvailable = isDomainCreditAvailable,
                 domainRegistrationClick = this::domainRegistrationClick

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCardViewModel.kt
@@ -104,7 +104,7 @@ class DomainTransferCardViewModel @Inject constructor(
 
     private fun positionIndex(siteSelected: SiteSelected?): Int {
         return siteSelected
-            ?.dashboardCardsAndItems
+            ?.dashboardData
             ?.indexOfFirst {
                 it is MySiteCardAndItem.Card.DomainTransferCardModel
             } ?: -1

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/plans/PlansCardUtils.kt
@@ -51,7 +51,7 @@ class PlansCardUtils @Inject constructor(
 
         dashboardUpdateDebounceJob = scope.launch(bgDispatcher) {
             val isVisible = siteSelected
-                ?.dashboardCardsAndItems
+                ?.dashboardData
                 ?.any { card ->
                     card is DashboardPlansCard
                 } ?: false
@@ -116,7 +116,7 @@ class PlansCardUtils @Inject constructor(
 
     private fun positionIndex(siteSelected: SiteSelected?): Int {
         return siteSelected
-            ?.dashboardCardsAndItems
+            ?.dashboardData
             ?.indexOfFirst {
                 it is DashboardPlansCard
             } ?: -1

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -1470,7 +1470,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)
-
     }
 
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -405,7 +405,6 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(quickStartRepository.activeTask).thenReturn(activeTask)
         whenever(quickStartRepository.quickStartType).thenReturn(quickStartType)
         whenever(jetpackBrandingUtils.getBrandingTextForScreen(any())).thenReturn(mock())
-        whenever(jetpackFeatureRemovalPhaseHelper.shouldShowDashboard()).thenReturn(true)
         whenever(blazeCardViewModelSlice.refresh).thenReturn(refresh)
         whenever(domainTransferCardViewModel.refresh).thenReturn(refresh)
         whenever(pagesCardViewModelSlice.getPagesCardBuilderParams(anyOrNull())).thenReturn(mock())
@@ -678,7 +677,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     /* DOMAIN REGISTRATION CARD */
     @Test
     fun `domain registration item click opens domain registration`() {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
         findDomainRegistrationCard()?.onClick?.click()
@@ -712,7 +711,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when domain registration card is shown, then card shown event is tracked`() = test {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
         verify(
@@ -725,7 +724,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start full screen dialog is opened`() {
-        initSelectedSite(isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true, isJetpackApp = true)
 
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
@@ -735,7 +734,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start task type item is clicked, then quick start active task is cleared`() {
-        initSelectedSite(isQuickStartInProgress = true)
+        initSelectedSite(isQuickStartInProgress = true, isJetpackApp = true)
 
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
@@ -745,7 +744,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when quick start card item clicked, then quick start card item tapped is tracked`() {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         requireNotNull(quickStartTaskTypeItemClickAction).invoke(QuickStartTaskType.CUSTOMIZE)
 
@@ -982,7 +981,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `given error dashboard card, when retry is clicked, then refresh is triggered`() =
         test {
-            initSelectedSite()
+            initSelectedSite(isJetpackApp = true)
             cardsUpdate.value = cardsUpdate.value?.copy(showErrorCard = true)
 
             requireNotNull(onDashboardErrorRetryClick).invoke()
@@ -994,23 +993,23 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given show stale msg not in cards update, when dashboard cards updated, then info item not shown`() {
-        initSelectedSite(showStaleMessage = false)
+        initSelectedSite(showStaleMessage = false, isJetpackApp = true)
 
         cardsUpdate.value = cardsUpdate.value?.copy(showStaleMessage = false)
 
         assertThat((uiModels.last() as SiteSelected)
-            .dashboardCardsAndItems.filterIsInstance(InfoItem::class.java))
+            .dashboardData.filterIsInstance(InfoItem::class.java))
             .isEmpty()
     }
 
     @Test
     fun `given show stale msg in cards update, when dashboard cards updated, then info item shown`() {
-        initSelectedSite(showStaleMessage = true)
+        initSelectedSite(showStaleMessage = true, isJetpackApp = true)
 
         cardsUpdate.value = cardsUpdate.value?.copy(showStaleMessage = true)
 
         assertThat((uiModels.last() as SiteSelected)
-            .dashboardCardsAndItems.filterIsInstance(InfoItem::class.java))
+            .dashboardData.filterIsInstance(InfoItem::class.java))
             .isNotEmpty
     }
 
@@ -1128,11 +1127,6 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given IS NOT Jetpack app, migration success card SHOULD NOT be shown`() {
-        val packageName = "packageName"
-        whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
-        whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
-
         initSelectedSite()
 
         assertThat(getSiteMenuTabLastItems()[0]).isNotInstanceOf(SingleActionCard::class.java)
@@ -1144,10 +1138,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given migration IS NOT completed, migration success card SHOULD NOT be shown`() {
         val packageName = "packageName"
         whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
 
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         assertThat(getSiteMenuTabLastItems()[0]).isNotInstanceOf(SingleActionCard::class.java)
         assertThat(getLastItems()[0]).isNotInstanceOf(SingleActionCard::class.java)
@@ -1156,10 +1149,9 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given WordPress app IS NOT installed, migration success card SHOULD NOT be shown`() {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
 
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         assertThat(getSiteMenuTabLastItems()[0]).isNotInstanceOf(SingleActionCard::class.java)
         assertThat(getLastItems()[0]).isNotInstanceOf(SingleActionCard::class.java)
@@ -1170,11 +1162,10 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `given IS JP app, migration IS complete and WP app IS installed, migration success card SHOULD be shown`() {
         val packageName = "packageName"
         whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
         whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
 
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         assertThat(getDashboardTabLastItems()[0]).isInstanceOf(SingleActionCard::class.java)
     }
@@ -1183,10 +1174,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `JP migration success card should have the correct text`() {
         val packageName = "packageName"
         whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
         whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         val expected = R.string.jp_migration_success_card_message
         assertThat((getDashboardTabLastItems()[0] as SingleActionCard).textResource).isEqualTo(expected)
@@ -1196,10 +1186,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `JP migration success card should have the correct image`() {
         val packageName = "packageName"
         whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
         whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         val expected = R.drawable.ic_wordpress_jetpack_appicon
         assertThat((getDashboardTabLastItems()[0] as SingleActionCard).imageResource).isEqualTo(expected)
@@ -1209,10 +1198,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     fun `JP migration success card click should be tracked`() {
         val packageName = "packageName"
         whenever(wordPressPublicData.currentPackageId()).thenReturn(packageName)
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
         whenever(appPrefsWrapper.isJetpackMigrationCompleted()).thenReturn(true)
         whenever(appStatus.isAppInstalled(packageName)).thenReturn(true)
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         (getDashboardTabLastItems()[0] as SingleActionCard).onActionClick.invoke()
 
@@ -1231,16 +1219,16 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     @Test
     fun `given selected site with tabs disabled, when all cards and items, then qs card exists`() {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
         assertThat(getLastItems().filterIsInstance(QuickStartCard::class.java)).isNotEmpty
     }
 
     @Test
     fun `given selected site, when dashboard cards and items, then dashboard cards exists`() {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
-        val items = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(MySiteCardAndItem.Card::class.java)).isNotEmpty
     }
@@ -1250,7 +1238,7 @@ class MySiteViewModelTest : BaseUnitTest() {
        // setUpSiteItemBuilder()
         initSelectedSite()
 
-        val items = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(ListItem::class.java)).isEmpty()
     }
@@ -1258,9 +1246,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Test
     fun `when dashboard cards items built, then qs card exists`() {
       //  setUpSiteItemBuilder()
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
 
-        val items = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(QuickStartCard::class.java)).isNotEmpty
     }
@@ -1271,7 +1259,7 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         initSelectedSite()
 
-        val items = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(QuickStartCard::class.java)).isEmpty()
     }
@@ -1280,7 +1268,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         setUpSiteItemBuilder()
         initSelectedSite()
 
-        val items = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(ListItem::class.java)).isNotEmpty
     }
@@ -1291,17 +1279,17 @@ class MySiteViewModelTest : BaseUnitTest() {
 
         initSelectedSite()
 
-        val items = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(QuickStartCard::class.java)).isEmpty()
     }
 
     @Test
     fun `given selected site with domain credit, when dashboard cards + items, then domain reg card exists`() {
-        initSelectedSite()
+        initSelectedSite(isJetpackApp = true)
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
-        val items = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isNotEmpty
     }
@@ -1311,7 +1299,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         initSelectedSite()
         isDomainCreditAvailable.value = DomainCreditAvailable(true)
 
-        val items = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+        val items = (uiModels.last() as SiteSelected).dashboardData
 
         assertThat(items.filterIsInstance(DomainRegistrationCard::class.java)).isEmpty()
     }
@@ -1446,13 +1434,13 @@ class MySiteViewModelTest : BaseUnitTest() {
 
     private fun findJetpackBadgeListItem() = getSiteMenuTabLastItems().filterIsInstance(JetpackBadge::class.java)
 
-    private fun getLastItems() = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+    private fun getLastItems() = (uiModels.last() as SiteSelected).dashboardData
 
-    private fun getMenuItems() = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+    private fun getMenuItems() = (uiModels.last() as SiteSelected).dashboardData
 
-    private fun getDashboardTabLastItems() = (uiModels.last() as SiteSelected).dashboardCardsAndItems
+    private fun getDashboardTabLastItems() = (uiModels.last() as SiteSelected).dashboardData
 
-    private fun getSiteMenuTabLastItems() = (uiModels.last() as SiteSelected).siteMenuCardsAndItems
+    private fun getSiteMenuTabLastItems() = (uiModels.last() as SiteSelected).dashboardData
 
     private fun getSiteInfoHeaderCard() = (uiModels.last() as SiteSelected).siteInfoHeader
 
@@ -1461,7 +1449,8 @@ class MySiteViewModelTest : BaseUnitTest() {
         isQuickStartInProgress: Boolean = false,
         showStaleMessage: Boolean = false,
         isSiteUsingWpComRestApi: Boolean = true,
-        shouldShowJetpackBranding: Boolean = true
+        shouldShowJetpackBranding: Boolean = true,
+        isJetpackApp: Boolean = false
     ) {
         whenever(
             mySiteInfoItemBuilder.build(InfoItemBuilderParams(isStaleMessagePresent = showStaleMessage))
@@ -1469,6 +1458,9 @@ class MySiteViewModelTest : BaseUnitTest() {
         quickStartUpdate.value = QuickStartUpdate(
             categories = if (isQuickStartInProgress) listOf(quickStartCategory) else emptyList()
         )
+        // in order to build the dashboard cards, this value should be true along with isSiteUsingWpComRestApi
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
+
         whenever(jetpackBrandingUtils.shouldShowJetpackBrandingInDashboard()).thenReturn(shouldShowJetpackBranding)
         if (isSiteUsingWpComRestApi) {
             site.setIsWPCom(true)
@@ -1478,6 +1470,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         onSiteSelected.value = siteLocalId
         onSiteChange.value = site
         selectedSite.value = SelectedSite(site)
+
     }
 
 


### PR DESCRIPTION
## Fixes 
#19461 

## Description
This PR fixes the issue in which the dashboard cards was shown in jetpack app for a self hosted site without Jetpack plugin. Only menu items would be shown if the self hosted site is not jetpack connected and when it is connected, dashboard card data will be shown 

## Screenshots
|  Before | After | 
|---|---|
| ![Screenshot_20231026-112801](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/69c2220a-3840-4ee9-bec2-00f46ddba235)  |  ![Screenshot_20231026-142025](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/a70cd095-fdd0-445d-8b30-f94bde824a7f)  |  

## To test:
### Jetpack app - Self hosted site - with and without Jetpack installed 
1. Login to Jetpack app with a self hosted site without jetpack 
2. Notice that menu items are shown in the dashboard 
3. Install Jetpack on the site 
4. Verify that the dashboard cards are shown in dashboard

### Regression testing - Wordpress app 
1. Login to the Wordpress app
2. Go to dashobard
3. Verify that only Menu items are shown in dashboard

## Regression Notes
1. Potential unintended areas of impact
Dashboard data is not shown as intended

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Unit tests and manual testing

5. What automated tests I added (or what prevented me from doing so)


PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)