### PR TITLE
[Bloganuary] Dashboard Nudge card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -50,9 +50,7 @@ class BloggingPromptsSettingsHelper @Inject constructor(
     }
 
     suspend fun shouldShowPromptsFeature(): Boolean {
-        val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return false
-
-        return isPromptsFeatureAvailable() && isPromptsSettingEnabled(siteId) && !isPromptSkippedForToday()
+        return isPromptsFeatureAvailable() && isPromptsSettingEnabled() && !isPromptSkippedForToday()
     }
 
     fun shouldShowPromptsSetting(): Boolean {
@@ -66,12 +64,13 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         return promptSkippedDate != null && isSameDay(promptSkippedDate, Date())
     }
 
-    private suspend fun isPromptsSettingEnabled(
-        siteId: Int
-    ): Boolean = bloggingRemindersStore
-        .bloggingRemindersModel(siteId)
-        .firstOrNull()
-        ?.isPromptsCardEnabled == true
+    suspend fun isPromptsSettingEnabled(): Boolean {
+        val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return false
+        return bloggingRemindersStore
+            .bloggingRemindersModel(siteId)
+            .firstOrNull()
+            ?.isPromptsCardEnabled == true
+    }
 
     companion object {
         private const val TRACK_PROPERTY_ENABLED = "enabled"

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/styles/DashboardCardTypography.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/styles/DashboardCardTypography.kt
@@ -28,9 +28,7 @@ object DashboardCardTypography {
 
     val detailText: TextStyle
         @Composable
-        get() = MaterialTheme.typography.bodyLarge.copy(
-            fontWeight = FontWeight.Normal,
-            fontSize = 14.sp,
+        get() = MaterialTheme.typography.bodyMedium.copy(
             color = colors.onSurface.copy(alpha = ContentAlpha.medium)
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.main.utils.MeGravatarLoader
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ActivityCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.BlazeCampaignsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.PromoteWithBlazeCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloggingPromptCard.BloggingPromptCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardPlansCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
@@ -32,6 +33,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.JetpackBadge
 import org.wordpress.android.ui.mysite.cards.blaze.BlazeCampaignsCardViewHolder
 import org.wordpress.android.ui.mysite.cards.blaze.PromoteWithBlazeCardViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityCardViewHolder
+import org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardViewHolder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptsCardAnalyticsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer.DomainTransferCardViewHolder
@@ -104,6 +106,7 @@ class MySiteAdapter(
                 learnMoreClicked
             )
 
+            MySiteCardAndItem.Type.BLOGANUARY_NUDGE_CARD.ordinal -> BloganuaryNudgeCardViewHolder(parent)
             MySiteCardAndItem.Type.DASHBOARD_DOMAIN_TRANSFER_CARD.ordinal -> DomainTransferCardViewHolder(parent)
             MySiteCardAndItem.Type.PROMOTE_WITH_BLAZE_CARD.ordinal -> PromoteWithBlazeCardViewHolder(parent, uiHelpers)
             MySiteCardAndItem.Type.BLAZE_CAMPAIGNS_CARD.ordinal -> BlazeCampaignsCardViewHolder(parent)
@@ -140,6 +143,7 @@ class MySiteAdapter(
             is TodaysStatsCardViewHolder -> holder.bind(getItem(position)  as TodaysStatsCardWithData)
             is PostCardViewHolder<*> -> holder.bind(getItem(position)  as PostCard)
             is BloggingPromptCardViewHolder -> holder.bind(getItem(position)  as BloggingPromptCardWithData)
+            is BloganuaryNudgeCardViewHolder -> holder.bind(getItem(position)  as BloganuaryNudgeCardModel)
             is DomainTransferCardViewHolder -> holder.bind(getItem(position)  as DomainTransferCardModel)
             is PromoteWithBlazeCardViewHolder -> holder.bind(getItem(position)  as PromoteWithBlazeCard)
             is BlazeCampaignsCardViewHolder -> holder.bind(getItem(position)  as BlazeCampaignsCardModel)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.DiffUtil
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ActivityCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.BlazeCampaignsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.PromoteWithBlazeCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloggingPromptCard.BloggingPromptCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DashboardPlansCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.DomainRegistrationCard
@@ -44,6 +45,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
             oldItem is TodaysStatsCardWithData && updatedItem is TodaysStatsCardWithData -> true
             oldItem is PostCardWithPostItems && updatedItem is PostCardWithPostItems -> true
             oldItem is BloggingPromptCardWithData && updatedItem is BloggingPromptCardWithData -> true
+            oldItem is BloganuaryNudgeCardModel && updatedItem is BloganuaryNudgeCardModel -> true
             oldItem is PromoteWithBlazeCard && updatedItem is PromoteWithBlazeCard -> true
             oldItem is BlazeCampaignsCardModel && updatedItem is BlazeCampaignsCardModel -> true
             oldItem is DomainTransferCardModel && updatedItem is DomainTransferCardModel -> true

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -307,6 +307,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val title: UiString,
             val text: UiString,
             val onLearnMoreClick: ListItemInteraction,
+            val onMoreMenuClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,
         ) : Card(Type.BLOGANUARY_NUDGE_CARD)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -44,6 +44,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         POST_CARD_ERROR,
         POST_CARD_WITH_POST_ITEMS,
         BLOGGING_PROMPT_CARD,
+        BLOGANUARY_NUDGE_CARD,
         PROMOTE_WITH_BLAZE_CARD,
         DASHBOARD_DOMAIN_TRANSFER_CARD,
         BLAZE_CAMPAIGNS_CARD,
@@ -301,6 +302,13 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                 val onRemoveClick: () -> Unit,
             ) : BloggingPromptCard(type = Type.BLOGGING_PROMPT_CARD)
         }
+
+        data class BloganuaryNudgeCardModel(
+            val title: UiString,
+            val text: UiString,
+            val onLearnMoreClick: ListItemInteraction,
+            val onHideMenuItemClick: ListItemInteraction,
+        ) : Card(Type.BLOGANUARY_NUDGE_CARD)
 
         data class DomainTransferCardModel(
             @StringRes val title: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -63,6 +63,7 @@ sealed class MySiteCardAndItemBuilderParams {
         val onErrorRetryClick: () -> Unit,
         val todaysStatsCardBuilderParams: TodaysStatsCardBuilderParams,
         val postCardBuilderParams: PostCardBuilderParams,
+        val bloganuaryNudgeCardBuilderParams: BloganuaryNudgeCardBuilderParams,
         val bloggingPromptCardBuilderParams: BloggingPromptCardBuilderParams,
         val domainTransferCardBuilderParams: DomainTransferCardBuilderParams? = null,
         val blazeCardBuilderParams: BlazeCardBuilderParams? = null,
@@ -154,6 +155,7 @@ sealed class MySiteCardAndItemBuilderParams {
     data class BloganuaryNudgeCardBuilderParams(
         val isEligible: Boolean,
         val onLearnMoreClick: () -> Unit,
+        val onMoreMenuClick: () -> Unit,
         val onHideMenuItemClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -151,6 +151,12 @@ sealed class MySiteCardAndItemBuilderParams {
         val onRemoveClick: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 
+    data class BloganuaryNudgeCardBuilderParams(
+        val isEligible: Boolean,
+        val onLearnMoreClick: () -> Unit,
+        val onHideMenuItemClick: () -> Unit
+    ) : MySiteCardAndItemBuilderParams()
+
     sealed class BlazeCardBuilderParams : MySiteCardAndItemBuilderParams() {
         data class PromoteWithBlazeCardBuilderParams(
             val onClick: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -751,6 +751,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         is SiteNavigationAction.OpenDashboardPersonalization -> activityNavigator.openDashboardPersonalization(
             requireActivity()
         )
+
+        is SiteNavigationAction.OpenBloganuaryNudgeOverlay -> {
+            TODO("thomashortadev: Implement Bloganuary nudge overlay")
+        }
     }
 
     private fun handleNavigation(action: BloggingPromptCardNavigationAction) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -753,7 +753,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         )
 
         is SiteNavigationAction.OpenBloganuaryNudgeOverlay -> {
-            TODO("thomashortadev: Implement Bloganuary nudge overlay")
+            // TODO thomashortadev: Implement Bloganuary nudge overlay
+            AppLog.d(AppLog.T.MY_SITE_DASHBOARD, "TODO: open Bloganuary nudge overlay")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -63,6 +63,7 @@ import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityLogCardViewModelSlice
+import org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardViewModelSlice
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardViewModelSlice
 import org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer.DomainTransferCardViewModel
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardViewModelSlice
@@ -167,6 +168,7 @@ class MySiteViewModel @Inject constructor(
     private val noCardsMessageViewModelSlice: NoCardsMessageViewModelSlice,
     private val siteInfoHeaderCardViewModelSlice: SiteInfoHeaderCardViewModelSlice,
     private val quickLinksItemViewModelSlice: QuickLinksItemViewModelSlice,
+    private val bloganuaryNudgeCardViewModelSlice: BloganuaryNudgeCardViewModelSlice,
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
@@ -226,6 +228,7 @@ class MySiteViewModel @Inject constructor(
         activityLogCardViewModelSlice.onNavigation,
         siteItemsViewModelSlice.onNavigation,
         bloggingPromptCardViewModelSlice.onNavigation,
+        bloganuaryNudgeCardViewModelSlice.onNavigation,
         personalizeCardViewModelSlice.onNavigation,
         siteInfoHeaderCardViewModelSlice.onNavigation,
         quickLinksItemViewModelSlice.navigation
@@ -314,6 +317,7 @@ class MySiteViewModel @Inject constructor(
     init {
         dispatcher.register(this)
         bloggingPromptCardViewModelSlice.initialize(viewModelScope, mySiteSourceManager)
+        bloganuaryNudgeCardViewModelSlice.initialize(viewModelScope)
         siteInfoHeaderCardViewModelSlice.initialize(viewModelScope)
         quickLinksItemViewModelSlice.initialization(viewModelScope)
         quickLinksItemViewModelSlice.start()
@@ -475,6 +479,7 @@ class MySiteViewModel @Inject constructor(
                 postCardBuilderParams = postsCardViewModelSlice.getPostsCardBuilderParams(
                     cardsUpdate?.cards?.firstOrNull { it is PostsCardModel } as? PostsCardModel
                 ),
+                bloganuaryNudgeCardBuilderParams = bloganuaryNudgeCardViewModelSlice.getBuilderParams(),
                 bloggingPromptCardBuilderParams = bloggingPromptCardViewModelSlice.getBuilderParams(
                     bloggingPromptUpdate
                 ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -107,6 +107,8 @@ sealed class SiteNavigationAction {
 
     data class OpenDomainTransferPage(val url: String) : SiteNavigationAction()
     object OpenDashboardPersonalization : SiteNavigationAction()
+
+    data class OpenBloganuaryNudgeOverlay(val isPromptsEnabled: Boolean): SiteNavigationAction()
 }
 
 sealed class BloggingPromptCardNavigationAction: SiteNavigationAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilder.kt
@@ -4,6 +4,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
 import org.wordpress.android.ui.mysite.cards.blaze.BlazeCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityCardBuilder
+import org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class CardsBuilder @Inject constructor(
     private val todaysStatsCardBuilder: TodaysStatsCardBuilder,
     private val postCardBuilder: PostCardBuilder,
+    private val bloganuaryNudgeCardBuilder: BloganuaryNudgeCardBuilder,
     private val bloggingPromptCardBuilder: BloggingPromptCardBuilder,
     private val domainTransferCardBuilder: DomainTransferCardBuilder,
     private val blazeCardBuilder: BlazeCardBuilder,
@@ -29,6 +31,9 @@ class CardsBuilder @Inject constructor(
         if (dashboardCardsBuilderParams.showErrorCard) {
             add(createErrorCard(dashboardCardsBuilderParams.onErrorRetryClick))
         } else {
+            bloganuaryNudgeCardBuilder.build(dashboardCardsBuilderParams.bloganuaryNudgeCardBuilderParams)
+                ?.let { add(it) }
+
             bloggingPromptCardBuilder.build(dashboardCardsBuilderParams.bloggingPromptCardBuilderParams)
                 ?.let { add(it) }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsShownTracker.kt
@@ -72,6 +72,12 @@ class CardsShownTracker @Inject constructor(
                 Type.BLOGGING_PROMPT.label
             )
         )
+        is Card.BloganuaryNudgeCardModel -> trackCardShown(
+            Pair(
+                card.type.toTypeValue().label,
+                Type.BLOGANUARY_NUDGE.label
+            )
+        )
         is Card.BlazeCard.PromoteWithBlazeCard -> trackCardShown(
             Pair(
                 card.type.toTypeValue().label,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -134,6 +134,7 @@ fun MySiteCardAndItem.Type.toTypeValue(): Type {
         MySiteCardAndItem.Type.TODAYS_STATS_CARD -> Type.STATS
         MySiteCardAndItem.Type.POST_CARD_ERROR -> Type.ERROR
         MySiteCardAndItem.Type.POST_CARD_WITH_POST_ITEMS -> Type.POST
+        MySiteCardAndItem.Type.BLOGANUARY_NUDGE_CARD -> Type.BLOGANUARY_NUDGE
         MySiteCardAndItem.Type.BLOGGING_PROMPT_CARD -> Type.BLOGGING_PROMPT
         MySiteCardAndItem.Type.PROMOTE_WITH_BLAZE_CARD -> Type.PROMOTE_WITH_BLAZE
         MySiteCardAndItem.Type.DASHBOARD_DOMAIN_TRANSFER_CARD -> Type.DASHBOARD_CARD_DOMAIN_TRANSFER

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsTracker.kt
@@ -23,6 +23,7 @@ class CardsTracker @Inject constructor(
         STATS("stats"),
         POST("post"),
         BLOGGING_PROMPT("blogging_prompt"),
+        BLOGANUARY_NUDGE("bloganuary_nudge"),
         PROMOTE_WITH_BLAZE("promote_with_blaze"),
         BLAZE_CAMPAIGNS("blaze_campaigns"),
         PAGES("pages"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
@@ -34,7 +35,7 @@ fun BloganuaryNudgeCard(
     modifier: Modifier = Modifier,
 ) {
     UnelevatedCard(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
     ) {
         Column {
             CardToolbar(model)
@@ -87,7 +88,7 @@ private fun CardToolbar(
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_bloganuary_24dp),
-            contentDescription = stringResource(R.string.bloganuary_dashboard_nudge_icon_content_description),
+            contentDescription = null,
             modifier = Modifier.size(24.dp),
             tint = MaterialTheme.colors.onSurface
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -1,0 +1,103 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
+import org.wordpress.android.ui.utils.ListItemInteraction
+
+@Composable
+fun BloganuaryNudgeCard(
+    model: BloganuaryNudgeCardModel,
+    modifier: Modifier = Modifier,
+) {
+    UnelevatedCard(
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_bloganuary_24dp),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colors.onSurface
+                )
+                CardDropDownMenu(
+                    onMoreMenuClick = model.onMoreMenuClick,
+                    onHideItemClick = model.onHideMenuItemClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CardDropDownMenu(
+    onMoreMenuClick: ListItemInteraction,
+    onHideItemClick: ListItemInteraction,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        var isExpanded by remember { mutableStateOf(false) }
+
+        IconButton(
+            onClick = {
+                isExpanded = true
+                onMoreMenuClick.click()
+            }
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.MoreVert,
+                contentDescription = stringResource(id = R.string.more),
+                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+            )
+        }
+
+        DropdownMenu(
+            expanded = isExpanded,
+            onDismissRequest = { isExpanded = false },
+            modifier = Modifier
+                .background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(id = R.string.my_site_dashboard_card_more_menu_hide_card)) },
+                onClick = {
+                    isExpanded = false
+                    onHideItemClick.click()
+                }
+            )
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -87,7 +87,7 @@ private fun CardToolbar(
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_bloganuary_24dp),
-            contentDescription = null,
+            contentDescription = stringResource(R.string.bloganuary_dashboard_nudge_icon_content_description),
             modifier = Modifier.size(24.dp),
             tint = MaterialTheme.colors.onSurface
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
@@ -39,27 +40,27 @@ fun BloganuaryNudgeCard(
         Column {
             CardToolbar(model)
 
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(Margin.Medium.value))
 
             Text(
                 text = uiStringText(model.title),
                 style = DashboardCardTypography.subTitle,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = Margin.ExtraLarge.value),
             )
 
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(Margin.Small.value))
 
             Text(
                 text = uiStringText(model.text),
                 style = DashboardCardTypography.detailText,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = Margin.ExtraLarge.value),
             )
 
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(Margin.Small.value))
 
             TextButton(
                 onClick = { model.onLearnMoreClick.click() },
-                modifier = Modifier.padding(horizontal = 4.dp)
+                modifier = Modifier.padding(horizontal = Margin.Small.value)
             ) {
                 Text(
                     text = stringResource(id = R.string.bloganuary_dashboard_nudge_learn_more),
@@ -67,7 +68,7 @@ fun BloganuaryNudgeCard(
                 )
             }
 
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(Margin.Medium.value))
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -1,28 +1,10 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,7 +12,8 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
-import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbarContextMenuItem
 
 @Composable
 fun BloganuaryNudgeCard(
@@ -40,64 +23,30 @@ fun BloganuaryNudgeCard(
     UnelevatedCard(
         modifier = modifier,
     ) {
-        Column(
-            modifier = Modifier.padding(start = 16.dp)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_bloganuary_24dp),
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colors.onSurface
-                )
-                CardDropDownMenu(
-                    onMoreMenuClick = model.onMoreMenuClick,
-                    onHideItemClick = model.onHideMenuItemClick,
-                )
-            }
+        Column {
+            CardToolbar(model)
         }
     }
 }
 
 @Composable
-private fun CardDropDownMenu(
-    onMoreMenuClick: ListItemInteraction,
-    onHideItemClick: ListItemInteraction,
-    modifier: Modifier = Modifier,
+private fun CardToolbar(
+    model: BloganuaryNudgeCardModel,
 ) {
-    Box(modifier = modifier) {
-        var isExpanded by remember { mutableStateOf(false) }
-
-        IconButton(
-            onClick = {
-                isExpanded = true
-                onMoreMenuClick.click()
-            }
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.MoreVert,
-                contentDescription = stringResource(id = R.string.more),
-                tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+    MySiteCardToolbar(
+        onContextMenuClick = { model.onMoreMenuClick.click() },
+        contextMenuItems = listOf(
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(id = R.string.my_site_dashboard_card_more_menu_hide_card),
+                onClick = { model.onHideMenuItemClick.click() }
             )
-        }
-
-        DropdownMenu(
-            expanded = isExpanded,
-            onDismissRequest = { isExpanded = false },
-            modifier = Modifier
-                .background(MaterialTheme.colors.surface.copy(alpha = ContentAlpha.high))
-        ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(id = R.string.my_site_dashboard_card_more_menu_hide_card)) },
-                onClick = {
-                    isExpanded = false
-                    onHideItemClick.click()
-                }
-            )
-        }
+        )
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_bloganuary_24dp),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colors.onSurface
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -1,19 +1,32 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
 import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbarContextMenuItem
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString
 
 @Composable
 fun BloganuaryNudgeCard(
@@ -25,6 +38,36 @@ fun BloganuaryNudgeCard(
     ) {
         Column {
             CardToolbar(model)
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = uiStringText(model.title),
+                style = DashboardCardTypography.subTitle,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = uiStringText(model.text),
+                style = DashboardCardTypography.detailText,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            TextButton(
+                onClick = { model.onLearnMoreClick.click() },
+                modifier = Modifier.padding(horizontal = 4.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.bloganuary_dashboard_nudge_learn_more),
+                    style = DashboardCardTypography.footerCTA,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
         }
     }
 }
@@ -48,5 +91,26 @@ private fun CardToolbar(
             modifier = Modifier.size(24.dp),
             tint = MaterialTheme.colors.onSurface
         )
+    }
+}
+
+@Preview(name = "Light Mode")
+@Preview(name = "Dark Mode", uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun BloganuaryNudgeCardPreview() {
+    AppTheme {
+        Surface(
+            modifier = Modifier.padding(8.dp)
+        ) {
+            BloganuaryNudgeCard(
+                model = BloganuaryNudgeCardModel(
+                    UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+                    UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text),
+                    onLearnMoreClick = ListItemInteraction.create { },
+                    onMoreMenuClick = ListItemInteraction.create { },
+                    onHideMenuItemClick = ListItemInteraction.create { },
+                )
+            )
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -100,18 +99,14 @@ private fun CardToolbar(
 @Composable
 fun BloganuaryNudgeCardPreview() {
     AppTheme {
-        Surface(
-            modifier = Modifier.padding(8.dp)
-        ) {
-            BloganuaryNudgeCard(
-                model = BloganuaryNudgeCardModel(
-                    UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title),
-                    UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text),
-                    onLearnMoreClick = ListItemInteraction.create { },
-                    onMoreMenuClick = ListItemInteraction.create { },
-                    onHideMenuItemClick = ListItemInteraction.create { },
-                )
+        BloganuaryNudgeCard(
+            model = BloganuaryNudgeCardModel(
+                UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+                UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text),
+                onLearnMoreClick = ListItemInteraction.create { },
+                onMoreMenuClick = ListItemInteraction.create { },
+                onHideMenuItemClick = ListItemInteraction.create { },
             )
-        }
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
@@ -14,6 +14,7 @@ class BloganuaryNudgeCardBuilder @Inject constructor() {
                 title = UiStringRes(R.string.bloganuary_dashboard_nudge_title),
                 text = UiStringRes(R.string.bloganuary_dashboard_nudge_text),
                 onLearnMoreClick = ListItemInteraction.create(params.onLearnMoreClick),
+                onMoreMenuClick = ListItemInteraction.create(params.onMoreMenuClick),
                 onHideMenuItemClick = ListItemInteraction.create(params.onHideMenuItemClick),
             )
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import org.wordpress.android.R
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import javax.inject.Inject
+
+class BloganuaryNudgeCardBuilder @Inject constructor() {
+    fun build(params: BloganuaryNudgeCardBuilderParams): BloganuaryNudgeCardModel? {
+        return if (params.isEligible) {
+            BloganuaryNudgeCardModel(
+                title = UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+                text = UiStringRes(R.string.bloganuary_dashboard_nudge_text),
+                onLearnMoreClick = ListItemInteraction.create(params.onLearnMoreClick),
+                onHideMenuItemClick = ListItemInteraction.create(params.onHideMenuItemClick),
+            )
+        } else {
+            null
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import org.wordpress.android.databinding.BloganuaryNudgeCardBinding
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
@@ -11,8 +12,10 @@ import org.wordpress.android.util.extensions.viewBinding
 
 class BloganuaryNudgeCardViewHolder(parent: ViewGroup) :
     MySiteCardAndItemViewHolder<BloganuaryNudgeCardBinding>(parent.viewBinding(BloganuaryNudgeCardBinding::inflate)) {
-    fun bind(cardModel: BloganuaryNudgeCardModel) = with(binding) {
-        bloganuaryNudgeCard.setContent {
+    fun bind(cardModel: BloganuaryNudgeCardModel) = with(binding.bloganuaryNudgeCard) {
+        // Dispose of the Composition when the view's LifecycleOwner is destroyed
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool)
+        setContent {
             AppTheme {
                 BloganuaryNudgeCard(
                     model = cardModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import org.wordpress.android.databinding.BloganuaryNudgeCardBinding
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
+import org.wordpress.android.util.extensions.viewBinding
+
+class BloganuaryNudgeCardViewHolder(parent: ViewGroup) :
+    MySiteCardAndItemViewHolder<BloganuaryNudgeCardBinding>(parent.viewBinding(BloganuaryNudgeCardBinding::inflate)) {
+    fun bind(cardModel: BloganuaryNudgeCardModel) = with(binding) {
+        bloganuaryNudgeCard.setContent {
+            AppTheme {
+                BloganuaryNudgeCard(
+                    model = cardModel,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -25,6 +25,7 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     }
 
     fun getBuilderParams(): BloganuaryNudgeCardBuilderParams {
+        // TODO thomashortadev: check if current device date is in December 2023
         val isEligible = bloganuaryNudgeFeatureConfig.isEnabled() &&
                 bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -1,0 +1,48 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+class BloganuaryNudgeCardViewModelSlice @Inject constructor(
+    private val bloganuaryNudgeFeatureConfig: BloganuaryNudgeFeatureConfig,
+    private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
+) {
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
+
+    private lateinit var scope: CoroutineScope
+
+    fun initialize(scope: CoroutineScope) {
+        this.scope = scope
+    }
+
+    fun getBuilderParams(): BloganuaryNudgeCardBuilderParams {
+        val isEligible = bloganuaryNudgeFeatureConfig.isEnabled() &&
+                bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()
+
+        return BloganuaryNudgeCardBuilderParams(
+            isEligible = isEligible,
+            onLearnMoreClick = ::openBloganuaryNudgeLearnMore,
+            onHideMenuItemClick = ::hideCard,
+        )
+    }
+
+    private fun openBloganuaryNudgeLearnMore() {
+        scope.launch {
+            val isPromptsEnabled = bloggingPromptsSettingsHelper.isPromptsSettingEnabled()
+            _onNavigation.value = Event(SiteNavigationAction.OpenBloganuaryNudgeOverlay(isPromptsEnabled))
+        }
+    }
+
+    private fun hideCard() {
+        // TODO thomashortadev: create an AppPref and store hide state
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -30,19 +30,24 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
 
         return BloganuaryNudgeCardBuilderParams(
             isEligible = isEligible,
-            onLearnMoreClick = ::openBloganuaryNudgeLearnMore,
-            onHideMenuItemClick = ::hideCard,
+            onLearnMoreClick = ::onLearnMoreClick,
+            onMoreMenuClick = ::onMoreMenuClick,
+            onHideMenuItemClick = ::onHideMenuItemClick,
         )
     }
 
-    private fun openBloganuaryNudgeLearnMore() {
+    private fun onLearnMoreClick() {
         scope.launch {
             val isPromptsEnabled = bloggingPromptsSettingsHelper.isPromptsSettingEnabled()
             _onNavigation.value = Event(SiteNavigationAction.OpenBloganuaryNudgeOverlay(isPromptsEnabled))
         }
     }
 
-    private fun hideCard() {
+    private fun onMoreMenuClick() {
+        // TODO thomashortadev: track analytics for this action
+    }
+
+    private fun onHideMenuItemClick() {
         // TODO thomashortadev: create an AppPref and store hide state
     }
 }

--- a/WordPress/src/main/res/layout/bloganuary_nudge_card.xml
+++ b/WordPress/src/main/res/layout/bloganuary_nudge_card.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/bloganuary_nudge_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:ignore="RtlSymmetry" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/bloganuary_nudge_card.xml
+++ b/WordPress/src/main/res/layout/bloganuary_nudge_card.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/bloganuary_nudge_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        tools:composableName="org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardKt.BloganuaryNudgeCardPreview"
         tools:ignore="RtlSymmetry" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4817,7 +4817,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="notification_security_key_needed" tools:ignore="UnusedResources" a8c-src-lib="login">Please provide your security key to continue.</string>
 
     <!-- Bloganuary -->
-    <string name="bloganuary_dashboard_nudge_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
     <string name="bloganuary_dashboard_nudge_learn_more">@string/learn_more</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4819,4 +4819,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Bloganuary -->
     <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
+    <string name="bloganuary_dashboard_nudge_learn_more">@string/learn_more</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4815,4 +4815,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="login_text_security_key" tools:ignore="UnusedResources" a8c-src-lib="login">Use a security key</string>
     <string name="login_error_security_key" tools:ignore="UnusedResources" a8c-src-lib="login">There was some trouble with the Security key login</string>
     <string name="notification_security_key_needed" tools:ignore="UnusedResources" a8c-src-lib="login">Please provide your security key to continue.</string>
+
+    <!-- Bloganuary -->
+    <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
+    <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4817,6 +4817,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="notification_security_key_needed" tools:ignore="UnusedResources" a8c-src-lib="login">Please provide your security key to continue.</string>
 
     <!-- Bloganuary -->
+    <string name="bloganuary_dashboard_nudge_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
     <string name="bloganuary_dashboard_nudge_learn_more">@string/learn_more</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -138,7 +138,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given site is not selected, when isPromptsFeatureActive, then returns false`() = test {
+    fun `given site is not selected, when shouldShowPromptsFeature, then returns false`() = test {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
         val result = helper.shouldShowPromptsFeature()
@@ -147,7 +147,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given prompts feature not available, when isPromptsFeatureActive, then returns false`() = test {
+    fun `given prompts feature not available, when shouldShowPromptsFeature, then returns false`() = test {
         whenever(bloggingPromptsFeature.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
 
@@ -157,7 +157,7 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given prompts setting off, when isPromptsFeatureActive, then returns false`() = test {
+    fun `given prompts setting off, when shouldShowPromptsFeature, then returns false`() = test {
         // prompts feature is available
         whenever(bloggingPromptsFeature.isEnabled()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
@@ -172,9 +172,8 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         assertThat(result).isFalse
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `given prompts setting on and skipped for today, when isPromptsFeatureActive, then returns false`() =
+    fun `given prompts setting on and skipped for today, when shouldShowPromptsFeature, then returns false`() =
         test {
             // prompts feature is available
             whenever(bloggingPromptsFeature.isEnabled()).thenReturn(true)
@@ -193,9 +192,8 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
         }
 
 
-    @Suppress("MaxLineLength")
     @Test
-    fun `given prompts setting on and not skipped for today, when isPromptsFeatureActive, then returns false`() =
+    fun `given prompts setting on and not skipped for today, when shouldShowPromptsFeature, then returns true`() =
         test {
             // prompts feature is available
             whenever(bloggingPromptsFeature.isEnabled()).thenReturn(true)
@@ -251,7 +249,40 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
 
         val result = helper.shouldShowPromptsSetting()
 
-        assertThat(result).isTrue()
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `given site is not selected, when isPromptsSettingEnabled, then returns false`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val result = helper.isPromptsSettingEnabled()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given prompts card setting disabled, when isPromptsSettingEnabled, then returns false`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(createRemindersModel(isPromptsCardEnabled = false))
+        }
+
+        val result = helper.isPromptsSettingEnabled()
+
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `given prompts card setting enabled, when isPromptsSettingEnabled, then returns true`() = test {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(createRemindersModel(isPromptsCardEnabled = true))
+        }
+
+        val result = helper.isPromptsSettingEnabled()
+
+        assertThat(result).isTrue
     }
 
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -76,6 +76,7 @@ import org.wordpress.android.ui.mysite.cards.CardsBuilder
 import org.wordpress.android.ui.mysite.cards.DomainRegistrationCardShownTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityLogCardViewModelSlice
+import org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardViewModelSlice
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardViewModelSlice
 import org.wordpress.android.ui.mysite.cards.dashboard.domaintransfer.DomainTransferCardViewModel
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardViewModelSlice
@@ -277,6 +278,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var quickLinksItemViewModelSlice: QuickLinksItemViewModelSlice
 
+    @Mock
+    lateinit var bloganuaryNudgeViewModelSlice: BloganuaryNudgeCardViewModelSlice
+
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<MySiteViewModel.State>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -412,6 +416,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(activityLogCardViewModelSlice.getActivityLogCardBuilderParams(anyOrNull())).thenReturn(mock())
         whenever(personalizeCardViewModelSlice.getBuilderParams()).thenReturn(mock())
         whenever(personalizeCardBuilder.build(any())).thenReturn(mock())
+        whenever(bloganuaryNudgeViewModelSlice.getBuilderParams()).thenReturn(mock())
         whenever(bloggingPromptCardViewModelSlice.getBuilderParams(anyOrNull())).thenReturn(mock())
         whenever(quickLinksItemViewModelSlice.uiState).thenReturn(mock())
         whenever(quickStartRepository.quickStartMenuStep).thenReturn(mock())
@@ -467,7 +472,8 @@ class MySiteViewModelTest : BaseUnitTest() {
             bloggingPromptCardViewModelSlice,
             noCardsMessageViewModelSlice,
             siteInfoHeaderCardViewModelSlice,
-            quickLinksItemViewModelSlice
+            quickLinksItemViewModelSlice,
+            bloganuaryNudgeViewModelSlice,
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.ActivityCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BlazeCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloggingPromptCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardPlansBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardsBuilderParams
@@ -131,6 +132,12 @@ class CardsBuilderTest {
                 onErrorRetryClick = mock(),
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
+                bloganuaryNudgeCardBuilderParams = BloganuaryNudgeCardBuilderParams(
+                    false,
+                    mock(),
+                    mock(),
+                    mock(),
+                ),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(),
                     mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardWithPostItems
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PagesCard.PagesCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.PromoteWithBlazeCard
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.TodaysStatsCard.TodaysStatsCardWithData
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardCardPlansBuilderParams
@@ -29,9 +30,11 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DashboardC
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.PostCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.TodaysStatsCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BlazeCardBuilderParams.PromoteWithBlazeCardBuilderParams
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DomainTransferCardBuilderParams
 import org.wordpress.android.ui.mysite.cards.blaze.BlazeCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.ActivityCardBuilder
+import org.wordpress.android.ui.mysite.cards.dashboard.bloganuary.BloganuaryNudgeCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingPromptCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.pages.PagesCardBuilder
 import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardBuilder
@@ -68,6 +71,9 @@ class CardsBuilderTest : BaseUnitTest() {
     @Mock
     lateinit var mDomainTransferCardBuilder: DomainTransferCardBuilder
 
+    @Mock
+    lateinit var bloganuaryCardBuilder: BloganuaryNudgeCardBuilder
+
     private lateinit var cardsBuilder: CardsBuilder
 
     @Before
@@ -75,6 +81,7 @@ class CardsBuilderTest : BaseUnitTest() {
         cardsBuilder = CardsBuilder(
             todaysStatsCardBuilder,
             postCardBuilder,
+            bloganuaryCardBuilder,
             bloggingPromptCardsBuilder,
             mDomainTransferCardBuilder,
             blazeCardBuilder,
@@ -229,6 +236,21 @@ class CardsBuilderTest : BaseUnitTest() {
         assertThat(cards.findActivityCard()).isNotNull
     }
 
+    /* BLOGANUARY CARD */
+    @Test
+    fun `when is eligible for bloganuary nudge card, then bloganuary nudge card is built`() {
+        val cards = buildDashboardCards(isEligibleForBloganuaryNudge = true)
+
+        assertThat(cards.findBloganuaryNudgeCard()).isNotNull
+    }
+
+    @Test
+    fun `when is not eligible for bloganuary nudge card, then bloganuary nudge card is not built`() {
+        val cards = buildDashboardCards(isEligibleForBloganuaryNudge = false)
+
+        assertThat(cards.findBloganuaryNudgeCard()).isNull()
+    }
+
     private fun List<Card>.findTodaysStatsCard() =
         this.find { it is TodaysStatsCardWithData } as? TodaysStatsCardWithData
 
@@ -250,6 +272,9 @@ class CardsBuilderTest : BaseUnitTest() {
     private fun List<Card>.findActivityCard() =
         this.find { it is ActivityCardWithItems } as? ActivityCardWithItems
 
+    private fun List<Card>.findBloganuaryNudgeCard() =
+        this.find { it is BloganuaryNudgeCardModel } as? BloganuaryNudgeCardModel
+
     private fun List<Card>.findErrorCard() = this.find { it is ErrorCard } as? ErrorCard
 
     private val todaysStatsCard = mock<TodaysStatsCardWithData>()
@@ -263,6 +288,8 @@ class CardsBuilderTest : BaseUnitTest() {
     private val pagesCard = mock<PagesCardWithData>()
 
     private val activityCard = mock<ActivityCardWithItems>()
+
+    private val bloganuaryNudgeCard = mock<BloganuaryNudgeCardModel>()
 
     private fun createPostCards() = listOf(
         PostCardWithPostItems(
@@ -282,8 +309,9 @@ class CardsBuilderTest : BaseUnitTest() {
         isEligibleForDomainTransferCard: Boolean = false,
         isEligibleForBlaze: Boolean = false,
         isEligibleForPlansCard: Boolean = false,
+        isEligibleForBloganuaryNudge: Boolean = false,
         hasPagesCard: Boolean = false,
-        hasActivityCard: Boolean = false
+        hasActivityCard: Boolean = false,
     ): List<Card> {
         doAnswer { if (hasTodaysStats) todaysStatsCard else null }.whenever(todaysStatsCardBuilder).build(any())
         doAnswer { if (hasPostsForPostCard) createPostCards() else emptyList() }.whenever(postCardBuilder)
@@ -293,6 +321,8 @@ class CardsBuilderTest : BaseUnitTest() {
             .build(any())
         doAnswer { if (isEligibleForPlansCard) dashboardPlansCard else null }.whenever(dashboardPlansCardBuilder)
             .build(any())
+        doAnswer { if (isEligibleForBloganuaryNudge) bloganuaryNudgeCard else null }.whenever(bloganuaryCardBuilder)
+            .build(any())
         doAnswer { if (hasPagesCard) pagesCard else null }.whenever(pagesCardBuilder).build(any())
         doAnswer { if (hasActivityCard) activityCard else null }.whenever(activityCardBuilder).build(any())
         return cardsBuilder.build(
@@ -301,6 +331,12 @@ class CardsBuilderTest : BaseUnitTest() {
                 onErrorRetryClick = { },
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
+                bloganuaryNudgeCardBuilderParams = BloganuaryNudgeCardBuilderParams(
+                    isEligibleForBloganuaryNudge,
+                    mock(),
+                    mock(),
+                    mock(),
+                ),
                 bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
                     mock(), mock(), mock(), mock(), mock(), mock(), mock()
                 ),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilderTest.kt
@@ -1,0 +1,47 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
+import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.R
+
+class BloganuaryNudgeCardBuilderTest {
+    @Test
+    fun `GIVEN not eligible, WHEN build is called, THEN return null`() {
+        val params = BloganuaryNudgeCardBuilderParams(
+            isEligible = false,
+            onLearnMoreClick = {},
+            onMoreMenuClick = {},
+            onHideMenuItemClick = {},
+        )
+        val cardModel = BloganuaryNudgeCardBuilder().build(params)
+        assertThat(cardModel).isNull()
+    }
+
+    @Test
+    fun `GIVEN eligible, WHEN build is called, THEN return correct model`() {
+        var currentAction = ""
+
+        val params = BloganuaryNudgeCardBuilderParams(
+            isEligible = true,
+            onLearnMoreClick = { currentAction = "onLearnMoreClick" },
+            onMoreMenuClick = { currentAction = "onMoreMenuClick" },
+            onHideMenuItemClick = { currentAction = "onHideMenuItemClick" },
+        )
+        val cardModel = BloganuaryNudgeCardBuilder().build(params)
+
+        assertThat(cardModel!!).isNotNull
+        assertThat(cardModel.title).isEqualTo(UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title))
+        assertThat(cardModel.text).isEqualTo(UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text))
+
+        // check if the callbacks are hooked correctly
+        assertThat(currentAction).isEmpty()
+        cardModel.onLearnMoreClick.click()
+        assertThat(currentAction).isEqualTo("onLearnMoreClick")
+        cardModel.onMoreMenuClick.click()
+        assertThat(currentAction).isEqualTo("onMoreMenuClick")
+        cardModel.onHideMenuItemClick.click()
+        assertThat(currentAction).isEqualTo("onHideMenuItemClick")
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
@@ -1,0 +1,80 @@
+package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
+import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
+    @Mock
+    lateinit var bloganuaryNudgeFeatureConfig: BloganuaryNudgeFeatureConfig
+
+    @Mock
+    lateinit var bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper
+
+    lateinit var viewModel: BloganuaryNudgeCardViewModelSlice
+
+    @Before
+    fun setUp() {
+        viewModel = BloganuaryNudgeCardViewModelSlice(
+            bloganuaryNudgeFeatureConfig,
+            bloggingPromptsSettingsHelper
+        )
+        viewModel.initialize(testScope())
+    }
+
+    @Test
+    fun `GIVEN FF disabled, WHEN getting builder params, THEN not eligible`() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(false)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.isEligible).isFalse
+    }
+
+    @Test
+    fun `GIVEN prompts not available, WHEN getting builder params, THEN not eligible`() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(false)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.isEligible).isFalse
+    }
+
+    @Test
+    fun `GIVEN FF enabled and prompts available, WHEN getting builder params, THEN eligible`() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.isEligible).isTrue
+    }
+
+    @Test
+    fun `GIVEN builder params, WHEN calling onLearnMoreClick, THEN navigate to overlay`() = test {
+        val isPromptsEnabled = true
+        whenever(bloggingPromptsSettingsHelper.isPromptsSettingEnabled()).thenReturn(isPromptsEnabled)
+
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+
+        val params = viewModel.getBuilderParams()
+        params.onLearnMoreClick.invoke()
+
+        advanceUntilIdle()
+        assertThat(viewModel.onNavigation.value?.peekContent()).isEqualTo(
+            SiteNavigationAction.OpenBloganuaryNudgeOverlay(isPromptsEnabled)
+        )
+    }
+
+    // TODO thomashortadev: test onMoreMenuClick and onHideMenuItemClick when they are implemented
+}


### PR DESCRIPTION
Part of #19663 

This only contains the UI part of the Bloganuary Nudge Card and basic logic to show it on the dashboard, the interactions are still TODOs and will be done in different PRs.

Light Mode | Dark Mode
--- | ---
![bloganuary-nudge-light-mode](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/0639afe0-c665-4515-a2f8-66ac43038fca) | ![bloganuary-nudge-dark-mode](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/2da2aa66-cf06-4fb3-9110-7f1a8985aa18)


-----

## To Test:

1. Install and log into Jetpack (with a site that can see Blogging Prompts)
2. Go to Debug settings
3. Confirm the `bloganuary_dashboard_nudge` FF is ON (should be by default)
4. Go to My Site Dashboard
5. **Verify** the "Bloganuary is coming" card is shown (the buttons/interactions still don't work)
6. Go to Debug settings
7. Disable the `bloganuary_dashboard_nudge` FF
8. Go to My Site Dashboard
9. **Verify** the Bloganuary card is not shown

-----

## Regression Notes

1. Potential unintended areas of impact

    - Other cards UI/behavior affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

10. What automated tests I added (or what prevented me from doing so)

    - Unit tests for Bloganuary card builder
    - Unit tests for Bloganuary ViewModel slice
    - Updated unit tests for existing modified classes

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
