### PR TITLE
Prevents crashing when the titleLayout is not initialised

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.text.Layout
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -130,10 +131,10 @@ sealed class PostListItemViewHolder(
                     titleTextView.viewTreeObserver.removeOnPreDrawListener(this)
 
                     // Get the layout of the title text
-                    val titleLayout = titleTextView.layout
+                    val titleLayout: Layout? = titleTextView.layout
 
                     // Check if the title occupies more than 2 lines
-                    when (titleLayout.lineCount) {
+                    when (titleLayout?.lineCount) {
                         1 -> {
                             excerptTextView.maxLines = 2
                         }


### PR DESCRIPTION
Fixes #19660

## Description
This PR prevents the app from crashing when the `titleLayout` has not yet been initialised in the `onPreDraw` of the post list row. 

Note: I wasn't able to recreate the conditions of the crash thus I consider that this might be an extreme scenario and handled the null case causing the crash. The crash seems to occur after closing the editor on the posts list. I've tried different scenarios with long and short titles, and with long post list so that the `d/WordPress-API: : ListStore: Loading next page` call is triggered as indicated from the Sentry breadcrumb.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.text.Layout.getLineCount()' on a null object reference
    at org.wordpress.android.ui.posts.PostListItemViewHolder$setBasicValues$1.onPreDraw(PostListItemViewHolder.kt:136)
```
To test the behaviour of the app when the `titleLayout` is null I hardcoded the value (L:134) and the app behaved normally with the only side effect being to render only one line for the excerpt. 

-----

## To Test:

1. Open the posts list
2. Create a new post or open an existing one
3. Close the editor
4. Verify that no crash occurs

-----

## Regression Notes

1. Potential unintended areas of impact

    - Posts list

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

6. What automated tests I added (or what prevented me from doing so)

    - The fix is on the UI code

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
