### PR TITLE
UI Modernization Posts: tweak post list item UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListFragment.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.viewmodel.posts.PagedPostList
 import org.wordpress.android.viewmodel.posts.PostListEmptyUiState
 import org.wordpress.android.viewmodel.posts.PostListItemIdentifier.LocalPostId
 import org.wordpress.android.viewmodel.posts.PostListViewModel
-import org.wordpress.android.widgets.RecyclerItemDecoration
 import javax.inject.Inject
 
 private const val EXTRA_POST_LIST_TYPE = "post_list_type"
@@ -57,8 +56,6 @@ class PostListFragment : ViewPagerFragment() {
     private var recyclerView: RecyclerView? = null
     private var actionableEmptyView: ActionableEmptyView? = null
     private var progressLoadMore: ProgressBar? = null
-
-    private lateinit var itemDecorationStandardLayout: RecyclerItemDecoration
 
     private lateinit var postListType: PostListType
 
@@ -172,13 +169,8 @@ class PostListFragment : ViewPagerFragment() {
         actionableEmptyView = view.findViewById(R.id.actionable_empty_view)
 
         val context = nonNullActivity
-        itemDecorationStandardLayout = RecyclerItemDecoration(
-            0,
-            context.resources.getDimensionPixelSize(R.dimen.margin_medium)
-        )
         recyclerView?.layoutManager = LinearLayoutManager(context)
         recyclerView?.adapter = postListAdapter
-        recyclerView?.addItemDecoration(itemDecorationStandardLayout)
 
         swipeRefreshLayout?.let {
             swipeToRefreshHelper = buildSwipeToRefreshHelper(it) {


### PR DESCRIPTION
Closes #19456 

This PR tweaks the top/bottom spacing on the post list made https://github.com/wordpress-mobile/WordPress-Android/pull/19425#pullrequestreview-1696854361. Both top/bottom are set to 8dp

<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/1e671cca-c02b-40e9-800d-7fc00dc2e31e">

FYI: @osullivanchris 
**To test:**
- Install the app
- Sign in and select a site that has posts
- Navigate to My Site > More > Posts
- ✅ Verify the top/bottom row spacing looks good

## Regression Notes
1. Potential unintended areas of impact
Spacing needs adjustment

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual visual test

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
