### PR TITLE
Update the domain message UI in site preview screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -14,6 +14,7 @@ import android.view.View.OnLayoutChangeListener
 import android.view.animation.DecelerateInterpolator
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
@@ -85,7 +86,8 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         viewModel.uiState.observe(this@SiteCreationPreviewFragment) {
             it?.let { ui ->
                 uiHelpers.setTextOrHide(siteCreationPreviewHeaderItem.sitePreviewSubtitle, ui.subtitle)
-                uiHelpers.setTextOrHide(sitePreviewCaption, ui.caption)
+                uiHelpers.setTextOrHide(sitePreviewCaptionText, ui.caption)
+                sitePreviewCaption.isVisible = ui.caption != null
                 updateContentLayout(ui.urlData, isFirstContent = ui is SitePreviewLoadingShimmerState)
                 siteCreationPreviewWebViewContainer.apply {
                     uiHelpers.updateVisibility(sitePreviewWebView, ui.webViewVisibility)

--- a/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout-land/site_creation_preview_screen_default.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/content_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,12 +24,28 @@
             android:id="@+id/site_creation_preview_header_item"
             layout="@layout/site_creation_preview_header_item" />
 
-        <TextView
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/sitePreviewCaption"
-            style="@style/SiteCreationHeaderV2Subtitle"
-            android:lineSpacingExtra="@null"
-            android:paddingBottom="@null"
-            android:text="@string/new_site_creation_preview_caption_paid" />
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_large"
+            app:cardBackgroundColor="@color/dashboard_card_plans_info_background"
+            app:cardCornerRadius="8dp">
+
+            <TextView
+                android:id="@+id/sitePreviewCaptionText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="@dimen/margin_extra_large"
+                android:padding="@dimen/margin_extra_large"
+                android:text="@string/new_site_creation_preview_caption_paid"
+                android:textAlignment="viewStart"
+                android:textColor="@color/dashboard_card_plans_info_text_color"
+                android:textSize="@dimen/text_sz_small"
+                app:drawableStartCompat="@drawable/ic_info_outline_grey_dark_24dp"
+                app:drawableTint="@color/gray_20" />
+
+        </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/okButton"

--- a/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
+++ b/WordPress/src/main/res/layout/site_creation_preview_screen_default.xml
@@ -16,24 +16,39 @@
         android:layout_marginHorizontal="@dimen/margin_extra_large"
         android:layout_marginVertical="@dimen/margin_large" />
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/sitePreviewCaption"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/site_creation_preview_header_item"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        app:cardBackgroundColor="@color/dashboard_card_plans_info_background"
+        app:cardCornerRadius="8dp">
+
+        <TextView
+            android:id="@+id/sitePreviewCaptionText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/margin_extra_large"
+            android:padding="@dimen/margin_extra_large"
+            android:text="@string/new_site_creation_preview_caption_paid"
+            android:textAlignment="viewStart"
+            android:textColor="@color/dashboard_card_plans_info_text_color"
+            android:textSize="@dimen/text_sz_small"
+            app:drawableStartCompat="@drawable/ic_info_outline_grey_dark_24dp"
+            app:drawableTint="@color/gray_20" />
+
+    </com.google.android.material.card.MaterialCardView>
+
     <include
         android:id="@+id/site_creation_preview_web_view_container"
         layout="@layout/site_creation_preview_web_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/sitePreviewCaption"
-        android:layout_below="@id/site_creation_preview_header_item"
-        android:layout_marginHorizontal="@dimen/margin_extra_large" />
-
-    <TextView
-        android:id="@+id/sitePreviewCaption"
-        style="@style/SiteCreationHeaderV2Subtitle"
-        android:layout_above="@+id/sitePreviewOkButtonContainer"
-        android:lineSpacingExtra="@null"
+        android:layout_above="@id/sitePreviewOkButtonContainer"
+        android:layout_below="@id/sitePreviewCaption"
         android:layout_marginHorizontal="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_large"
-        android:paddingBottom="@null"
-        android:text="@string/new_site_creation_preview_caption_paid" />
+        android:layout_marginTop="@dimen/margin_large" />
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/sitePreviewOkButtonContainer"


### PR DESCRIPTION
This updates the view for the `It may take up to 30 minutes for your custom domain to start working.` message and makes it more prominent to ensure that it is not overlooked by the user.

See design discussion: p1698419259984079/1698270714.971209-slack-C05SY592UG4
See rationale to include this as a beta-fix: p1699041111187389/1699038644.934359-slack-C05SY592UG4

> [!NOTE] 
> The new design for the message is received from [plans_purchase_success_fragment.xml](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/res/layout/plans_purchase_success_fragment.xml#L57-L80).

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/c3dbc3a7-f7d9-4156-a012-2010a4cf49c8" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/24d9b5a7-b893-47cb-a788-b3539977f8c4" width=320>|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/9cfc4a4e-b9f5-49c8-a012-d6f094aae1b1" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/cc105b88-0391-42af-a815-ec5fe54b2293" width=320>|

**With accessibility settings**

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ee3d8062-6bba-46f5-813e-7bc22529ac47" width=320>

To test:
1. Launch the JP app.
2. Log in.
3. Create a new site by purchasing a new paid domain. (pc8HXX-14D-p2)
4. After the checkout, the site preview screen will open.
5. Verify the domain message is above the site preview, as shown in the screenshot.
6. Change orientation to landscape.
7. Verify that the screen remains readable and is displayed correctly.

**Free domain**
1. Repeat the test by creating a site with a free domain. 
2. Verify that it is still as before.

## Regression Notes
1. Potential unintended areas of impact
Site preview screen for free domain.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
This makes a minor change to view UI and is not suitable for automated tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)