### PR TITLE
Bump Kotlin version from 1.8.21 to 1.9.10

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ColumnWithFrostedGlassBackground.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
@@ -85,15 +84,13 @@ fun ColumnWithFrostedGlassBackground(
 
         val clippedBackgroundPlaceables = subcompose(ClippedBackground) {
             background(
-                clipModifier = Modifier.clip(buttonsClipShape),
-                blurModifier = Modifier.composed {
-                    if (VERSION.SDK_INT >= VERSION_CODES.S) {
-                        blur(blurRadius, BlurredEdgeTreatment.Unbounded)
-                    } else {
-                        // On versions older than Android 12 the blur modifier is not supported,
-                        // so we make the text transparent to have the buttons stand out.
-                        alpha(0.05f)
-                    }
+                Modifier.clip(buttonsClipShape),
+                if (VERSION.SDK_INT >= VERSION_CODES.S) {
+                    Modifier.blur(blurRadius, BlurredEdgeTreatment.Unbounded)
+                } else {
+                    // On versions older than Android 12 the blur modifier is not supported,
+                    // so we make the text transparent to have the buttons stand out.
+                    Modifier.alpha(0.05f)
                 }
             )
         }.map { it.measure(constraints) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -54,7 +54,7 @@ fun SiteList(
     LazyColumn(
         state = listState,
         modifier = modifier
-            .conditionalThen(userScrollEnabled, Modifier.disableUserScroll())
+            .conditionalThen(!userScrollEnabled, Modifier.disableUserScroll())
             .background(MaterialTheme.colors.background)
             .fillMaxHeight()
             .then(blurModifier),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -35,6 +34,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.text.Message
 import org.wordpress.android.ui.compose.components.text.Subtitle
 import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.modifiers.disableUserScroll
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.utils.uiStringText
@@ -46,15 +46,15 @@ import org.wordpress.android.ui.main.jetpack.migration.compose.dimmed
 fun SiteList(
     uiState: UiState.Content.Welcome,
     listState: LazyListState,
-    userScrollEnabled: Boolean = true,
-    bottomPaddingPx: Int = 0,
     modifier: Modifier = Modifier,
     blurModifier: Modifier = Modifier,
+    userScrollEnabled: Boolean = true,
+    bottomPaddingPx: Int = 0,
 ) {
     LazyColumn(
         state = listState,
         modifier = modifier
-            .composed { if (userScrollEnabled) this else disableUserScroll() }
+            .conditionalThen(userScrollEnabled, Modifier.disableUserScroll())
             .background(MaterialTheme.colors.background)
             .fillMaxHeight()
             .then(blurModifier),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
@@ -62,19 +61,19 @@ fun WelcomeStep(uiState: UiState.Content.Welcome): Unit = with(uiState) {
                 SiteList(
                     uiState = uiState,
                     listState = listState,
+                    modifier = clipModifier,
                     userScrollEnabled = !isProcessing,
                     bottomPaddingPx = buttonsHeightPx,
-                    modifier = clipModifier,
                 )
             },
             blurBackground = { clipModifier, blurModifier, buttonsHeightPx ->
                 SiteList(
                     uiState = uiState,
                     listState = blurredListState,
-                    userScrollEnabled = false,
-                    bottomPaddingPx = buttonsHeightPx,
                     modifier = clipModifier.clearAndSetSemantics {},
                     blurModifier = blurModifier,
+                    userScrollEnabled = false,
+                    bottomPaddingPx = buttonsHeightPx,
                 )
             },
             buttonsColumn = {
@@ -153,10 +152,7 @@ private fun SiteListScaffold(
         }
 
         val siteListPlaceables = subcompose(SlotsEnum.SiteList) {
-            siteList(
-                clipModifier = Modifier.clip(siteListClipShape),
-                buttonsHeightPx = buttonsHeight
-            )
+            siteList(Modifier.clip(siteListClipShape), buttonsHeight)
         }.map { it.measure(constraints) }
 
         val buttonsClipShape = object : Shape {
@@ -174,15 +170,13 @@ private fun SiteListScaffold(
 
         val clippedBackgroundPlaceables = subcompose(SlotsEnum.ClippedBackground) {
             blurBackground(
-                clipModifier = Modifier.clip(buttonsClipShape),
-                blurModifier = Modifier.composed {
-                    if (VERSION.SDK_INT >= VERSION_CODES.S) {
-                        blur(blurRadius, BlurredEdgeTreatment.Unbounded)
-                    } else {
-                        alpha(0.05f)
-                    }
+                Modifier.clip(buttonsClipShape),
+                if (VERSION.SDK_INT >= VERSION_CODES.S) {
+                    Modifier.blur(blurRadius, BlurredEdgeTreatment.Unbounded)
+                } else {
+                    Modifier.alpha(0.05f)
                 },
-                buttonsHeightPx = buttonsHeight,
+                buttonsHeight,
             )
         }.map { it.measure(constraints) }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
     androidxAppcompatVersion = '1.6.1'
     androidxArchCoreVersion = '2.2.0'
     androidxComposeBomVersion = '2023.10.00'
-    androidxComposeCompilerVersion = '1.4.7'
+    androidxComposeCompilerVersion = '1.5.3'
     androidxCardviewVersion = '1.0.0'
     androidxConstraintlayoutVersion = '2.1.4'
     androidxConstraintlayoutComposeVersion = '1.0.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.kotlinVersion = '1.8.21'
+    gradle.ext.kotlinVersion = '1.9.10'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.googleServicesVersion = '4.3.15'
     gradle.ext.navigationVersion = '2.5.3'


### PR DESCRIPTION
Fixes #19464 

This PR bumps the Kotlin version used in the project from 1.8.21 to 1.9.10, which is the required version for the Kotlin standard libs in a PR opened by dependabot recently (https://github.com/wordpress-mobile/WordPress-Android/pull/19399). 

For this Kotlin update I also needed to bump the Compose Compiler version to 1.5.3 and fix a few Compose warnings and errors.

Note: most Kotlin changes from 1.8.21 to 1.9.10 are related to K2, Kotlin/Native, and some APIs becoming stable, which shouldn't affect us.

To test:

Since this touches the language version, which is used everywhere, a sanity test in some app features should be enough, prioritizing Compose-specific flows and features, such as: some dashboard cards, Blogging Prompts list, Jetpack Social sharing bottom sheets in the Post Editor, and especially the **Jetpack Migration flow**.

## Regression Notes
1. Potential unintended areas of impact
Compose UI issues.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
