### PR TITLE
Fix: Site info header not showing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -560,6 +560,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         siteInfoContainer.subtitle.text = siteInfoHeader.url
         siteInfoContainer.subtitle.setOnClickListener { siteInfoHeader.onUrlClick.click() }
         switchSite.setOnClickListener { siteInfoHeader.onSwitchSiteClick.click() }
+        siteInfoCard.visibility = View.VISIBLE
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -523,6 +523,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
     private fun MySiteFragmentBinding.loadData(state: State.SiteSelected) {
         appbarMain.visibility = View.VISIBLE
         siteInfo.loadMySiteDetails(state.siteInfoHeader)
+        appbarMain.setExpanded(true, true)
 
         recyclerView.setVisible(true)
         (recyclerView.adapter as? MySiteAdapter)?.submitList(state.dashboardData)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -267,7 +267,7 @@ class MySiteViewModel @Inject constructor(
         }
 
     val uiModel: LiveData<State> = merge(state, quickLinks) { cards, quickLinks ->
-        val nonNullCards = cards ?: return@merge buildNoSiteState(cards?.currentAvatarUrl, cards?.avatarName)
+        val nonNullCards = cards ?: return@merge buildNoSiteState(null, null)
         with(nonNullCards) {
             val state = if (site != null) {
                 cardsUpdate?.checkAndShowSnackbarError()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -360,7 +360,7 @@ class MySiteViewModel @Inject constructor(
                 getPositionOfQuickStartItem(siteItems)
             )
         }
-        // It is okay to use !! here because we are explicitly creating the lists
+
         return SiteSelected(
             siteInfoHeader = siteInfo,
             dashboardData = siteItems


### PR DESCRIPTION
This PR fixes an issue in which the siteHeader was not showing after creating a new site. This was identified during the cft. See the following for more info: pcdRpT-4na-p2#comment-7341

The issue arose when the header was configured to be hidden during the EmptyViewState handling, yet it remained invisible when the siteInfoHeader needs to be displayed.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

**To recreate issue**
- Install the current beta build
- Follow the sign up flow
- After you are signed up and the app has launched again
- Create a new wp site
- Follow the create process through to the end
- Verify the site header is not shown

**Test that the issue has been fixed**
- Install the app associated with this PR
- Follow the sign up flow
- After you are signed up and the app has launched again
- Create a new wp site
- Follow the create process through to the end
- Verify the site header is not shown
-----

## Regression Notes

1. Potential unintended areas of impact
The site header is still not showing

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)


-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: N/A