### PR TITLE
Part-1: Compiler Warnings as Errors - WordPress Module - FragmentManager 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
@@ -41,8 +41,11 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
     companion object {
         const val TAG = "private_at_cookie_progress_dialog"
 
-        @Suppress("DEPRECATION")
-        fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment? = null) {
+        fun showIfNecessary(fragmentManager: FragmentManager?) {
+            showIfNecessary(fragmentManager, null)
+        }
+
+        fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment?) {
             fragmentManager?.let {
                 val thisFragment = fragmentManager.findFragmentByTag(TAG)
                 if (thisFragment == null ||

--- a/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
@@ -7,7 +7,6 @@ import android.app.ProgressDialog
 import android.content.DialogInterface
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import org.wordpress.android.R
 
@@ -28,11 +27,10 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
         return dialog != null && dialog!!.isShowing
     }
 
-    @Suppress("DEPRECATION")
     override fun onCancel(dialog: DialogInterface) {
         super.onCancel(dialog)
-        if (targetFragment is PrivateAtCookieProgressDialogOnDismissListener) {
-            (targetFragment as PrivateAtCookieProgressDialogOnDismissListener).onCookieProgressDialogCancelled()
+        if (parentFragment is PrivateAtCookieProgressDialogOnDismissListener) {
+            (parentFragment as PrivateAtCookieProgressDialogOnDismissListener).onCookieProgressDialogCancelled()
         } else if (activity is PrivateAtCookieProgressDialogOnDismissListener) {
             (activity as PrivateAtCookieProgressDialogOnDismissListener).onCookieProgressDialogCancelled()
         }
@@ -42,18 +40,14 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
         const val TAG = "private_at_cookie_progress_dialog"
 
         fun showIfNecessary(fragmentManager: FragmentManager?) {
-            showIfNecessary(fragmentManager, null)
-        }
-
-        fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment?) {
             fragmentManager?.let {
                 val thisFragment = fragmentManager.findFragmentByTag(TAG)
-                if (thisFragment == null ||
-                    (thisFragment is PrivateAtCookieRefreshProgressDialog && !thisFragment.isDialogVisible())
-                ) {
+                if (thisFragment == null) {
                     val progressFragment = PrivateAtCookieRefreshProgressDialog()
-                    progressFragment.setTargetFragment(targetFragment, 0)
                     progressFragment.show(fragmentManager, TAG)
+                }
+                if (thisFragment is PrivateAtCookieRefreshProgressDialog && !thisFragment.isDialogVisible()) {
+                    thisFragment.show(fragmentManager, TAG)
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/PrivateAtCookieRefreshProgressDialog.kt
@@ -41,12 +41,8 @@ class PrivateAtCookieRefreshProgressDialog : DialogFragment() {
     companion object {
         const val TAG = "private_at_cookie_progress_dialog"
 
-        fun showIfNecessary(fragmentManager: FragmentManager?) {
-            showIfNecessary(fragmentManager, null)
-        }
-
         @Suppress("DEPRECATION")
-        fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment?) {
+        fun showIfNecessary(fragmentManager: FragmentManager?, targetFragment: Fragment? = null) {
             fragmentManager?.let {
                 val thisFragment = fragmentManager.findFragmentByTag(TAG)
                 if (thisFragment == null ||

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -23,9 +24,11 @@ import androidx.core.app.RemoteInput;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
+
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -15,7 +15,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
-
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,11 +23,9 @@ import androidx.core.app.RemoteInput;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
-
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -476,7 +473,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
 
         if (canShowAppRatingPrompt) {
-            AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getFragmentManager());
+            AppRatingDialog.INSTANCE.showRateDialogIfNeeded(getSupportFragmentManager());
         }
 
         scheduleLocalNotifications();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -26,7 +26,6 @@ import android.webkit.WebView
 import android.widget.ImageView.ScaleType.CENTER_CROP
 import android.widget.ProgressBar
 import android.widget.TextView
-import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.ListPopupWindow

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1495,7 +1495,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         viewModel.onShowPost(blogId = blogId, postId = postId)
     }
 
-    @Suppress("unused", "DEPRECATION")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onPrivateAtomicCookieFetched(event: OnPrivateAtomicCookieFetched) {
         if (!isAdded) {
@@ -1515,7 +1515,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             )
         }
 
-        PrivateAtCookieRefreshProgressDialog.dismissIfNecessary(fragmentManager)
+        PrivateAtCookieRefreshProgressDialog.dismissIfNecessary(parentFragmentManager)
         renderer?.beginRender()
     }
 
@@ -1554,7 +1554,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         null -> false
     }
 
-    @Suppress("DEPRECATION")
     private fun showPostInWebView(post: ReaderPost, fragment: Fragment) {
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))
@@ -1568,7 +1567,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         // if the post is from private atomic site postpone render until we have a special access cookie
         if (post.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {
-            PrivateAtCookieRefreshProgressDialog.showIfNecessary(fragmentManager, fragment)
+            PrivateAtCookieRefreshProgressDialog.showIfNecessary(parentFragmentManager, fragment)
             requestPrivateAtomicCookie()
         } else if (post.isPrivateAtomic && privateAtomicCookie.exists()) {
             // make sure we add cookie to the cookie manager if it exists before starting render

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1567,7 +1567,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         // if the post is from private atomic site postpone render until we have a special access cookie
         if (post.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {
-            PrivateAtCookieRefreshProgressDialog.showIfNecessary(parentFragmentManager, fragment)
+            PrivateAtCookieRefreshProgressDialog.showIfNecessary(childFragmentManager, fragment)
             requestPrivateAtomicCookie()
         } else if (post.isPrivateAtomic && privateAtomicCookie.exists()) {
             // make sure we add cookie to the cookie manager if it exists before starting render

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1515,7 +1515,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             )
         }
 
-        PrivateAtCookieRefreshProgressDialog.dismissIfNecessary(parentFragmentManager)
+        PrivateAtCookieRefreshProgressDialog.dismissIfNecessary(childFragmentManager)
         renderer?.beginRender()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -26,6 +26,7 @@ import android.webkit.WebView
 import android.widget.ImageView.ScaleType.CENTER_CROP
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.ListPopupWindow
@@ -39,7 +40,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -904,7 +904,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             is ReaderNavigationEvents.ReplaceRelatedPostDetailsWithHistory ->
                 replaceRelatedPostDetailWithHistory(postId = this.postId, blogId = this.blogId)
 
-            is ReaderNavigationEvents.ShowPostInWebView -> showPostInWebView(post, this@ReaderPostDetailFragment)
+            is ReaderNavigationEvents.ShowPostInWebView -> showPostInWebView(post)
             is ReaderNavigationEvents.ShowEngagedPeopleList -> {
                 ActivityLauncher.viewPostLikesListActivity(
                     activity,
@@ -1554,7 +1554,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         null -> false
     }
 
-    private fun showPostInWebView(post: ReaderPost, fragment: Fragment) {
+    private fun showPostInWebView(post: ReaderPost) {
         readerWebView.setIsPrivatePost(post.isPrivate)
         readerWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(post.blogUrl))
         readerProgressBar.visibility = View.VISIBLE
@@ -1567,7 +1567,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         // if the post is from private atomic site postpone render until we have a special access cookie
         if (post.isPrivateAtomic && privateAtomicCookie.isCookieRefreshRequired()) {
-            PrivateAtCookieRefreshProgressDialog.showIfNecessary(childFragmentManager, fragment)
+            PrivateAtCookieRefreshProgressDialog.showIfNecessary(childFragmentManager)
             requestPrivateAtomicCookie()
         } else if (post.isPrivateAtomic && privateAtomicCookie.exists()) {
             // make sure we add cookie to the cookie manager if it exists before starting render

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -90,7 +90,7 @@ class StatsWidgetConfigureFragment : Fragment() {
         return inflater.inflate(R.layout.stats_widget_configure_fragment, container, false)
     }
 
-    @Suppress("DEPRECATION", "LongMethod")
+    @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()
@@ -126,12 +126,12 @@ class StatsWidgetConfigureFragment : Fragment() {
             }
 
             siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-                StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
+                StatsWidgetSiteSelectionDialogFragment().show(parentFragmentManager, "stats_site_selection_fragment")
             })
 
             colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
                 StatsWidgetColorSelectionDialogFragment().show(
-                    requireFragmentManager(),
+                    parentFragmentManager,
                     "stats_view_mode_selection_fragment"
                 )
             })

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/configuration/StatsWidgetConfigureFragment.kt
@@ -125,16 +125,19 @@ class StatsWidgetConfigureFragment : Fragment() {
                 viewModel.addWidget()
             }
 
-            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-                StatsWidgetSiteSelectionDialogFragment().show(parentFragmentManager, "stats_site_selection_fragment")
-            })
+            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
+                StatsWidgetSiteSelectionDialogFragment().show(
+                    childFragmentManager,
+                    "stats_site_selection_fragment"
+                )
+            }
 
-            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetColorSelectionDialogFragment().show(
-                    parentFragmentManager,
+                    childFragmentManager,
                     "stats_view_mode_selection_fragment"
                 )
-            })
+            }
 
             merge(siteSelectionViewModel.notification, colorSelectionViewModel.notification).observeEvent(
                 viewLifecycleOwner,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -95,21 +95,21 @@ class StatsMinifiedWidgetConfigureFragment : Fragment(R.layout.stats_widget_conf
 
             siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetSiteSelectionDialogFragment().show(
-                    parentFragmentManager,
+                    childFragmentManager,
                     "stats_site_selection_fragment"
                 )
             }
 
             colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetColorSelectionDialogFragment().show(
-                    parentFragmentManager,
+                    childFragmentManager,
                     "stats_view_mode_selection_fragment"
                 )
             }
 
             dataTypeSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetDataTypeSelectionDialogFragment().show(
-                    parentFragmentManager,
+                    childFragmentManager,
                     "stats_data_type_selection_fragment"
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/StatsMinifiedWidgetConfigureFragment.kt
@@ -52,7 +52,7 @@ class StatsMinifiedWidgetConfigureFragment : Fragment(R.layout.stats_widget_conf
     private lateinit var colorSelectionViewModel: StatsColorSelectionViewModel
     private lateinit var dataTypeSelectionViewModel: StatsDataTypeSelectionViewModel
 
-    @Suppress("DEPRECATION", "LongMethod")
+    @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val nonNullActivity = requireActivity()
@@ -93,23 +93,26 @@ class StatsMinifiedWidgetConfigureFragment : Fragment(R.layout.stats_widget_conf
                 viewModel.addWidget()
             }
 
-            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
-                StatsWidgetSiteSelectionDialogFragment().show(requireFragmentManager(), "stats_site_selection_fragment")
-            })
+            siteSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
+                StatsWidgetSiteSelectionDialogFragment().show(
+                    parentFragmentManager,
+                    "stats_site_selection_fragment"
+                )
+            }
 
-            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+            colorSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetColorSelectionDialogFragment().show(
-                    requireFragmentManager(),
+                    parentFragmentManager,
                     "stats_view_mode_selection_fragment"
                 )
-            })
+            }
 
-            dataTypeSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner, {
+            dataTypeSelectionViewModel.dialogOpened.observeEvent(viewLifecycleOwner) {
                 StatsWidgetDataTypeSelectionDialogFragment().show(
-                    requireFragmentManager(),
+                    parentFragmentManager,
                     "stats_data_type_selection_fragment"
                 )
-            })
+            }
 
             mergeNotNull(
                 siteSelectionViewModel.notification,

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
@@ -1,10 +1,6 @@
-@file:Suppress("DEPRECATION")
-
 package org.wordpress.android.widgets
 
 import android.app.Dialog
-import android.app.DialogFragment
-import android.app.FragmentManager
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.DialogInterface
@@ -13,6 +9,8 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
@@ -74,7 +72,7 @@ object AppRatingDialog {
      * Show the rate dialog if the criteria is satisfied.
      * @return true if shown, false otherwise.
      */
-    @Suppress("DEPRECATION")
+
     fun showRateDialogIfNeeded(fragmentManger: FragmentManager): Boolean {
         return if (shouldShowRateDialog()) {
             showRateDialog(fragmentManger)
@@ -109,7 +107,6 @@ object AppRatingDialog {
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun showRateDialog(fragmentManger: FragmentManager) {
         var dialog = fragmentManger.findFragmentByTag(AppRatingDialog.TAG_APP_RATING_PROMPT_DIALOG)
         if (dialog == null) {
@@ -119,33 +116,32 @@ object AppRatingDialog {
         }
     }
 
-    @Suppress("DEPRECATION")
     class AppRatingDialog : DialogFragment() {
         companion object {
             internal const val TAG_APP_RATING_PROMPT_DIALOG = "TAG_APP_RATING_PROMPT_DIALOG"
         }
 
-        @Suppress("SwallowedException", "OVERRIDE_DEPRECATION")
+        @Suppress("SwallowedException", )
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            val builder = MaterialAlertDialogBuilder(activity)
+            val builder = MaterialAlertDialogBuilder(requireActivity())
             val appName = getString(R.string.app_name)
             val title = getString(R.string.app_rating_title, appName)
             builder.setTitle(title)
                 .setMessage(R.string.app_rating_message)
                 .setCancelable(true)
                 .setPositiveButton(R.string.app_rating_rate_now) { _, _ ->
-                    val appPackage = activity.packageName
+                    val appPackage = requireActivity().packageName
                     val url = "market://details?id=$appPackage"
                     try {
-                        activity.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                        requireActivity().startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                     } catch (e: ActivityNotFoundException) {
                         // play store app isn't on this device so open app's page in browser instead
-                        activity.startActivity(
+                        requireActivity().startActivity(
                             Intent(
                                 Intent.ACTION_VIEW,
                                 Uri.parse(
                                     "http://play.google.com/store/apps/details?id=" +
-                                            activity.packageName
+                                            requireActivity().packageName
                                 )
                             )
                         )
@@ -166,8 +162,7 @@ object AppRatingDialog {
             return builder.create()
         }
 
-        @Suppress("OVERRIDE_DEPRECATION")
-        override fun onCancel(dialog: DialogInterface?) {
+        override fun onCancel(dialog: DialogInterface) {
             super.onCancel(dialog)
             clearSharedPreferences()
             storeAskLaterDate()

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppRatingDialog.kt
@@ -121,7 +121,7 @@ object AppRatingDialog {
             internal const val TAG_APP_RATING_PROMPT_DIALOG = "TAG_APP_RATING_PROMPT_DIALOG"
         }
 
-        @Suppress("SwallowedException", )
+        @Suppress("SwallowedException")
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             val builder = MaterialAlertDialogBuilder(requireActivity())
             val appName = getString(R.string.app_name)


### PR DESCRIPTION
Partially #17253 (Sub-ticket of #17246)

Replaced deprecated `fragmentManager` API with `parentFragmentManager` or `childFragmentManager` which are direct recommended replacements for above mentioned deprecated API.
This replacement required migration of `AppRatingDialog` from `android.app.DialogFragment` to `androidx.fragment.app.DialogFragment` and hence it is done so.

## Regression Notes
1. Potential unintended areas of impact
   Mostly none because the newer API's are a direct replacement.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   Manual Testing

3. What automated tests I added (or what prevented me from doing so)
   None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
