### PR TITLE
Removes font families from the stored block settings response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.108.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2.55.0'
+    wordPressFluxCVersion = '2.55.1'
     wordPressLoginVersion = '1.8.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Partially handles https://github.com/wordpress-mobile/WordPress-Android/issues/9685

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2904

-----

## To Test:

Follow the steps in https://github.com/wordpress-mobile/WordPress-Android/issues/9685#issuecomment-1822130656

-----

## Regression Notes

1. Potential unintended areas of impact

Editor functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

This PR involves only a FluxC reference update

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)