### PR TITLE
[Prompt] Check bloganuary_id for mapping attribution

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
 
 enum class BloggingPromptAttribution(
     val value: String,
@@ -22,8 +23,24 @@ enum class BloggingPromptAttribution(
     );
 
     companion object {
-        fun fromString(value: String): BloggingPromptAttribution = entries
+        private fun fromString(value: String): BloggingPromptAttribution = entries
             .firstOrNull { it.value == value }
             ?: NO_ATTRIBUTION
+
+        /**
+         * Returns the [BloggingPromptAttribution] for the given [BloggingPromptModel], prioritizing the content of the
+         * [BloggingPromptModel.bloganuaryId] field before the actual [BloggingPromptModel.attribution] field for
+         * detecting [BLOGANUARY] attribution.
+         *
+         * This is a workaround for the fact that the [BloggingPromptModel.attribution] field is not going to be used
+         * for the BLOGANUARY campaign at this point, but might be in the future.
+         */
+        fun fromPrompt(
+            prompt: BloggingPromptModel
+        ): BloggingPromptAttribution = if (!prompt.bloganuaryId.isNullOrBlank()) {
+            BLOGANUARY
+        } else {
+            fromString(prompt.attribution)
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -28,7 +28,7 @@ class BloggingPromptCardBuilder @Inject constructor() {
             isAnswered = params.bloggingPrompt.isAnswered,
             promptId = params.bloggingPrompt.id,
             tagUrl = params.bloggingPrompt.answeredLink,
-            attribution = BloggingPromptAttribution.fromString(params.bloggingPrompt.attribution),
+            attribution = BloggingPromptAttribution.fromPrompt(params.bloggingPrompt),
             onShareClick = params.onShareClick,
             onAnswerClick = params.onAnswerClick,
             onSkipClick = params.onSkipClick,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -185,7 +185,7 @@ class WPMainActivityViewModel @Inject constructor(
                         promptTitle = UiStringText(it.text),
                         isAnswered = prompt.isAnswered,
                         promptId = prompt.id,
-                        attribution = BloggingPromptAttribution.fromString(prompt.attribution),
+                        attribution = BloggingPromptAttribution.fromPrompt(prompt),
                         onClickAction = ::onAnswerPromptActionClicked,
                         onHelpAction = ::onHelpPrompActionClicked
                     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -62,6 +62,14 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given blogging prompt with bloganuary_id, when card is built, then return matching card`() {
+        val promptCard = buildBloggingPromptCardBuilderParams(
+            bloggingPromptModel("dayone").copy(bloganuaryId = "bloganuary-2023-01")
+        )
+        assertThat(promptCard).isEqualTo(bloggingPromptCard(BloggingPromptAttribution.BLOGANUARY))
+    }
+
+    @Test
     fun `given no blogging prompt, when card is built, then return null`() {
         val statCard = buildBloggingPromptCardBuilderParams(null)
 


### PR DESCRIPTION
At first we will not have the `bloganuary` attribution for the Bloganuary posts, so we should rely on the `bloganuary_id` being present to decide if the post is from Bloganuary or not.

-----

## To Test:

The testing setup is the same as the one explained here: https://github.com/wordpress-mobile/WordPress-Android/pull/19590 (Charles Setup and mocked json response), but make sure to check if the prompt for the day you're testing is in the list and manually set the `attribution` field for that item to "" or "dayone" to confirm the `bloganuary-id` takes precedence.

### Test Steps
1. Download, install, and log in the Jetpack version from this PR
3. **Disable** the `Map Local` setting in Charles (so we hit the actual endpoint)
4. Refresh the app dashboard
5. **Verify** the prompt card either shows no attribution UI or the `Day One` attribution (if today's prompt is a Day One prompt)
6. **Enable** the `Map Local` setting in Charles (so we hit our mocked json response)
7. Refresh the app dashboard
8. **Verify** the prompt card shows the attribution UI for `Bloganuary`

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated mapping tests.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
