### PR TITLE
Update values associated with "Low" and "Medium" image quality settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.text.TextUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -10,6 +10,7 @@ import androidx.preference.PreferenceManager;
 
 import com.google.gson.Gson;
 
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -777,7 +778,19 @@ public class AppPrefs {
 
     public static int getImageOptimizeQuality() {
         int quality = getInt(DeletablePrefKey.IMAGE_OPTIMIZE_QUALITY, 0);
-        return quality > 1 ? quality : WPMediaUtils.OPTIMIZE_IMAGE_ENCODER_QUALITY;
+
+        // It's necessary to check that the quality int exists in the quality array in case of changes
+        // See #19644 for an example of when the array's values were changed
+        Context context = WordPress.getContext();
+        String[] validQualityValues = context.getResources().getStringArray(R.array.site_settings_image_quality_values);
+        boolean isQualityValid = Arrays.asList(validQualityValues).contains(String.valueOf(quality));
+
+        // If quality int does not exist in settings array, return the default quality value instead
+        if (!isQualityValid) {
+            setImageOptimizeQuality(WPMediaUtils.OPTIMIZE_IMAGE_ENCODER_QUALITY);
+        }
+
+        return quality;
     }
 
     public static boolean isVideoOptimize() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -779,6 +779,7 @@ public class AppPrefs {
 
     public static int getImageOptimizeQuality() {
         int quality = getInt(DeletablePrefKey.IMAGE_OPTIMIZE_QUALITY, 0);
+        int defaultQuality = WPMediaUtils.OPTIMIZE_IMAGE_ENCODER_QUALITY;
 
         // It's necessary to check that the quality int exists in the quality array in case of changes
         // See #19644 for an example of when the array's values were changed
@@ -788,7 +789,8 @@ public class AppPrefs {
 
         // If quality int does not exist in settings array, return the default quality value instead
         if (!isQualityValid) {
-            setImageOptimizeQuality(WPMediaUtils.OPTIMIZE_IMAGE_ENCODER_QUALITY);
+            setImageOptimizeQuality(defaultQuality);
+            return defaultQuality;
         }
 
         return quality;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -56,7 +56,7 @@ public class WPMediaUtils {
 
     // Max picture size will be 3000px wide. That's the maximum resolution you can set in the current picker.
     public static final int OPTIMIZE_IMAGE_MAX_SIZE = 3000;
-    public static final int OPTIMIZE_IMAGE_ENCODER_QUALITY = 85;
+    public static final int OPTIMIZE_IMAGE_ENCODER_QUALITY = 80;
     public static final int OPTIMIZE_VIDEO_MAX_WIDTH = 1280;
     public static final int OPTIMIZE_VIDEO_ENCODER_BITRATE_KB = 3000;
 

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -2996,11 +2996,11 @@ Language: ar
     <string name="editor_post_saved_online">تم حفظ المقالة على الإنترنت</string>
     <string name="site_settings_image_quality_hint">جودة الصور. تُشير القيم الأعلى إلى الصور ذات الجودة الأفضل.</string>
     <string name="site_settings_optimize_images_summary">تمكين تغيير حجم الصور وضغطها</string>
-    <string name="media_encoder_quality_100">الحد الأقصى</string>
-    <string name="media_encoder_quality_95">مرتفع للغاية</string>
-    <string name="media_encoder_quality_90">مرتفع</string>
-    <string name="media_encoder_quality_85">متوسط</string>
-    <string name="media_encoder_quality_80">منخفض</string>
+    <string name="media_encoder_quality_maximum">الحد الأقصى</string>
+    <string name="media_encoder_quality_very_high">مرتفع للغاية</string>
+    <string name="media_encoder_quality_high">مرتفع</string>
+    <string name="media_encoder_quality_medium">متوسط</string>
+    <string name="media_encoder_quality_low">منخفض</string>
     <string name="media_upload_state_uploaded">تم الرفع</string>
     <string name="media_upload_state_deleted">محذوف</string>
     <string name="media_upload_state_queued">تم الوضع في قائمة الانتظار</string>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -221,11 +221,11 @@ Language: bg
     <string name="photo_picker_title">Избор на изображение</string>
     <string name="editor_post_saved_online">Публикацията е запазена онлайн.</string>
     <string name="site_settings_image_quality_hint">Качество на изображенията. Високите стойности означават снимки с по-високо качество.</string>
-    <string name="media_encoder_quality_100">Максимум</string>
-    <string name="media_encoder_quality_95">Много високо</string>
-    <string name="media_encoder_quality_90">Високо</string>
-    <string name="media_encoder_quality_85">Средно</string>
-    <string name="media_encoder_quality_80">Ниско</string>
+    <string name="media_encoder_quality_maximum">Максимум</string>
+    <string name="media_encoder_quality_very_high">Много високо</string>
+    <string name="media_encoder_quality_high">Високо</string>
+    <string name="media_encoder_quality_medium">Средно</string>
+    <string name="media_encoder_quality_low">Ниско</string>
     <string name="media_upload_state_uploaded">Качено</string>
     <string name="media_upload_state_deleted">Изтрито</string>
     <string name="media_upload_state_deleting">Изтрива се</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -2776,11 +2776,11 @@ Language: cs_CZ
     <string name="editor_post_saved_online">Příspěvek je uložený online</string>
     <string name="site_settings_image_quality_hint">Kvalita obrázků. Vyšší hodnoty znamenají lepší kvalitu obrázků.</string>
     <string name="site_settings_optimize_images_summary">Povolit změnu velikosti a kompresi obrázků</string>
-    <string name="media_encoder_quality_100">Maximální</string>
-    <string name="media_encoder_quality_95">Hodně vysoká</string>
-    <string name="media_encoder_quality_90">Vysoká</string>
-    <string name="media_encoder_quality_85">Střední</string>
-    <string name="media_encoder_quality_80">Nízká</string>
+    <string name="media_encoder_quality_maximum">Maximální</string>
+    <string name="media_encoder_quality_very_high">Hodně vysoká</string>
+    <string name="media_encoder_quality_high">Vysoká</string>
+    <string name="media_encoder_quality_medium">Střední</string>
+    <string name="media_encoder_quality_low">Nízká</string>
     <string name="media_upload_state_uploaded">Nahráno</string>
     <string name="media_upload_state_deleted">Smazáno</string>
     <string name="media_upload_state_deleting">Mazání</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -3003,11 +3003,11 @@ Language: de
     <string name="editor_post_saved_online">Der Beitrag wurde online gespeichert</string>
     <string name="site_settings_image_quality_hint">Qualität der Bilder. Höhere Werte bedeuten bessere Bilder.</string>
     <string name="site_settings_optimize_images_summary">Aktivieren, um die Größe von Bildern zu ändern und sie zu komprimieren</string>
-    <string name="media_encoder_quality_100">Maximal</string>
-    <string name="media_encoder_quality_95">Sehr hoch</string>
-    <string name="media_encoder_quality_90">Hoch</string>
-    <string name="media_encoder_quality_85">Mittel</string>
-    <string name="media_encoder_quality_80">Niedrig</string>
+    <string name="media_encoder_quality_maximum">Maximal</string>
+    <string name="media_encoder_quality_very_high">Sehr hoch</string>
+    <string name="media_encoder_quality_high">Hoch</string>
+    <string name="media_encoder_quality_medium">Mittel</string>
+    <string name="media_encoder_quality_low">Niedrig</string>
     <string name="media_upload_state_uploaded">Hochgeladen</string>
     <string name="media_upload_state_failed">Hochladen fehlgeschlagen</string>
     <string name="media_upload_state_deleted">Gelöscht</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -561,11 +561,11 @@ Language: el_GR
     <string name="editor_post_saved_online">Το άρθρο αποθηκεύτηκε διαδικτυακά</string>
     <string name="site_settings_image_quality_hint">Ποιότητα εικόνων. Υψηλότερες τιμές σημαίνουν εικόνες καλύτερης ποιότητας.</string>
     <string name="site_settings_optimize_images_summary">Ενεργοποιήστε για αλλαγή μεγέθους και συμπίεσης εικόνων</string>
-    <string name="media_encoder_quality_100">Μέγιστο</string>
-    <string name="media_encoder_quality_95">Πολύ Υψηλό</string>
-    <string name="media_encoder_quality_90">Υψηλό</string>
-    <string name="media_encoder_quality_85">Μεσαίο</string>
-    <string name="media_encoder_quality_80">Χαμηλό</string>
+    <string name="media_encoder_quality_maximum">Μέγιστο</string>
+    <string name="media_encoder_quality_very_high">Πολύ Υψηλό</string>
+    <string name="media_encoder_quality_high">Υψηλό</string>
+    <string name="media_encoder_quality_medium">Μεσαίο</string>
+    <string name="media_encoder_quality_low">Χαμηλό</string>
     <string name="media_upload_state_uploaded">Μεταφορτώθηκε</string>
     <string name="media_upload_state_deleted">Διαγράφηκε</string>
     <string name="media_upload_state_deleting">Γίνεται διαγραφή</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -1076,11 +1076,11 @@ Language: en_AU
     <string name="editor_post_saved_online">Post saved online</string>
     <string name="site_settings_image_quality_hint">Quality of pictures. Higher values mean better quality pictures.</string>
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
-    <string name="media_encoder_quality_100">Maximum</string>
-    <string name="media_encoder_quality_95">Very High</string>
-    <string name="media_encoder_quality_90">High</string>
-    <string name="media_encoder_quality_85">Medium</string>
-    <string name="media_encoder_quality_80">Low</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
+    <string name="media_encoder_quality_very_high">Very High</string>
+    <string name="media_encoder_quality_high">High</string>
+    <string name="media_encoder_quality_medium">Medium</string>
+    <string name="media_encoder_quality_low">Low</string>
     <string name="media_upload_state_uploaded">Uploaded</string>
     <string name="media_upload_state_deleted">Deleted</string>
     <string name="media_upload_state_deleting">Deleting</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -2673,11 +2673,11 @@ Language: en_CA
     <string name="editor_post_saved_online">Post saved online</string>
     <string name="site_settings_image_quality_hint">Quality of pictures. Higher values mean better quality pictures.</string>
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
-    <string name="media_encoder_quality_100">Maximum</string>
-    <string name="media_encoder_quality_95">Very High</string>
-    <string name="media_encoder_quality_90">High</string>
-    <string name="media_encoder_quality_85">Medium</string>
-    <string name="media_encoder_quality_80">Low</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
+    <string name="media_encoder_quality_very_high">Very High</string>
+    <string name="media_encoder_quality_high">High</string>
+    <string name="media_encoder_quality_medium">Medium</string>
+    <string name="media_encoder_quality_low">Low</string>
     <string name="media_upload_state_uploaded">Uploaded</string>
     <string name="media_upload_state_deleted">Deleted</string>
     <string name="media_upload_state_deleting">Deleting</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -2833,11 +2833,11 @@ Language: en_GB
     <string name="editor_post_saved_online">Post saved online</string>
     <string name="site_settings_image_quality_hint">Quality of pictures. Higher values mean better quality pictures.</string>
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
-    <string name="media_encoder_quality_100">Maximum</string>
-    <string name="media_encoder_quality_95">Very High</string>
-    <string name="media_encoder_quality_90">High</string>
-    <string name="media_encoder_quality_85">Medium</string>
-    <string name="media_encoder_quality_80">Low</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
+    <string name="media_encoder_quality_very_high">Very High</string>
+    <string name="media_encoder_quality_high">High</string>
+    <string name="media_encoder_quality_medium">Medium</string>
+    <string name="media_encoder_quality_low">Low</string>
     <string name="media_upload_state_uploaded">Uploaded</string>
     <string name="media_upload_state_deleted">Deleted</string>
     <string name="media_upload_state_deleting">Deleting</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -844,11 +844,11 @@ Language: es_CL
     <string name="editor_post_saved_online">Entrada guardada en línea</string>
     <string name="site_settings_image_quality_hint">Calidad de las imágenes. Valores más altos significan imágenes de mejor calidad.</string>
     <string name="site_settings_optimize_images_summary">Habilitar para cambiar el tamaño y comprimir imágenes</string>
-    <string name="media_encoder_quality_90">Alto</string>
-    <string name="media_encoder_quality_85">Mediano</string>
-    <string name="media_encoder_quality_100">Máximo</string>
-    <string name="media_encoder_quality_80">Baja</string>
-    <string name="media_encoder_quality_95">Muy alta</string>
+    <string name="media_encoder_quality_high">Alto</string>
+    <string name="media_encoder_quality_medium">Mediano</string>
+    <string name="media_encoder_quality_maximum">Máximo</string>
+    <string name="media_encoder_quality_low">Baja</string>
+    <string name="media_encoder_quality_very_high">Muy alta</string>
     <string name="media_upload_state_uploaded">Subido</string>
     <string name="media_upload_state_failed">Falló la Carga</string>
     <string name="media_upload_state_deleted">Eliminado</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -2514,11 +2514,11 @@ Language: es_CO
     <string name="editor_post_saved_online">La entrada se ha guardado online</string>
     <string name="site_settings_image_quality_hint">Calidad de las imágenes: cuanto más alto es el valor, más calidad tienen las imágenes.</string>
     <string name="site_settings_optimize_images_summary">Activa la opción para cambiar el tamaño de las imágenes y comprimirlas</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_95">Muy alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_80">Baja</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_very_high">Muy alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_low">Baja</string>
     <string name="media_upload_state_uploaded">Subido</string>
     <string name="media_upload_state_failed">Fallo al subir</string>
     <string name="media_upload_state_deleted">Se ha eliminado</string>

--- a/WordPress/src/main/res/values-es-rMX/strings.xml
+++ b/WordPress/src/main/res/values-es-rMX/strings.xml
@@ -1740,11 +1740,11 @@ Language: es_MX
     <string name="editor_post_saved_online">La entrada se ha guardado online</string>
     <string name="site_settings_image_quality_hint">Calidad de las imágenes: cuanto más alto es el valor, más calidad tienen las imágenes.</string>
     <string name="site_settings_optimize_images_summary">Activa la opción para cambiar el tamaño de las imágenes y comprimirlas</string>
-    <string name="media_encoder_quality_80">Baja</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_95">Muy alta</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_90">Alta</string>
+    <string name="media_encoder_quality_low">Baja</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_very_high">Muy alta</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_high">Alta</string>
     <string name="media_upload_state_uploaded">Se ha subido</string>
     <string name="media_upload_state_deleted">Se ha eliminado</string>
     <string name="media_upload_state_deleting">Eliminando</string>

--- a/WordPress/src/main/res/values-es-rVE/strings.xml
+++ b/WordPress/src/main/res/values-es-rVE/strings.xml
@@ -2535,11 +2535,11 @@ Language: es_VE
     <string name="editor_post_saved_online">La entrada se ha guardado online</string>
     <string name="site_settings_image_quality_hint">Calidad de las imágenes: cuanto más alto es el valor, más calidad tienen las imágenes.</string>
     <string name="site_settings_optimize_images_summary">Activa la opción para cambiar el tamaño de las imágenes y comprimirlas</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_95">Muy alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_80">Baja</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_very_high">Muy alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_low">Baja</string>
     <string name="media_upload_state_uploaded">Subido</string>
     <string name="media_upload_state_failed">Fallo al subir</string>
     <string name="media_upload_state_deleted">Se ha eliminado</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -3006,11 +3006,11 @@ Language: es
     <string name="editor_post_saved_online">La entrada se ha guardado online</string>
     <string name="site_settings_image_quality_hint">Calidad de las imágenes: cuanto más alto es el valor, más calidad tienen las imágenes.</string>
     <string name="site_settings_optimize_images_summary">Activa la opción para cambiar el tamaño de las imágenes y comprimirlas</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_95">Muy alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_80">Baja</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_very_high">Muy alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_low">Baja</string>
     <string name="media_upload_state_uploaded">Subido</string>
     <string name="media_upload_state_failed">Fallo al subir</string>
     <string name="media_upload_state_deleted">Se ha eliminado</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -3000,11 +3000,11 @@ Language: fr
     <string name="editor_post_saved_online">Article enregistré en ligne</string>
     <string name="site_settings_image_quality_hint">Qualité des images. Des valeurs élevées signifient une meilleure qualité d’image.</string>
     <string name="site_settings_optimize_images_summary">Autoriser le redimensionnement et la compression des images</string>
-    <string name="media_encoder_quality_100">Maximum</string>
-    <string name="media_encoder_quality_95">Très élevé</string>
-    <string name="media_encoder_quality_90">Élevé</string>
-    <string name="media_encoder_quality_85">Moyen</string>
-    <string name="media_encoder_quality_80">Faible</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
+    <string name="media_encoder_quality_very_high">Très élevé</string>
+    <string name="media_encoder_quality_high">Élevé</string>
+    <string name="media_encoder_quality_medium">Moyen</string>
+    <string name="media_encoder_quality_low">Faible</string>
     <string name="media_upload_state_uploaded">Téléversé</string>
     <string name="media_upload_state_failed">Téléversement échoué</string>
     <string name="media_upload_state_deleted">Supprimé</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -3000,11 +3000,11 @@ Language: fr
     <string name="editor_post_saved_online">Article enregistré en ligne</string>
     <string name="site_settings_image_quality_hint">Qualité des images. Des valeurs élevées signifient une meilleure qualité d’image.</string>
     <string name="site_settings_optimize_images_summary">Autoriser le redimensionnement et la compression des images</string>
-    <string name="media_encoder_quality_100">Maximum</string>
-    <string name="media_encoder_quality_95">Très élevé</string>
-    <string name="media_encoder_quality_90">Élevé</string>
-    <string name="media_encoder_quality_85">Moyen</string>
-    <string name="media_encoder_quality_80">Faible</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
+    <string name="media_encoder_quality_very_high">Très élevé</string>
+    <string name="media_encoder_quality_high">Élevé</string>
+    <string name="media_encoder_quality_medium">Moyen</string>
+    <string name="media_encoder_quality_low">Faible</string>
     <string name="media_upload_state_uploaded">Téléversé</string>
     <string name="media_upload_state_failed">Téléversement échoué</string>
     <string name="media_upload_state_deleted">Supprimé</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -3006,11 +3006,11 @@ Language: gl_ES
     <string name="editor_post_saved_online">A entrada gardouse en liña</string>
     <string name="site_settings_image_quality_hint">Calidade das imaxes: canto máis alto é o valor, máis calidade teñen as imaxes.</string>
     <string name="site_settings_optimize_images_summary">Activa a opción para cambiar o tamaño das imaxes e comprimilas</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_95">Moi alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_80">Baixa</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_very_high">Moi alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_low">Baixa</string>
     <string name="media_upload_state_uploaded">Subida</string>
     <string name="media_upload_state_failed">Fallou a subida.</string>
     <string name="media_upload_state_deleted">Borrado</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -2997,11 +2997,11 @@ Language: he_IL
     <string name="editor_post_saved_online">הפוסט נשמר ברשת</string>
     <string name="site_settings_image_quality_hint">איכות תמונות. ערכים גבוהים יותר מאפשרים איכות טובה יותר של התמונות.</string>
     <string name="site_settings_optimize_images_summary">הפעלת עריכה של גודל תמונות ודחיסתן</string>
-    <string name="media_encoder_quality_100">מקסימום</string>
-    <string name="media_encoder_quality_95">גבוהה מאוד</string>
-    <string name="media_encoder_quality_90">גבוהה</string>
-    <string name="media_encoder_quality_85">בינונית</string>
-    <string name="media_encoder_quality_80">נמוכה</string>
+    <string name="media_encoder_quality_maximum">מקסימום</string>
+    <string name="media_encoder_quality_very_high">גבוהה מאוד</string>
+    <string name="media_encoder_quality_high">גבוהה</string>
+    <string name="media_encoder_quality_medium">בינונית</string>
+    <string name="media_encoder_quality_low">נמוכה</string>
     <string name="media_upload_state_uploaded">הועלה</string>
     <string name="media_upload_state_failed">העלאה נכשלה</string>
     <string name="media_upload_state_deleted">נמחק</string>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -108,7 +108,7 @@ Language: hi_IN
     <string name="editor_post_saved_locally">पोस्ट डिवाइस पर सहेजा गया</string>
     <string name="button_sync">सिंक</string>
     <string name="wp_media_title">वर्डप्रेस मीडिया </string>
-    <string name="media_encoder_quality_80">निम्न</string>
+    <string name="media_encoder_quality_low">निम्न</string>
     <string name="error_unknown_post_type">अज्ञात पोस्ट प्रारूप</string>
     <string name="confirm">पुष्टि करें</string>
     <string name="reader_label_visit">साईट पर जाये</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -3003,11 +3003,11 @@ Language: id
     <string name="editor_post_saved_online">Pos disimpan secara online</string>
     <string name="site_settings_image_quality_hint">Kualitas gambar. Semakin tinggi nilainya, semakin bagus kualitas gambarnya.</string>
     <string name="site_settings_optimize_images_summary">Memungkinkan pengubahan ukuran dan kompresi gambar</string>
-    <string name="media_encoder_quality_100">Maksimum</string>
-    <string name="media_encoder_quality_95">Sangat Tinggi</string>
-    <string name="media_encoder_quality_90">Tinggi</string>
-    <string name="media_encoder_quality_85">Sedang</string>
-    <string name="media_encoder_quality_80">Rendah</string>
+    <string name="media_encoder_quality_maximum">Maksimum</string>
+    <string name="media_encoder_quality_very_high">Sangat Tinggi</string>
+    <string name="media_encoder_quality_high">Tinggi</string>
+    <string name="media_encoder_quality_medium">Sedang</string>
+    <string name="media_encoder_quality_low">Rendah</string>
     <string name="media_upload_state_uploaded">Diunggah</string>
     <string name="media_upload_state_failed">Unggahan Gagal</string>
     <string name="media_upload_state_deleted">Dihapus</string>

--- a/WordPress/src/main/res/values-is/strings.xml
+++ b/WordPress/src/main/res/values-is/strings.xml
@@ -26,11 +26,11 @@ Language: is
     <string name="photo_picker_title">Veldu mynd</string>
     <string name="site_settings_image_quality_hint">Gæði mynda. Hærra gildi þýðir betri gæði mynda.</string>
     <string name="site_settings_optimize_images_summary">Virkjaðu til þess að minnka og þjappa myndum</string>
-    <string name="media_encoder_quality_100">Hámark</string>
-    <string name="media_encoder_quality_80">Lítil</string>
-    <string name="media_encoder_quality_85">Miðlungi gott</string>
-    <string name="media_encoder_quality_90">Hár</string>
-    <string name="media_encoder_quality_95">Mjög hátt</string>
+    <string name="media_encoder_quality_maximum">Hámark</string>
+    <string name="media_encoder_quality_low">Lítil</string>
+    <string name="media_encoder_quality_medium">Miðlungi gott</string>
+    <string name="media_encoder_quality_high">Hár</string>
+    <string name="media_encoder_quality_very_high">Mjög hátt</string>
     <string name="media_upload_state_uploaded">Efni upphlaðið</string>
     <string name="media_upload_state_deleted">Eytt</string>
     <string name="media_upload_state_deleting">Eyði</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -3002,11 +3002,11 @@ Language: it
     <string name="editor_post_saved_online">L\'articolo è stato salvato online</string>
     <string name="site_settings_image_quality_hint">Qualità delle immagini. Valori più elevati indicano una migliore qualità delle immagini.</string>
     <string name="site_settings_optimize_images_summary">Consenti di ridimensionare e comprimere le immagini</string>
-    <string name="media_encoder_quality_100">Massima</string>
-    <string name="media_encoder_quality_95">Molto alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Media</string>
-    <string name="media_encoder_quality_80">Bassa</string>
+    <string name="media_encoder_quality_maximum">Massima</string>
+    <string name="media_encoder_quality_very_high">Molto alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Media</string>
+    <string name="media_encoder_quality_low">Bassa</string>
     <string name="media_upload_state_uploaded">Caricato</string>
     <string name="media_upload_state_failed">Caricamento fallito</string>
     <string name="media_upload_state_deleted">Eliminato</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -2997,11 +2997,11 @@ Language: ja_JP
     <string name="editor_post_saved_online">投稿をオンラインで保存しました</string>
     <string name="site_settings_image_quality_hint">写真の画質。値が高いほど、画質が良いことを意味します。</string>
     <string name="site_settings_optimize_images_summary">写真をリサイズして圧縮できます</string>
-    <string name="media_encoder_quality_100">最高</string>
-    <string name="media_encoder_quality_95">非常に高い</string>
-    <string name="media_encoder_quality_90">高い</string>
-    <string name="media_encoder_quality_85">普通</string>
-    <string name="media_encoder_quality_80">低い</string>
+    <string name="media_encoder_quality_maximum">最高</string>
+    <string name="media_encoder_quality_very_high">非常に高い</string>
+    <string name="media_encoder_quality_high">高い</string>
+    <string name="media_encoder_quality_medium">普通</string>
+    <string name="media_encoder_quality_low">低い</string>
     <string name="media_upload_state_uploaded">アップロード済み</string>
     <string name="media_upload_state_failed">アップロード失敗</string>
     <string name="media_upload_state_deleted">削除済み</string>

--- a/WordPress/src/main/res/values-kmr/strings.xml
+++ b/WordPress/src/main/res/values-kmr/strings.xml
@@ -1661,11 +1661,11 @@ Language: ku_TR
     <string name="editor_post_saved_online">Şandî bi serhêlî hat tomarkirin</string>
     <string name="site_settings_image_quality_hint">Kalîteya wêneyan. Nirxên bilindtir tê wateya wêneyên kalîteya wan çêtir.</string>
     <string name="site_settings_optimize_images_summary">Dewisandin û ji nû ve rehendina wêneyan biçalakîne</string>
-    <string name="media_encoder_quality_100">Herî bilind</string>
-    <string name="media_encoder_quality_95">Pir bilind</string>
-    <string name="media_encoder_quality_90">Bilind</string>
-    <string name="media_encoder_quality_85">Navîn</string>
-    <string name="media_encoder_quality_80">Nizm</string>
+    <string name="media_encoder_quality_maximum">Herî bilind</string>
+    <string name="media_encoder_quality_very_high">Pir bilind</string>
+    <string name="media_encoder_quality_high">Bilind</string>
+    <string name="media_encoder_quality_medium">Navîn</string>
+    <string name="media_encoder_quality_low">Nizm</string>
     <string name="media_upload_state_uploaded">Hat hilxistin</string>
     <string name="media_upload_state_deleted">Hat jêbirin</string>
     <string name="media_upload_state_deleting">Tê jêbirin</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -3000,11 +3000,11 @@ Language: ko_KR
     <string name="editor_post_saved_online">글이 온라인으로 저장되었습니다.</string>
     <string name="site_settings_image_quality_hint">사진 품질. 값이 클수록 고품질의 사진을 의미합니다.</string>
     <string name="site_settings_optimize_images_summary">사진 크기를 조정하고 압축할 수 있습니다.</string>
-    <string name="media_encoder_quality_100">최대</string>
-    <string name="media_encoder_quality_95">매우 높음</string>
-    <string name="media_encoder_quality_90">높음</string>
-    <string name="media_encoder_quality_85">보통</string>
-    <string name="media_encoder_quality_80">낮음</string>
+    <string name="media_encoder_quality_maximum">최대</string>
+    <string name="media_encoder_quality_very_high">매우 높음</string>
+    <string name="media_encoder_quality_high">높음</string>
+    <string name="media_encoder_quality_medium">보통</string>
+    <string name="media_encoder_quality_low">낮음</string>
     <string name="media_upload_state_uploaded">업로드됨</string>
     <string name="media_upload_state_failed">실패</string>
     <string name="media_upload_state_deleted">삭제됨</string>

--- a/WordPress/src/main/res/values-lv/strings.xml
+++ b/WordPress/src/main/res/values-lv/strings.xml
@@ -2920,11 +2920,11 @@ Language: lv
     <string name="editor_post_saved_online">Ziņa saglabāta tiešsaistē</string>
     <string name="site_settings_image_quality_hint">Attēlu kvalitāte. Augstākas vērtības nozīmē labākas kvalitātes attēlus.</string>
     <string name="site_settings_optimize_images_summary">Iespējot attēlu lieluma maiņu un saspiešanu</string>
-    <string name="media_encoder_quality_100">Maksimāla</string>
-    <string name="media_encoder_quality_95">Ļoti augsta</string>
-    <string name="media_encoder_quality_90">Augsta</string>
-    <string name="media_encoder_quality_85">Vidēja</string>
-    <string name="media_encoder_quality_80">Zema</string>
+    <string name="media_encoder_quality_maximum">Maksimāla</string>
+    <string name="media_encoder_quality_very_high">Ļoti augsta</string>
+    <string name="media_encoder_quality_high">Augsta</string>
+    <string name="media_encoder_quality_medium">Vidēja</string>
+    <string name="media_encoder_quality_low">Zema</string>
     <string name="media_upload_state_uploaded">Augšupielādēts</string>
     <string name="media_upload_state_failed">Augšupielāde neizdevās</string>
     <string name="media_upload_state_deleted">Dzēsts</string>

--- a/WordPress/src/main/res/values-ms/strings.xml
+++ b/WordPress/src/main/res/values-ms/strings.xml
@@ -268,12 +268,12 @@ Language: ms
     <string name="editor_post_saved_online">Kiriman disimpan atas talian</string>
     <string name="site_settings_image_quality_hint">Kualiti gambar. Nilai lebih tinggi bermakna kualiti gambar yang lebih baik.</string>
     <string name="site_settings_optimize_images_summary">Bolehkan untuk saiz semula dan mampatkan gambar</string>
-    <string name="media_encoder_quality_90">Tinggi</string>
-    <string name="media_encoder_quality_80">Rendah</string>
-    <string name="media_encoder_quality_100">Maksimum</string>
-    <string name="media_encoder_quality_85">Medium</string>
+    <string name="media_encoder_quality_high">Tinggi</string>
+    <string name="media_encoder_quality_low">Rendah</string>
+    <string name="media_encoder_quality_maximum">Maksimum</string>
+    <string name="media_encoder_quality_medium">Medium</string>
     <string name="media_upload_state_uploaded">Dimuat naik</string>
-    <string name="media_encoder_quality_95">Sangat Tinggi</string>
+    <string name="media_encoder_quality_very_high">Sangat Tinggi</string>
     <string name="media_upload_state_deleted">Dihapuskan</string>
     <string name="media_upload_state_deleting">Menghapuskan</string>
     <string name="media_upload_state_queued">Digilir</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -1839,11 +1839,11 @@ Language: nb_NO
     <string name="editor_post_saved_online">Innlegget ble lagret på nettet</string>
     <string name="site_settings_image_quality_hint">Bildenes kvalitet. Høyere verdier = bedre kvalitet.</string>
     <string name="site_settings_optimize_images_summary">Aktiver for å komprimere og endre størrelsen på bilder</string>
-    <string name="media_encoder_quality_100">Maksimum</string>
-    <string name="media_encoder_quality_95">Veldig høy</string>
-    <string name="media_encoder_quality_90">Høy</string>
-    <string name="media_encoder_quality_85">Middels</string>
-    <string name="media_encoder_quality_80">Lav</string>
+    <string name="media_encoder_quality_maximum">Maksimum</string>
+    <string name="media_encoder_quality_very_high">Veldig høy</string>
+    <string name="media_encoder_quality_high">Høy</string>
+    <string name="media_encoder_quality_medium">Middels</string>
+    <string name="media_encoder_quality_low">Lav</string>
     <string name="media_upload_state_uploaded">Lastet opp</string>
     <string name="media_upload_state_failed">Opplastingmislyktes</string>
     <string name="media_upload_state_deleted">Slettet</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -2955,11 +2955,11 @@ Language: nl
     <string name="editor_post_saved_online">Het bericht is online opgeslagen</string>
     <string name="site_settings_image_quality_hint">Kwaliteit van afbeeldingen. Hoe hoger de waarde, hoe beter de kwaliteit van je afbeeldingen.</string>
     <string name="site_settings_optimize_images_summary">Het aanpassen van de grootte en het comprimeren van afbeeldingen inschakelen</string>
-    <string name="media_encoder_quality_100">Maximaal</string>
-    <string name="media_encoder_quality_95">Zeer hoog</string>
-    <string name="media_encoder_quality_90">Hoog</string>
-    <string name="media_encoder_quality_85">Gemiddeld</string>
-    <string name="media_encoder_quality_80">Laag</string>
+    <string name="media_encoder_quality_maximum">Maximaal</string>
+    <string name="media_encoder_quality_very_high">Zeer hoog</string>
+    <string name="media_encoder_quality_high">Hoog</string>
+    <string name="media_encoder_quality_medium">Gemiddeld</string>
+    <string name="media_encoder_quality_low">Laag</string>
     <string name="media_upload_state_uploaded">Geüpload</string>
     <string name="media_upload_state_failed">Upload mislukt</string>
     <string name="media_upload_state_deleted">Verwijderd</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -2535,12 +2535,12 @@ Language: pl
     <string name="editor_post_saved_online">Wpis został zapisany online</string>
     <string name="site_settings_image_quality_hint">Jakość obrazków. Wyższa wartość oznacza lepszą jakość.</string>
     <string name="site_settings_optimize_images_summary">Uaktywnij aby zmienić rozmiar i skompresować obrazki</string>
-    <string name="media_encoder_quality_95">Bardzo wysoka</string>
-    <string name="media_encoder_quality_90">Wysoka</string>
-    <string name="media_encoder_quality_80">Niska</string>
+    <string name="media_encoder_quality_very_high">Bardzo wysoka</string>
+    <string name="media_encoder_quality_high">Wysoka</string>
+    <string name="media_encoder_quality_low">Niska</string>
     <string name="media_upload_state_uploaded">Wysłano</string>
-    <string name="media_encoder_quality_85">Średnio</string>
-    <string name="media_encoder_quality_100">Maksimum</string>
+    <string name="media_encoder_quality_medium">Średnio</string>
+    <string name="media_encoder_quality_maximum">Maksimum</string>
     <string name="media_upload_state_deleted">Usunięto</string>
     <string name="media_upload_state_deleting">Usuwanie</string>
     <string name="media_upload_state_uploading">Przesyłanie</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -2812,11 +2812,11 @@ Language: pt_BR
     <string name="editor_post_saved_online">Post salvo online</string>
     <string name="site_settings_image_quality_hint">Qualidade das imagens. Valores maiores significam melhor qualidade das imagens.</string>
     <string name="site_settings_optimize_images_summary">Habilite para redimensionar e comprimir imagens</string>
-    <string name="media_encoder_quality_100">Máxima</string>
-    <string name="media_encoder_quality_95">Muito alta</string>
-    <string name="media_encoder_quality_90">Alta</string>
-    <string name="media_encoder_quality_85">Média</string>
-    <string name="media_encoder_quality_80">Baixa</string>
+    <string name="media_encoder_quality_maximum">Máxima</string>
+    <string name="media_encoder_quality_very_high">Muito alta</string>
+    <string name="media_encoder_quality_high">Alta</string>
+    <string name="media_encoder_quality_medium">Média</string>
+    <string name="media_encoder_quality_low">Baixa</string>
     <string name="media_upload_state_uploaded">Upload realizado</string>
     <string name="media_upload_state_failed">Falha no upload</string>
     <string name="media_upload_state_deleted">Excluído</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -3006,11 +3006,11 @@ Language: ro
     <string name="editor_post_saved_online">Articol salvat online</string>
     <string name="site_settings_image_quality_hint">Calitatea imaginilor. Valorile mai mari înseamnă imagini de calitate mai bună.</string>
     <string name="site_settings_optimize_images_summary">Activează pentru a redimensiona și comprima imagini</string>
-    <string name="media_encoder_quality_100">Maximă</string>
-    <string name="media_encoder_quality_95">Foarte bună</string>
-    <string name="media_encoder_quality_90">Bună</string>
-    <string name="media_encoder_quality_85">Medie</string>
-    <string name="media_encoder_quality_80">Slabă</string>
+    <string name="media_encoder_quality_maximum">Maximă</string>
+    <string name="media_encoder_quality_very_high">Foarte bună</string>
+    <string name="media_encoder_quality_high">Bună</string>
+    <string name="media_encoder_quality_medium">Medie</string>
+    <string name="media_encoder_quality_low">Slabă</string>
     <string name="media_upload_state_uploaded">Încărcată</string>
     <string name="media_upload_state_failed">Încărcarea a eșuat</string>
     <string name="media_upload_state_deleted">Ștearsă</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -3006,11 +3006,11 @@ Language: ru
     <string name="editor_post_saved_online">Запись сохранена в Интернете.</string>
     <string name="site_settings_image_quality_hint">Качество фотографий. Чем выше значение, тем выше качество изображений.</string>
     <string name="site_settings_optimize_images_summary">Включить функцию изменения размера и сжатия изображений</string>
-    <string name="media_encoder_quality_100">Максимальное</string>
-    <string name="media_encoder_quality_95">Очень высокое</string>
-    <string name="media_encoder_quality_90">Высокое</string>
-    <string name="media_encoder_quality_85">Среднее</string>
-    <string name="media_encoder_quality_80">Низкое</string>
+    <string name="media_encoder_quality_maximum">Максимальное</string>
+    <string name="media_encoder_quality_very_high">Очень высокое</string>
+    <string name="media_encoder_quality_high">Высокое</string>
+    <string name="media_encoder_quality_medium">Среднее</string>
+    <string name="media_encoder_quality_low">Низкое</string>
     <string name="media_upload_state_uploaded">Загружено</string>
     <string name="media_upload_state_failed">Загрузка не удалась</string>
     <string name="media_upload_state_deleted">Удалено</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -817,11 +817,11 @@ Language: sk
     <string name="editor_post_saved_online">článok uložený online.</string>
     <string name="site_settings_image_quality_hint">Kvalita obrázkov. Vyššie hodnoty znamenajú lepšiu kvalitu obrázkov.</string>
     <string name="site_settings_optimize_images_summary">Povoliť zmenu veľkosti a komprimovanie obrázkov.</string>
-    <string name="media_encoder_quality_100">Maximálna</string>
-    <string name="media_encoder_quality_95">Veľmi vysoká</string>
-    <string name="media_encoder_quality_90">Vysoká</string>
-    <string name="media_encoder_quality_85">Stredná</string>
-    <string name="media_encoder_quality_80">Nízka</string>
+    <string name="media_encoder_quality_maximum">Maximálna</string>
+    <string name="media_encoder_quality_very_high">Veľmi vysoká</string>
+    <string name="media_encoder_quality_high">Vysoká</string>
+    <string name="media_encoder_quality_medium">Stredná</string>
+    <string name="media_encoder_quality_low">Nízka</string>
     <string name="media_upload_state_uploaded">Nahraté</string>
     <string name="media_upload_state_failed">Nahrávanie zlyhalo</string>
     <string name="media_upload_state_deleted">Vymazané</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -2997,11 +2997,11 @@ Language: sq_AL
     <string name="editor_post_saved_online">Postimi u ruajt në internet</string>
     <string name="site_settings_image_quality_hint">Cilësi fotosh. Vlera më të mëdha do të thotë cilësi më e lartë fotosh.</string>
     <string name="site_settings_optimize_images_summary">Aktivizojeni që të ripërmasoni dhe ngjeshni foto</string>
-    <string name="media_encoder_quality_100">Maksimum</string>
-    <string name="media_encoder_quality_95">Shumë e Lartë</string>
-    <string name="media_encoder_quality_90">E lartë</string>
-    <string name="media_encoder_quality_85">E mesme</string>
-    <string name="media_encoder_quality_80">E ulët</string>
+    <string name="media_encoder_quality_maximum">Maksimum</string>
+    <string name="media_encoder_quality_very_high">Shumë e Lartë</string>
+    <string name="media_encoder_quality_high">E lartë</string>
+    <string name="media_encoder_quality_medium">E mesme</string>
+    <string name="media_encoder_quality_low">E ulët</string>
     <string name="media_upload_state_uploaded">U ngarkua</string>
     <string name="media_upload_state_failed">Ngarkimi Dështoi</string>
     <string name="media_upload_state_deleted">U fshi</string>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -1455,11 +1455,11 @@ Language: sr_RS
     <string name="photo_picker_title">Одабери фотографију</string>
     <string name="editor_post_saved_online">Чланак сачуван онлајн</string>
     <string name="site_settings_image_quality_hint">Квалитет слика. Више вредности представљају слике бољег квалитета.</string>
-    <string name="media_encoder_quality_100">Максималан</string>
-    <string name="media_encoder_quality_95">Врло висок</string>
-    <string name="media_encoder_quality_90">Висок</string>
-    <string name="media_encoder_quality_85">Средњи</string>
-    <string name="media_encoder_quality_80">Низак</string>
+    <string name="media_encoder_quality_maximum">Максималан</string>
+    <string name="media_encoder_quality_very_high">Врло висок</string>
+    <string name="media_encoder_quality_high">Висок</string>
+    <string name="media_encoder_quality_medium">Средњи</string>
+    <string name="media_encoder_quality_low">Низак</string>
     <string name="media_upload_state_uploaded">Отпремљено</string>
     <string name="media_upload_state_failed">Неуспело отпремање</string>
     <string name="media_upload_state_deleted">Обрисано</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -3006,11 +3006,11 @@ Language: sv_SE
     <string name="editor_post_saved_online">Inlägget har sparats on-line</string>
     <string name="site_settings_image_quality_hint">Bildkvalitet. Ett högre värde innebär bilder med högre kvalitet.</string>
     <string name="site_settings_optimize_images_summary">Gör det möjligt att ändra storlek på och komprimera bildfiler</string>
-    <string name="media_encoder_quality_100">Max</string>
-    <string name="media_encoder_quality_95">Mycket hög</string>
-    <string name="media_encoder_quality_90">Hög</string>
-    <string name="media_encoder_quality_85">Medium</string>
-    <string name="media_encoder_quality_80">Låg</string>
+    <string name="media_encoder_quality_maximum">Max</string>
+    <string name="media_encoder_quality_very_high">Mycket hög</string>
+    <string name="media_encoder_quality_high">Hög</string>
+    <string name="media_encoder_quality_medium">Medium</string>
+    <string name="media_encoder_quality_low">Låg</string>
     <string name="media_upload_state_uploaded">Uppladdat</string>
     <string name="media_upload_state_failed">Uppladdningen misslyckades</string>
     <string name="media_upload_state_deleted">Raderat</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -3006,11 +3006,11 @@ Language: tr
     <string name="editor_post_saved_online">Yazı çevrimiçi kaydedildi.</string>
     <string name="site_settings_image_quality_hint">Görüntülerin kalitesi. Daha yüksek değerler daha kaliteli görüntü anlamına gelir.</string>
     <string name="site_settings_optimize_images_summary">Görüntülerin boyutlandırılıp sıkıştırılabilmelerini etkinleştir</string>
-    <string name="media_encoder_quality_100">En yüksek</string>
-    <string name="media_encoder_quality_95">Çok yüksek</string>
-    <string name="media_encoder_quality_90">Yüksek</string>
-    <string name="media_encoder_quality_85">Orta</string>
-    <string name="media_encoder_quality_80">Düşük</string>
+    <string name="media_encoder_quality_maximum">En yüksek</string>
+    <string name="media_encoder_quality_very_high">Çok yüksek</string>
+    <string name="media_encoder_quality_high">Yüksek</string>
+    <string name="media_encoder_quality_medium">Orta</string>
+    <string name="media_encoder_quality_low">Düşük</string>
     <string name="media_upload_state_uploaded">Yüklendi</string>
     <string name="media_upload_state_failed">Yükleme başarısız oldu</string>
     <string name="media_upload_state_deleted">Silindi</string>

--- a/WordPress/src/main/res/values-vi/strings.xml
+++ b/WordPress/src/main/res/values-vi/strings.xml
@@ -2493,11 +2493,11 @@ Language: vi_VN
     <string name="editor_post_saved_online">Đã lưu bài viết online</string>
     <string name="site_settings_image_quality_hint">Chất lượng ảnh. Thông số càng cao thì chất lượng ảnh càng cao.</string>
     <string name="site_settings_optimize_images_summary">Thay đổi kích thước và nén hình</string>
-    <string name="media_encoder_quality_100">Tối đa</string>
-    <string name="media_encoder_quality_95">Rất cao</string>
-    <string name="media_encoder_quality_90">Cao</string>
-    <string name="media_encoder_quality_85">Trung bình</string>
-    <string name="media_encoder_quality_80">Thấp</string>
+    <string name="media_encoder_quality_maximum">Tối đa</string>
+    <string name="media_encoder_quality_very_high">Rất cao</string>
+    <string name="media_encoder_quality_high">Cao</string>
+    <string name="media_encoder_quality_medium">Trung bình</string>
+    <string name="media_encoder_quality_low">Thấp</string>
     <string name="media_upload_state_uploaded">Đã tải lên</string>
     <string name="media_upload_state_failed">Tải lên thất bại</string>
     <string name="media_upload_state_deleted">Đã xóa</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -2996,11 +2996,11 @@ Language: zh_CN
     <string name="editor_post_saved_online">文章已在线保存</string>
     <string name="site_settings_image_quality_hint">图片质量。值越高，表示图片质量越好。</string>
     <string name="site_settings_optimize_images_summary">启用以调整图片大小和压缩图片</string>
-    <string name="media_encoder_quality_100">最大值</string>
-    <string name="media_encoder_quality_95">非常高</string>
-    <string name="media_encoder_quality_90">高</string>
-    <string name="media_encoder_quality_85">中</string>
-    <string name="media_encoder_quality_80">低</string>
+    <string name="media_encoder_quality_maximum">最大值</string>
+    <string name="media_encoder_quality_very_high">非常高</string>
+    <string name="media_encoder_quality_high">高</string>
+    <string name="media_encoder_quality_medium">中</string>
+    <string name="media_encoder_quality_low">低</string>
     <string name="media_upload_state_uploaded">已上传</string>
     <string name="media_upload_state_failed">上传失败</string>
     <string name="media_upload_state_deleted">已删除</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -2998,11 +2998,11 @@ Language: zh_TW
     <string name="editor_post_saved_online">文章已在線上儲存</string>
     <string name="site_settings_image_quality_hint">照片品質。越高的值代表越高的照片品質。</string>
     <string name="site_settings_optimize_images_summary">啟用即可調整照片大小和壓縮照片</string>
-    <string name="media_encoder_quality_100">上限</string>
-    <string name="media_encoder_quality_95">超高</string>
-    <string name="media_encoder_quality_90">高</string>
-    <string name="media_encoder_quality_85">中</string>
-    <string name="media_encoder_quality_80">低</string>
+    <string name="media_encoder_quality_maximum">上限</string>
+    <string name="media_encoder_quality_very_high">超高</string>
+    <string name="media_encoder_quality_high">高</string>
+    <string name="media_encoder_quality_medium">中</string>
+    <string name="media_encoder_quality_low">低</string>
     <string name="media_upload_state_uploaded">已上傳</string>
     <string name="media_upload_state_failed">上傳失敗</string>
     <string name="media_upload_state_deleted">已刪除</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -2998,11 +2998,11 @@ Language: zh_TW
     <string name="editor_post_saved_online">文章已在線上儲存</string>
     <string name="site_settings_image_quality_hint">照片品質。越高的值代表越高的照片品質。</string>
     <string name="site_settings_optimize_images_summary">啟用即可調整照片大小和壓縮照片</string>
-    <string name="media_encoder_quality_100">上限</string>
-    <string name="media_encoder_quality_95">超高</string>
-    <string name="media_encoder_quality_90">高</string>
-    <string name="media_encoder_quality_85">中</string>
-    <string name="media_encoder_quality_80">低</string>
+    <string name="media_encoder_quality_maximum">上限</string>
+    <string name="media_encoder_quality_very_high">超高</string>
+    <string name="media_encoder_quality_high">高</string>
+    <string name="media_encoder_quality_medium">中</string>
+    <string name="media_encoder_quality_low">低</string>
     <string name="media_upload_state_uploaded">已上傳</string>
     <string name="media_upload_state_failed">上傳失敗</string>
     <string name="media_upload_state_deleted">已刪除</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -356,11 +356,11 @@
     </string-array>
 
     <string-array name="site_settings_image_quality_entries" translatable="false">
-        <item>@string/media_encoder_quality_80</item>
-        <item>@string/media_encoder_quality_85</item>
-        <item>@string/media_encoder_quality_90</item>
-        <item>@string/media_encoder_quality_95</item>
-        <item>@string/media_encoder_quality_100</item>
+        <item>@string/media_encoder_quality_low</item>
+        <item>@string/media_encoder_quality_medium</item>
+        <item>@string/media_encoder_quality_high</item>
+        <item>@string/media_encoder_quality_very_high</item>
+        <item>@string/media_encoder_quality_maximum</item>
     </string-array>
 
     <string-array name="site_settings_image_quality_values" translatable="false">
@@ -386,11 +386,11 @@
     </string-array>
 
     <string-array name="site_settings_video_bitrate_entries" translatable="false">
-        <item>@string/media_encoder_quality_80</item>
-        <item>@string/media_encoder_quality_85</item>
-        <item>@string/media_encoder_quality_90</item>
-        <item>@string/media_encoder_quality_95</item>
-        <item>@string/media_encoder_quality_100</item>
+        <item>@string/media_encoder_quality_low</item>
+        <item>@string/media_encoder_quality_medium</item>
+        <item>@string/media_encoder_quality_high</item>
+        <item>@string/media_encoder_quality_very_high</item>
+        <item>@string/media_encoder_quality_maximum</item>
     </string-array>
 
     <string-array name="site_settings_video_bitrate_values" translatable="false">

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -364,8 +364,8 @@
     </string-array>
 
     <string-array name="site_settings_image_quality_values" translatable="false">
+        <item>70</item>
         <item>80</item>
-        <item>85</item>
         <item>90</item>
         <item>95</item>
         <item>100</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -174,11 +174,11 @@
     <string name="media_upload_state_failed">Upload Failed</string>
     <string name="media_upload_state_uploaded">Uploaded</string>
 
-    <string name="media_encoder_quality_80">Low</string>
-    <string name="media_encoder_quality_85">Medium</string>
-    <string name="media_encoder_quality_90">High</string>
-    <string name="media_encoder_quality_95">Very High</string>
-    <string name="media_encoder_quality_100">Maximum</string>
+    <string name="media_encoder_quality_low">Low</string>
+    <string name="media_encoder_quality_medium">Medium</string>
+    <string name="media_encoder_quality_high">High</string>
+    <string name="media_encoder_quality_very_high">Very High</string>
+    <string name="media_encoder_quality_maximum">Maximum</string>
     <string name="media_browse_for_items">Browse for items</string>
 
     <!-- Edit Media -->


### PR DESCRIPTION
> **Note**
> Although this PR is large, the vast majority of file changes are the result of a change to a string name, as can be viewed in https://github.com/wordpress-mobile/WordPress-Android/pull/19644/commits/452ed672ac3d147571376dc954eb907bb4f34c23.

Merging into https://github.com/wordpress-mobile/WordPress-Android/pull/19581.

## Description

This PR changes the default values associated with the `Low` and `Medium` image quality settings found under _Me_ → _App Settings_.

The `Low` value has been changed from `80` to `70`, and the `Medium` value has been changed from `85` to `80`. This brings the Android app with the values introduced for iOS in https://github.com/wordpress-mobile/WordPress-iOS/pull/21981.

We've decided to change these values without explicitly notifying users, with the following in mind:

- Users don’t technically select `85`. They choose `Medium` or `Low`. The decision around what these values meant was set around 6 or 7 years ago. We think it’s fair to reassess what `Medium` or `Low` means in this day and age (now that image quality tends to be a lot higher, and therefore 80% compression may not be as visually impactful as it would have been years ago).
- 5% isn’t that meaningful a difference, and we wouldn't expect most users who've chosen `Medium` to notice it.
- Those users who've selected `Low` know the route to follow to change this setting, and have already manually indicated that they value speed over quality.

Related discussion: pcdRpT-4tj-p2 

-----

## To Test

- Add an image to your phone's library with a large file size.
- Navigate to _Me_ → _App Settings_ and ensure **Optimize Images** is toggled on.
- Select either **Low** or **Medium** from the **Image Quality** dropdown.
- Navigate to the post editor and add an image block.
- Tap on the **Choose from device** option.
- Select the image previously added with a large file size, and wait for the image upload to finish.
- Go to the browser and navigate to the **Media** screen of the site.
- Select the uploaded image and click on the **Edit** button.
- Observe that the file size under the FILE SIZE section is smaller than the original file size and is of the quality you'd expect.

-----

## Regression Notes

1. Potential unintended areas of impact

    - As we're changing numerous language files, there's a chance translations could be unintentionally impacted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - I manually tested the app in a few different languages to verify there were no regressions.

3. What automated tests I added (or what prevented me from doing so)

    - Automated tests for the image optimization settings are to follow in a separate PR.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.