### PR TITLE
Jetpack Focus: Implement no-sites user migration path

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/ContentMigrationAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/ContentMigrationAnalyticsTracker.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.localcontentmigration
 
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker.ErrorType.Companion.ERROR_TYPE
+import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker.ErrorType.Companion.NO_SITES
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker.ErrorType.EmailError
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
@@ -39,8 +40,14 @@ class ContentMigrationAnalyticsTracker @Inject constructor(
     fun trackThanksScreenShown() =
         analyticsTracker.track(Stat.JPMIGRATION_THANKS_SCREEN_SHOWN)
 
+    fun trackNoSitesFlowThanksScreenShown() =
+        analyticsTracker.track(Stat.JPMIGRATION_THANKS_SCREEN_SHOWN, mapOf(NO_SITES to true))
+
     fun trackThanksScreenFinishButtonTapped() =
         analyticsTracker.track(Stat.JPMIGRATION_THANKS_SCREEN_FINISH_BUTTON_TAPPED)
+
+    fun trackNoSitesFlowThanksScreenFinishButtonTapped() =
+        analyticsTracker.track(Stat.JPMIGRATION_THANKS_SCREEN_FINISH_BUTTON_TAPPED, mapOf(NO_SITES to true))
 
     fun trackPleaseDeleteWordPressCardTapped() =
         analyticsTracker.track(Stat.JPMIGRATION_PLEASE_DELETE_WORDPRESS_CARD_TAPPED)
@@ -75,6 +82,7 @@ class ContentMigrationAnalyticsTracker @Inject constructor(
 
         companion object {
             const val ERROR_TYPE = "error_type"
+            const val NO_SITES = "no_sites"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalContentEntity.kt
@@ -43,7 +43,7 @@ sealed class LocalContentEntityData {
 
     data class ReaderPostsData(val posts: ReaderPostList) : LocalContentEntityData()
     data class BloggingRemindersData(val reminders: List<BloggingRemindersModel>) : LocalContentEntityData()
-    data class SitesData(val sites: List<SiteModel>) : LocalContentEntityData()
+    data class SitesData(val sites: List<SiteModel>, val isLoggedOn: Boolean) : LocalContentEntityData()
     data class PostsData(val localIds: List<Int>) : LocalContentEntityData()
     data class PostData(val post: PostModel) : LocalContentEntityData()
     object EmptyData : LocalContentEntityData()

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.localcontentmigration
 
+import android.util.Log
 import com.wellsql.generated.PostModelTable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.LocalDraftContentIsPresent
@@ -19,11 +20,14 @@ class LocalEligibilityStatusProviderHelper @Inject constructor(
     // TODO: check for eligibility of media? - I guess this might be covered by posts and pages - except for
     // media that is not part of a post or page ??
     override fun getData(localEntityId: Int?): LocalContentEntityData {
-        val (eligibleSites) = localMigrationSiteProviderHelper.getData()
+        val sitesData = localMigrationSiteProviderHelper.getData()
+        if (!sitesData.isLoggedOn) {
+            return EligibilityStatusData(false, WPNotLoggedIn)
+        }
         return when {
-            eligibleSites.isEmpty() -> EligibilityStatusData(false, WPNotLoggedIn)
+            sitesData.sites.isEmpty() -> EligibilityStatusData(true)
             else -> when {
-                eligibleSites.flatMap(::getLocalDraftPostAndPageIdsForSite).isNotEmpty() ->
+                sitesData.sites.flatMap(::getLocalDraftPostAndPageIdsForSite).isNotEmpty() ->
                     EligibilityStatusData(false, LocalDraftContentIsPresent)
                 else -> EligibilityStatusData(true)
             }

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.localcontentmigration
 
-import android.util.Log
 import com.wellsql.generated.PostModelTable
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.localcontentmigration.LocalContentEntityData.Companion.IneligibleReason.LocalDraftContentIsPresent

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalEligibilityStatusProviderHelper.kt
@@ -18,18 +18,13 @@ class LocalEligibilityStatusProviderHelper @Inject constructor(
     @Suppress("ForbiddenComment")
     // TODO: check for eligibility of media? - I guess this might be covered by posts and pages - except for
     // media that is not part of a post or page ??
-    override fun getData(localEntityId: Int?): LocalContentEntityData {
-        val sitesData = localMigrationSiteProviderHelper.getData()
-        if (!sitesData.isLoggedOn) {
-            return EligibilityStatusData(false, WPNotLoggedIn)
-        }
-        return when {
-            sitesData.sites.isEmpty() -> EligibilityStatusData(true)
-            else -> when {
-                sitesData.sites.flatMap(::getLocalDraftPostAndPageIdsForSite).isNotEmpty() ->
-                    EligibilityStatusData(false, LocalDraftContentIsPresent)
-                else -> EligibilityStatusData(true)
-            }
+    override fun getData(localEntityId: Int?) = with(localMigrationSiteProviderHelper.getData()) {
+        when {
+            !isLoggedOn -> EligibilityStatusData(false, WPNotLoggedIn)
+            sites.isEmpty() -> EligibilityStatusData(true)
+            sites.flatMap(::getLocalDraftPostAndPageIdsForSite).isNotEmpty() ->
+                EligibilityStatusData(false, LocalDraftContentIsPresent)
+            else -> EligibilityStatusData(true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
@@ -12,8 +12,7 @@ class LocalSiteProviderHelper @Inject constructor(
     override fun getData(localEntityId: Int?): SitesData =
         if (accountStore.hasAccessToken()) {
             SitesData(sites = siteStore.sites, true)
-        }
-        else {
+        } else {
             // self-hosted only
             val sites = siteStore.sites.filter { !it.isUsingWpComRestApi }
             SitesData(sites = sites, sites.isNotEmpty())

--- a/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/localcontentmigration/LocalSiteProviderHelper.kt
@@ -10,9 +10,12 @@ class LocalSiteProviderHelper @Inject constructor(
     private val accountStore: AccountStore,
 ) : LocalDataProviderHelper {
     override fun getData(localEntityId: Int?): SitesData =
-        if (accountStore.hasAccessToken())
-            SitesData(sites = siteStore.sites)
-        else
-        // self-hosted only
-            SitesData(sites = siteStore.sites.filter { !it.isUsingWpComRestApi })
+        if (accountStore.hasAccessToken()) {
+            SitesData(sites = siteStore.sites, true)
+        }
+        else {
+            // self-hosted only
+            val sites = siteStore.sites.filter { !it.isUsingWpComRestApi }
+            SitesData(sites = sites, sites.isNotEmpty())
+        }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -124,17 +124,15 @@ class JetpackMigrationViewModel @Inject constructor(
 
             migrationState is Initial -> emit(Loading)
 
-            migrationState is Migrating
-                    || migrationState is Successful && !continueClicked && migrationState.data.sites.isNotEmpty() ->
+            (migrationState is Migrating || migrationState is Successful) && migrationState.data.sites.isEmpty() ->
+                emit(initSuccessScreenUiForNoSites())
+
+            migrationState is Migrating || (migrationState is Successful && !continueClicked) ->
                 emit(initWelcomeScreenUi(migrationState.data, continueClicked))
 
             migrationState is Successful -> when {
-                !notificationContinueClicked && migrationState.data.sites.isNotEmpty() ->
-                    emit(initNotificationsScreenUi())
-                else -> {
-                    if (migrationState.data.sites.isNotEmpty()) emit(initSuccessScreenUi())
-                    else emit(initSuccessScreenUiForNoSites())
-                }
+                !notificationContinueClicked -> emit(initNotificationsScreenUi())
+                else -> emit(initSuccessScreenUi())
             }
 
             migrationState is Failure -> emit(initErrorScreenUi())

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -338,7 +338,9 @@ class JetpackMigrationViewModel @Inject constructor(
     private fun onFinishClicked() {
         _refreshAppTheme.value = Unit
         migrationAnalyticsTracker.trackThanksScreenFinishButtonTapped()
-        migrationEmailHelper.notifyMigrationComplete()
+         if (siteStore.sites.isNotEmpty()) {
+            migrationEmailHelper.notifyMigrationComplete()
+        }
         appPrefsWrapper.setJetpackMigrationCompleted(true)
         appPrefsWrapper.setJetpackMigrationInProgress(false)
         dispatchFetchAccountActionIfNeeded()
@@ -400,10 +402,10 @@ class JetpackMigrationViewModel @Inject constructor(
                 title = UiStringRes(R.string.jp_migration_welcome_title),
                 subtitle = UiStringRes(R.string.jp_migration_welcome_subtitle),
                 message = UiStringRes(
-                    if (sites.size > 1) {
-                        R.string.jp_migration_welcome_sites_found_message
-                    } else {
-                        R.string.jp_migration_welcome_site_found_message
+                    when (sites.size) {
+                        0 -> R.string.jp_migration_welcome_no_sites_message
+                        1 -> R.string.jp_migration_welcome_site_found_message
+                        else -> R.string.jp_migration_welcome_sites_found_message
                     }
                 ),
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -156,7 +156,6 @@ class JetpackMigrationViewModel @Inject constructor(
         this.deepLinkData = deepLinkData
 
         tryMigration(application)
-        // todo: set the flow
     }
 
     private fun resetIfNeeded(application: WordPress) {
@@ -230,7 +229,7 @@ class JetpackMigrationViewModel @Inject constructor(
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun initSuccessScreenUiForNoSites(): Done {
-        migrationAnalyticsTracker.trackThanksScreenShown()
+        migrationAnalyticsTracker.trackNoSitesFlowThanksScreenShown()
 
         return Done(
             showDeleteWPApp = false,
@@ -353,10 +352,13 @@ class JetpackMigrationViewModel @Inject constructor(
 
     private fun onFinishClicked() {
         _refreshAppTheme.value = Unit
-        migrationAnalyticsTracker.trackThanksScreenFinishButtonTapped()
+
          if (siteStore.sites.isNotEmpty()) {
+            migrationAnalyticsTracker.trackThanksScreenFinishButtonTapped()
             migrationEmailHelper.notifyMigrationComplete()
-        }
+        } else {
+             migrationAnalyticsTracker.trackNoSitesFlowThanksScreenFinishButtonTapped()
+         }
         appPrefsWrapper.setJetpackMigrationCompleted(true)
         appPrefsWrapper.setJetpackMigrationInProgress(false)
         dispatchFetchAccountActionIfNeeded()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModel.kt
@@ -419,7 +419,6 @@ class JetpackMigrationViewModel @Inject constructor(
                 subtitle = UiStringRes(R.string.jp_migration_welcome_subtitle),
                 message = UiStringRes(
                     when (sites.size) {
-                        0 -> R.string.jp_migration_welcome_no_sites_message
                         1 -> R.string.jp_migration_welcome_site_found_message
                         else -> R.string.jp_migration_welcome_sites_found_message
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.compose.components.text.Title
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.DonePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState
 import org.wordpress.android.ui.main.jetpack.migration.compose.components.ScreenIcon
@@ -49,27 +50,31 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
             Title(text = uiStringText(title))
             Subtitle(text = uiStringText(subtitle))
 
-            Spacer(modifier = Modifier.weight(0.5f))
-            Image(
-                painter = painterResource(deleteWpIcon),
-                contentDescription = stringResource(R.string.jp_migration_remove_wp_app_icon_content_description),
-                modifier = Modifier
-                    .padding(top = 10.dp, bottom = 10.dp)
-                    .size(70.dp)
-                    .align(Alignment.CenterHorizontally)
-            )
-            Text(
-                text = htmlToAnnotatedString(uiStringText(message)),
-                textAlign = TextAlign.Center,
-                fontSize = 14.sp,
-                lineHeight = 18.sp,
-                color = colorResource(R.color.gray_50),
-                modifier = Modifier
-                    .fillMaxWidth(0.75f)
-                    .align(Alignment.CenterHorizontally)
-                    .padding(bottom = 10.dp)
-            )
-            Spacer(modifier = Modifier.weight(0.5f))
+            if (showDeleteWPApp) {
+                Spacer(modifier = Modifier.weight(0.5f))
+                Image(
+                    painter = painterResource(deleteWpIcon),
+                    contentDescription = stringResource(R.string.jp_migration_remove_wp_app_icon_content_description),
+                    modifier = Modifier
+                        .padding(top = 10.dp, bottom = 10.dp)
+                        .size(70.dp)
+                        .align(Alignment.CenterHorizontally)
+                )
+                Text(
+                    text = htmlToAnnotatedString(uiStringText(message)),
+                    textAlign = TextAlign.Center,
+                    fontSize = 14.sp,
+                    lineHeight = 18.sp,
+                    color = colorResource(R.color.gray_50),
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .align(Alignment.CenterHorizontally)
+                        .padding(bottom = 10.dp)
+                )
+                Spacer(modifier = Modifier.weight(0.5f))
+            } else {
+                Subtitle(text = uiStringText(noSitesMessage))
+            }
         }
         ButtonsColumn {
             PrimaryButton(
@@ -87,6 +92,15 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
 private fun PreviewDoneStep() {
     AppTheme {
         val uiState = UiState.Content.Done(DonePrimaryButton {})
+        DoneStep(uiState)
+    }
+}
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL)
+@Composable
+private fun PreviewDoneStepNoSites() {
+    AppTheme {
+        val uiState = UiState.Content.Done(
+            JetpackMigrationViewModel.ActionButton.DoneNoSitesFlowPrimaryButton {}, false)
         DoneStep(uiState)
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4450,7 +4450,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_avatar_content_description">Your profile photo</string>
     <string name="jp_migration_welcome_sites_found_message">We found your sites. Continue to transfer all your data and sign in to Jetpack automatically.</string>
     <string name="jp_migration_welcome_site_found_message">We found your site. Continue to transfer all your data and sign in to Jetpack automatically.</string>
-    <string name="jp_migration_welcome_no_sites_message">Continue signing in to Jetpack automatically.</string>
     <string name="jp_migration_continue_button">Continue</string>
     <string name="jp_migration_help_button">Need help?</string>
     <string name="jp_migration_notifications_allow_title">Allow notifications to keep up with your site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4450,6 +4450,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_avatar_content_description">Your profile photo</string>
     <string name="jp_migration_welcome_sites_found_message">We found your sites. Continue to transfer all your data and sign in to Jetpack automatically.</string>
     <string name="jp_migration_welcome_site_found_message">We found your site. Continue to transfer all your data and sign in to Jetpack automatically.</string>
+    <string name="jp_migration_welcome_no_sites_message">Continue signing in to Jetpack automatically.</string>
     <string name="jp_migration_continue_button">Continue</string>
     <string name="jp_migration_help_button">Need help?</string>
     <string name="jp_migration_notifications_allow_title">Allow notifications to keep up with your site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4473,6 +4473,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="jp_migration_delete_message">We recommend &lt;b&gt;uninstalling the WordPress app&lt;/b&gt; on your device to avoid data conflicts.</string>
     <string name="jp_migration_got_it_button">Got it</string>
     <string name="jp_migration_need_help_button">Need help?</string>
+    <string name="jp_migration_done_no_sites_message">It\'s time to continue your WordPress journey on the Jetpack app.</string>
+    <string name="jp_migration_lets_go_button">Let\'s go</string>
 
     <!-- Open Web Links With Jetpack -->
     <string name="preference_open_links_in_jetpack">Open links in Jetpack</string>

--- a/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalMigrationResultTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalMigrationResultTest.kt
@@ -102,7 +102,7 @@ class LocalMigrationResultTest {
     @Test
     fun `Should emitTo correct state if current state IS Initial and data IS SitesData`() {
         val sites = listOf(SiteModel(), SiteModel())
-        val data = SitesData(sites)
+        val data = SitesData(sites, true)
         val mutableStateFlow: MutableStateFlow<LocalMigrationState> = MutableStateFlow(Initial)
         Success(data).emitTo(mutableStateFlow)
         val expected = Migrating(WelcomeScreenData(sites = sites)).data
@@ -125,7 +125,7 @@ class LocalMigrationResultTest {
     @Test
     fun `Should emitTo correct state if current state IS NOT Initial and data IS SitesData`() {
         val sites = listOf(SiteModel(), SiteModel())
-        val data = SitesData(sites)
+        val data = SitesData(sites, true)
         val mutableStateFlow: MutableStateFlow<LocalMigrationState> = MutableStateFlow(Migrating(WelcomeScreenData()))
         Success(data).emitTo(mutableStateFlow)
         val expected = Migrating(WelcomeScreenData(sites = sites)).data

--- a/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/localcontentmigration/LocalPostProviderHelperTest.kt
@@ -45,7 +45,7 @@ class LocalPostProviderHelperTest {
         whenever(mockPostModel.id).thenReturn(mockPostId)
         whenever(mockPostModel2.id).thenReturn(mockPostId2)
         whenever(postStore.getPostsForSite(mockSiteModel)).thenReturn(mockPostList)
-        whenever(siteProviderHelper.getData()).thenReturn(SitesData(sites = listOf(mockSiteModel)))
+        whenever(siteProviderHelper.getData()).thenReturn(SitesData(sites = listOf(mockSiteModel), true))
         whenever(mockSiteModel.id).thenReturn(mockSiteId)
         whenever(dbWrapper.giveMeReadableDb()).thenReturn(mockDb)
         whenever(

--- a/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/sharedlogin/resolver/LocalMigrationOrchestratorTest.kt
@@ -224,7 +224,7 @@ class LocalMigrationOrchestratorTest : BaseUnitTest() {
     private fun mockHappyPath() {
         whenever(eligibilityHelper.validate()).thenReturn(Success(EligibilityStatusData(true)))
         whenever(sharedLoginHelper.login()).thenReturn(Success(AccessTokenData("", avatarUrl)))
-        whenever(sitesMigrationHelper.migrateSites()).thenReturn(Success(SitesData(sites)))
+        whenever(sitesMigrationHelper.migrateSites()).thenReturn(Success(SitesData(sites, true)))
         whenever(userFlagsHelper.migrateUserFlags()).thenReturn(Success(UserFlagsData(mapOf(), listOf(), listOf())))
         whenever(readerSavedPostsHelper.migrateReaderSavedPosts())
             .thenReturn(Success(ReaderPostsData(ReaderPostList())))

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.SiteAction
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationViewModelTest.kt
@@ -19,6 +19,8 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.action.SiteAction
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.SitesModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.localcontentmigration.ContentMigrationAnalyticsTracker
@@ -251,19 +253,36 @@ class JetpackMigrationViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should track when success screen is shown`() {
+    fun `when sites flow, Should track when success screen is shown`() {
         classToTest.initSuccessScreenUi()
 
         verify(contentMigrationAnalyticsTracker).trackThanksScreenShown()
     }
 
     @Test
-    fun `Should track when finish button is tapped on success screen`() {
+    fun `when no sites flow, Should track when success screen is shown`() {
+        classToTest.initSuccessScreenUiForNoSites()
+
+        verify(contentMigrationAnalyticsTracker).trackNoSitesFlowThanksScreenShown()
+    }
+
+    @Test
+    fun `when sites flow, then should track when finish button is tapped on success screen`() {
+        whenever(siteStore.sites).thenReturn(listOf(SiteModel()))
         val successScreen = classToTest.initSuccessScreenUi()
 
         successScreen.primaryActionButton.onClick.invoke()
 
         verify(contentMigrationAnalyticsTracker).trackThanksScreenFinishButtonTapped()
+    }
+
+    @Test
+    fun `when no sites flow, then should track when finish button is tapped on success screen`() {
+        val successScreen = classToTest.initSuccessScreenUiForNoSites()
+
+        successScreen.primaryActionButton.onClick.invoke()
+
+        verify(contentMigrationAnalyticsTracker).trackNoSitesFlowThanksScreenShown()
     }
 
     @Test


### PR DESCRIPTION
This PR implements support for "no-sites" migration path

- With not wanting to add too much complexity, the `isLoggedOn` property was added to `SitesData` . This value is used in `LocalEligibilityStatusProviderHelper` to determine if the migration can continue. I had thought about swapping out SitesProvider for an AuthenticatedProvider, but SitesProvider still needs to check for access, as does Posts. I am all for swapping in this type of implementation if suggested.

- ~~The "migration flow" screens are still a WIP because it has not yet been decided which screens should show. For now, there is a new check for no-sites to stop the migration email from being sent. In addition, I added a "no-sites" content message for the welcome screen.~~

- It was decided that the no-sites flow only show the "done" view with slightly different messaging, button text, and no delete prompting. The uiState logic was altered to check the site list for empty/not empty which will determine which view gets shown. 

- The following track events will include an additional `no-sites=true` property when in the no-sites flow.
jpmigration_thanks_screen_shown and jpmigration_thanks_screen_finish_button_tapped

- More information on the no-sites flow is available here: p1700588790429529-slack-C04SFL0RP51

-----

## To Test:
Recording: https://github.com/wordpress-mobile/WordPress-Android/assets/506707/5bd5968e-c80a-40c1-b81d-584a97263ab7

- Uninstall any/all versions of the JP and WP apps from your device
- Install the WordPress app from this PR
- Log in using an account that has no sites or create a new account (do not add any sites)
- Stop - At this point, we need to simulate the click of "download Jetpack app"
- Install the Jetpack app from this PR 
- ✅ Verify you are shown the Thanks for switching to Jetpack view
- Tap on the "Let's go" button
- ✅ Verify you that you land on the home page with a “Create Site” CTA
- ✅ Verify that you are logged in and can create a site now
- ✅ Verify that you did not receive a “Migration Done” email from WordPress 
- ✅ Verify logs contain
       🔵 Tracked: jpmigration_thanks_screen_shown, Properties: {"no_sites":true}
       🔵 Tracked: jpmigration_thanks_screen_finish_button_tapped, Properties: {"no_sites":true}
-----

Note: To repeat the migration flow; swipe both apps closed, delete all data from both apps, launch WP first and login, and then launch the JP app.

## Regression Notes

1. Potential unintended areas of impact
The normal WP/JP flow is broken

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated existing tests

3. What automated tests I added (or what prevented me from doing so)
- N/a

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: N/A
