### PR TITLE
Adds All Domains CTA to Site Domains Screen

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -722,7 +722,7 @@
         <!-- Domains -->
         <activity
             android:name=".ui.domains.DomainsDashboardActivity"
-            android:label="@string/domains_title"
+            android:label="@string/site_domain_title"
             android:theme="@style/WordPress.NoActionBar" />
 
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -3,10 +3,15 @@ package org.wordpress.android.ui.domains
 import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.DomainsDashboardFragmentBinding
@@ -18,21 +23,30 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.config.DomainManagementFeatureConfig
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
-class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
+class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment), MenuProvider {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
 
     @Inject
     lateinit var uiHelpers: UiHelpers
+
+    @Inject
+    lateinit var domainManagementFeatureConfig: DomainManagementFeatureConfig
+
     private lateinit var viewModel: DomainsDashboardViewModel
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
+
+        if (BuildConfig.IS_JETPACK_APP && domainManagementFeatureConfig.isEnabled()) {
+            requireActivity().addMenuProvider(this, viewLifecycleOwner)
+        }
 
         with(DomainsDashboardFragmentBinding.bind(view)) {
             setupViews()
@@ -43,6 +57,18 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment) {
 
     private fun DomainsDashboardFragmentBinding.setupViews() {
         contentRecyclerView.adapter = DomainsDashboardAdapter(uiHelpers)
+    }
+
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.domains_dashboard_menu, menu)
+    }
+
+    override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
+        R.id.all_domains_item -> {
+            context?.let { ActivityLauncher.openDomainManagement(it) }
+            true
+        }
+        else -> true
     }
 
     private fun setupViewModel() {

--- a/WordPress/src/main/res/menu/domains_dashboard_menu.xml
+++ b/WordPress/src/main/res/menu/domains_dashboard_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/all_domains_item"
+        android:title="@string/domain_management_site_domains_button"
+        app:showAsAction="always">
+    </item>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2715,6 +2715,7 @@
     <string name="domain_management_empty_title">You don\'t have any domains</string>
     <string name="domain_management_empty_subtitle">Tap below to find your perfect domain.</string>
     <string name="domain_management_empty_find_domain">Find a domain</string>
+    <string name="domain_management_site_domains_button">All</string>
 
     <!-- Domain Management - Purchase Domain Screen -->
     <string name="purchase_domain_screen_title">Purchase Domain</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2651,6 +2651,7 @@
 
     <!-- Domain Registration -->
     <string name="domains_title">Domains</string>
+    <string name="site_domain_title">Site Domain</string>
     <string name="register_domain">Register Domain</string>
     <string name="domains_suggestions_select_domain">Select domain</string>
     <string name="domains_suggestions_empty_list">No suggestions found</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2707,7 +2707,7 @@
 
     <!-- Domain Management -->
     <string name="domain_management_expires">Expires %1$s</string>
-    <string name="domain_management_my_domains_title">My Domains</string>
+    <string name="domain_management_my_domains_title">All Domains</string>
     <string name="domain_management_purchase_a_domain">Purchase a domain</string>
     <string name="domain_management_search_your_domains">Search your domains</string>
     <string name="domain_management_open_domain_details">Open domain details</string>


### PR DESCRIPTION
Fixes #19385

## Description
This PR:
1. Adds all domains CTA as a single menu item on the domain dashboard screen
* The current Android design (ref: rvVgXupiyONUcJMgPSoMFj-fi-2565_27501) has a globe icon on the right of the toolbar. Considering @hassaanelgarem comment (ref: rvVgXupiyONUcJMgPSoMFj-fi-2565:27501#582615651) to align with iOS I decided to go with a shortened `ALL` button since this aligns more with the menu item design pattern on Android. @paulforgione let me know if this makes sense design wise. Note the full screen revamp is part of a different issue https://github.com/wordpress-mobile/WordPress-Android/issues/19386
2. Changes domains dashboard title to `Site Domain`
3. Changes domain management title to `All Domains` to align with the web (ref p1698233690522349-slack-C05NS0YV7HS)

## To test
### All domains button
1. Disable the `domain_management` feature flag disabled
5. Open `Domains` from `My Site`
6. **Verify** that the `ALL` button is not visible
7. Enable the `domain_management` feature flag
8. Open `Domains` from `My Site`
9. **Verify** that the `ALL` button is visible
### Title changes
1. Open `Domains` from `My Site`
2. **Verify** that the new title is displayed: Site Domain
3. Open `Domains` from the `Me`screen
4. **Verify** that the new title is displayed: All Domains

|Before|After feature OFF|After feature ON|Night mode|
|---|---|---|---|
|![Screenshot_20231030_160425](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/6b8afe6b-cfe9-4a5a-b577-0403ab220ee5)|![Screenshot_20231030_161707](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/69da13d8-8328-45bd-a4a4-8a5452659a4c)|![Screenshot_20231030_154646](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/16cfcc73-0e00-4181-a5ae-4722e6d1e6d9)|![Screenshot_20231030_154623](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/9369e6a4-2c91-4076-9535-834775f37c33)|

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/2bbc5bca-bfb5-42a9-a8a1-ea214654d5b2

## Regression Notes
1. Potential unintended areas of impact
Domains dashboard (My Site > Domains)

10. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

11. What automated tests I added (or what prevented me from doing so)
N/A. I tried to avoid wide spread changes that would allow testing the visibility of the button since there might be a follow up task that would revamp the whole screen https://github.com/wordpress-mobile/WordPress-Android/issues/19386

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)