### PR TITLE
Update WordPress-Login-Flow-Android dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     gutenbergMobileVersion = 'v1.107.0'
     wordPressAztecVersion = 'v1.8.0'
     wordPressFluxCVersion = 'trunk-7fd7840a9bd900fde8e32ad8bd5632ad8f05dff3'
-    wordPressLoginVersion = '1.6.0'
+    wordPressLoginVersion = 'trunk-9963d78096edf65f8704b803e5b93c08fc9174cd'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'


### PR DESCRIPTION
Discussion: p1698668159519919-slack-C0180B5PRJ4

We were previously fetching the user subscriptions after signing in with a 2FA enabled account. This request was [removed from WordPress-Login-Flow-Android](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/127) and this PR is updating the dependency version.

To test:
- Install WP and log in (to trigger the JP app migration)
- Install JP: the migration login should happen as expected and there should be no requests to `/read/following/mine` coming from the library
- Uninstall WP 
- Log in to JP using an account that has 2FA enabled: the login should happen as expected and there should be no requests to `/read/following/mine` coming from the library

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
--

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)