### PR TITLE
Removes category selection from page pre-publishing options

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewModel.kt
@@ -123,16 +123,18 @@ class PrepublishingHomeViewModel @Inject constructor(
                 site
             )
 
-            add(HomeUiState(
-                navigationAction = PrepublishingScreenNavigation.Categories,
-                actionResult = if (categoriesString.isNotEmpty()) {
-                    UiStringText(categoriesString)
-                } else {
-                    run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) }
-                },
-                actionClickable = true,
-                onNavigationActionClicked = ::onActionClicked
-            ))
+            if (!editPostRepository.isPage) {
+                add(HomeUiState(
+                    navigationAction = PrepublishingScreenNavigation.Categories,
+                    actionResult = if (categoriesString.isNotEmpty()) {
+                        UiStringText(categoriesString)
+                    } else {
+                        run { UiStringRes(R.string.prepublishing_nudges_home_categories_not_set) }
+                    },
+                    actionClickable = true,
+                    onNavigationActionClicked = ::onActionClicked
+                ))
+            }
 
             add(SocialUiState.Hidden)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PrepublishingHomeViewModelTest.kt
@@ -112,7 +112,7 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
     @Test
     fun `verify that page home actions are propagated to prepublishingHomeUiState once the viewModel is started`() {
         // arrange
-        val expectedActionsAmount = 2
+        val expectedActionsAmount = 1
         whenever(editPostRepository.isPage).thenReturn(true)
 
         // act
@@ -146,6 +146,30 @@ class PrepublishingHomeViewModelTest : BaseUnitTest() {
 
         // assert
         assertThat(getHomeUiState(PrepublishingScreenNavigation.Tags)).isNull()
+    }
+
+    @Test
+    fun `verify that categories actions is propagated to prepublishingHomeUiState once post is not a page`() {
+        // arrange
+        whenever(editPostRepository.isPage).thenReturn(false)
+
+        // act
+        viewModel.start(editPostRepository, site, false)
+
+        // assert
+        assertThat(getHomeUiState(PrepublishingScreenNavigation.Categories)).isNotNull()
+    }
+
+    @Test
+    fun `verify that categories actions is not propagated to prepublishingHomeUiState once post is a page`() {
+        // arrange
+        whenever(editPostRepository.isPage).thenReturn(true)
+
+        // act
+        viewModel.start(editPostRepository, site, false)
+
+        // assert
+        assertThat(getHomeUiState(PrepublishingScreenNavigation.Categories)).isNull()
     }
 
     @Test


### PR DESCRIPTION
Fixes #19557

## Description
This PR removes category selection from page pre-publishing options aligning with the current options available on the web

![Screenshot 2023-11-23 at 3 34 05 PM](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/58113883-d3e4-4bfd-811b-e94556ded41d)

|Before|After|
|---|---|
|![before](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/2b398006-9707-4906-92f9-b9efec08ac06)|![Screenshot_20231123_153824](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/fa14f28b-5370-4c61-ab0e-1764a358068e)|

-----

## To Test:

1. Create a page
2. Press publish
3. **Verify** that no category selection option is available in the prepublishing nudges

-----

## Regression Notes

1. Potential unintended areas of impact

Prepublishing nudge for posts/pages

4. What I did to test those areas of impact (or what existing automated tests I relied on)

 Manual testing

5. What automated tests I added (or what prevented me from doing so)

  Added tests verifying the applied change

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
