### PR TITLE
Adds referrer information when opening a Google Play store link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -83,5 +83,10 @@ class ActivityLauncherWrapper @Inject constructor() {
         const val GOOGLE_STORE_REFERRER = "referrer"
         const val GOOGLE_STORE_UTM_SOURCE = "utm_source"
         const val GOOGLE_STORE_UTM_CAMPAIGN = "utm_campaign"
+        const val CAMPAIGN_SITE_CREATION = "site_creation"
+        const val CAMPAIGN_BOTTOM_SHEET = "bottom_sheet"
+        const val CAMPAIGN_STATIC_POSTER = "static_poster"
+        const val CAMPAIGN_INDIVIDUAL_PLUGIN = "individual_plugin"
+        const val CAMPAIGN_JETPACK_OVERLAY = "jetpack_overlay"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncherWrapper.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
+import org.wordpress.android.util.UrlUtils
 import javax.inject.Inject
 
 /**
@@ -36,13 +37,13 @@ class ActivityLauncherWrapper @Inject constructor() {
     ) = ActivityLauncher.previewPostOrPageForResult(activity, site, post, remotePreviewType)
 
     @Suppress("SwallowedException")
-    fun openPlayStoreLink(activity: Activity, packageName: String) {
+    fun openPlayStoreLink(activity: Activity, packageName: String, utmCampaign: String? = null) {
         var intent: Intent? = activity.packageManager.getLaunchIntentForPackage(packageName)
         val isAppAlreadyInstalled = intent != null
 
         if (intent == null) {
             intent = Intent(Intent.ACTION_VIEW).apply {
-                data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+                data = Uri.parse(getPlayStoreUrl(activity.application.packageName, packageName, utmCampaign))
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 setPackage("com.android.vending")
             }
@@ -60,6 +61,15 @@ class ActivityLauncherWrapper @Inject constructor() {
         }
     }
 
+    fun getPlayStoreUrl(appPackageName: String, destinationPackageName: String, utmCampaign: String? = null): String {
+        val referrer = utmCampaign?.let {
+            val encoded = UrlUtils.urlEncode("$GOOGLE_STORE_UTM_SOURCE=$appPackageName&$GOOGLE_STORE_UTM_CAMPAIGN=$it")
+            "$GOOGLE_STORE_REFERRER=$encoded"
+        }
+        val storeUrl = "$GOOGLE_STORE_URL_APP_DETAILS?$GOOGLE_STORE_URL_APP_ID=$destinationPackageName"
+        return referrer?.let { "$storeUrl&$it" } ?: storeUrl
+    }
+
     private fun preventBackNavigation(activity: Activity, shouldPrevent: Boolean) {
         if (shouldPrevent) {
             activity.finishAffinity()
@@ -68,5 +78,10 @@ class ActivityLauncherWrapper @Inject constructor() {
 
     companion object {
         const val JETPACK_PACKAGE_NAME = "com.jetpack.android"
+        const val GOOGLE_STORE_URL_APP_DETAILS = "https://play.google.com/store/apps/details"
+        const val GOOGLE_STORE_URL_APP_ID = "id"
+        const val GOOGLE_STORE_REFERRER = "referrer"
+        const val GOOGLE_STORE_UTM_SOURCE = "utm_source"
+        const val GOOGLE_STORE_UTM_CAMPAIGN = "utm_campaign"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureFullScreenOverlayFragment.kt
@@ -10,6 +10,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.databinding.JetpackFeatureRemovalOverlayBinding
 import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.CAMPAIGN_JETPACK_OVERLAY
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureOverlayActions.DismissDialog
@@ -93,7 +94,7 @@ class JetpackFeatureFullScreenOverlayFragment : BottomSheetDialogFragment() {
                 is OpenPlayStore -> {
                     dismiss()
                     activity?.let {
-                        activityLauncherWrapper.openPlayStoreLink(it, JETPACK_PACKAGE_NAME)
+                        activityLauncherWrapper.openPlayStoreLink(it, JETPACK_PACKAGE_NAME, CAMPAIGN_JETPACK_OVERLAY)
                     }
                 }
                 is DismissDialog -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
@@ -81,7 +81,8 @@ class WPJetpackIndividualPluginFragment : BottomSheetDialogFragment() {
         when (actionEvent) {
             is ActionEvent.PrimaryButtonClick -> activityLauncher.openPlayStoreLink(
                 requireActivity(),
-                ActivityLauncherWrapper.JETPACK_PACKAGE_NAME
+                ActivityLauncherWrapper.JETPACK_PACKAGE_NAME,
+                ActivityLauncherWrapper.CAMPAIGN_INDIVIDUAL_PLUGIN
             )
 
             is ActionEvent.Dismiss -> dismiss()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.CAMPAIGN_STATIC_POSTER
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
@@ -59,7 +60,8 @@ class JetpackStaticPosterFragment : Fragment() {
             when (event) {
                 is Event.PrimaryButtonClick -> activityLauncher.openPlayStoreLink(
                     requireActivity(),
-                    JETPACK_PACKAGE_NAME
+                    JETPACK_PACKAGE_NAME,
+                    CAMPAIGN_STATIC_POSTER
                 )
                 is Event.SecondaryButtonClick -> event.url?.let {
                     WPWebViewActivity.openURL(requireContext(), UrlUtils.addUrlSchemeIfNeeded(it, true))

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/jetpackbadge/JetpackPoweredBottomSheetFragment.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.JetpackPoweredBottomSheetBinding
 import org.wordpress.android.databinding.JetpackPoweredExpandedBottomSheetBinding
 import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.CAMPAIGN_BOTTOM_SHEET
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType.ME
@@ -130,7 +131,7 @@ class JetpackPoweredBottomSheetFragment : BottomSheetDialogFragment() {
                 is OpenPlayStore -> {
                     dismiss()
                     activity?.let {
-                        activityLauncherWrapper.openPlayStoreLink(it, JETPACK_PACKAGE_NAME)
+                        activityLauncherWrapper.openPlayStoreLink(it, JETPACK_PACKAGE_NAME, CAMPAIGN_BOTTOM_SHEET)
                     }
                 }
                 is DismissDialog -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityLauncherWrapper
+import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.CAMPAIGN_SITE_CREATION
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.accounts.HelpActivity.Origin
@@ -188,7 +189,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
             when (action) {
                 is OpenPlayStore -> {
                     fragment.dismiss()
-                    activityLauncherWrapper.openPlayStoreLink(this, JETPACK_PACKAGE_NAME)
+                    activityLauncherWrapper.openPlayStoreLink(this, JETPACK_PACKAGE_NAME, CAMPAIGN_SITE_CREATION)
                 }
                 is DismissDialog -> {
                     fragment.dismiss()

--- a/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
@@ -68,7 +68,7 @@ class ActivityLauncherWrapperTest {
         val packageManager = mock<PackageManager>()
         whenever(activity.packageManager).thenReturn(packageManager)
         whenever(activity.application).thenReturn(application)
-        whenever(application.packageName).thenReturn("org.wordpress.android")
+        whenever(application.packageName).thenReturn(SOURCE_PACKAGE)
 
         if (isInstalled) {
             whenever(packageManager.getLaunchIntentForPackage(any())).thenReturn(mock())

--- a/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/ActivityLauncherWrapperTest.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui
 
 import android.app.Activity
+import android.app.Application
 import android.content.pm.PackageManager
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,16 +47,39 @@ class ActivityLauncherWrapperTest {
         verify(activity).finishAffinity()
     }
 
+    @Test
+    fun `when a campaign is passed the store url includes a referrer`() {
+        val expectedStoreUrl = "https://play.google.com/store/apps/details?id=com.jetpack.android" +
+                "&referrer=utm_source%3Dorg.wordpress.android%26utm_campaign%3Dtest_campaign"
+        val actualStoreUrl = classToTest.getPlayStoreUrl(SOURCE_PACKAGE, TARGET_PACKAGE, TEST_CAMPAIGN)
+        assertThat(actualStoreUrl).isEqualTo(expectedStoreUrl)
+    }
+
+    @Test
+    fun `when a campaign is not passed the store url does not include a referrer`() {
+        val expectedStoreUrl = "https://play.google.com/store/apps/details?id=com.jetpack.android"
+        val actualStoreUrl = classToTest.getPlayStoreUrl(SOURCE_PACKAGE, TARGET_PACKAGE)
+        assertThat(actualStoreUrl).isEqualTo(expectedStoreUrl)
+    }
 
     private fun mockAppPreinstalled(isInstalled: Boolean): Activity {
         val activity = mock<Activity>()
+        val application = mock<Application>()
         val packageManager = mock<PackageManager>()
         whenever(activity.packageManager).thenReturn(packageManager)
+        whenever(activity.application).thenReturn(application)
+        whenever(application.packageName).thenReturn("org.wordpress.android")
 
         if (isInstalled) {
             whenever(packageManager.getLaunchIntentForPackage(any())).thenReturn(mock())
         }
 
         return activity
+    }
+
+    companion object {
+        const val SOURCE_PACKAGE = "org.wordpress.android"
+        const val TARGET_PACKAGE = "com.jetpack.android"
+        const val TEST_CAMPAIGN = "test_campaign"
     }
 }


### PR DESCRIPTION
## Description
Adds referrer information when opening a Google Play store link (internal ref: pcdRpT-4hf-p2#comment-7000)

## To test
1. Uninstall the Jetpack app
2. Install the WordPress app from this branch
3. Browse to a Jetpack installation prompt (e.g. Reader, Site creation, Stats)
4. Tap on the Switch button
5. (Optional) Verify that the intent contains the correct data with a breakpoint (e.g. ActivityLauncherWrapper.kt:52)
6. Download and install the app from the store
7. Wait a few minutes
8. Verify that the `jpandroid_installation_referrer_obtained` event contains the right information in Tracks live view. 
Examples:
![Screenshot 2023-11-02 at 10 23 59 AM](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/c709ad15-e29e-4f9d-aa1c-ba5d4a4cc640)
![Screenshot 2023-11-02 at 10 23 19 AM](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/40c12c4c-4ba3-49b9-9d86-1df7795d7b70)


## Regression Notes
1. Potential unintended areas of impact
Open Google Play link mechanism

10. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing `ActivityLauncherWrapperTest` test cases

11. What automated tests I added (or what prevented me from doing so)
Added new `ActivityLauncherWrapperTest` test cases

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)