### PR TITLE
🤖 Adds error state when adding a domain to the cart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
@@ -89,6 +89,7 @@ class PurchaseDomainActivity : AppCompatActivity() {
                     uiState = uiState,
                     onNewDomainCardSelected = viewModel::onNewDomainSelected,
                     onExistingSiteCardSelected = viewModel::onExistingSiteSelected,
+                    onErrorButtonTapped = viewModel::onErrorButtonTapped,
                     onBackPressed = viewModel::onBackPressed,
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModel.kt
@@ -50,6 +50,12 @@ class PurchaseDomainViewModel @AssistedInject constructor(
         }
     }
 
+    fun onErrorButtonTapped() {
+        launch {
+            _uiStateFlow.update { UiState.Initial }
+        }
+    }
+
     fun onSiteChosen(site: SiteModel?) {
         analyticsTracker.track(Stat.DOMAIN_MANAGEMENT_PURCHASE_DOMAIN_SCREEN_EXISTING_SITE_CHOSEN)
         createCart(site, productId, domain, privacy)
@@ -77,14 +83,13 @@ class PurchaseDomainViewModel @AssistedInject constructor(
             false
         )
 
-        launch {
-            delay(loadingStateAnimationResetDelay)
-            _uiStateFlow.update { UiState.Initial }
-        }
-
         if (event.isError) {
-            // TODO Handle failed cart creation
+            _uiStateFlow.update { UiState.ErrorSubmittingCart }
         } else {
+            launch {
+                delay(loadingStateAnimationResetDelay)
+                _uiStateFlow.update { UiState.Initial }
+            }
             if (site != null) {
                 _actionEvents.emit(ActionEvent.GoToExistingSite(domain = domain, siteModel = site))
             } else {
@@ -97,6 +102,8 @@ class PurchaseDomainViewModel @AssistedInject constructor(
         object Initial : UiState
         object SubmittingJustDomainCart : UiState
         object SubmittingSiteDomainCart : UiState
+
+        object ErrorSubmittingCart : UiState
     }
 
     sealed class ActionEvent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -44,6 +45,7 @@ fun PurchaseDomainScreen(
     uiState: UiState,
     onNewDomainCardSelected: () -> Unit,
     onExistingSiteCardSelected: () -> Unit,
+    onErrorButtonTapped: () -> Unit,
     onBackPressed: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -65,22 +67,26 @@ fun PurchaseDomainScreen(
             )
         },
         content = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface)
-                    .padding(it)
-            ) {
-                Column(
+            if (uiState == UiState.ErrorSubmittingCart) {
+                ErrorScreen(onButtonTapped = onErrorButtonTapped)
+            } else {
+                Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(contentScrollState)
-                        .padding(16.dp)
+                        .background(MaterialTheme.colorScheme.surface)
+                        .padding(it)
                 ) {
-                    ScreenHeader()
-                    ScreenDescription()
-                    DomainCards(uiState, onNewDomainCardSelected, onExistingSiteCardSelected)
-                    DiscountNotice()
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(contentScrollState)
+                            .padding(16.dp)
+                    ) {
+                        ScreenHeader()
+                        ScreenDescription()
+                        DomainCards(uiState, onNewDomainCardSelected, onExistingSiteCardSelected)
+                        DiscountNotice()
+                    }
                 }
             }
         }
@@ -236,6 +242,31 @@ private fun DomainOptionCard(
     }
 }
 
+@Composable
+fun ErrorScreen(onButtonTapped: () -> Unit) {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.purchase_domain_screen_error_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.outline,
+        )
+        Text(
+            text = stringResource(R.string.purchase_domain_screen_error_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.outline,
+        )
+        PrimaryButton(
+            text = stringResource(R.string.purchase_domain_screen_error_button_title),
+            onClick = onButtonTapped,
+            modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+        )
+    }
+}
+
 private val isPortrait: Boolean @Composable get() = LocalConfiguration.current.orientation == ORIENTATION_PORTRAIT
 
 @Preview(name = "Light mode", locale = "en")
@@ -245,7 +276,16 @@ private val isPortrait: Boolean @Composable get() = LocalConfiguration.current.o
 @Composable
 fun PurchaseDomainScreenPreview() {
     M3Theme {
-        PurchaseDomainScreen(Initial, {}, {}, {})
+        PurchaseDomainScreen(Initial, {}, {}, {}, {})
+    }
+}
+
+@Preview(name = "Light mode", locale = "en")
+@Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PurchaseDomainScreenErrorPreview() {
+    M3Theme {
+        PurchaseDomainScreen(UiState.ErrorSubmittingCart, {}, {}, {}, {})
     }
 }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2734,6 +2734,9 @@
     <string name="purchase_domain_screen_existing_domain_card_description">Use with a site you already started.</string>
     <string name="purchase_domain_screen_existing_domain_card_button">Choose Site</string>
     <string name="purchase_domain_screen_discount_notice">*A free domain for one year is included with all paid annual plans.</string>
+    <string name="purchase_domain_screen_error_title">Error</string>
+    <string name="purchase_domain_screen_error_subtitle">Something went wrong while adding the domain to the cart. Make sure you are online and retry.</string>
+    <string name="purchase_domain_screen_error_button_title">OK</string>
 
     <!-- Domain Management - Search For A New Domain Screen -->
     <string name="new_domain_search_screen_title">Search for a domain</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainViewModelTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomain
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.Initial
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingJustDomainCart
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.SubmittingSiteDomainCart
+import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.ErrorSubmittingCart
 import org.wordpress.android.ui.domains.usecases.CreateCartUseCase
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -108,6 +109,23 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `WHEN an error occurs while submitting the cart THEN the ui is set to the ErrorSubmittingCart state`() = test {
+        mockCartError()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+        viewModel.onNewDomainSelected()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(ErrorSubmittingCart)
+    }
+
+
+    @Test
+    fun `WHEN the error button is tapped THEN the ui is set to the Initial state`() = test {
+        mockCartError()
+        viewModel.onNewDomainSelected()
+        viewModel.onErrorButtonTapped()
+        assertThat(viewModel.uiStateFlow.value).isEqualTo(Initial)
+    }
+
+    @Test
     fun `WHEN a site is chosen THEN send the GoToExistingSite action event`() = testWithActionEvents { events ->
         viewModel.onSiteChosen(testSite)
         advanceUntilIdle()
@@ -173,6 +191,19 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
         )
     }
 
+    private fun mockCartError() = test {
+        whenever(
+            createCartUseCase.execute(
+                null, productId, domain,
+                isDomainPrivacyEnabled = true,
+                isTemporary = false,
+                planProductId = null
+            )
+        ).thenReturn(
+            TransactionsStore.OnShoppingCartCreated(shoppingCartCreateError)
+        )
+    }
+
     private fun testWithActionEvents(block: suspend TestScope.(events: List<ActionEvent>) -> Unit) = test {
         val actionEvents = mutableListOf<ActionEvent>()
         val job = launch { viewModel.actionEvents.toList(actionEvents) }
@@ -190,5 +221,9 @@ class PurchaseDomainViewModelTest : BaseUnitTest() {
         private const val supportsPrivacy = true
         private val testSite = SiteModel().also { it.siteId = siteId }
         private val testProduct = Product(productId, domain, Extra(privacy = true))
+        private val shoppingCartCreateError = TransactionsStore.CreateShoppingCartError(
+            TransactionsStore.CreateCartErrorType.GENERIC_ERROR,
+            "Error Creating Cart"
+        )
     }
 }


### PR DESCRIPTION
Fixes #19543

**Based on:** https://github.com/wordpress-mobile/WordPress-Android/pull/19554

## Description
This PR adds error state when adding a domain to the cart

## To test
1. Enable the `domain_management` feature flag
2. Open the domain management (`Me>Domains` or `My Site>More>Domains>ALL)
3. Tap the `Add(+)` button
4. Search for a domain
5. Tap on the domain of your choosing
6. Set the device on flight mode
7. Tap the `Get Domain` button
8. **Verify** that the error screen is shown
9. Tap `OK`
10. Disable flight mode
11. **Verify** that the selected domain is added in the cart

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/38846516-4c20-4f01-837a-ddbe2a64f171

## Regression Notes
1. Potential unintended areas of impact
Purchase screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Added tests in `PurchaseDomainViewModelTest`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
