### PR TITLE
Introduce a themed adaptive icon for Jetpack app

### DIFF
--- a/WordPress/src/jetpack/res/drawable/app_icon_monochromatic.xml
+++ b/WordPress/src/jetpack/res/drawable/app_icon_monochromatic.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M54,78C67.25,78 78,67.25 78,54C78,40.75 67.25,30 54,30C40.75,30 30,40.75 30,54C30,67.25 40.75,78 54,78ZM55.19,49.97V73.24L67.19,49.97H55.19ZM52.76,34.76V57.98H40.81L52.76,34.76Z"
+      android:fillColor="#069E08"
+      android:fillType="evenOdd"/>
+</vector>

--- a/WordPress/src/jetpack/res/mipmap-anydpi-v26/app_icon.xml
+++ b/WordPress/src/jetpack/res/mipmap-anydpi-v26/app_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/app_icon_background"/>
     <foreground android:drawable="@drawable/app_icon_foreground"/>
+    <monochrome android:drawable="@drawable/app_icon_monochromatic"/>
 </adaptive-icon>


### PR DESCRIPTION
P2 pcdRpT-499-p2

Starting from Android 13, Google introduced themed adaptive icons for Android launchers. The system uses the coloring of the user's chosen wallpaper and theme or custom colors to determine the icon's tint color. This PR adds the adaptive icon for the Jetpack app.

https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/876745a6-9da7-4dfe-a6a5-d3f669b68d19

-----

## To Test:

- [ ] Build the app with the `jetpackVanillaDebug` build variant on Android 13 or 14 device/emulator. (I test on a Google Pixel)
- [ ] Move the app icon to the Android Launcher
- [ ] Long tap on the launcher background to display a popup menu
- [ ] Go to `Wallpaper & style`
- [ ] Toggle the `Themed icons` setting to enable the feature
- [ ] Go back to the launcher and make sure the Jetpack app's icon has changed and been themed

-----

## Regression Notes

1. Potential unintended areas of impact
Jetpack app icon

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)