### PR TITLE
Fixes a test breakage introduced with the integration of the latest FluxC version

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUIModelMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUIModelMapperTest.kt
@@ -39,6 +39,7 @@ class CampaignListingUIModelMapperTest : BaseUnitTest() {
         budgetCents = 100,
         createdAt = mock(),
         endDate = mock(),
+        targetUrn = null,
     )
 
     @Test
@@ -67,6 +68,7 @@ class CampaignListingUIModelMapperTest : BaseUnitTest() {
         budgetCents = 100,
         createdAt = mock(),
         endDate = mock(),
+        targetUrn = null,
     )
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
@@ -33,6 +33,7 @@ val campaign = BlazeCampaignModel(
     budgetCents = 20L,
     impressions = 1,
     clicks = 1,
+    targetUrn = null,
 )
 
 val onCreateCampaignClick = { }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.107.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = 'trunk-7fd7840a9bd900fde8e32ad8bd5632ad8f05dff3'
+    wordPressFluxCVersion = 'trunk-82a701e28d0eeb8c1612b256fd9d772182a13b6a'
     wordPressLoginVersion = 'trunk-9963d78096edf65f8704b803e5b93c08fc9174cd'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
## Description
Fixes a test breakage introduced with the integration of the latest FluxC version with the addition of the `targetUrn` parameter in the `BlazeCampaignModel` https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2888/files#diff-5f28daf648e65a5fbc900cd76b432652675fb68bf96556e190536f1cd45ce084R22

## To test
Verify that the test code is compiling and the CI checks are all green.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
