### PR TITLE
Tooling: Update Dangermattic gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 8406e79e3b20e71421462a525c50a0525da697aa
+  revision: 078aa57c084790327da4cb401f18b350a4d1e329
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)
@@ -32,8 +32,8 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.843.0)
-    aws-sdk-core (3.185.1)
+    aws-partitions (1.844.0)
+    aws-sdk-core (3.186.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -280,7 +280,7 @@ GEM
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.7.2)
     rainbow (3.1.1)
     rake (13.1.0)
     rake-compiler (1.2.5)


### PR DESCRIPTION
Updates the Dangermattic gem, basically to get the fix implemented on https://github.com/Automattic/dangermattic/pull/26.

With this update, the error reported on https://github.com/wordpress-mobile/WordPress-Android/pull/19488 should be fixed.