### PR TITLE
Add error handling to new domain search screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/ErrorScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/ErrorScreen.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.domains.management
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,11 +22,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import kotlinx.coroutines.launch
-import org.wordpress.android.R
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun ErrorScreen(onRefresh: () -> Unit) {
+fun ErrorScreen(
+    @StringRes titleRes: Int,
+    @StringRes descriptionRes: Int,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     val refreshScope = rememberCoroutineScope()
     val isRefreshing by remember { mutableStateOf(false) }
     val refreshState = rememberPullRefreshState(
@@ -33,7 +38,7 @@ fun ErrorScreen(onRefresh: () -> Unit) {
         onRefresh = { refreshScope.launch { onRefresh() } },
     )
 
-    Box(Modifier.pullRefresh(refreshState)) {
+    Box(modifier.pullRefresh(refreshState)) {
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -42,12 +47,12 @@ fun ErrorScreen(onRefresh: () -> Unit) {
                 .verticalScroll(rememberScrollState()),
         ) {
             Text(
-                text = stringResource(R.string.domain_management_error_title),
+                text = stringResource(titleRes),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.outline,
             )
             Text(
-                text = stringResource(R.string.domain_management_error_subtitle),
+                text = stringResource(descriptionRes),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.outline,
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
@@ -99,7 +99,11 @@ fun MyDomainsScreen(
                     onDomainTapped,
                 )
 
-                Error -> ErrorScreen(onRefresh)
+                Error -> ErrorScreen(
+                    titleRes = R.string.domain_management_error_title,
+                    descriptionRes = R.string.domain_management_error_subtitle,
+                    onRefresh = onRefresh
+                )
                 Empty -> EmptyScreen(onFindDomainTapped)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchActivity.kt
@@ -30,6 +30,7 @@ class NewDomainSearchActivity : AppCompatActivity() {
                 NewDomainSearchScreen(
                     uiState = uiState,
                     onSearchQueryChanged = viewModel::onSearchQueryChanged,
+                    onRefresh = viewModel::onRefresh,
                     onTransferDomainClicked = viewModel::onTransferDomainClicked,
                     onDomainTapped = viewModel::onDomainTapped,
                     onBackPressed = viewModel::onBackPressed,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchViewModel.kt
@@ -72,6 +72,15 @@ class NewDomainSearchViewModel @Inject constructor(
         }
     }
 
+    fun onRefresh() {
+        launch {
+            val query = debouncedQuery.value.trim()
+            if (query.isEmpty()) return@launch
+            val result = fetchDomains(query)
+            handleDomainsResult(result)
+        }
+    }
+
     fun onTransferDomainClicked() {
         analyticsTracker.track(AnalyticsTracker.Stat.DOMAIN_MANAGEMENT_TRANSFER_DOMAIN_TAPPED)
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/composable/NewDomainSearchScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/composable/NewDomainSearchScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.zIndex
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.domains.management.ErrorScreen
 import org.wordpress.android.ui.domains.management.composable.DomainsSearchTextField
 import org.wordpress.android.ui.domains.management.composable.PendingGhostStrip
 import org.wordpress.android.ui.domains.management.newdomainsearch.NewDomainSearchViewModel.UiState
@@ -44,6 +45,7 @@ import org.wordpress.android.ui.domains.management.success
 fun NewDomainSearchScreen(
     uiState: UiState,
     onSearchQueryChanged: (String) -> Unit,
+    onRefresh: () -> Unit,
     onTransferDomainClicked: () -> Unit,
     onDomainTapped: (domain: ProposedDomain) -> Unit,
     onBackPressed: () -> Unit,
@@ -79,7 +81,12 @@ fun NewDomainSearchScreen(
                         modifier = Modifier.weight(1f)
                     )
                     is UiState.Loading -> LoadingPlaceholder(modifier = Modifier.weight(1f))
-                    is UiState.Error -> Spacer(modifier = Modifier.weight(1f))
+                    is UiState.Error -> ErrorScreen(
+                        titleRes = R.string.new_domain_search_screen_error_title,
+                        descriptionRes = R.string.new_domain_search_screen_error_subtitle,
+                        onRefresh = onRefresh,
+                        modifier = Modifier.weight(1f)
+                    )
                 }
                 TransferDomainFooter(onTransferDomainClicked = onTransferDomainClicked)
             }
@@ -243,6 +250,7 @@ fun NewDomainSearchScreenPreview() {
             )
         ),
         onSearchQueryChanged = {},
+        onRefresh = {},
         onTransferDomainClicked = {},
         onDomainTapped = {},
         onBackPressed = {}

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/composable/NewDomainSearchScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/composable/NewDomainSearchScreen.kt
@@ -83,7 +83,7 @@ fun NewDomainSearchScreen(
                     is UiState.Loading -> LoadingPlaceholder(modifier = Modifier.weight(1f))
                     is UiState.Error -> ErrorScreen(
                         titleRes = R.string.new_domain_search_screen_error_title,
-                        descriptionRes = R.string.new_domain_search_screen_error_subtitle,
+                        descriptionRes = R.string.domain_management_error_subtitle,
                         onRefresh = onRefresh,
                         modifier = Modifier.weight(1f)
                     )

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2746,7 +2746,6 @@
     <string name="new_domain_search_screen_list_item_regular_price">%s / year</string>
     <string name="new_domain_search_screen_list_item_sale_price">%s for the first year</string>
     <string name="new_domain_search_screen_error_title">Couldn\'t retrieve domains</string>
-    <string name="new_domain_search_screen_error_subtitle">Check that you\'re online and pull to refresh.</string>
 
     <!-- Automated Transfer Eligibility Errors -->
     <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2745,6 +2745,8 @@
     <string name="new_domain_search_screen_transfer_domain_button">Transfer domain</string>
     <string name="new_domain_search_screen_list_item_regular_price">%s / year</string>
     <string name="new_domain_search_screen_list_item_sale_price">%s for the first year</string>
+    <string name="new_domain_search_screen_error_title">Couldn\'t retrieve domains</string>
+    <string name="new_domain_search_screen_error_subtitle">Check that you\'re online and pull to refresh.</string>
 
     <!-- Automated Transfer Eligibility Errors -->
     <string name="plugin_install_site_ineligible_default_error">If you just registered a domain name, please wait until we finish setting it up and try again.\n\nIf not, looks like something went wrong and plugin feature might not be available for this site.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchViewModelTest.kt
@@ -219,6 +219,29 @@ class NewDomainSearchViewModelTest : BaseUnitTest() {
         verifyNoInteractions(repository)
     }
 
+    @Test
+    fun `GIVEN empty saved query WHEN onRefresh THEN do not fetch domains`() =
+        test {
+            viewModel.onRefresh()
+            advanceUntilIdle()
+
+            verifyNoInteractions(repository)
+        }
+
+    @Test
+    fun `GIVEN recent search call returns error WHEN onRefresh THEN fetch domains with the saved query`() =
+        testWithUiStates { states ->
+            whenever(repository.searchForDomains("query")).thenReturn(DomainsResult.Error)
+            viewModel.onSearchQueryChanged("query")
+            val domains = listOf(ProposedDomain(0, "", "", "", true))
+            whenever(repository.searchForDomains("query")).thenReturn(DomainsResult.Success(domains))
+
+            viewModel.onRefresh()
+            advanceUntilIdle()
+
+            assertThat(states.last()).isEqualTo(UiState.PopulatedDomains(domains = domains))
+        }
+
     @Suppress("MaxLineLength")
     @Test
     fun `GIVEN repeated queries with redundant blank symbols WHEN onSearchQueryChanged THEN fetch domains only once`() =


### PR DESCRIPTION
Fixes #19578

This PR contains an error handling on the domain search screen that allows users to see an error message if an API call error response and to pull to refresh to try again.

To test:
- Enable `domain_management` feature flag
- Go to Me -> Domains -> (+)
- Go offline and input some search query
- [x] Ensure you can see an error message on the screen
- Go to online and pull to refresh
- [x] Make sure you can see retrieved domains


https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/e5252e96-b3de-436b-aef3-abed1d3d6e5c


## Regression Notes
1. Potential unintended areas of impact
Domain search screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, Unit testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
