### PR TITLE
Hide domains button on Me screen for logged out users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -237,11 +237,17 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
+        refreshDomainManagementVisibility()
+    }
+
+    private fun MeFragmentBinding.refreshDomainManagementVisibility() {
         if (shouldShowDomainButton) {
-            domainManagementContainer.visibility = VISIBLE
+            domainManagementContainer.visibility = View.VISIBLE
             domainManagementContainer.setOnClickListener {
                 context?.let { ActivityLauncher.openDomainManagement(it) }
             }
+        } else {
+            domainManagementContainer.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -214,15 +214,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             viewModel.showUnifiedAbout()
         }
 
-        if (shouldShowQrCodeLogin()) {
-            rowScanLoginCode.isVisible = true
-            scanLoginCodeDivider.isVisible = true
-
-            rowScanLoginCode.setOnClickListener {
-                viewModel.showScanLoginCode()
-            }
-        }
-
         initRecommendUiState()
 
         rowLogout.setOnClickListener {
@@ -237,10 +228,22 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        refreshDomainManagementVisibility()
+        refreshWPCOMLoggedInOnlyButtonsVisibility()
     }
 
-    private fun MeFragmentBinding.refreshDomainManagementVisibility() {
+    private fun MeFragmentBinding.refreshWPCOMLoggedInOnlyButtonsVisibility() {
+        if (shouldShowQrCodeLogin()) {
+            rowScanLoginCode.isVisible = true
+            scanLoginCodeDivider.isVisible = true
+
+            rowScanLoginCode.setOnClickListener {
+                viewModel.showScanLoginCode()
+            }
+        } else {
+            rowScanLoginCode.isVisible = false
+            scanLoginCodeDivider.isVisible = false
+        }
+
         if (shouldShowDomainButton) {
             domainManagementContainer.visibility = View.VISIBLE
             domainManagementContainer.setOnClickListener {
@@ -287,7 +290,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
                 true -> showDisconnectDialog()
                 false -> {
                     hideDisconnectDialog()
-                    refreshDomainManagementVisibility()
+                    refreshWPCOMLoggedInOnlyButtonsVisibility()
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -147,6 +147,8 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     private val viewModel: MeViewModel by viewModels()
 
+    private val shouldShowDomainButton
+        get() = BuildConfig.IS_JETPACK_APP && domainManagementFeatureConfig.isEnabled() && accountStore.hasAccessToken()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
@@ -236,7 +238,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        if (BuildConfig.IS_JETPACK_APP && domainManagementFeatureConfig.isEnabled()) {
+        if (shouldShowDomainButton) {
             domainManagementContainer.visibility = VISIBLE
             domainManagementContainer.setOnClickListener {
                 context?.let { ActivityLauncher.openDomainManagement(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -281,9 +281,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner, {
+        viewModel.showUnifiedAbout.observeEvent(viewLifecycleOwner) {
             startActivity(Intent(activity, UnifiedAboutActivity::class.java))
-        })
+        }
 
         viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner) {
             when (it) {
@@ -295,11 +295,11 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             }
         }
 
-        viewModel.recommendUiState.observeEvent(viewLifecycleOwner, {
+        viewModel.recommendUiState.observeEvent(viewLifecycleOwner) {
             if (!isAdded) return@observeEvent
 
             manageRecommendUiState(it)
-        })
+        }
 
         viewModel.showScanLoginCode.observeEvent(viewLifecycleOwner) {
             ActivityLauncher.startQRCodeAuthFlow(requireContext())
@@ -449,7 +449,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     }
 
     private fun MeFragmentBinding.loadAvatar(injectFilePath: String?) {
-        val newAvatarUploaded = injectFilePath != null && injectFilePath.isNotEmpty()
+        val newAvatarUploaded = !injectFilePath.isNullOrEmpty()
         val avatarUrl = meGravatarLoader.constructGravatarUrl(accountStore.account.avatarUrl)
         meGravatarLoader.load(
             newAvatarUploaded,
@@ -567,7 +567,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         when (requestCode) {
             RequestCodes.PHOTO_PICKER -> if (resultCode == Activity.RESULT_OK && data != null) {
                 val mediaUriStringsArray = data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
-                if (mediaUriStringsArray == null || mediaUriStringsArray.size == 0) {
+                if (mediaUriStringsArray.isNullOrEmpty()) {
                     AppLog.e(
                         UTILS,
                         "Can't resolve picked or captured image"

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -282,12 +282,15 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             startActivity(Intent(activity, UnifiedAboutActivity::class.java))
         })
 
-        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner, {
+        viewModel.showDisconnectDialog.observeEvent(viewLifecycleOwner) {
             when (it) {
                 true -> showDisconnectDialog()
-                false -> hideDisconnectDialog()
+                false -> {
+                    hideDisconnectDialog()
+                    refreshDomainManagementVisibility()
+                }
             }
-        })
+        }
 
         viewModel.recommendUiState.observeEvent(viewLifecycleOwner, {
             if (!isAdded) return@observeEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
 import android.view.View.OnClickListener
-import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment


### PR DESCRIPTION
Fixes #19499

### Description

This PR hides the domains button on the Me screen for users that are not logged in to WordPress.com (i.e. when only self-hosted sites are present / logged in). This also extracts the visibility logic to a computed property.

Note: This PR also provides a similar fix for the "Scan Login Code" button, which remains visible after logging out (until the screen is manually refreshed, i.e. by leaving the "Me" tab and tapping it again).


To test:

Prerequisite: A self-hosted site will be used for this test (e.g. Jurassic Ninja).

1. Log in to a self-hosted site
2. Navigate to the "Me" tab
   * Observe that neither the domains button nor the scan login code button are visible
3. Log in to WordPress.com (sign in using a WordPress account)
   * Observe that the domains button and scan login code button are now visible
4. Log out of WordPress.com
   * Observe that the domains button and scan login code buttons are no longer visible


#### Screenshots:

| Logged in | Logged out | Logged out (before) |
|-|-|-|
|![image](https://github.com/wordpress-mobile/WordPress-Android/assets/8507675/625c3365-77f1-4051-97e6-ebf4c0030486)|![image](https://github.com/wordpress-mobile/WordPress-Android/assets/8507675/5c5e44c9-54a5-49c0-9a3f-1369d8893d93)|![image](https://github.com/wordpress-mobile/WordPress-Android/assets/8507675/677c0bbc-eac2-40cf-8b56-afcf543a32d4)|


## Regression Notes
1. Potential unintended areas of impact
Scan Login Code button

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

7. What automated tests I added (or what prevented me from doing so)
Setting up the necessary testing structure for this was out of scope for this task.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
