### PR TITLE
Ui Modernization: Posts and Pages release notes and minor tweaks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,8 @@
 * [***] [Jetpack-only] Added the All Domains screen enabling the users to manage their domains from within the app [https://github.com/wordpress-mobile/WordPress-Android/pull/19599]
 * [*] Block Editor: Fix error when pasting deeply nested structure content [https://github.com/WordPress/gutenberg/pull/55613]
 * [*] Block Editor: Fix crash related to accessing undefined value in `TextColorEdit` [https://github.com/WordPress/gutenberg/pull/55664]
+* [**] Posts & Pages: Redesigned the posts and pages screen. We’ve consolidated the “default” and “compact” display options [https://github.com/wordpress-mobile/WordPress-Android/issues/19341] &  [https://github.com/wordpress-mobile/WordPress-Android/issues/19348]
+* [*] Posts & Pages: Moved actions to a context menu and added new actions such as “comment”, “settings”  [https://github.com/wordpress-mobile/WordPress-Android/issues/19343] & [https://github.com/wordpress-mobile/WordPress-Android/issues/19356]
 
 23.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesListActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesListActions.kt
@@ -71,7 +71,6 @@ enum class PagesListAction(
     PROMOTE_WITH_BLAZE(
         R.string.pages_promote_with_blaze,
         R.drawable.ic_blaze_flame_24dp,
-        0,
         actionGroup = ActionGroup.SHARE_AND_PROMOTE,
         positionInGroup = 2,
     ),

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButtonType.kt
@@ -162,7 +162,7 @@ enum class PostListButtonType constructor(
         18,
         R.string.button_promote_with_blaze,
         R.drawable.ic_blaze_flame_24dp,
-        0,
+        MaterialR.attr.colorOnSurface,
         SHARE_AND_PROMOTE_GROUP_ID,
         2
     ),

--- a/WordPress/src/main/res/layout/page_list_item.xml
+++ b/WordPress/src/main/res/layout/page_list_item.xml
@@ -110,6 +110,7 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/more"
             android:src="@drawable/gb_ic_more_vertical"
+            android:padding="8dp"
             app:tint="?attr/colorOnSurface"
             app:layout_constraintBottom_toBottomOf="@+id/featured_image"
             app:layout_constraintEnd_toEndOf="parent"

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -48,6 +48,7 @@
             android:layout_height="wrap_content"
             android:importantForAccessibility="no"
             android:src="@drawable/gb_ic_more_vertical"
+            android:padding="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
This PR makes minor changes to pages/posts
- Sets the blaze icon color to colorOnSurface so it shows properly in dark mode
- Add 8dp of padding to the more icon on the pages/posts list item to give it more tap space
- Add release notes for pages/posts

-----

## To Test:
- Install the JP app
- Login and select a site that has pages and posts
- Turn your device to dark mode
- Navigate to My Site > Posts
- Locate an item within the published posts list that is eligible for blaze
- Tap on the more icon
- ✅ Verify the blaze icon color matches the rest of the icons within the context menu
- Navigate back to My Site > Pages
- Locate an item within the published pages list that is eligible for blaze
- Tap on the more icon
- ✅ Verify the blaze icon color matches the rest of the icons within the context menu

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact
The blaze icon still shows as black when in dark mode

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: 
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
