### PR TITLE
Pass selected domain for Calypso error case in the site creation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -60,7 +60,7 @@ class SiteCreationPlansViewModel @Inject constructor(
     }
 
     fun onCalypsoError() {
-        postActionEvent(SiteCreationPlansActionEvent.CreateSite(null, ""))
+        postActionEvent(SiteCreationPlansActionEvent.CreateSite(null, domain.domainName))
     }
 
     private fun showPlans() {


### PR DESCRIPTION
This fixes the incorrect domain name in the site creation flow for the Calypso error fallback case.

Due to a Calypso error, some devices have trouble seeing the plans page in the site creation flow. We added a fallback solution for these users to bypass the plans page with https://github.com/wordpress-mobile/WordPress-Android/pull/19639, but it fails to pass the domain name to the site creation process. Consequently, if the user selects a free domain and creates a site, they end up with a site using a random domain. This PR fixes the issue.

-----

## To Test:

Testing Procedure:
Firstly, ensure that you have a device/emulator encountering the Calypso error. Emulators typically exhibit this issue.
1. Launch the JP app on an emulator.
2. Log in.
3. Tap the ⌄ button near the site name. 
4. Tap the + button and Create WordPress.com site.
5. Skip the topic screen.
6. Skip the theme screen.
7. Search for a domain name.
8. Select a free domain.
9. Verify that the created site has your selected domain name.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

10. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

11. What automated tests I added (or what prevented me from doing so)

    - There should be unit tests for the plans page. However, since this is a beta fix, I opened https://github.com/wordpress-mobile/WordPress-Android/issues/19653 to address it later.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)