### PR TITLE
Remove `PROJECT_ROOT_FOLDER` env var

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'trunk'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'deprecate/project-root-folder-env-var'
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'nokogiri'
 
 ### Fastlane Plugins
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.2'
 # gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'deprecate/project-root-folder-env-var'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: ''
 
 
 ### Gems needed only for generating Promo Screenshots

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,48 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 4389f85a9e6a9264a14101eaf93589e0880f35d8
+  branch: deprecate/project-root-folder-env-var
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (9.1.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.8)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.830.0)
-    aws-sdk-core (3.184.0)
+    aws-partitions (1.842.0)
+    aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -26,9 +54,11 @@ GEM
       aws-sdk-core (~> 3, >= 3.181.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.6)
-    aws-sigv4 (1.6.0)
+    aws-sigv4 (1.6.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     buildkit (1.5.0)
       sawyer (>= 0.6)
     chroma (0.2.0)
@@ -38,6 +68,7 @@ GEM
     commander (4.6.0)
       highline (~> 2.0.0)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     declarative (0.0.20)
     diffy (3.4.2)
     digest-crc (0.6.5)
@@ -45,6 +76,8 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
+    drb (2.1.1)
+      ruby2_keywords
     emoji_regex (3.2.3)
     excon (0.104.0)
     faraday (1.10.3)
@@ -116,28 +149,11 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-wpmreleasetoolkit (9.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.18.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    google-apis-androidpublisher_v3 (0.50.0)
+    google-apis-androidpublisher_v3 (0.51.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.1)
       addressable (~> 2.5, >= 2.5.1)
@@ -186,10 +202,11 @@ GEM
     jwt (2.7.1)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.20.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)
+    mutex_m (0.1.2)
     nanaimo (0.3.0)
     naturally (2.2.1)
     nokogiri (1.15.4)
@@ -268,7 +285,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit (~> 9.1)
+  fastlane-plugin-wpmreleasetoolkit!
   nokogiri
   rmagick (~> 4.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 4389f85a9e6a9264a14101eaf93589e0880f35d8
-  branch: deprecate/project-root-folder-env-var
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (9.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -41,7 +18,7 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.842.0)
+    aws-partitions (1.843.0)
     aws-sdk-core (3.185.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -149,13 +126,30 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-wpmreleasetoolkit (9.2.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
     gh_inspector (1.1.3)
     git (1.18.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.51.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-core (0.11.1)
+    google-apis-core (0.11.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -225,7 +219,7 @@ GEM
       options (~> 2.3.0)
     public_suffix (5.0.3)
     racc (1.7.1)
-    rake (13.0.6)
+    rake (13.1.0)
     rake-compiler (1.2.5)
       rake
     rchardet (1.8.0)
@@ -285,9 +279,9 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2)
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 9.2)
   nokogiri
   rmagick (~> 4.1)
 
 BUNDLED WITH
-   2.4.10
+   2.4.21

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,7 @@ PROTOTYPE_BUILD_DOMAIN = 'https://d2twmm2nzpx3bg.cloudfront.net'
 
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 FASTLANE_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'fastlane')
+RELEASE_NOTES_SOURCE_PATH = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
 
 VERSION_PROPERTIES_PATH = File.join(PROJECT_ROOT_FOLDER, 'version.properties')
 
@@ -48,9 +49,7 @@ fastlane_require 'dotenv'
 USER_ENV_FILE_PATH = File.join(Dir.home, '.wpandroid-env.default')
 Dotenv.load(USER_ENV_FILE_PATH)
 
-ENV[GHHELPER_REPO = 'wordpress-mobile/WordPress-Android']
-ENV['PROJECT_ROOT_FOLDER'] = File.dirname(File.expand_path(__dir__)) + '/'
-ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'trunk'
+GHHELPER_REPO = 'wordpress-mobile/WordPress-Android'
 DEFAULT_BRANCH = 'trunk'
 REPOSITORY_NAME = 'WordPress-Android'
 

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -302,7 +302,8 @@ platform :android do
         library_name: lib[:name],
         import_key: lib[:import_key],
         repository: lib[:repository],
-        file_path: lib[:strings_file_path]
+        file_path: lib[:strings_file_path],
+        build_gradle_path: File.join(PROJECT_ROOT_FOLDER, 'build.gradle')
       )
 
       if download_path.nil?

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -54,7 +54,7 @@ platform :android do
 
     extract_release_notes_for_version(
       version: new_version,
-      release_notes_file_path: "#{ENV['PROJECT_ROOT_FOLDER']}RELEASE-NOTES.txt",
+      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH,
       extracted_notes_file_path: release_notes_path('wordpress')
     )
     # Jetpack Release notes are based on WP Release notes
@@ -65,7 +65,11 @@ platform :android do
       sh('git', 'commit', '-m', "Update draft release notes for Jetpack #{new_version}.")
     end
     cleanup_release_files(files: release_notes_short_paths)
-    android_update_release_notes(new_version: new_version) # Adds empty section for next version
+    # Adds empty section for next version
+    android_update_release_notes(
+      new_version: new_version,
+      release_notes_file_path: RELEASE_NOTES_SOURCE_PATH
+    )
 
     UI.message("Jetpack release notes were based on the same ones as WordPress. Don't forget to check #{release_notes_path('jetpack')} and amend them as necessary if any item does not apply for Jetpack before sending them to Editorial.")
 
@@ -488,22 +492,22 @@ platform :android do
 
   def release_notes_path(app)
     paths = {
-      wordpress: File.join(ENV['PROJECT_ROOT_FOLDER'], 'WordPress', 'metadata', 'release_notes.txt'),
-      jetpack: File.join(ENV['PROJECT_ROOT_FOLDER'], 'WordPress', 'jetpack_metadata', 'release_notes.txt')
+      wordpress: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'metadata', 'release_notes.txt'),
+      jetpack: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'jetpack_metadata', 'release_notes.txt')
     }
     paths[app.to_sym] || paths[:wordpress]
   end
 
   def release_notes_short_paths
     [
-      File.join(ENV['PROJECT_ROOT_FOLDER'], 'WordPress', 'metadata', 'release_notes_short.txt'),
-      File.join(ENV['PROJECT_ROOT_FOLDER'], 'WordPress', 'jetpack_metadata', 'release_notes_short.txt')
+      File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'metadata', 'release_notes_short.txt'),
+      File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'jetpack_metadata', 'release_notes_short.txt')
     ]
   end
 
   def bundle_file_path(app, version_name)
     prefix = APP_SPECIFIC_VALUES[app.to_sym][:bundle_name_prefix]
-    File.join(ENV['PROJECT_ROOT_FOLDER'], 'build', "#{prefix}-#{version_name}.aab")
+    File.join(PROJECT_ROOT_FOLDER, 'build', "#{prefix}-#{version_name}.aab")
   end
 
   def signed_apk_path(app, version_name)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -285,7 +285,9 @@ platform :android do
   #####################################################################################
   desc 'Updates store metadata and runs the release checks'
   lane :finalize_release do |options|
-    UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes') if android_current_branch_is_hotfix
+    if android_current_branch_is_hotfix(version_properties_path: VERSION_PROPERTIES_PATH)
+      UI.user_error!('Please use `finalize_hotfix_release` lane for hotfixes')
+    end
 
     ensure_git_status_clean
     ensure_git_branch(branch: '^release/')


### PR DESCRIPTION
This PR removes the deprecated `PROJECT_ROOT_FOLDER` environment variable from the Fastfile:
- An explicit path is now passed to `android_update_release_notes` instead of using the `PROJECT_ROOT_FOLDER` and `PROJECT_NAME` env vars
- An explicit path is now passed to `android_current_branch_is_hotfix` instead of using the `PROJECT_ROOT_FOLDER` env var
- An explicit path is now passed to `android_download_file_by_version` instead of using the `PROJECT_ROOT_FOLDER` env var

- [x] ~I added the "Do Not Merge" label because this PR relies upon changes in the Release Toolkit: https://github.com/wordpress-mobile/release-toolkit/pull/519. That PR must be merged and this PR updated to a new version of the Release Toolkit before it can be merged.~ This was completed in https://github.com/wordpress-mobile/WordPress-Android/commit/842ceb668b64edb8f3b729372575c32e34057e77