### PR TITLE
UI Modernization Posts and Pages: single user site access

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -216,7 +216,8 @@ class PostListMainViewModel @Inject constructor(
      * This behavior is consistent with Calypso as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isUsingWpComRestApi && site.hasCapabilityEditOthersPosts && !site.isSingleUserSite
+        site.isUsingWpComRestApi && site.hasCapabilityEditOthersPosts
+                && (site.isSingleUserSite != null && !site.isSingleUserSite)
     }
 
     init {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PageListViewModel.kt
@@ -97,7 +97,8 @@ class PageListViewModel @Inject constructor(
 
     private val showAuthorName: Boolean by lazy {
         // show if the site is a single user site and the users in the site has the capability to edit/add pages
-        !pagesViewModel.site.isSingleUserSite && pagesViewModel.site.hasCapabilityEditOthersPages
+        (pagesViewModel.site.isSingleUserSite != null && !pagesViewModel.site.isSingleUserSite)
+        && pagesViewModel.site.hasCapabilityEditOthersPages
     }
 
     private val featuredImageMap = mutableMapOf<Long, String>()

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -994,7 +994,8 @@ class PagesViewModel
      * This behavior is consistent with Calypso and Posts as of 11/4/2019.
      */
     private val isFilteringByAuthorSupported: Boolean by lazy {
-        site.isUsingWpComRestApi && site.hasCapabilityEditOthersPages && !site.isSingleUserSite
+        site.isUsingWpComRestApi && site.hasCapabilityEditOthersPages
+                && (site.isSingleUserSite != null && !site.isSingleUserSite)
     }
 
     @SuppressLint("NullSafeMutableLiveData")

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListViewModel.kt
@@ -79,7 +79,7 @@ class PostListViewModel @Inject constructor(
     private val isFilteringByAuthorSupported: Boolean by lazy {
         connector.site.isUsingWpComRestApi &&
                 connector.site.hasCapabilityEditOthersPosts &&
-                !connector.site.isSingleUserSite
+                (connector.site.isSingleUserSite != null && !connector.site.isSingleUserSite)
     }
     private var isStarted: Boolean = false
     private lateinit var connector: PostListViewModelConnector


### PR DESCRIPTION
This PR wraps `site.singleUserSite` access with a null check to prevent a crash while investigation is ongoing.

**To test:**
- Install the app
- Login
- Navigate to My Site > More > Posts
- ✅ Verify the post list loads and the author filter works correctly
- Navigate to My Site > More > pages
- ✅ Verify the pages list loads and the author filter works correctly

## Regression Notes
1. Potential unintended areas of impact
The posts or pages list crash on site.singleUserSite with a null exception

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing - the values are set in the initialization of a property

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
 