### PR TITLE
Disables image preloading when site creation is disabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -134,7 +134,7 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private fun loadGravatar(imgIcon: ImageView, avatarUrl: String) {
-        if (avatarUrl.isNullOrEmpty()) {
+        if (avatarUrl.isEmpty()) {
             AppLog.d(AppLog.T.MAIN, "Attempted to load an empty Gravatar URL!")
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -134,6 +134,10 @@ class WPMainNavigationView @JvmOverloads constructor(
     }
 
     private fun loadGravatar(imgIcon: ImageView, avatarUrl: String) {
+        if (avatarUrl.isNullOrEmpty()) {
+            AppLog.d(AppLog.T.MAIN, "Attempted to load an empty Gravatar URL!")
+            return
+        }
         AppLog.d(AppLog.T.MAIN, meGravatarLoader.constructGravatarUrl(avatarUrl))
         imgIcon.let {
             meGravatarLoader.load(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -183,6 +183,9 @@ class SiteCreationMainVM @Inject constructor(
     }
 
     fun preloadThumbnails(context: Context) {
+        if (jetpackFeatureRemovalOverlayUtil.shouldDisableSiteCreation()) {
+            return // no need to preload thumbnails if site creation is disabled
+        }
         if (preloadingJob == null) {
             preloadingJob = viewModelScope.launch(Dispatchers.IO) {
                 if (networkUtils.isNetworkAvailable()) {


### PR DESCRIPTION
Partially #17154

## Description
This PR disables site creation thumbnail preloading when the site creation is disabled.

Checking the [stack trace of the linked issue](https://a8c.sentry.io/share/issue/556f598b913648d39b199ab5c3188bae/
) thumbnail [preloading is triggered on the WordPress app](https://github.com/wordpress-mobile/WordPress-Android/blob/402eb0ae49f3df53741154b41727f8d292975462/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt#L185) even when the site creation functionality is disabled.
```
java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
There was 1 root cause:
com.android.volley.NoConnectionError(java.net.ConnectException: Failed to connect to s0.wp.com/192.0.77.32:443)
 call GlideException#logRootCauses(String) for more detail
    at com.bumptech.glide.request.RequestFutureTarget.doGet(RequestFutureTarget.java:217)
    at com.bumptech.glide.request.RequestFutureTarget.get(RequestFutureTarget.java:130)
    at org.wordpress.android.util.image.ImageManager.preload(ImageManager.kt:315)
    at org.wordpress.android.ui.sitecreation.SiteCreationMainVM$preloadThumbnails$1.invokeSuspend(SiteCreationMainVM.kt:200)
```

Note: I've tried using the [siteCreationDisabled variable](https://github.com/wordpress-mobile/WordPress-Android/blob/402eb0ae49f3df53741154b41727f8d292975462/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt#L124) but this didn't work for me probably due to a race condition.

## To reproduce
1. Set a breakpoint at [ImageManager.preload function](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt#L309)
2. Debug a clean version of the WordPress app (from `trunk`)
3. Login
4. Tap the `Create a new site` button
5. Notice that [ImageManager.preload function](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt#L309) is called

## To test
1. Set a breakpoint at [ImageManager.preload function](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt#L309)
2. Debug a clean version of the WordPress app from this branch
3. Login
4. Tap the `Create a new site` button
5. Notice that [ImageManager.preload function](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt#L309) not is called

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

8. What automated tests I added (or what prevented me from doing so)
Relied on existing site creation tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
