### PR TITLE
UI Modernization Posts: Implement Share Action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -47,9 +47,9 @@ import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
 import org.wordpress.android.ui.blaze.BlazeFlowSource;
-import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity;
 import org.wordpress.android.ui.blaze.PageUIModel;
 import org.wordpress.android.ui.blaze.PostUIModel;
+import org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity;
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsDetailsActivity;
@@ -1927,10 +1927,11 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void openShareIntent(@NonNull Context context, @NonNull String link) {
+    public static void openShareIntent(@NonNull Context context, @NonNull PostModel postModel) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TEXT, link);
+        intent.putExtra(Intent.EXTRA_TEXT, postModel.getLink());
+        intent.putExtra(Intent.EXTRA_TITLE, postModel.getTitle());
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_link)));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1926,4 +1926,11 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, DomainManagementActivity.class);
         context.startActivity(intent);
     }
+
+    public static void openShareIntent(@NonNull Context context, @NonNull String link) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, link);
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_link)));
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts
 
 import android.content.Intent
-import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.PostActionBuilder
@@ -36,7 +35,7 @@ import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COMMENTS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY_URL
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHARE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -120,7 +119,7 @@ class PostActionHandler(
                 }
             }
             BUTTON_COPY -> copyPost(site, post, true)
-            BUTTON_COPY_URL -> triggerPostListAction.invoke(copyUrlAction(post))
+            BUTTON_SHARE -> triggerPostListAction.invoke(share(post))
             BUTTON_DELETE, BUTTON_DELETE_PERMANENTLY -> {
                 postListDialogHelper.showDeletePostConfirmationDialog(post)
             }
@@ -141,20 +140,8 @@ class PostActionHandler(
         }
     }
 
-    private fun copyUrlAction(post: PostModel) = PostListAction.CopyUrl(
-        site = site,
-        post = post,
-        showSnackbar = showSnackbar,
-        messageSuccess = SnackbarMessageHolder(
-            UiStringRes(R.string.post_link_copied_to_clipboard),
-            duration = Snackbar.LENGTH_SHORT,
-            isImportant = false
-        ),
-        messageError = SnackbarMessageHolder(
-            UiStringRes(R.string.error_copy_to_clipboard),
-            duration = Snackbar.LENGTH_SHORT,
-            isImportant = false
-        )
+    private fun share(post: PostModel) = PostListAction.SharePost(
+        post = post
     )
 
     private fun cancelPendingAutoUpload(post: PostModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -118,7 +118,7 @@ fun handlePostListAction(
                 null)
         }
         is PostListAction.SharePost -> {
-            ActivityLauncher.openShareIntent(activity, action.post.link)
+            ActivityLauncher.openShareIntent(activity, action.post)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts
 
-import android.content.ClipData
 import androidx.fragment.app.FragmentActivity
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
@@ -9,7 +8,6 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.PagePostCreationSourcesDetail.POST_FROM_POSTS_LIST
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
 import org.wordpress.android.ui.blaze.BlazeFlowSource
-import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.prefs.AppPrefs
@@ -17,8 +15,6 @@ import org.wordpress.android.ui.reader.ReaderActivityLauncher
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity
 import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment
 import org.wordpress.android.ui.uploads.UploadService
-import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.extensions.clipboardManager
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 
 sealed class PostListAction {
@@ -44,19 +40,12 @@ sealed class PostListAction {
         val trackAnalytics: Boolean = PostUtils.isFirstTimePublish(post)
     ) : PostListAction()
 
-    class CopyUrl(
-        val site: SiteModel,
-        val post: PostModel,
-        val showSnackbar: (SnackbarMessageHolder) -> Unit,
-        val messageSuccess: SnackbarMessageHolder,
-        val messageError: SnackbarMessageHolder
-    ) : PostListAction()
-
     class ViewStats(val site: SiteModel, val post: PostModel) : PostListAction()
     class ViewPost(val site: SiteModel, val post: PostModel) : PostListAction()
     class DismissPendingNotification(val pushId: Int) : PostListAction()
     class ShowPromoteWithBlaze(val post: PostModel) : PostListAction()
     class ShowComments(val site: SiteModel, val post: PostModel) : PostListAction()
+    class SharePost(val post: PostModel) : PostListAction()
 }
 
 @Suppress("TooGenericExceptionCaught", "LongMethod", "ComplexMethod", "LongParameterList")
@@ -117,22 +106,6 @@ fun handlePostListAction(
             blazeFeatureUtils.trackEntryPointTapped(BlazeFlowSource.POSTS_LIST)
             ActivityLauncher.openPromoteWithBlaze(activity, action.post, BlazeFlowSource.POSTS_LIST)
         }
-        is PostListAction.CopyUrl -> {
-            try {
-                activity.clipboardManager?.setPrimaryClip(
-                    ClipData.newPlainText("${action.post.id}", action.post.link)
-                ) ?: throw NullPointerException("ClipboardManager is not supported on this device")
-
-                action.showSnackbar.invoke(action.messageSuccess)
-            } catch (e: Exception) {
-                /**
-                 * Ignore any exceptions here as certain devices have bugs and will fail.
-                 * See https://crrev.com/542cb9cfcc927295615809b0c99917b09a219d9f for more info.
-                 */
-                AppLog.e(AppLog.T.POSTS, e)
-                action.showSnackbar.invoke(action.messageError)
-            }
-        }
         is PostListAction.ShowComments -> {
             ReaderActivityLauncher.showReaderPostDetail(
                 activity,
@@ -143,6 +116,9 @@ fun handlePostListAction(
                 0,
                 false,
                 null)
+        }
+        is PostListAction.SharePost -> {
+            ActivityLauncher.openShareIntent(activity, action.post.link)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListActionTracker.kt
@@ -8,7 +8,7 @@ import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COMMENTS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY_URL
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHARE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -52,7 +52,7 @@ fun trackPostListAction(site: SiteModel, buttonType: PostListButtonType, postDat
         BUTTON_MOVE_TO_DRAFT -> "move_to_draft"
         BUTTON_CANCEL_PENDING_AUTO_UPLOAD -> "cancel_pending_auto_upload"
         BUTTON_SHOW_MOVE_TRASHED_POST_TO_DRAFT_DIALOG -> "show_move_trashed_post_to_draft_post_dialog"
-        BUTTON_COPY_URL -> "copy_url"
+        BUTTON_SHARE -> "share"
         BUTTON_PROMOTE_WITH_BLAZE -> "promote_with_blaze"
         BUTTON_COMMENTS -> "comments"
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -49,7 +49,7 @@ import org.wordpress.android.widgets.PostListButtonType
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COMMENTS
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY
-import org.wordpress.android.widgets.PostListButtonType.BUTTON_COPY_URL
+import org.wordpress.android.widgets.PostListButtonType.BUTTON_SHARE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_DELETE_PERMANENTLY
 import org.wordpress.android.widgets.PostListButtonType.BUTTON_EDIT
@@ -415,7 +415,7 @@ class PostListItemUiStateHelper @Inject constructor(
                 !isLocallyChanged &&
                 shouldShowStatsInJetpackRemovalPhase
         val canShowCopy = postStatus == PUBLISHED || postStatus == DRAFT
-        val canShowCopyUrlButton = !isLocalDraft && postStatus != TRASHED
+        val canShowShareButton = !isLocalDraft && postStatus != TRASHED
         val canShowViewButton = !canRetryUpload && postStatus != TRASHED
         val canShowPublishButton = canRetryUpload || canPublishPost
         val buttonTypes = ArrayList<PostListButtonType>()
@@ -449,8 +449,8 @@ class PostListItemUiStateHelper @Inject constructor(
 
         buttonTypes.addMoveToDraftActionIfAvailable(postStatus)
 
-        if (canShowCopyUrlButton) {
-            buttonTypes.add(BUTTON_COPY_URL)
+        if (canShowShareButton) {
+            buttonTypes.add(BUTTON_SHARE)
         }
 
         if (shouldShowPromoteWithBlaze) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -150,7 +150,7 @@ enum class PostListButtonType constructor(
         TAKE_AN_ACTION_GROUP_ID,
         7
     ),
-    BUTTON_COPY_URL(
+    BUTTON_SHARE(
         17,
         R.string.button_share,
         R.drawable.gb_ic_share,

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelperTest.kt
@@ -95,7 +95,7 @@ class PostListItemUiStateHelperTest {
         assertThat(state.moreActions.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(state.moreActions.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
         assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(state.moreActions.actions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.moreActions.actions).hasSize(5)
     }
@@ -124,7 +124,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SUBMIT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(5)
     }
@@ -156,7 +156,7 @@ class PostListItemUiStateHelperTest {
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(4)
     }
@@ -189,7 +189,7 @@ class PostListItemUiStateHelperTest {
 
         assertThat(state.moreActions.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(state.moreActions.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.moreActions.actions).hasSize(4)
     }
@@ -222,7 +222,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
@@ -240,7 +240,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(6)
@@ -257,7 +257,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_STATS)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
@@ -275,7 +275,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(6)
@@ -292,7 +292,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(7)
@@ -311,7 +311,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(6)
@@ -336,7 +336,7 @@ class PostListItemUiStateHelperTest {
 
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
-        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(3)
     }
@@ -350,7 +350,7 @@ class PostListItemUiStateHelperTest {
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SYNC)
-        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(4)
     }
@@ -366,7 +366,7 @@ class PostListItemUiStateHelperTest {
 
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
-        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(3)
     }
@@ -379,7 +379,7 @@ class PostListItemUiStateHelperTest {
 
         assertThat(state.moreActions.actions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
         assertThat(state.moreActions.actions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_PUBLISH)
-        assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.moreActions.actions).hasSize(4)
     }
@@ -393,7 +393,7 @@ class PostListItemUiStateHelperTest {
 
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_VIEW)
-        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(3)
     }
@@ -412,7 +412,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(7)
@@ -430,7 +430,7 @@ class PostListItemUiStateHelperTest {
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
-        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(4)
     }
@@ -447,7 +447,7 @@ class PostListItemUiStateHelperTest {
         val moreActions = state.moreActions.actions
         assertThat(moreActions[0].buttonType).isEqualTo(PostListButtonType.BUTTON_PREVIEW)
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
-        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(4)
     }
@@ -465,7 +465,7 @@ class PostListItemUiStateHelperTest {
         assertThat(state.moreActions.actions[1].buttonType)
             .isEqualTo(PostListButtonType.BUTTON_CANCEL_PENDING_AUTO_UPLOAD)
         assertThat(state.moreActions.actions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(state.moreActions.actions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(state.moreActions.actions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(state.moreActions.actions).hasSize(5)
     }
@@ -493,7 +493,7 @@ class PostListItemUiStateHelperTest {
         assertThat(moreActions[1].buttonType).isEqualTo(PostListButtonType.BUTTON_RETRY)
         assertThat(moreActions[2].buttonType).isEqualTo(PostListButtonType.BUTTON_MOVE_TO_DRAFT)
         assertThat(moreActions[3].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY)
-        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_COPY_URL)
+        assertThat(moreActions[4].buttonType).isEqualTo(PostListButtonType.BUTTON_SHARE)
         assertThat(moreActions[5].buttonType).isEqualTo(PostListButtonType.BUTTON_COMMENTS)
         assertThat(moreActions[6].buttonType).isEqualTo(PostListButtonType.BUTTON_TRASH)
         assertThat(moreActions).hasSize(7)


### PR DESCRIPTION
Closes #19479 

This PR swaps out the copyURL function with Share functionality
- Renaming CopyURL to Share
- Track "share" instead of "copy_url"
- Update unit tests

<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/6a7cc35b-65e2-42f4-a9f7-ea57a0e09cdc">

**To test:**
- Install the app
- Login and select a site
- Navigate to My Site > More > Posts
- Identify a row and tap the More icon to launch the context menu
- Tap the "Share" item
- ✅ Verify the logs contain: 🔵 Tracked: post_list_button_pressed, Properties: {"blog_id":{id},"post_id":{post-d},"site_type":"blog",**"action":"share"**,"is_jetpack":false}
- ✅ Verify the share intent is launched instead of copy url 


## Regression Notes
1. Potential unintended areas of impact
Share intent does not launch

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual and PostListItemUiStateHelperTest

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A

