### PR TITLE
[My Site Dashboard] Compose cards reusable toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.ui.mysite.cards.blaze
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,21 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,6 +30,8 @@ import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.BlazeCampaignsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.BlazeCampaignsCardModel.BlazeCampaignsCardItem.BlazeCampaignStats
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbarContextMenuItem
 import org.wordpress.android.ui.utils.UiString
 
 @Composable
@@ -55,21 +43,8 @@ fun BlazeCampaignsCard(
     UnelevatedCard(
         modifier = modifier.clickable { blazeCampaignCardModel.onClick.click() },
         content = {
-            Column(
-                modifier = Modifier.padding(top = 16.dp)
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
-                        text = uiStringText(uiString = blazeCampaignCardModel.title),
-                        style = DashboardCardTypography.smallTitle,
-                        textAlign = TextAlign.Start,
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-                    CardDropDownMenu(moreMenuOptions = blazeCampaignCardModel.moreMenuOptions)
-                }
+            Column {
+                CardToolbar(blazeCampaignCardModel)
                 Column(
                     modifier = Modifier
                         .padding(start = 16.dp, end = 16.dp, bottom = 8.dp)
@@ -115,6 +90,35 @@ fun BlazeCampaignsCard(
             }
         },
     )
+}
+
+@Composable
+private fun CardToolbar(
+    blazeCampaignCardModel: BlazeCampaignsCardModel,
+) {
+    MySiteCardToolbar(
+        onContextMenuClick = { blazeCampaignCardModel.moreMenuOptions.onMoreClick.click() },
+        menuItems = listOf(
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(id = R.string.blaze_campaigns_card_more_menu_view_all_campaigns),
+                onClick = { blazeCampaignCardModel.moreMenuOptions.viewAllCampaignsItemClick.click() }
+            ),
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(id = R.string.blaze_campaigns_card_more_menu_learn_more),
+                onClick = { blazeCampaignCardModel.moreMenuOptions.learnMoreClick.click() }
+            ),
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(id = R.string.blaze_campaigns_card_more_menu_hide_this),
+                onClick = { blazeCampaignCardModel.moreMenuOptions.hideThisMenuItemClick.click() }
+            ),
+        ),
+    ) {
+        Text(
+            text = uiStringText(uiString = blazeCampaignCardModel.title),
+            style = DashboardCardTypography.smallTitle,
+            textAlign = TextAlign.Start,
+        )
+    }
 }
 
 @Composable
@@ -190,53 +194,5 @@ private fun CampaignStat(title: String, value: UiString, modifier: Modifier = Mo
             style = DashboardCardTypography.largeText,
             textAlign = TextAlign.Start
         )
-    }
-}
-
-
-@Composable
-private fun CardDropDownMenu(moreMenuOptions: BlazeCampaignsCardModel.MoreMenuOptions, modifier: Modifier = Modifier) {
-    Box(modifier = modifier) {
-        var isExpanded by remember { mutableStateOf(false) }
-
-        IconButton(onClick = {
-            isExpanded = true
-            moreMenuOptions.onMoreClick.click()
-        }) {
-            Icon(
-                imageVector = Icons.Rounded.MoreVert,
-                contentDescription = stringResource(id = R.string.more),
-                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
-            )
-        }
-
-        DropdownMenu(
-            expanded = isExpanded,
-            onDismissRequest = { isExpanded = false },
-            modifier = Modifier
-                .background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
-        ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_view_all_campaigns)) },
-                onClick = {
-                    isExpanded = false
-                    moreMenuOptions.viewAllCampaignsItemClick.click()
-                }
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_learn_more)) },
-                onClick = {
-                    isExpanded = false
-                    moreMenuOptions.learnMoreClick.click()
-                }
-            )
-            DropdownMenuItem(
-                text = { Text(stringResource(id = R.string.blaze_campaigns_card_more_menu_hide_this)) },
-                onClick = {
-                    isExpanded = false
-                    moreMenuOptions.hideThisMenuItemClick.click()
-                }
-            )
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCard.kt
@@ -98,7 +98,7 @@ private fun CardToolbar(
 ) {
     MySiteCardToolbar(
         onContextMenuClick = { blazeCampaignCardModel.moreMenuOptions.onMoreClick.click() },
-        menuItems = listOf(
+        contextMenuItems = listOf(
             MySiteCardToolbarContextMenuItem.Option(
                 text = stringResource(id = R.string.blaze_campaigns_card_more_menu_view_all_campaigns),
                 onClick = { blazeCampaignCardModel.moreMenuOptions.viewAllCampaignsItemClick.click() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.mysite.cards.compose
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -29,8 +31,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
+import org.wordpress.android.ui.compose.theme.AppTheme
 
 /**
  * A toolbar for MySite cards written in Compose, that tries to match behavior and positioning of cards written in XML.
@@ -137,4 +143,82 @@ sealed interface MySiteCardToolbarContextMenuItem {
     ) : MySiteCardToolbarContextMenuItem
 
     data object Divider : MySiteCardToolbarContextMenuItem
+}
+
+@Preview(
+    name = "Light Mode"
+)
+@Preview(
+    name = "Dark Mode",
+    showBackground = true,
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Composable
+private fun MySiteCardToolbarPreview() {
+    AppTheme {
+        MySiteCardToolbar(
+            onContextMenuClick = {},
+            contextMenuItems = listOf(
+                MySiteCardToolbarContextMenuItem.Option(
+                    text = "An option",
+                    onClick = {}
+                ),
+                MySiteCardToolbarContextMenuItem.Divider,
+                MySiteCardToolbarContextMenuItem.Option(
+                    text = "Another option",
+                    onClick = {}
+                ),
+            ),
+        ) {
+            Text(
+                text = "Card Title",
+                style = DashboardCardTypography.smallTitle,
+            )
+        }
+    }
+}
+
+@Preview(
+    name = "Light Mode"
+)
+@Preview(
+    name = "Dark Mode",
+    showBackground = true,
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Composable
+private fun MySiteCardToolbarInCardPreview() {
+    AppTheme {
+        UnelevatedCard(
+            modifier = Modifier.padding(8.dp)
+        ) {
+            Column {
+                MySiteCardToolbar(
+                    onContextMenuClick = {},
+                    contextMenuItems = listOf(
+                        MySiteCardToolbarContextMenuItem.Option(
+                            text = "An option",
+                            onClick = {}
+                        ),
+                        MySiteCardToolbarContextMenuItem.Divider,
+                        MySiteCardToolbarContextMenuItem.Option(
+                            text = "Another option",
+                            onClick = {}
+                        ),
+                    ),
+                ) {
+                    Text(
+                        text = "Card Title",
+                        style = DashboardCardTypography.smallTitle,
+                    )
+                }
+
+                Box(Modifier.padding(16.dp)) {
+                    Text(
+                        text = "This is my card content!"
+                    )
+                }
+            }
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
@@ -78,7 +78,10 @@ fun MySiteCardToolbar(
     ) {
         content?.invoke(this)
 
-        Spacer(modifier = Modifier.width(16.dp)) // minimum spacing between content and context menu
+        if (content != null && showContextMenu) {
+            // minimum spacing between content and context menu if both are shown
+            Spacer(modifier = Modifier.width(16.dp))
+        }
 
         if (showContextMenu) {
             CardDropDownMenu(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
@@ -1,0 +1,140 @@
+package org.wordpress.android.ui.mysite.cards.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+
+/**
+ * A toolbar for MySite cards written in Compose, that tries to match behavior and positioning of cards written in XML.
+ *
+ * When using this component, there is no need to set top, start, and end padding on the card, as this component sets
+ * those values internally to closely match my_site_card_toolbar.xml.
+ *
+ * It's important to note this component is stateful, meaning the UI for the context menu is managed internally. Use
+ * [onContextMenuClick] and the [menuItems] click callbacks to handle behavior NOT related to the dropdown menu UI.
+ *
+ * @param modifier Modifier to be applied to the toolbar (should not be used in most cases).
+ * @param onContextMenuClick Callback to be invoked when the context menu is clicked.
+ * @param menuItems List of [MySiteCardToolbarContextMenuItem] to be displayed in the context menu.
+ * @param showContextMenu Whether or not to show the context menu. Default: true if [menuItems] is not empty.
+ * @param content Content to be displayed in the toolbar. Usually some sort of title that will be left aligned and
+ * vertically aligned with the context menu. If null, the context menu will be right aligned.
+ */
+@Composable
+fun MySiteCardToolbar(
+    modifier: Modifier = Modifier,
+    onContextMenuClick: (() -> Unit)? = null,
+    menuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
+    showContextMenu: Boolean = menuItems.isNotEmpty(),
+    content: @Composable (RowScope.() -> Unit)? = null,
+) {
+    val horizontalArrangement = Arrangement.SpaceBetween.takeIf { content != null } ?: Arrangement.End
+    val padding = if (showContextMenu) {
+        PaddingValues(start = 16.dp, end = 12.dp, top = 8.dp)
+    } else {
+        PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp)
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = horizontalArrangement,
+        modifier = modifier
+            .padding(padding)
+            .fillMaxWidth()
+    ) {
+        content?.invoke(this)
+
+        Spacer(modifier = Modifier.width(16.dp)) // minimum spacing between content and context menu
+
+        if (showContextMenu) {
+            GenericCardDropDownMenu(
+                onContextMenuClick = onContextMenuClick,
+                menuItems = menuItems,
+            )
+        }
+    }
+}
+
+@Composable
+private fun GenericCardDropDownMenu(
+    modifier: Modifier = Modifier,
+    onContextMenuClick: (() -> Unit)? = null,
+    menuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
+) {
+    Box(modifier = modifier) {
+        var isExpanded by remember { mutableStateOf(false) }
+
+        IconButton(
+            modifier = Modifier.size(32.dp), // to match the icon in my_site_card_toolbar.xml
+            onClick = {
+                isExpanded = true
+                onContextMenuClick?.invoke()
+            }
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.MoreVert,
+                contentDescription = stringResource(id = R.string.more),
+                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+            )
+        }
+
+        DropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            modifier = Modifier.background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
+        ) {
+            menuItems.map { item ->
+                when (item) {
+                    is MySiteCardToolbarContextMenuItem.Option -> {
+                        DropdownMenuItem(
+                            text = { Text(item.text) },
+                            onClick = {
+                                isExpanded = false
+                                item.onClick()
+                            }
+                        )
+                    }
+
+                    MySiteCardToolbarContextMenuItem.Divider -> Divider()
+                }
+            }
+        }
+    }
+}
+
+sealed interface MySiteCardToolbarContextMenuItem {
+    data class Option(
+        val text: String,
+        val onClick: () -> Unit,
+    ) : MySiteCardToolbarContextMenuItem
+
+    data object Divider : MySiteCardToolbarContextMenuItem
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
@@ -39,12 +39,12 @@ import org.wordpress.android.R
  * those values internally to closely match my_site_card_toolbar.xml.
  *
  * It's important to note this component is stateful, meaning the UI for the context menu is managed internally. Use
- * [onContextMenuClick] and the [menuItems] click callbacks to handle behavior NOT related to the dropdown menu UI.
+ * [onContextMenuClick] and the [contextMenuItems] callbacks to handle behavior NOT related to the dropdown menu UI.
  *
  * @param modifier Modifier to be applied to the toolbar (should not be used in most cases).
  * @param onContextMenuClick Callback to be invoked when the context menu is clicked.
- * @param menuItems List of [MySiteCardToolbarContextMenuItem] to be displayed in the context menu.
- * @param showContextMenu Whether or not to show the context menu. Default: true if [menuItems] is not empty.
+ * @param contextMenuItems List of [MySiteCardToolbarContextMenuItem] to be displayed in the context menu.
+ * @param showContextMenu Whether or not to show the context menu. Default: true if [contextMenuItems] is not empty.
  * @param content Content to be displayed in the toolbar. Usually some sort of title that will be left aligned and
  * vertically aligned with the context menu. If null, the context menu will be right aligned.
  */
@@ -52,8 +52,8 @@ import org.wordpress.android.R
 fun MySiteCardToolbar(
     modifier: Modifier = Modifier,
     onContextMenuClick: (() -> Unit)? = null,
-    menuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
-    showContextMenu: Boolean = menuItems.isNotEmpty(),
+    contextMenuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
+    showContextMenu: Boolean = contextMenuItems.isNotEmpty(),
     content: @Composable (RowScope.() -> Unit)? = null,
 ) {
     val horizontalArrangement = Arrangement.SpaceBetween.takeIf { content != null } ?: Arrangement.End
@@ -75,19 +75,19 @@ fun MySiteCardToolbar(
         Spacer(modifier = Modifier.width(16.dp)) // minimum spacing between content and context menu
 
         if (showContextMenu) {
-            GenericCardDropDownMenu(
+            CardDropDownMenu(
                 onContextMenuClick = onContextMenuClick,
-                menuItems = menuItems,
+                contextMenuItems = contextMenuItems,
             )
         }
     }
 }
 
 @Composable
-private fun GenericCardDropDownMenu(
+private fun CardDropDownMenu(
     modifier: Modifier = Modifier,
     onContextMenuClick: (() -> Unit)? = null,
-    menuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
+    contextMenuItems: List<MySiteCardToolbarContextMenuItem> = emptyList(),
 ) {
     Box(modifier = modifier) {
         var isExpanded by remember { mutableStateOf(false) }
@@ -111,7 +111,7 @@ private fun GenericCardDropDownMenu(
             onDismissRequest = { isExpanded = false },
             modifier = Modifier.background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
         ) {
-            menuItems.map { item ->
+            contextMenuItems.map { item ->
                 when (item) {
                     is MySiteCardToolbarContextMenuItem.Option -> {
                         DropdownMenuItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/domaintransfer/DomainTransferCard.kt
@@ -3,28 +3,16 @@ package org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -38,6 +26,8 @@ import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainTransferCardModel
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbarContextMenuItem
 import org.wordpress.android.ui.utils.ListItemInteraction
 
 @Composable
@@ -49,39 +39,7 @@ fun DomainTransferCard(
         modifier = modifier.clickable { domainTransferCardModel.onClick.click() },
         content = {
             Column {
-                Row(
-                    Modifier.padding(start = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(id = domainTransferCardModel.title),
-                        style = DashboardCardTypography.smallTitle,
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
-                    Box() {
-                        var isExpanded by remember { mutableStateOf(false) }
-
-                        IconButton(onClick = {
-                            isExpanded = true
-                            domainTransferCardModel.onMoreMenuClick.click()
-                        }) {
-                            Icon(
-                                imageVector = Icons.Rounded.MoreVert,
-                                contentDescription = stringResource(id = R.string.more),
-                                tint = MaterialTheme.colors.onSurface
-                            )
-                        }
-
-                        DropdownMenu(
-                            expanded = isExpanded,
-                            onDismissRequest = { isExpanded = false }) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(id = R.string.domain_transfer_card_more_menu_hide_this)) },
-                                onClick = { domainTransferCardModel.onHideMenuItemClick.click() }
-                            )
-                        }
-                    }
-                }
+                CardToolbar(domainTransferCardModel)
                 Row(
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -116,6 +74,26 @@ fun DomainTransferCard(
                 }
             }
         })
+}
+
+@Composable
+private fun CardToolbar(
+    domainTransferCardModel: DomainTransferCardModel,
+) {
+    MySiteCardToolbar(
+        onContextMenuClick = { domainTransferCardModel.onMoreMenuClick.click() },
+        contextMenuItems = listOf(
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(id = R.string.domain_transfer_card_more_menu_hide_this),
+                onClick = { domainTransferCardModel.onHideMenuItemClick.click() }
+            ),
+        ),
+    ) {
+        Text(
+            text = stringResource(id = domainTransferCardModel.title),
+            style = DashboardCardTypography.smallTitle,
+        )
+    }
 }
 
 @Preview(


### PR DESCRIPTION
I am working on another Dashboard card using Compose and realized that the 2 existing Compose cards are currently repeating a lot of code regarding the "Toolbar" part with the Context Menu. Besides that, the toolbar section of those Compose cards does not match visually with the existing XML/Android View cards, causing icon misalignment and different title paddings.

This PRs aims at creating a reusable composable `MySiteCardToolbar` that can be used in My Site Dashboard cards and make them fit in a bit better with the other existing cards. It also makes it easier to create the Context Menu items and callbacks.

The 2 cards that were refactored to use this new Toolbar are:
- `DomainTransferCard`
- `BlazeCampaignsCard`

I added @ravishanker and @zwarm because of the cards that I touched, but don't worry if you can't review at this time.

Before | After
--- | ---
![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/c01d9870-552b-4ab0-afac-aafc0f56e37f) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/9077f765-5464-442c-95ad-e9e2515242bb)


-----

## To Test:

### `DomainTransferCard`
1. Install and log into the Jetpack app
2. Go to My Site Dashboard
3. **Verify** the domain transfer card looks correct
4. **Verify** the domain transfer card interactions are working as expected (including context menu)

### `BlazeCampaignsCard`
Pre-requisite: you need to use an account/site that has Blaze Campaigns, so I recommend using the text account mentioned in pe7hp4-nI-p2 to do so.

1. Install and log into the app (with an account/site that has Blaze Campaigns)
2. Go to My Site Dashboard
3. **Verify** the Blaze campaigns card looks correct
4. **Verify** the Blaze campaigns card interactions are working as expected (including context menu)

-----

## Regression Notes

1. Potential unintended areas of impact

    - Issue with the interactions on the cards

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

7. What automated tests I added (or what prevented me from doing so)

    - Only UI refactor

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)