### PR TITLE
[Reader] Update limit of fetched tag posts from 20 to 7 in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.reader;
 
 public class ReaderConstants {
     // max # posts to request when updating posts
-    public static final int READER_MAX_POSTS_TO_REQUEST = 20;
+    public static final int READER_MAX_POSTS_TO_REQUEST = 7;
 
     // max # results to request when searching posts & sites
     public static final int READER_MAX_SEARCH_RESULTS_TO_REQUEST = 20;


### PR DESCRIPTION
Fixes #19472

To test:
- Install JP and log in;
- Open Reader and select "Following" tab;
- Verify that there are only 7 posts in the list. Scroll down to fetch the next page and verify that the new page also has 7 items.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
-- 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
