### PR TITLE
Adds site picker simple mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
@@ -50,7 +50,7 @@ class PurchaseDomainActivity : AppCompatActivity() {
         object : ActivityResultContract<Unit, SiteModel?>() {
             override fun createIntent(context: Context, input: Unit) =
                 Intent(context, SitePickerActivity::class.java).apply {
-                    putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.DEFAULT_MODE)
+                    putExtra(SitePickerActivity.KEY_SITE_PICKER_MODE, SitePickerMode.SIMPLE_MODE)
                 }
 
             override fun parseResult(resultCode: Int, intent: Intent?) =

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -162,7 +162,10 @@ public class SitePickerActivity extends LocaleAwareActivity
                 unitEvent -> unitEvent.applyIfNotHandled(action -> {
                     switch (action.getActionType()) {
                         case NAVIGATE_TO_STATE:
-                            if (!(mSitePickerMode != null && mSitePickerMode.isReblogMode())) break;
+                            if (!(mSitePickerMode != null
+                                  && (mSitePickerMode.isReblogMode() || mSitePickerMode.isSimpleMode()))) {
+                                break;
+                            }
                             switch (((NavigateToState) action).getNavigateState()) {
                                 case TO_SITE_SELECTED:
                                     mSitePickerMode = SitePickerMode.REBLOG_CONTINUE_MODE;
@@ -186,7 +189,10 @@ public class SitePickerActivity extends LocaleAwareActivity
                             }
                             break;
                         case CONTINUE_REBLOG_TO:
-                            if (!(mSitePickerMode != null && mSitePickerMode.isReblogMode())) break;
+                            if (!(mSitePickerMode != null && (mSitePickerMode.isReblogMode()
+                                                              || mSitePickerMode.isSimpleMode()))) {
+                                break;
+                            }
                             SiteRecord siteToReblog = ((ContinueReblogTo) action).getSiteForReblog();
                             if (siteToReblog != null) selectSiteAndFinish(siteToReblog);
                             break;
@@ -273,6 +279,7 @@ public class SitePickerActivity extends LocaleAwareActivity
         if (getAdapter().getIsInSearchMode()
             || mSitePickerMode == null
             || mSitePickerMode.isReblogMode()
+            || mSitePickerMode.isSimpleMode()
             || mSitePickerMode.isBloggingPromptsMode()) {
             mMenuEdit.setVisible(false);
             mMenuAdd.setVisible(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -82,6 +82,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             return this == REBLOG_SELECT_MODE || this == REBLOG_CONTINUE_MODE;
         }
 
+        public boolean isSimpleMode() {
+            return this == SIMPLE_MODE;
+        }
+
         public boolean isBloggingPromptsMode() {
             return this == BLOGGING_PROMPTS_MODE;
         }
@@ -345,7 +349,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 DisplayUtils.dpToPx(holder.itemView.getContext(), 4));
 
         if ((site.mLocalId == mCurrentLocalId && !mIsMultiSelectEnabled
-             && mSitePickerMode == SitePickerMode.DEFAULT_MODE)
+             && (mSitePickerMode == SitePickerMode.DEFAULT_MODE || mSitePickerMode.isSimpleMode()))
             || (mIsMultiSelectEnabled && isItemSelected(position))
             || (mSitePickerMode == SitePickerMode.REBLOG_CONTINUE_MODE && mSelectedLocalId == site.mLocalId)) {
             holder.mLayoutContainer.setBackgroundColor(mSelectedItemBackground);
@@ -695,7 +699,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     public List<SiteModel> getBlogsForCurrentView() {
-        if (mSitePickerMode.isReblogMode() || mSitePickerMode.isBloggingPromptsMode()) {
+        if (mSitePickerMode.isReblogMode() || mSitePickerMode.isBloggingPromptsMode()
+            || mSitePickerMode.isSimpleMode()) {
             // If we are reblogging we only want to select or search into the WPCom visible sites.
             return mSiteStore.getVisibleSitesAccessedViaWPCom();
         } else if (mIsInSearchMode) {


### PR DESCRIPTION
Fixes #19381

## Description
Implements and uses a simple site picker mode where only the search button is visible 

|Before|After|
|---|---|
|![Screenshot_20231108_113219](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/7a16132d-66c2-44c5-9d43-86ee33ceb933)|![Screenshot_20231108_113028](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/baf95c6f-d8f5-4f43-9aa4-80f49e8d9898)|

## To test
1. Enable the `domain_management` feature flag
2. Open the domain management (`Me>Domains` or `My Site>More>Domains>ALL)
3. Tap the `Add(+)` button
4. Search for a domain
5. Tap on the domain of your choosing
6. Tap the `Choose Site` button
7. Set the device on flight mode
8. Tap the `Get Domain` button
9. **Verify** that only the search header button is available

## Regression Notes
1. Potential unintended areas of impact
SitePicker

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
This is a UI change that would require major changes to the site picker implementation to be testable

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
