### PR TITLE
Fix personalize dashboard crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
@@ -61,7 +61,7 @@ class DashboardCardPersonalizationViewModelSlice @Inject constructor(
     }
 
     private suspend fun getBloggingPromptCardState(): DashboardCardState? {
-        return if (bloggingPromptsSettingsHelper.shouldShowPromptsFeature()) {
+        return if (bloggingPromptsSettingsHelper.shouldShowPromptsSetting()) {
             DashboardCardState(
                 title = R.string.personalization_screen_blogging_prompts_card_title,
                 description = R.string.personalization_screen_blogging_prompts_card_description,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSlice.kt
@@ -179,9 +179,12 @@ class DashboardCardPersonalizationViewModelSlice @Inject constructor(
 
     private fun updateCardState(cardType: CardType, enabled: Boolean) {
         val currentCards: MutableList<DashboardCardState> = _uiState.value!!.toMutableList()
-        val updated = currentCards.find { it.cardType == cardType }!!.copy(enabled = enabled)
-        currentCards[cardType.order] = updated
-        _uiState.postValue(currentCards)
+        val cardIndex = currentCards.indexOfFirst { it.cardType == cardType }
+        if (cardIndex != -1) {
+            val updated = currentCards[cardIndex].copy(enabled = enabled)
+            currentCards[cardIndex] = updated
+            _uiState.postValue(currentCards)
+        }
     }
 
     private fun isStatsCardShown(siteId: Long) = !appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(siteId)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
@@ -66,7 +66,7 @@ class DashboardCardPersonalizationViewModelSliceTest : BaseUnitTest() {
 
         whenever(blazeFeatureUtils.isSiteBlazeEligible(site)).thenReturn(true)
         test {
-            whenever(bloggingPromptsSettingsHelper.shouldShowPromptsFeature()).thenReturn(true)
+            whenever(bloggingPromptsSettingsHelper.shouldShowPromptsSetting()).thenReturn(true)
         }
 
         viewModelSlice = DashboardCardPersonalizationViewModelSlice(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/personalization/DashboardCardPersonalizationViewModelSliceTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -22,6 +23,7 @@ import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import kotlin.test.assertNull
 
 @ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
@@ -273,5 +275,15 @@ class DashboardCardPersonalizationViewModelSliceTest : BaseUnitTest() {
             AnalyticsTracker.Stat.PERSONALIZATION_SCREEN_CARD_HIDE_TAPPED,
             mapOf(CARD_TYPE_TRACK_PARAM to cardType.trackingName)
         )
+    }
+
+    @Test
+    fun `given blaze state is not built, when cards are fetched, then blaze is not present and app does not crash`() {
+        whenever(blazeFeatureUtils.isSiteBlazeEligible(anyOrNull())).thenReturn(false)
+
+        viewModelSlice.start(123L)
+        val cardState = uiStateList.last().find { it.cardType == CardType.BLAZE }
+
+        assertNull(cardState)
     }
 }


### PR DESCRIPTION
Fixes #19536 

The issue here is that we are trying to access an index in the list that doesn't exist. Instead of using the order property of cardType to index into the list, we now find the index of the card in the list and update it. 

What caused the issue to be noticed was: the "blaze" card was completely removed when it was expected to be present. 

**Note**: There is a known issue with Blogging Prompts setting not showing at all once it has been toggled off. If I have time, I will address in this issue; if not, then it will be taken up in a separate PR. Check commit https://github.com/wordpress-mobile/WordPress-Android/pull/19537/commits/098b3de038447f886afb608bf6d38632170b7f1c for the fix.

**To test:**
**Test crash behavior**
- Download `release/23.6` branch
- Navigate and open `DashboardCardPersonalizationViewModelSlice`
- In fun `getBlazeCardState` always return a null
- Build and launch the app
- Login, select a site and navigate to My Site > Personalize Your Home Tab
- Toggle off a card (I used blogging prompt)
- ✅ Verify a crash happens

 **Test crash behavior**
- Download this branch
- Navigate and open `DashboardCardPersonalizationViewModelSlice`
- In fun `getBlazeCardState` always return a null
- Build and launch the app
- Login, select a site and navigate to My Site > Personalize Your Home Tab
- Toggle off a card (I used blogging prompt)
- ✅ Verify a crash does not happen

**Test normal behavior**
- Download the build from this PR
- Launch the app
- Login, select a site and navigate to My Site > Personalize Your Home Tab
- Toggle off a card  
- ✅ Verify the app does not crash

## Regression Notes
1. Potential unintended areas of impact
The personalize view does not work as intended

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual 

3. What automated tests I added (or what prevented me from doing so) N/A
 
PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A