### PR TITLE
Fix NullPointerException on singleUserSite access

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -236,7 +236,7 @@ class PostListMainViewModel @Inject constructor(
      * This behavior is consistent with Calypso as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isWPCom && site.hasCapabilityEditOthersPosts && (site.isSingleUserSite?.not() == false)
+        site.isWPCom && site.hasCapabilityEditOthersPosts && (site.isSingleUserSite != null && !site.isSingleUserSite)
     }
 
     init {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -236,7 +236,7 @@ class PostListMainViewModel @Inject constructor(
      * This behavior is consistent with Calypso as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isWPCom && site.hasCapabilityEditOthersPosts && !site.isSingleUserSite
+        site.isWPCom && site.hasCapabilityEditOthersPosts && (site.isSingleUserSite?.not() == false)
     }
 
     init {

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -228,13 +228,4 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.onFabLongPressedForCreateMenu.value?.peekContent()).isNotNull
     }
-
-    @Test
-    fun `given start, when isSingleUserSite is null, then an exception is not thrown`() {
-        whenever(site.isSingleUserSite).thenReturn(null)
-
-        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
-
-        // no exception thrown
-    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostListMainViewModelTest.kt
@@ -228,4 +228,13 @@ class PostListMainViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.onFabLongPressedForCreateMenu.value?.peekContent()).isNotNull
     }
+
+    @Test
+    fun `given start, when isSingleUserSite is null, then an exception is not thrown`() {
+        whenever(site.isSingleUserSite).thenReturn(null)
+
+        viewModel.start(site, PostListRemotePreviewState.NONE, currentBottomSheetPostId, editPostRepository)
+
+        // no exception thrown
+    }
 }


### PR DESCRIPTION
Fixes #19518 
Sentry Issue: [WORDPRESS-ANDROID-2S4V](https://a8c.sentry.io/issues/4592283711/?referrer=github_integration)

This fixes a NullPointerException crash while checking the value of site.isSingleUserSite. This PR addresses the immediate crash; however how the boolean value is getting set to null is still needs investigation. 

Tested
- New site creation sets a non-null value in the db
- Migrating the db sets a non-null value in the db
- gson setting false

cc: @oguzkocer 

**To test:**
- Install the app
- Login and select a site
- Navigate to MySite > More > Posts
- ✅ Validate the post list loads as normal and the author filter functions as expected

If you want to force the null
- Download this branch
- Download the associated FluxC branch
- Set FluxC to build locally within WP (local-builds.config)
- Navigate to `siteResponseToSiteModel` within `SiteRestClient`
- Change  the following line from `site.setIsSingleUserSite(from.single_user_site)` to `site.setIsSingleUserSite(null)`
- Build and launch the app
- In Android Studio, Navigate to DatabaseInspector > SiteModel
- Notice that IsSingleUserSite = null
- In the app, navigate to MySite > More > Posts
- ✅ Validate the post list loads as normal

## Regression Notes
1. Potential unintended areas of impact
The posts list still crashes and the author filter does not work properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Add new unit test to PostListMainViewModelTest

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
