### PR TITLE
Revert "[Reader] Update limit of fetched tag posts from 20 to 7 in Reader"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.reader;
 
 public class ReaderConstants {
     // max # posts to request when updating posts
-    public static final int READER_MAX_POSTS_TO_REQUEST = 7;
+    public static final int READER_MAX_POSTS_TO_REQUEST = 20;
 
     // max # results to request when searching posts & sites
     public static final int READER_MAX_SEARCH_RESULTS_TO_REQUEST = 20;


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#19473

In @develric's tests he found that the new fetch limit makes creates a bad experience with the inserted items animation (easily seen if you search for a tag and scroll down, for example). I suspect this already existed for a long time but the new limit makes it more obvious. We're reverting this [until adding new items without shifting the existing ones is fixed](https://github.com/wordpress-mobile/WordPress-Android/issues/19627).