### PR TITLE
[JP Social] Crash fix: use null-safe Object.equals for comparison

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
 import org.wordpress.android.util.WebViewUtils;
 import org.wordpress.android.util.helpers.WebChromeClientWithVideoPoster;
 
+import java.util.Objects;
+
 import javax.inject.Inject;
 
 public class PublicizeWebViewFragment extends PublicizeBaseFragment {
@@ -173,9 +175,9 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
             // does this url denotes that we made it past the auth stage?
             if (isAdded() && url != null) {
                 Uri uri = Uri.parse(url);
-                if (uri.getHost().equals("public-api.wordpress.com")
-                    && uri.getPath().equals("/connect/")
-                    && uri.getQueryParameter("action").equals("verify")) {
+                if (Objects.equals(uri.getHost(), "public-api.wordpress.com")
+                    && Objects.equals(uri.getPath(), "/connect/")
+                    && Objects.equals(uri.getQueryParameter("action"), "verify")) {
                     // "denied" param will appear on failure or cancellation
                     String denied = uri.getQueryParameter("denied");
                     if (!TextUtils.isEmpty(denied)) {


### PR DESCRIPTION
Fixes #19372 

To test:
I have not been able to reproduce the crash as it could be a result of our users navigating to different URLs inside the JP Social connection WebView or related to some web service unavailability from the services we support, so there's no good way to test the fix.

However, it's possible to test that the functionality still works by doing the social connection flow:
1. Open and log in to the Jetpack app
2. On the dashboard, tap "More"
3. Tap "Social"
4. Choose and connect your account to one of the services
5. **Verify** the connection is made successfully

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
No UI changes.