### PR TITLE
UI Modernization posts: Add comments action to post list context menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -79,6 +79,7 @@ class PostActionHandler(
         invalidateList.invoke()
     })
 
+    @Suppress("LongMethod")
     fun handlePostButton(buttonType: PostListButtonType, post: PostModel, hasAutoSave: Boolean) {
         when (buttonType) {
             BUTTON_EDIT -> editPostButtonAction(site, post)
@@ -134,7 +135,9 @@ class PostActionHandler(
             BUTTON_PROMOTE_WITH_BLAZE -> {
                 triggerPostListAction.invoke(PostListAction.ShowPromoteWithBlaze(post))
             }
-            BUTTON_COMMENTS -> {} // todo: implement
+            BUTTON_COMMENTS -> {
+                triggerPostListAction.invoke(PostListAction.ShowComments(site, post))
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -13,6 +13,8 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.prefs.AppPrefs
+import org.wordpress.android.ui.reader.ReaderActivityLauncher
+import org.wordpress.android.ui.reader.ReaderPostPagerActivity
 import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment
 import org.wordpress.android.ui.uploads.UploadService
 import org.wordpress.android.util.AppLog
@@ -53,8 +55,8 @@ sealed class PostListAction {
     class ViewStats(val site: SiteModel, val post: PostModel) : PostListAction()
     class ViewPost(val site: SiteModel, val post: PostModel) : PostListAction()
     class DismissPendingNotification(val pushId: Int) : PostListAction()
-
     class ShowPromoteWithBlaze(val post: PostModel) : PostListAction()
+    class ShowComments(val site: SiteModel, val post: PostModel) : PostListAction()
 }
 
 @Suppress("TooGenericExceptionCaught", "LongMethod", "ComplexMethod", "LongParameterList")
@@ -130,6 +132,17 @@ fun handlePostListAction(
                 AppLog.e(AppLog.T.POSTS, e)
                 action.showSnackbar.invoke(action.messageError)
             }
+        }
+        is PostListAction.ShowComments -> {
+            ReaderActivityLauncher.showReaderPostDetail(
+                activity,
+                false,
+                action.site.siteId,
+                action.post.remotePostId,
+                ReaderPostPagerActivity.DirectOperation.COMMENT_JUMP,
+                0,
+                false,
+                null)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.viewmodel.posts.PostListItemType.PostListItemUiStat
 import org.wordpress.android.viewmodel.uistate.ProgressBarUiState
 import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_COMMENTS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY_URL
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
@@ -113,7 +114,6 @@ class PostListItemUiStateHelper @Inject constructor(
                 post
             ),
         )
-        // val defaultActions = createDefaultViewActions(buttonTypes, onButtonClicked)
         val moreActions = createMoreActions(buttonTypes, onButtonClicked)
 
         val remotePostId = RemotePostId(RemoteId(post.remotePostId))
@@ -459,6 +459,8 @@ class PostListItemUiStateHelper @Inject constructor(
 
         buttonTypes.addDeletingOrTrashAction(isLocalDraft, postStatus)
 
+        buttonTypes.addCommentActionIfNeeded(postStatus)
+
         return sortPostListButtons(buttonTypes)
     }
 
@@ -489,6 +491,12 @@ class PostListItemUiStateHelper @Inject constructor(
 
         if (canMovePostToDraft) {
             add(BUTTON_MOVE_TO_DRAFT)
+        }
+    }
+
+    private fun MutableList<PostListButtonType>.addCommentActionIfNeeded(postStatus: PostStatus) {
+        if (postStatus == PUBLISHED) {
+            add(BUTTON_COMMENTS)
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -224,8 +224,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
-        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(6)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(7)
     }
 
     @Test
@@ -240,8 +241,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(5)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(6)
     }
 
     @Test
@@ -257,8 +259,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
-        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(6)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(7)
     }
 
     @Test
@@ -273,8 +276,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(5)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(6)
     }
 
     @Test
@@ -289,8 +293,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(6)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(7)
     }
 
     @Test
@@ -307,8 +312,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(5)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(6)
     }
 
     @Test
@@ -407,8 +413,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(6)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(7)
    }
 
     @Test
@@ -487,8 +494,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
-        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
-        assertThat(moreActions).hasSize(6)
+        assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
+        assertThat(moreActions).hasSize(7)
     }
 
     @Test
@@ -824,8 +832,9 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
-        assertThat(moreActions).hasSize(4)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_DELETE)
+        assertThat(moreActions).hasSize(5)
     }
 
     @Test


### PR DESCRIPTION
Closes #19344 

This PR implements add "Comments" to the Post List context menu.
- "Comments" action will show only for published post status
- On tap, the user will be navigated directly to the comments detail view

Comments Visible | Comments not visible
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/256bfdd9-15b6-4380-afc5-13a7dc175e1c"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/313cc23c-a86e-49f4-a91d-769958c56594">


| Video 1 
| ------------- 
| <video src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/fa8e56dd-bf5f-4c1d-8625-8a14ec5cede7">

**To test:**
- Install, launch the app, and login
- Select a site
- Navigate to My Site > Posts
- Scroll to a post that is in "published" status 
- Tap on the More icon to launch the context menu
- ✅ Verify the "comments" action is visible
- Tap on the comments action
- ✅ Verify the "comments" view is launched
- Navigate back to the posts list
- Scroll to an post item that is marked as "private" (note: private is an actual post status)
- Tap on the More icon to launch the context menu
- ✅ Verify the "comments" action is not visible

## Regression Notes
1. Potential unintended areas of impact
Comments action is shown when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
