### PR TITLE
Improve reader footer progress indicator UI

### DIFF
--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -59,10 +59,7 @@
 
     <ProgressBar
         android:id="@+id/progress_loading_more"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_medium"
-        android:layout_marginStart="@dimen/margin_extra_large"
+        style="@style/ReaderFooterProgressBar"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -69,9 +69,7 @@
 
     <ProgressBar
         android:id="@+id/progress_footer"
-        style="@style/ReaderProgressBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/ReaderFooterProgressBar"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:visibility="gone"

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -107,5 +107,6 @@
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_dark</color>
     <color name="reader_blog_section_avatar_internal_border">@color/white_translucent_20</color>
     <color name="reader_post_body_link">@color/blue_30</color>
+    <color name="reader_footer_progress_background">@color/background_dark_elevated</color>
 
 </resources>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -110,6 +110,7 @@
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_light</color>
     <color name="reader_blog_section_avatar_internal_border">@color/black_translucent_20</color>
     <color name="reader_post_body_link">@color/blue_50</color>
+    <color name="reader_footer_progress_background">@color/white</color>
 
     <!-- These colors were removed from the login library and moved here as they are still being
     used by some old layouts. They should be replaced here as well, whenever possible. -->

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -150,6 +150,8 @@
 
     <dimen name="reader_video_overlay_size">56dp</dimen>
 
+    <dimen name="reader_footer_progress_bar_size">48dp</dimen>
+
     <!-- padding inside the card (space between card border and card content) -->
     <dimen name="reader_card_content_padding">16dp</dimen>
 

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -359,6 +359,16 @@
     <!-- progress bars -->
     <style name="ReaderProgressBar" parent="Widget.AppCompat.ProgressBar" />
 
+    <style name="ReaderFooterProgressBar" parent="Widget.AppCompat.ProgressBar" >
+        <item name="android:layout_width">@dimen/reader_footer_progress_bar_size</item>
+        <item name="android:layout_height">@dimen/reader_footer_progress_bar_size</item>
+        <item name="android:background">@drawable/bg_oval_surface</item>
+        <item name="android:backgroundTint">@color/reader_footer_progress_background</item>
+        <item name="android:elevation">@dimen/card_elevation</item>
+        <item name="android:padding">@dimen/margin_medium</item>
+        <item name="android:layout_margin">@dimen/margin_large</item>
+    </style>
+
     <!-- chips -->
     <style name="ReaderChip" parent="@style/Widget.MaterialComponents.Chip.Filter">
         <item name="android:textSize">@dimen/text_sz_large</item>


### PR DESCRIPTION
Fixes #19453

Added background and elevation, and reduced its size a bit.

![reader_footer_progress_improved](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/068acc6a-f460-480d-946d-57d6f131a842)

To test:
1. Go to the Reader
2. Scroll until the end of the feed
3. **Verify** the footer progress bar is shown with the new style

Do the steps above in all feeds (Following, Discover, Site, Tag) and dark/light modes, and **verify** the style is correct.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
