### PR TITLE
Fix Null Pointer Exception on getSelectedSite 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -107,6 +107,7 @@ class MenuActivity : AppCompatActivity() {
         viewModel.navigation.observe(this) { handleNavigationAction(it.getContentIfNotHandled()) }
         viewModel.onSnackbarMessage.observe(this) { showSnackbar(it.getContentIfNotHandled()) }
         viewModel.onQuickStartMySitePrompts.observe(this) { handleActiveTutorialPrompt(it.getContentIfNotHandled()) }
+        viewModel.onSelectedSiteMissing.observe(this) { finish() }
 
         // Set the Compose callback for SnackbarSequencer
         snackbarSequencer.setComposeSnackbarCallback { item ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuViewModel.kt
@@ -75,6 +75,10 @@ class MenuViewModel @Inject constructor(
     private val _snackbar = MutableSharedFlow<SnackbarMessage>()
     val snackBar = _snackbar.asSharedFlow()
 
+
+    private val _onSelectedSiteMissing = MutableLiveData<Unit>()
+    val onSelectedSiteMissing = _onSelectedSiteMissing as LiveData<Unit>
+
     private var quickStartEvent: QuickStartEvent? = null
     private var isStarted = false
 
@@ -86,7 +90,13 @@ class MenuViewModel @Inject constructor(
         if (isStarted) {
             return
         }
-        val site = selectedSiteRepository.getSelectedSite()!!
+
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            _onSelectedSiteMissing.value = Unit
+            return
+        }
+
         this.quickStartEvent = quickStartEvent
         if (quickStartEvent != null) {
             quickStartRepository.setActiveTask(quickStartEvent.task, true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/menu/MenuViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/menu/MenuViewModelTest.kt
@@ -165,6 +165,20 @@ class MenuViewModelTest : BaseUnitTest() {
         }
     }
 
+    @Test
+    fun `given vm start, when selected site is null, then site is missing event is raised`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val observer = mutableListOf<Unit>()
+        viewModel.onSelectedSiteMissing.observeForever { event ->
+            observer.add(event)
+        }
+
+        viewModel.start()
+
+        assert(observer.isNotEmpty())
+    }
+
     private fun findBackupListItem(items: List<MenuItemState>) =
         items.filterIsInstance(MenuItemState.MenuListItem::class.java)
             .firstOrNull { it.listItemAction == ListItemAction.BACKUP }


### PR DESCRIPTION
Fixes #19520 
Sentry [JETPACK-ANDROID-E2J](https://a8c.sentry.io/issues/4592008344/?referrer=github_integration)

This PR prevents a crash when siteRepository.getSelectedSite returns a null. If there is no site, we can continue.
Note: I could not reproduce this crash, so this a preventative measure

**To test:**
- Install the app
- Login and select a site
- Navigate to My Site > More
- ✅ Verify the more menu is shown
- Navigate around to different options and verify that the menu continues to respond

 
## Regression Notes
1. Potential unintended areas of impact
The app crashes when the more menu is accessed

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added a test to `MenuViewModelTest`

3. What automated tests I added (or what prevented me from doing so) N/A

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A

