### PR TITLE
Fixes: Dashboard showing data when there is no sites 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -382,9 +382,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.setupObservers() {
         viewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             hideRefreshIndicatorIfNeeded()
-            when (val state = uiModel) {
-                is State.SiteSelected -> loadData(state)
-                is State.NoSites -> loadEmptyView(state)
+            when (uiModel) {
+                is State.SiteSelected -> loadData(uiModel)
+                is State.NoSites -> loadEmptyView(uiModel)
             }
         }
         viewModel.onBasicDialogShown.observeEvent(viewLifecycleOwner) { model ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -564,6 +564,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
 
     private fun MySiteFragmentBinding.loadEmptyView(state: State.NoSites) {
+        recyclerView.setVisible(false)
+        siteInfo.siteInfoCard.setVisible(false)
+
         if (!noSitesView.actionableEmptyView.isVisible) {
             noSitesView.actionableEmptyView.setVisible(true)
             noSitesView.actionableEmptyView.image.setVisible(state.shouldShowImage)


### PR DESCRIPTION
## Closes 
#19587 

## Description
This PR fixes the UI of 
1. Jetpack app - Dashboard shows self hosted site details when logged out of WP com account
2. Wordpress app - Dashboard shows no sites message when the site is deleted. 

## To test:
### Jetpack app
1. Login to the jetpack app with a wp.com account 
2. Add a self hosted site 
3. Switch to the self hosted site 
4. Logout of wordpress account by Me → Logout 
5. Go to dashboard
6. Verify that the self hosted site details are shown 

###. Wordpress app
1. Login to the App with a wp.com account having one site 
2. Delete the site 
3. Verify that the dashboard shows no sites message 

## Regression Notes
1. Potential unintended areas of impact
No Sites view is not correct 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
