### PR TITLE
UI Modernization Posts: Update author filter rule

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -216,7 +216,7 @@ class PostListMainViewModel @Inject constructor(
      * This behavior is consistent with Calypso as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isWPCom && site.hasCapabilityEditOthersPosts && !site.isSingleUserSite
+        site.isUsingWpComRestApi && site.hasCapabilityEditOthersPosts && !site.isSingleUserSite
     }
 
     init {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -77,7 +77,7 @@ class PostListViewModel @Inject constructor(
         SiteUtils.isAccessedViaWPComRest(connector.site) && connector.site.hasCapabilityViewStats
     }
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        connector.site.isWPCom &&
+        connector.site.isUsingWpComRestApi &&
                 connector.site.hasCapabilityEditOthersPosts &&
                 !connector.site.isSingleUserSite
     }


### PR DESCRIPTION
Parent #19339 

This PR changes the Author filter rule for posts lists from site.wpCom to site.isUsingWpComRestApi. See here p1698840268022769-slack-C04SFL0RP51 for more detail.


**Prereqs**
Accounts that have the following types of sites:
- WP.com (one that has a single user and one that has multiple users with edit capability)
- Jetpack
- Self-hosted
- Atomic

**Shows author filter on posts**
- From either path above
- Navigate to a WP.com site that has more than 1 user
- Navigate to My Site > Posts
- ✅ Verify the author filter is shown
- Navigate to My Site > Pages
- ✅ Verify the author filter is shown

**Does not show author filter on posts**
- From either starting path above
- Navigate to a WP.com site that has a single user
- Navigate to My Site > Posts
- ✅ Verify the author filter is not shown
- Navigate to My Site > Pages
- ✅ Verify the author filter is not shown

**Self-hosted sites do not show author filter on posts**
- From either starting path above
- Navigate to a self-hosted site (user count does not matter)
- Navigate to My Site > Posts
- ✅ Verify the author filter is not shown

**Shows author filter on posts for AT sites**
- From either path above
- Navigate to a AT site that has more than 1 user
- Navigate to My Site > Posts
- ✅ Verify the author filter is shown

 
## Regression Notes
1. Potential unintended areas of impact
The author filter shows when it shouldn't

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
