### PR TITLE
[Reader] Show loading indicator when loading and feed not empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2382,10 +2382,10 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (updateAction == UpdateAction.REQUEST_OLDER) {
             // show/hide progress bar at bottom if these are older posts
             showLoadingProgress(isUpdating);
-        } else if (isUpdating && isPostAdapterEmpty()) {
-            // show swipe-to-refresh if update started and no posts are showing
+        } else if (isUpdating) {
+            // show swipe-to-refresh if update started
             mRecyclerView.setRefreshing(true);
-        } else if (!isUpdating) {
+        } else {
             // hide swipe-to-refresh progress if update is complete
             mRecyclerView.setRefreshing(false);
         }


### PR DESCRIPTION
Fixes #19454 

When the feed is not empty and we are loading posts, we don't show a loading progress indicator and just silently fetch data. The issue is that when fetch is finished the screen suddenly updates with the new posts and that looks bad to the user as it didn't look like anything was going on.

This fixes it by always showing the progress indicator (swipe-to-refresh) even when there are posts being shown.

Note: @hassaanelgarem I'm just adding you because you reported this bug, but no need to review, unless you want of course! 😅 

To test:

1. Fresh install the app
2. Navigate to the Discover tab
3. Tap on any post
4. Tap on the author
5. ⚠️ Notice that the page shows only one post, which is the post from step 3
6. **Verify** the progress indicator is shown
7. **Verify** that the posts are loaded after some time and the indicator is hidden

## Regression Notes
1. Potential unintended areas of impact
Showing the indicator when not wanted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
