### PR TITLE
[Reader] Only show/announce empty state when empty after updating posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActionableEmptyView.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import androidx.appcompat.widget.AppCompatButton
+import androidx.core.view.isVisible
 import org.wordpress.android.R
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.widgets.WPTextView
@@ -154,7 +155,11 @@ class ActionableEmptyView : LinearLayout {
             subtitle.contentDescription
         } else {
             subtitle.text
-        }
+        }.takeIf {
+            // only use the subtitle if it's visible as this view is used with only the title some times and the
+            // subtitle has a default value that is not relevant
+            subtitle.isVisible
+        } ?: ""
 
         announceForAccessibility("${title.text}.$subTitle")
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -59,6 +59,7 @@ public class ReaderConstants {
 
     static final String KEY_POST_SLUGS_RESOLUTION_UNDERWAY = "post_slugs_resolution_underway";
     static final String KEY_ALREADY_UPDATED = "already_updated";
+    static final String KEY_ALREADY_REQUESTED = "already_requested";
     static final String KEY_RESTORE_POSITION = "restore_position";
     static final String KEY_SITE_SEARCH_RESTORE_POSITION = "site_search_restore_position";
     static final String KEY_WAS_PAUSED = "was_paused";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1913,7 +1913,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private final ReaderInterfaces.DataLoadedListener mDataLoadedListener = new ReaderInterfaces.DataLoadedListener() {
         @Override
         public void onDataLoaded(boolean isEmpty) {
-            if (!isAdded() && !mHasUpdatedPosts) {
+            if (!isAdded() || !mHasUpdatedPosts) {
                 return;
             }
             if (isEmpty) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -209,6 +209,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
 
     private boolean mIsUpdating;
     private boolean mWasPaused;
+    private boolean mHasRequestedPosts;
     private boolean mHasUpdatedPosts;
     private boolean mIsAnimatingOutNewPostsBar;
 
@@ -417,6 +418,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mSiteSearchRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_SITE_SEARCH_RESTORE_POSITION);
             mWasPaused = savedInstanceState.getBoolean(ReaderConstants.KEY_WAS_PAUSED);
+            mHasRequestedPosts = savedInstanceState.getBoolean(ReaderConstants.KEY_ALREADY_REQUESTED);
             mHasUpdatedPosts = savedInstanceState.getBoolean(ReaderConstants.KEY_ALREADY_UPDATED);
             mFirstLoad = savedInstanceState.getBoolean(ReaderConstants.KEY_FIRST_LOAD);
             mSearchTabsPos = savedInstanceState.getInt(ReaderConstants.KEY_ACTIVE_SEARCH_TAB, NO_POSITION);
@@ -897,8 +899,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (isAdded() && mRecyclerView.getAdapter() == null) {
             mRecyclerView.setAdapter(getPostAdapter());
             refreshPosts();
-            if (!mHasUpdatedPosts && NetworkUtils.isNetworkAvailable(getActivity())) {
-                mHasUpdatedPosts = true;
+            if (!mHasRequestedPosts && NetworkUtils.isNetworkAvailable(getActivity())) {
+                mHasRequestedPosts = true;
                 if (getPostListType().isTagType()) {
                     updateCurrentTagIfTime();
                 } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
@@ -967,6 +969,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         outState.putLong(ReaderConstants.ARG_BLOG_ID, mCurrentBlogId);
         outState.putLong(ReaderConstants.ARG_FEED_ID, mCurrentFeedId);
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
+        outState.putBoolean(ReaderConstants.KEY_ALREADY_REQUESTED, mHasRequestedPosts);
         outState.putBoolean(ReaderConstants.KEY_ALREADY_UPDATED, mHasUpdatedPosts);
         outState.putBoolean(ReaderConstants.KEY_FIRST_LOAD, mFirstLoad);
         if (mRecyclerView != null) {
@@ -1656,6 +1659,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         UpdateAction updateAction = event.getOffset() == 0 ? UpdateAction.REQUEST_NEWER : UpdateAction.REQUEST_OLDER;
         setIsUpdating(true, updateAction);
         setEmptyTitleDescriptionAndButton(false);
+        showEmptyView();
     }
 
     @SuppressWarnings("unused")
@@ -1909,7 +1913,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private final ReaderInterfaces.DataLoadedListener mDataLoadedListener = new ReaderInterfaces.DataLoadedListener() {
         @Override
         public void onDataLoaded(boolean isEmpty) {
-            if (!isAdded()) {
+            if (!isAdded() && !mHasUpdatedPosts) {
                 return;
             }
             if (isEmpty) {
@@ -2262,6 +2266,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
         setIsUpdating(true, event.getAction());
         setEmptyTitleDescriptionAndButton(false);
+        showEmptyView();
     }
 
     @SuppressWarnings("unused")
@@ -2275,6 +2280,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             return;
         }
         setIsUpdating(false, event.getAction());
+        mHasUpdatedPosts = true;
 
         // don't show new posts if user is searching - posts will automatically
         // appear when search is exited

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1659,7 +1659,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         UpdateAction updateAction = event.getOffset() == 0 ? UpdateAction.REQUEST_NEWER : UpdateAction.REQUEST_OLDER;
         setIsUpdating(true, updateAction);
         setEmptyTitleDescriptionAndButton(false);
-        showEmptyView();
+        if (isPostAdapterEmpty()) showEmptyView();
     }
 
     @SuppressWarnings("unused")
@@ -2266,7 +2266,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         }
         setIsUpdating(true, event.getAction());
         setEmptyTitleDescriptionAndButton(false);
-        showEmptyView();
+        if (isPostAdapterEmpty()) showEmptyView();
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #19452

The Reader fragment was showing the empty view (and asking for it to be announced on Talkback) for a fraction of a second before updating the "Fetching posts" message (on that same view). This caused talkback to say the message for an empty view, since the message update did not request an announcement to the user.

This was fixed by introducing a new flag that checks if the posts were actually updated from the backend to only show the empty view if we in fact have no posts.

Note: @hassaanelgarem I only included you as reviewer because you reported the issue but feel free to ignore it.

To test:
1. Enable talk back
2. Navigate to the reader
3. Open any post
4. Tap on any tag not previously opened
5. **Verify** talkback reads the correct state (fetching)

## Regression Notes
1. Potential unintended areas of impact
Showing/reading wrong feed state in other scenarios.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
