### PR TITLE
Adds: the logic to handle site removed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.menu
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -61,6 +62,7 @@ import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.SiteSettingsFragment
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
@@ -100,6 +102,14 @@ class MenuActivity : AppCompatActivity() {
                     MenuScreen()
                 }
             }
+        }
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (resultCode == SiteSettingsFragment.RESULT_BLOG_REMOVED) {
+            viewModel.handleSiteRemoved()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuViewModel.kt
@@ -282,6 +282,12 @@ class MenuViewModel @Inject constructor(
         removeFocusPoints()
     }
 
+    fun handleSiteRemoved() {
+        selectedSiteRepository.removeSite()
+        _onSelectedSiteMissing.value = Unit
+        return
+    }
+
     data class SnackbarMessage(
         val message: String,
         val actionLabel: String? = null,


### PR DESCRIPTION
## Closes
#19441

## Description
This PR fixes the issue in which a site was deleted and the dashboard was not reflected

## Root cause 
When clicked on site settings option in `MenuActivity` or `WPMainActivity`, the Site settings fragment - `BlogPreferencesActivity` is started as an activity for result. When we migrated the site settings options to **Menu Screen**, `onActivityResult` was not added to respond to the result code returned by `BlogPreferencesActivity`. In this PR, `onActivityResult` is added in `MenuActivity` to handle blog removed scenario.

Note: The `OnActivityResult` in `WPMainActivity` is not removed as the site settings can be opened from it in wordpress app or when site settings option is present in Quicklinks through personalization


| Before   |  After |  
|---|---|
| https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/8bda3335-e86e-4f5c-bf57-3b43da069009 | https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/d811ae28-6c99-4293-bf25-8ddf029a9b03 |   

## To test:
### Delete one and only site - JP App
1. Login to the jetpack app with an account having only one site 
2. Go to More → Site Settings → Delete Site 
3. Verify that the user is navigated back to dashboard with empty sites screen 

### Delete one and only site - WP app 
1. Login to the Wp app with an account having only one site 
2. Go to More → Site Settings → Delete Site 
3. Verify that the user is navigated back to dashboard with empty sites screen 

### Regression - Delete one site from multiple sites
1. Login to the WP app with an account having multiple sites
2. Go to More → Site Settings → Delete Site 
3. Verify that the user is navigated back to dashboard with the first site selected

## Regression Notes
1. Potential unintended areas of impact
Deleting a site is not working as intended

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)