### PR TITLE
Handle navigation back button on the All Domain screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
@@ -24,7 +24,8 @@ class DomainManagementActivity : AppCompatActivity() {
                     uiState = uiState,
                     onDomainTapped = viewModel::onDomainTapped,
                     onAddDomainTapped = viewModel::onAddDomainClicked,
-                    onFindDomainTapped = viewModel::onAddDomainClicked
+                    onFindDomainTapped = viewModel::onAddDomainClicked,
+                    onBackTapped = viewModel::onBackTapped
                 )
             }
         }
@@ -38,6 +39,7 @@ class DomainManagementActivity : AppCompatActivity() {
                 startActivity(DomainManagementDetailsActivity.createIntent(this, actionEvent.detailUrl))
             }
             is DomainManagementViewModel.ActionEvent.AddDomainTapped -> ActivityLauncher.openNewDomainSearch(this)
+            is DomainManagementViewModel.ActionEvent.NavigateBackTapped -> onBackPressedDispatcher.onBackPressed()
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementViewModel.kt
@@ -66,9 +66,16 @@ class DomainManagementViewModel @Inject constructor(
         }
     }
 
+    fun onBackTapped() {
+        launch {
+            _actionEvents.emit(ActionEvent.NavigateBackTapped)
+        }
+    }
+
     sealed class ActionEvent {
         data class DomainTapped(val detailUrl: String): ActionEvent()
         object AddDomainTapped: ActionEvent()
+        object NavigateBackTapped: ActionEvent()
     }
 
     sealed class UiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
@@ -41,9 +41,9 @@ import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState
-import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.PopulatedList
-import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.Error
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.Empty
+import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.Error
+import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.PopulatedList
 import org.wordpress.android.ui.domains.management.composable.DomainsSearchTextField
 
 @Composable
@@ -52,13 +52,14 @@ fun MyDomainsScreen(
     onDomainTapped: (detailUrl: String) -> Unit,
     onAddDomainTapped: () -> Unit,
     onFindDomainTapped: () -> Unit,
+    onBackTapped: () -> Unit,
 ) {
     Scaffold(
         topBar = {
             MainTopAppBar(
                 title = stringResource(R.string.domain_management_my_domains_title),
                 navigationIcon = NavigationIcons.BackIcon,
-                onNavigationIconClick = {},
+                onNavigationIconClick = onBackTapped,
                 actions = {
                     IconButton(
                         onClick = onAddDomainTapped,
@@ -75,7 +76,7 @@ fun MyDomainsScreen(
             )
         },
     ) { paddingValues ->
-        Column (Modifier.padding(paddingValues)) {
+        Column(Modifier.padding(paddingValues)) {
             var queryString by rememberSaveable { mutableStateOf("") }
             val listState = rememberLazyListState()
 
@@ -95,6 +96,7 @@ fun MyDomainsScreen(
                     listState = listState,
                     onDomainTapped,
                 )
+
                 Error -> ErrorScreen()
                 Empty -> EmptyScreen(onFindDomainTapped)
             }
@@ -104,7 +106,7 @@ fun MyDomainsScreen(
 
 @Composable
 fun ErrorScreen() {
-    Column (
+    Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxSize(),
@@ -124,7 +126,7 @@ fun ErrorScreen() {
 
 @Composable
 fun EmptyScreen(onFindDomainTapped: () -> Unit) {
-    Column (
+    Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.fillMaxSize(),
@@ -171,7 +173,6 @@ fun PrimaryButton(
 }
 
 
-
 @Composable
 fun MyDomainsSearchInput(
     elevation: Dp,
@@ -179,7 +180,7 @@ fun MyDomainsSearchInput(
     onQueryStringChanged: (String) -> Unit,
     enabled: Boolean = false,
 ) {
-    Surface (shadowElevation = elevation, modifier = Modifier.zIndex(1f)) {
+    Surface(shadowElevation = elevation, modifier = Modifier.zIndex(1f)) {
         DomainsSearchTextField(
             value = queryString,
             onValueChange = onQueryStringChanged,
@@ -209,6 +210,7 @@ fun MyDomainsList(
                         DomainListCard(uiState = DomainCardUiState.Initial)
                     }
                 }
+
             is PopulatedList.Loaded -> {
                 items(items = listUiState.domains) {
                     DomainListCard(uiState = DomainCardUiState.fromDomain(domain = it), onDomainTapped)
@@ -223,15 +225,28 @@ fun MyDomainsList(
 @Composable
 fun PreviewMyDomainsScreen() {
     M3Theme {
-        MyDomainsScreen(PopulatedList.Initial, onAddDomainTapped = {}, onDomainTapped = {}, onFindDomainTapped = {})
+        MyDomainsScreen(
+            uiState = PopulatedList.Initial,
+            onAddDomainTapped = {},
+            onDomainTapped = {},
+            onFindDomainTapped = {},
+            onBackTapped = {}
+        )
     }
 }
+
 @Preview(device = Devices.PIXEL_3A, group = "Error / Offline")
 @Preview(device = Devices.PIXEL_3A, uiMode = UI_MODE_NIGHT_YES, group = "Error / Offline")
 @Composable
 fun PreviewMyDomainsScreenError() {
     M3Theme {
-        MyDomainsScreen(Error, onAddDomainTapped = {}, onDomainTapped = {}, onFindDomainTapped = {})
+        MyDomainsScreen(
+            uiState = Error,
+            onAddDomainTapped = {},
+            onDomainTapped = {},
+            onFindDomainTapped = {},
+            onBackTapped = {}
+        )
     }
 }
 
@@ -240,6 +255,12 @@ fun PreviewMyDomainsScreenError() {
 @Composable
 fun PreviewMyDomainsScreenEmpty() {
     M3Theme {
-        MyDomainsScreen(Empty, onAddDomainTapped = {}, onDomainTapped = {}, onFindDomainTapped = {})
+        MyDomainsScreen(
+            uiState = Empty,
+            onAddDomainTapped = {},
+            onDomainTapped = {},
+            onFindDomainTapped = {},
+            onBackTapped = {}
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/DomainManagementViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/DomainManagementViewModelTest.kt
@@ -54,6 +54,14 @@ class DomainManagementViewModelTest : BaseUnitTest() {
         assertThat(events.last()).isEqualTo(ActionEvent.DomainTapped(testDomain))
     }
 
+    @Test
+    fun `WHEN a navigation back button is tapped THEN send NavigateBackTapped action event`() =
+        testWithActionEvents { events ->
+            viewModel.onBackTapped()
+            advanceUntilIdle()
+            assertThat(events.last()).isEqualTo(ActionEvent.NavigateBackTapped)
+        }
+
     private fun testWithActionEvents(block: suspend TestScope.(events: List<ActionEvent>) -> Unit) =
         test {
             val actionEvents = mutableListOf<ActionEvent>()


### PR DESCRIPTION
Fixes #19503

This PR handles navigation back button on the "All Domains" screen.

To test:
- Make sure you have enabled `domain_management` feature flag
- Go to "Me" tab -> Domains
- [ ] Make sure that the navigation back button navigates back to the "Me" tab

https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/f9c5802b-7180-4d49-87d5-bfc5a771353b

## Regression Notes
1. Potential unintended areas of impact
All Domains screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
