### PR TITLE
🤖 Prevent navigation outside the domain details webview

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -804,7 +804,7 @@
             android:theme="@style/WordPress.NoActionBar" />
 
         <activity
-            android:name=".ui.domains.management.DomainManagementDetailsActivity"
+            android:name=".ui.domains.management.details.DomainManagementDetailsActivity"
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.domains.management.purchasedomain.PurchaseDomainActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailWebViewNavigationDelegate.kt
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail
 
-import android.net.Uri
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate
 
-object CampaignDetailWebViewNavigationDelegate {
-    private val allowedUrls = listOf(
+object CampaignDetailWebViewNavigationDelegate : AbstractAllowedUrlsWebViewNavigationDelegate() {
+    override val allowedUrls = listOf(
         UrlMatcher(
             "wordpress.com".toRegex(),
             listOf(
@@ -11,19 +11,4 @@ object CampaignDetailWebViewNavigationDelegate {
             )
         )
     )
-
-    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
-
-    data class UrlMatcher(
-        private val host: Regex,
-        private val paths: List<Regex>
-    ) {
-        private fun matchesHost(url: Url) = url.host.matches(host)
-        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
-        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
-    }
-
-    data class Url(val host: String, val path: String)
-
-    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegate.kt
@@ -1,10 +1,11 @@
 package org.wordpress.android.ui.domains
 
-import android.net.Uri
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate
 
-object DomainRegistrationCheckoutWebViewNavigationDelegate {
+object DomainRegistrationCheckoutWebViewNavigationDelegate : AbstractAllowedUrlsWebViewNavigationDelegate() {
     private val optionalLanguagePath = "(?:/(?:\\w{2}-)?\\w{2})?".toRegex()
-    private val allowedUrls = listOf(
+
+    override val allowedUrls = listOf(
         UrlMatcher(
             ".*wordpress.com".toRegex(),
             listOf(
@@ -17,19 +18,4 @@ object DomainRegistrationCheckoutWebViewNavigationDelegate {
             )
         )
     )
-
-    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
-
-    data class UrlMatcher(
-        private val host: Regex,
-        private val paths: List<Regex>
-    ) {
-        private fun matchesHost(url: Url) = url.host.matches(host)
-        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
-        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
-    }
-
-    data class Url(val host: String, val path: String)
-
-    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.domains.management.details.DomainManagementDetailsActivity
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsActivity.kt
@@ -1,12 +1,14 @@
-package org.wordpress.android.ui.domains.management
+package org.wordpress.android.ui.domains.management.details
 
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 
-class DomainManagementDetailsActivity : WPWebViewActivity() {
+class DomainManagementDetailsActivity : WPWebViewActivity(),
+    DomainManagementDetailsWebViewClient.DomainManagementWebViewClientListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toggleNavbarVisibility(false)
@@ -15,6 +17,12 @@ class DomainManagementDetailsActivity : WPWebViewActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // We don't want any menu items
         return true
+    }
+
+    override fun createWebViewClient(allowedURL: List<String>?) = DomainManagementDetailsWebViewClient(this)
+
+    override fun onRedirectToExternalBrowser(url: String) {
+        ActivityLauncher.openUrlExternal(this, url)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewClient.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.domains.management.details
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import org.wordpress.android.ui.domains.management.details.DomainManagementDetailsWebViewNavigationDelegate.toUrl
+import org.wordpress.android.util.ErrorManagedWebViewClient
+
+class DomainManagementDetailsWebViewClient(
+    private val listener: DomainManagementWebViewClientListener
+) : ErrorManagedWebViewClient(listener) {
+    interface DomainManagementWebViewClientListener : ErrorManagedWebViewClientListener {
+        fun onRedirectToExternalBrowser(url: String)
+    }
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest) : Boolean {
+        if (canNavigateTo(request.url)) return false
+        listener.onRedirectToExternalBrowser(request.url.toString())
+        return true
+    }
+
+    private fun canNavigateTo(uri: Uri) =
+        DomainManagementDetailsWebViewNavigationDelegate.canNavigateTo(uri.toUrl())
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewClient.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewClient.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.domains.management.details
 
-import android.net.Uri
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import org.wordpress.android.ui.domains.management.details.DomainManagementDetailsWebViewNavigationDelegate.toUrl
@@ -9,16 +8,15 @@ import org.wordpress.android.util.ErrorManagedWebViewClient
 class DomainManagementDetailsWebViewClient(
     private val listener: DomainManagementWebViewClientListener
 ) : ErrorManagedWebViewClient(listener) {
+    private val navigationDelegate = DomainManagementDetailsWebViewNavigationDelegate
+
     interface DomainManagementWebViewClientListener : ErrorManagedWebViewClientListener {
         fun onRedirectToExternalBrowser(url: String)
     }
 
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest) : Boolean {
-        if (canNavigateTo(request.url)) return false
+        if (navigationDelegate.canNavigateTo(request.url.toUrl())) return false
         listener.onRedirectToExternalBrowser(request.url.toString())
         return true
     }
-
-    private fun canNavigateTo(uri: Uri) =
-        DomainManagementDetailsWebViewNavigationDelegate.canNavigateTo(uri.toUrl())
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegate.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.domains.management.details
+
+import android.net.Uri
+
+object DomainManagementDetailsWebViewNavigationDelegate {
+    private val allowedUrls = listOf(
+        UrlMatcher(
+            "wordpress.com".toRegex(),
+            listOf("/domains.*".toRegex())
+        )
+    )
+
+    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
+
+    data class UrlMatcher(
+        private val host: Regex,
+        private val paths: List<Regex>
+    ) {
+        private fun matchesHost(url: Url) = url.host.matches(host)
+        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
+        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
+    }
+
+    data class Url(val host: String, val path: String)
+
+    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegate.kt
@@ -1,27 +1,12 @@
 package org.wordpress.android.ui.domains.management.details
 
-import android.net.Uri
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate
 
-object DomainManagementDetailsWebViewNavigationDelegate {
-    private val allowedUrls = listOf(
+object DomainManagementDetailsWebViewNavigationDelegate: AbstractAllowedUrlsWebViewNavigationDelegate() {
+    override val allowedUrls = listOf(
         UrlMatcher(
             "wordpress.com".toRegex(),
             listOf("/domains.*".toRegex())
         )
     )
-
-    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
-
-    data class UrlMatcher(
-        private val host: Regex,
-        private val paths: List<Regex>
-    ) {
-        private fun matchesHost(url: Url) = url.host.matches(host)
-        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
-        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
-    }
-
-    data class Url(val host: String, val path: String)
-
-    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/AbstractAllowedUrlsWebViewNavigationDelegate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/AbstractAllowedUrlsWebViewNavigationDelegate.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.utils
+
+import android.net.Uri
+
+abstract class AbstractAllowedUrlsWebViewNavigationDelegate {
+    abstract val allowedUrls: List<UrlMatcher>
+
+    fun canNavigateTo(url: Url) = allowedUrls.any { it.matches(url) }
+
+    data class UrlMatcher(
+        private val host: Regex,
+        private val paths: List<Regex>
+    ) {
+        private fun matchesHost(url: Url) = url.host.matches(host)
+        private fun matchesPath(url: Url) = paths.any { url.path.matches(it) }
+        fun matches(url: Url) = matchesHost(url) && matchesPath(url)
+    }
+
+    data class Url(val host: String, val path: String)
+
+    fun Uri.toUrl() = Url(host.orEmpty(), path.orEmpty())
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignDetailWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/CampaignDetailWebViewNavigationDelegateTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailWebViewNavigationDelegate
-import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailWebViewNavigationDelegate.Url
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate.Url
 
 @ExperimentalCoroutinesApi
 class CampaignDetailWebViewNavigationDelegateTest : BaseUnitTest() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainRegistrationCheckoutWebViewNavigationDelegateTest.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewNavigationDelegate.Url
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate.Url
 
 @ExperimentalCoroutinesApi
 class DomainRegistrationCheckoutWebViewNavigationDelegateTest : BaseUnitTest() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegateTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.utils.AbstractAllowedUrlsWebViewNavigationDelegate.Url
 
 @ExperimentalCoroutinesApi
 class DomainManagementDetailsWebViewNavigationDelegateTest : BaseUnitTest() {
@@ -46,8 +47,7 @@ class DomainManagementDetailsWebViewNavigationDelegateTest : BaseUnitTest() {
     }
 
     companion object {
-        private fun buildUrls(vararg paths: String, host: String = "wordpress.com") = paths.toList().map {
-            DomainManagementDetailsWebViewNavigationDelegate.Url(host, it)
-        }
+        private fun buildUrls(vararg paths: String, host: String = "wordpress.com") =
+            paths.toList().map { Url(host, it) }
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegateTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/details/DomainManagementDetailsWebViewNavigationDelegateTest.kt
@@ -1,0 +1,53 @@
+package org.wordpress.android.ui.domains.management.details
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+
+@ExperimentalCoroutinesApi
+class DomainManagementDetailsWebViewNavigationDelegateTest : BaseUnitTest() {
+    private val navigationDelegate = DomainManagementDetailsWebViewNavigationDelegate
+
+    @Test
+    fun `when browsing in the domains path, then the web view can navigate`() {
+        Assertions.assertThat(
+            buildUrls(
+                "/domains/manage/all/some.domain/edit/some.domain", // standard details page
+                "/domains/mapping/some.domain/setup/some.domain?step=&show-errors=false&firstVisit=false" // fix errors
+            )
+        ).allMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `when browsing outside the domains path, then the web view cannot navigate`() {
+        Assertions.assertThat(
+            buildUrls(
+                "/email/antonis.me/manage/some.domain", // setup email
+                "/support/domains/https-ssl/" // support
+            )
+        ).noneMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    @Test
+    fun `when browsing outside in another host, then the web view cannot navigate`() {
+        Assertions.assertThat(
+            buildUrls(
+                "/domains/manage/all/some.domain/edit/some.domain",
+                host = "google.com"
+            )
+        ).noneMatch {
+            navigationDelegate.canNavigateTo(it)
+        }
+    }
+
+    companion object {
+        private fun buildUrls(vararg paths: String, host: String = "wordpress.com") = paths.toList().map {
+            DomainManagementDetailsWebViewNavigationDelegate.Url(host, it)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #19501

## Description
This PR prevents navigation outside of the domain details context. Any other url is intercepted and opened in the device’s browser instead.
It also extracts the common navigation delegate functionality used in two other places with https://github.com/wordpress-mobile/WordPress-Android/pull/19570/commits/d52d5b8bdb978c448f888f360a7da7368fd0a0a3

## To test:

1. Enable the `domain_management` feature flag
2. Open the domain management (`Me>Domains` or `My Site>More>Domains>ALL)
3. Tap on a domain
4. **Verify** that the details page opens
5. Try to browse outside the domains scope (e.g. by visiting a support page)
6. **Verify** that the link opens in an external browser

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/fb3ba217-6cda-4481-bd1e-4311b58d7025

## Regression Notes
1. Potential unintended areas of impact
campaign details webview and domain registration webview 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and relied on existing `DomainRegistrationCheckoutWebViewNavigationDelegateTest` and `CampaignDetailWebViewNavigationDelegateTest`

4. What automated tests I added (or what prevented me from doing so)
Added `DomainManagementDetailsWebViewNavigationDelegateTest`

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
