### PR TITLE
Fixes: Create Page not working from pages card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -715,7 +715,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             action.activityId,
             action.isRewindable
         )
-        is SiteNavigationAction.TriggerCreatePageFlow -> Unit // no-op
+        is SiteNavigationAction.TriggerCreatePageFlow -> wpMainActivityViewModel.triggerCreatePageFlow()
         is SiteNavigationAction.OpenPagesDraftsTab -> ActivityLauncher.viewCurrentBlogPagesOfType(
             requireActivity(),
             action.site,


### PR DESCRIPTION
## Closes
#19559

## Description
This PR fixes the issue - when clicking on create another page, the pages card was not triggering the page creation flow.

## To test:
1. Login to the jetpack app with a site having edit page capability
2. Go to Dashboard
3. Click on Create a page in pages card 
4. Verify that the pages creation flow is started

## Regression Notes
1. Potential unintended areas of impact
Create page click doesn't work

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
