### PR TITLE
[Reader Performance] Remove unnecessary requests to following/mine endpoint on "Following" tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1011,7 +1011,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
         if (forced) {
             // Update the tags on post refresh since following some sites (like P2) will change followed tags and blogs
             ReaderUpdateServiceStarter.startService(getContext(),
-                    EnumSet.of(UpdateTask.TAGS, UpdateTask.FOLLOWED_BLOGS));
+                    EnumSet.of(UpdateTask.TAGS));
         }
 
         if (mFirstLoad) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -341,12 +341,7 @@ class SubFilterViewModel @Inject constructor(
         }
 
         if (userIdChanged || accessTokenStatusChanged) {
-            _updateTagsAndSites.value = Event(
-                EnumSet.of(
-                    UpdateTask.TAGS,
-                    UpdateTask.FOLLOWED_BLOGS
-                )
-            )
+            _updateTagsAndSites.value = Event(EnumSet.of(UpdateTask.TAGS))
 
             setDefaultSubfilter()
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -237,10 +237,7 @@ class SubFilterViewModelTest : BaseUnitTest() {
         verify(appPrefsWrapper, times(0)).setLastReaderKnownAccessTokenStatus(any())
 
         assertThat(viewModel.updateTagsAndSites.value!!.peekContent()).isEqualTo(
-            EnumSet.of(
-                UpdateTask.TAGS,
-                UpdateTask.FOLLOWED_BLOGS
-            )
+            EnumSet.of(UpdateTask.TAGS)
         )
 
         assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)
@@ -258,10 +255,7 @@ class SubFilterViewModelTest : BaseUnitTest() {
         verify(appPrefsWrapper, times(1)).setLastReaderKnownAccessTokenStatus(any())
 
         assertThat(viewModel.updateTagsAndSites.value!!.peekContent()).isEqualTo(
-            EnumSet.of(
-                UpdateTask.TAGS,
-                UpdateTask.FOLLOWED_BLOGS
-            )
+            EnumSet.of(UpdateTask.TAGS)
         )
 
         assertThat(viewModel.currentSubFilter.value).isInstanceOf(SiteAll::class.java)


### PR DESCRIPTION
To test:
Reader "Following" tab should continue to work as expected, including:
- Opening Reader with empty DB (clear app data);
- Opening Reader again after DB is created;
- Swipe-to-refresh;
- Followed/unfollowed sites should be reflected in the list (including from other platforms such as web). This is not covered properly by the app right now and in some cases the "Following" tab list is also not updated in `trunk` after a new site is followed, but please let me know if you find any issues;
- Switching between SH and WP.com sites;

## Regression Notes
1. Potential unintended areas of impact
"Following" tab 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests.

3. What automated tests I added (or what prevented me from doing so
Updated `SubFilterViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
