### PR TITLE
Removes: the Redundant json fields in Blaze Campaign API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.107.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = 'trunk-b85a542abce556295bb4afc44e553bc2a395c3b4'
+    wordPressFluxCVersion = '2884-939681466ec15da79d58de8db5950d20020aa192'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.107.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2884-939681466ec15da79d58de8db5950d20020aa192'
+    wordPressFluxCVersion = '2884-7b0598631f1f5e20561475f87ef62fc879c0d19c'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.107.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2884-7b0598631f1f5e20561475f87ef62fc879c0d19c'
+    wordPressFluxCVersion = 'trunk-7fd7840a9bd900fde8e32ad8bd5632ad8f05dff3'
     wordPressLoginVersion = '1.6.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
## Fixes 
This PR Removes the redundant json fields in Blaze Campaign API

Depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2884

## To test:
1. Login to the Jetpack app 
2. Go to the dashboard 
3. Test whether the Blaze Card is working as expected 
4. Check whether Blaze Campaign listing screen is working as expected
5. Check whether the campaign detail page is working as expected
6. Create a campaign 

## Regression Notes
1. Potential unintended areas of impact
Blaze is not working as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Manual testing 

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
