### PR TITLE
Adds privacy notice banner event names

### DIFF
--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2285,6 +2285,12 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "app_settings_max_video_size_changed";
             case APP_SETTINGS_VIDEO_QUALITY_CHANGED:
                 return "app_settings_video_quality_changed";
+            case PRIVACY_CHOICES_BANNER_PRESENTED:
+                return "privacy_choices_banner_presented";
+            case PRIVACY_CHOICES_BANNER_SETTINGS_BUTTON_TAPPED:
+                return "privacy_choices_banner_settings_button_tapped";
+            case PRIVACY_CHOICES_BANNER_SAVE_BUTTON_TAPPED:
+                return "privacy_choices_banner_save_button_tapped";
             case PRIVACY_SETTINGS_OPENED:
                 return "privacy_settings_opened";
             case PRIVACY_SETTINGS_REPORT_CRASHES_TOGGLED:


### PR DESCRIPTION
## Description

This PR fixes an issue with the https://github.com/wordpress-mobile/WordPress-Android/issues/18569 implementation.

##To test:

1. Log in to the app
2. **Verify** that the `privacy_choices_banner_presented` event is logged
3. Tap on the *Save* button
4. **Verify** that the `privacy_choices_banner_save_button_tapped`  event is logged
5. Logout
6. Log in to the app
7. Tap the *Settings* button
8. **Verify** that the `privacy_choices_banner_settings_button_tapped`  event is logged

## Regression Notes
1. Potential unintended areas of impact
N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

10. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
