### PR TITLE
Update default max size to 2000 for optimized images

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -54,7 +54,7 @@ public class WPMediaUtils {
         void onMediaCapturePathReady(String mediaCapturePath);
     }
 
-    // 3000px is the utmost max resolution you can set in the current picker, but 2000px is the default mac for optimized images.
+    // 3000px is the utmost max resolution you can set in the picker but 2000px is the default max for optimized images.
     public static final int OPTIMIZE_IMAGE_MAX_SIZE = 2000;
     public static final int OPTIMIZE_IMAGE_ENCODER_QUALITY = 85;
     public static final int OPTIMIZE_VIDEO_MAX_WIDTH = 1280;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -54,8 +54,8 @@ public class WPMediaUtils {
         void onMediaCapturePathReady(String mediaCapturePath);
     }
 
-    // Max picture size will be 3000px wide. That's the maximum resolution you can set in the current picker.
-    public static final int OPTIMIZE_IMAGE_MAX_SIZE = 3000;
+    // 3000px is the utmost max resolution you can set in the current picker, but 2000px is the default mac for optimized images.
+    public static final int OPTIMIZE_IMAGE_MAX_SIZE = 2000;
     public static final int OPTIMIZE_IMAGE_ENCODER_QUALITY = 85;
     public static final int OPTIMIZE_VIDEO_MAX_WIDTH = 1280;
     public static final int OPTIMIZE_VIDEO_ENCODER_BITRATE_KB = 3000;


### PR DESCRIPTION
Merging into https://github.com/wordpress-mobile/WordPress-Android/pull/19581.

### Description

This PR changes the default maximum image size for optimized images from 3000px to 2000px.

A discussion and reasoning for this change can be found at pcdRpT-4Ec-p2, with the summary being that we believe 2000px is a more optimal default than 3000px. We arrived at this number after considering and researching recommendations for image sizes:

- According to [this article](https://href.li/?https://tiny-img.com/blog/best-image-size-for-website/), 1920 x 1080 px is the most used screen resolution, making it the recommended resolution for background images.
- A commonly [recommended size for featured images](https://wordpress.com/go/tutorials/controlling-wordpress-image-sizes/#the-perfect-featured-image-size) is 1200 x 628 px, while 1920 x 1080 px is the largest recommendation we could find for any theme.
- For images that appear in the main body of posts and pages, themes will generally enforce a maximum width via their code on the front end. For example, the default maximum content width in [Twenty Twenty-Three](https://href.li/?https://wordpress.org/themes/twentytwentythree/) is 650px. As such, even images uploaded at full resolution to posts in that theme will visually only appear at a maximum of 650px wide. 

Those who wish to have a greater default max size will continue to have the option of increasing it. 

-----

## To Test

**_Pre-requisite:_** When testing, you should first begin on an older version of the app that doesn't have these changes, before either updating to a version with these changes using either the installable build on this PR or switching from `trunk` to this branch locally.

<details>
 <summary>Verify new default ⤵️</summary>
 
- Ensure the optimization settings have never been set on your installed app.
- Update the app either using the installable build on this PR or switching to this branch locally.
- Navigate to _Me_ → _App Settings_. 
- Verify that optimization is enabled by default, and that 2000px is the max upload size.

</details>

<details>
 <summary>Ensure previous selections are preserved ⤵️</summary>

- In the initial version of your app, navigate to _Me_ → _App Settings_. 
- Enable image optimization and select a value for the max upload size that is any value other than 2000px.
- Update the app either using the installable build on this PR or switching to this branch locally.
- Navigate back to _Me_ → _App Settings_. 
- Verify that your initial selection has been preserved.

</details>

-----

## Regression Notes

1. Potential unintended areas of impact

- As we're changing default settings, we run a risk of setting new defaults for users who've previously set the max size to something else.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I ran through manually tests to ensure values that had previously been set were not changed.

3. What automated tests I added (or what prevented me from doing so)

- Automated tests for the image optimization settings are to follow in a separate PR.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----