### PR TITLE
🤖 Show loading indicator when submitting the cart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
@@ -12,11 +12,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,12 +36,12 @@ import androidx.compose.ui.zIndex
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.Empty
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.Error
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.PopulatedList
 import org.wordpress.android.ui.domains.management.composable.DomainsSearchTextField
+import org.wordpress.android.ui.domains.management.composable.PrimaryButton
 
 @Composable
 fun MyDomainsScreen(
@@ -147,27 +144,6 @@ fun EmptyScreen(onFindDomainTapped: () -> Unit) {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-        )
-    }
-}
-
-@Composable
-fun PrimaryButton(
-    onClick: () -> Unit,
-    text: String,
-    modifier: Modifier = Modifier,
-) {
-    Button(
-        onClick = onClick,
-        modifier = modifier,
-        shape = RoundedCornerShape(4.dp),
-        colors = ButtonDefaults.buttonColors(
-            contentColor = AppColor.White,
-        ),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelLarge,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/PrimaryButton.kt
@@ -1,0 +1,67 @@
+package org.wordpress.android.ui.domains.management.composable
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.domains.management.M3Theme
+
+@Composable
+fun PrimaryButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
+    isInProgress: Boolean = false,
+) {
+    Button(
+        onClick = onClick,
+        enabled = isEnabled,
+        modifier = modifier,
+        shape = RoundedCornerShape(4.dp),
+        colors = ButtonDefaults.buttonColors(
+            contentColor = AppColor.White,
+        ),
+    ) {
+        if (isInProgress) {
+            CircularProgressIndicator(
+                color = LocalContentColor.current,
+                strokeWidth = 2.dp,
+                modifier = Modifier.size(20.dp),
+            )
+        } else {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.labelLarge,
+            )
+        }
+    }
+}
+
+@Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PrimaryButtonPreview() {
+    M3Theme {
+        PrimaryButton(text = "Continue", onClick = {})
+    }
+}
+
+@Preview
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PrimaryButtonInProgressPreview() {
+    M3Theme {
+        PrimaryButton(text = "Continue", onClick = {}, isInProgress = true)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
@@ -8,6 +8,8 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.launch
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
@@ -82,7 +84,9 @@ class PurchaseDomainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             M3Theme {
+                val uiState by viewModel.uiStateFlow.collectAsState()
                 PurchaseDomainScreen(
+                    uiState = uiState,
                     onNewDomainCardSelected = viewModel::onNewDomainSelected,
                     onExistingSiteCardSelected = viewModel::onExistingSiteSelected,
                     onBackPressed = viewModel::onBackPressed,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -6,6 +6,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +77,10 @@ class PurchaseDomainViewModel @AssistedInject constructor(
             false
         )
 
-        _uiStateFlow.update { UiState.Initial }
+        launch {
+            delay(loadingStateAnimationResetDelay)
+            _uiStateFlow.update { UiState.Initial }
+        }
 
         if (event.isError) {
             // TODO Handle failed cart creation
@@ -108,6 +112,8 @@ class PurchaseDomainViewModel @AssistedInject constructor(
     }
 
     companion object {
+        const val loadingStateAnimationResetDelay = 1000L
+
         fun provideFactory(assistedFactory: Factory, productId: Int, domain: String, privacy: Boolean) =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -8,6 +8,9 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.UI_THREAD
@@ -25,6 +28,8 @@ class PurchaseDomainViewModel @AssistedInject constructor(
     @Assisted private val domain: String,
     @Assisted private val privacy: Boolean,
 ) : ScopedViewModel(mainDispatcher) {
+    private val _uiStateFlow = MutableStateFlow<UiState>(UiState.Initial)
+    val uiStateFlow = _uiStateFlow.asStateFlow()
     private val _actionEvents = MutableSharedFlow<ActionEvent>()
     val actionEvents: Flow<ActionEvent> = _actionEvents
 
@@ -61,7 +66,7 @@ class PurchaseDomainViewModel @AssistedInject constructor(
     }
 
     private fun createCart(site: SiteModel?, productId: Int, domainName: String, supportsPrivacy: Boolean) = launch {
-        // TODO Show loading indicator
+        _uiStateFlow.update { if (site == null) UiState.SubmittingJustDomainCart else UiState.SubmittingSiteDomainCart }
 
         val event = createCartUseCase.execute(
             site,
@@ -71,7 +76,7 @@ class PurchaseDomainViewModel @AssistedInject constructor(
             false
         )
 
-        // TODO Hide loading indicator
+        _uiStateFlow.update { UiState.Initial }
 
         if (event.isError) {
             // TODO Handle failed cart creation
@@ -82,6 +87,12 @@ class PurchaseDomainViewModel @AssistedInject constructor(
                 _actionEvents.emit(ActionEvent.GoToDomainPurchasing(domain = domain))
             }
         }
+    }
+
+    sealed interface UiState {
+        object Initial : UiState
+        object SubmittingJustDomainCart : UiState
+        object SubmittingSiteDomainCart : UiState
     }
 
     sealed class ActionEvent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
@@ -16,33 +16,32 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.domains.management.M3Theme
+import org.wordpress.android.ui.domains.management.composable.PrimaryButton
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.Initial
 import org.wordpress.android.ui.domains.management.success
 
 @Composable
 fun PurchaseDomainScreen(
+    uiState: UiState,
     onNewDomainCardSelected: () -> Unit,
     onExistingSiteCardSelected: () -> Unit,
     onBackPressed: () -> Unit,
@@ -80,7 +79,7 @@ fun PurchaseDomainScreen(
                 ) {
                     ScreenHeader()
                     ScreenDescription()
-                    DomainCards(onNewDomainCardSelected, onExistingSiteCardSelected)
+                    DomainCards(uiState, onNewDomainCardSelected, onExistingSiteCardSelected)
                     DiscountNotice()
                 }
             }
@@ -90,6 +89,7 @@ fun PurchaseDomainScreen(
 
 @Composable
 private fun DomainCards(
+    uiState: UiState,
     onNewDomainCardSelected: () -> Unit,
     onExistingSiteCardSelected: () -> Unit,
     modifier: Modifier = Modifier,
@@ -98,13 +98,13 @@ private fun DomainCards(
         val arrangement = Arrangement.spacedBy(16.dp)
         if (isPortrait) {
             Column(verticalArrangement = arrangement) {
-                NewDomainCard(onNewDomainCardSelected)
-                ExistingSiteCard(onExistingSiteCardSelected)
+                NewDomainCard(uiState, onNewDomainCardSelected)
+                ExistingSiteCard(uiState, onExistingSiteCardSelected)
             }
         } else {
             Row(horizontalArrangement = arrangement) {
-                NewDomainCard(onNewDomainCardSelected, modifier = Modifier.weight(1f))
-                ExistingSiteCard(onExistingSiteCardSelected, modifier = Modifier.weight(1f))
+                NewDomainCard(uiState, onNewDomainCardSelected, modifier = Modifier.weight(1f))
+                ExistingSiteCard(uiState, onExistingSiteCardSelected, modifier = Modifier.weight(1f))
             }
         }
     }
@@ -149,6 +149,7 @@ private fun DiscountNotice(modifier: Modifier = Modifier) {
 
 @Composable
 private fun NewDomainCard(
+    uiState: UiState,
     onNewDomainCardSelected: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -157,6 +158,8 @@ private fun NewDomainCard(
         title = R.string.purchase_domain_screen_new_domain_card_title,
         description = R.string.purchase_domain_screen_new_domain_card_description,
         button = R.string.purchase_domain_screen_new_domain_card_button,
+        isEnabled = uiState == Initial,
+        isInProgress = uiState == UiState.SubmittingJustDomainCart,
         onOptionSelected = onNewDomainCardSelected,
         modifier = modifier,
     )
@@ -164,6 +167,7 @@ private fun NewDomainCard(
 
 @Composable
 private fun ExistingSiteCard(
+    uiState: UiState,
     onExistingSiteCardSelected: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -172,6 +176,8 @@ private fun ExistingSiteCard(
         title = R.string.purchase_domain_screen_existing_domain_card_title,
         description = R.string.purchase_domain_screen_existing_domain_card_description,
         button = R.string.purchase_domain_screen_existing_domain_card_button,
+        isEnabled = uiState == Initial,
+        isInProgress = uiState == UiState.SubmittingSiteDomainCart,
         onOptionSelected = onExistingSiteCardSelected,
         modifier = modifier,
     )
@@ -183,6 +189,8 @@ private fun DomainOptionCard(
     @StringRes title: Int,
     @StringRes description: Int,
     @StringRes button: Int,
+    isEnabled: Boolean,
+    isInProgress: Boolean,
     onOptionSelected: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -216,32 +224,15 @@ private fun DomainOptionCard(
             ),
             modifier = Modifier.padding(top = 8.dp)
         )
-        Button(
+        PrimaryButton(
+            isEnabled = isEnabled,
+            isInProgress = isInProgress,
             onClick = onOptionSelected,
-            shape = MaterialTheme.shapes.small.copy(CornerSize(36.dp)),
-            elevation = ButtonDefaults.buttonElevation(
-                defaultElevation = 0.dp,
-                pressedElevation = 0.dp,
-                disabledElevation = 0.dp,
-                hoveredElevation = 0.dp,
-                focusedElevation = 0.dp
-            ),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.success
-            ),
+            text = stringResource(button),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 16.dp)
-        ) {
-            Text(
-                text = stringResource(button),
-                modifier = Modifier.padding(vertical = 4.dp),
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    color = Color.White,
-                ),
-                fontWeight = FontWeight.Medium
-            )
-        }
+                .padding(16.dp)
+        )
     }
 }
 
@@ -253,8 +244,8 @@ private val isPortrait: Boolean @Composable get() = LocalConfiguration.current.o
 @Preview(name = "Landscape orientation", device = Devices.AUTOMOTIVE_1024p)
 @Composable
 fun PurchaseDomainScreenPreview() {
-    AppTheme {
-        PurchaseDomainScreen({}, {}, {})
+    M3Theme {
+        PurchaseDomainScreen(Initial, {}, {}, {})
     }
 }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
@@ -26,6 +26,9 @@ import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomain
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoBack
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoToDomainPurchasing
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoToSitePicker
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.Initial
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingJustDomainCart
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingSiteDomainCart
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -58,6 +61,11 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `WHEN ViewModel initialized THEN the ui is set to the Initial state`() {
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+    }
+
+    @Test
     fun `WHEN new domain selected THEN track DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_NEW_DOMAIN_TAPPED event`() {
         viewModel.onNewDomainSelected()
         verify(analyticsTracker).track(DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_NEW_DOMAIN_TAPPED)
@@ -70,6 +78,15 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `WHEN new domain selected THEN the ui is set to the SubmittingJustDomainCart state`() = test {
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+        viewModel.onNewDomainSelected()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(SubmittingJustDomainCart)
+        advanceUntilIdle()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+    }
+
+    @Test
     fun `WHEN a site is chosen THEN track DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_EXISTING_SITE_CHOSEN event`() {
         viewModel.onSiteChosen(testSite)
         verify(analyticsTracker).track(DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_EXISTING_SITE_CHOSEN)
@@ -79,6 +96,15 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     fun `WHEN a site is chosen THEN the cart is submitted with the selected domain`() = test {
         viewModel.onSiteChosen(testSite)
         verify(createCartUseCase, atLeastOnce()).execute(testSite, productId, domain, supportsPrivacy, false, null)
+    }
+
+    @Test
+    fun `WHEN a site is chosen THEN the ui is set to the SubmittingSiteDomainCart state`() = test {
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+        viewModel.onSiteChosen(testSite)
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(SubmittingSiteDomainCart)
+        advanceUntilIdle()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
     }
 
     @Test


### PR DESCRIPTION
Partially #19543 (The error state is added with the follow up PR https://github.com/wordpress-mobile/WordPress-Android/pull/19555)


## Description
This PR:
* Extracts the primary material 3 "rectangle" button and adds an inProgress state (like [the old material button](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt#L34))
* Adds ui states for each type of cart (just domain, site domain)
* Refactors the purchase screen to use the new button and track the loading state

## To test
1. Enable the `domain_management` feature flag
2. Open the domain management (`Me>Domains` or `My Site>More>Domains>ALL)
3. Tap the `Add(+)` button
4. Search for a domain
5. Tap on the domain of your choosing
6. Tap the `Get Domain` button
7. **Verify** that the `Get Domain` button shows a loading indicator
8.  **Verify** that the `Choose Site` button shows is disabled
9. **Verify** that the selected domain is added in the cart
10. Go back
11. Tap the `Choose Site` button
12. Select an existing site
13. **Verify** that the `Choose Site` button shows a loading indicator
14. **Verify** that the `Get Domain` button shows is disabled
15. **Verify** that the selected domain is added in the cart

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/2bfd8e48-ac52-4d2d-95fe-ad8eb98d01de

## Regression Notes
1. Potential unintended areas of impact
Purchase screen and cart creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Added tests in `PurchaseDomainViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)