### PR TITLE
Fix VideoPress preview tap issue in the Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -15,6 +15,8 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import androidx.annotation.NonNull;
+
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.WPWebView;
@@ -220,6 +222,10 @@ public class ReaderWebView extends WPWebView {
         }
     }
 
+    private boolean isVideoPressPreview(@NonNull String url) {
+        return url.startsWith("https://videos.files.wordpress.com");
+    }
+
     /*
      * detect when a link is tapped
      */
@@ -228,26 +234,25 @@ public class ReaderWebView extends WPWebView {
     public boolean onTouchEvent(MotionEvent event) {
         if (event.getAction() == MotionEvent.ACTION_UP && mUrlClickListener != null) {
             HitTestResult hr = getHitTestResult();
-            if (hr != null) {
-                if (isValidClickedUrl(hr.getExtra())) {
-                    if (UrlUtils.isImageUrl(hr.getExtra())) {
-                        if (isValidEmbeddedImageClick(hr)) {
-                            return super.onTouchEvent(event);
-                        } else {
-                            return mUrlClickListener.onImageUrlClick(
-                                    hr.getExtra(),
-                                    this,
-                                    (int) event.getX(),
-                                    (int) event.getY());
-                        }
+            String url = hr.getExtra();
+            if (isValidClickedUrl(url)) {
+                if (UrlUtils.isImageUrl(url)) {
+                    if (isValidEmbeddedImageClick(hr) || isVideoPressPreview(url)) {
+                        return super.onTouchEvent(event);
                     } else {
-                        return mUrlClickListener.onUrlClick(hr.getExtra());
+                        return mUrlClickListener.onImageUrlClick(
+                            url,
+                            this,
+                            (int) event.getX(),
+                            (int) event.getY());
                     }
                 } else {
-                    String pageJump = UrlUtils.getPageJumpOrNull(hr.getExtra());
-                    if (null != pageJump) {
-                        return mUrlClickListener.onPageJumpClick(pageJump);
-                    }
+                    return mUrlClickListener.onUrlClick(url);
+                }
+            } else {
+                String pageJump = UrlUtils.getPageJumpOrNull(url);
+                if (null != pageJump) {
+                    return mUrlClickListener.onPageJumpClick(pageJump);
                 }
             }
         }


### PR DESCRIPTION
Fixes #18836

> When opening a post in the Reader that contains a ViedoPress video, tapping on the video displays a fullscreen modal with the message "Unable to preview image". The video can still be played but only when tapping in the play icon button.

The issue occurred because while tapping on the video outside the play button, we handled it as an image tap. I excluded videopress cover images from the tap listener to fix the issue

https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/b3672ceb-55e6-4aac-a5c9-7a418b7d28fd


-----

## To Test:

- Open a post that contains a VideoPress video in the Reader.
- Tap on the video. NOTE: Avoid tapping on the play button as it will play it.
- [x] Ensure that the video is played and you don't see a fullscreen modal with the message "Unable to preview image".

-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader embedded WebView

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual tests

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
