### PR TITLE
Quick Links - fix null pointer exception with siteRepository

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quicklinksitem/QuickLinksItemViewModelSlice.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.blaze.BlazeFeatureUtils
@@ -76,14 +77,14 @@ class QuickLinksItemViewModelSlice @Inject constructor(
             site()?.let { site ->
                 jetpackCapabilitiesUseCase.getJetpackPurchasedProducts(site.siteId).collect {
                     _uiState.postValue(
-                        convertToQuickLinkRibbonItem(
+                        convertToQuickLinkRibbonItem(site,
                             siteItemsBuilder.build(
                                 MySiteCardAndItemBuilderParams.SiteItemsBuilderParams(
                                     site = site,
                                     enableFocusPoints = true,
                                     activeTask = null,
                                     onClick = this@QuickLinksItemViewModelSlice::onClick,
-                                    isBlazeEligible = isSiteBlazeEligible(),
+                                    isBlazeEligible = isSiteBlazeEligible(site),
                                     backupAvailable = it.backup,
                                     scanAvailable = (it.scan && !site.isWPCom && !site.isWPComAtomic)
                                 )
@@ -96,9 +97,10 @@ class QuickLinksItemViewModelSlice @Inject constructor(
     }
 
     private fun convertToQuickLinkRibbonItem(
+        site: SiteModel,
         listItems: List<MySiteCardAndItem>,
     ): MySiteCardAndItem.Card.QuickLinksItem {
-        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
+        val siteId = site.siteId
         val activeListItems = listItems.filterIsInstance(MySiteCardAndItem.Item.ListItem::class.java)
             .filter { isActiveQuickLink(it.listItemAction, siteId = siteId) }
         val activeQuickLinks = activeListItems.map { listItem ->
@@ -122,8 +124,8 @@ class QuickLinksItemViewModelSlice @Inject constructor(
         )
     }
 
-    private fun isSiteBlazeEligible() =
-        blazeFeatureUtils.isSiteBlazeEligible(selectedSiteRepository.getSelectedSite()!!)
+    private fun isSiteBlazeEligible(site: SiteModel) =
+        blazeFeatureUtils.isSiteBlazeEligible(site)
 
 
     private fun onClick(action: ListItemAction) {


### PR DESCRIPTION
Fixes #19535 

This PR passes along SiteModel instead of relying on SelectedSiteRepository. 

I could not recreate the issue, but somewhere between the first access of selectedSiteRepository in `site()` and the collect of `jetpackCapabilitiesUseCase.getJetpackPurchasedProducts` the selectedSite is becoming null. This PR is a precautionary fix to use the site "as is" within the `let`. 

**To test:**
- Launch the app
- Sign-in, select a site
- Navigate to My Site
- ✅ Verify the quick links card is shown and the app does not crash

## Regression Notes
1. Potential unintended areas of impact
The quick links card is not built

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Unable to recreate the issue

PR submission checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
