### PR TITLE
Move the Domain Transfer card below the main dashboard cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/CardsBuilder.kt
@@ -28,13 +28,13 @@ class CardsBuilder @Inject constructor(
         jetpackInstallFullPluginCardBuilder.build(jetpackInstallFullPluginCardBuilderParams)?.let {
             cards.add(it)
         }
-        if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
-            cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
-        }
         quickStartCardBuilderParams.quickStartCategories.takeIf { it.isNotEmpty() }?.let {
             cards.add(quickStartCardBuilder.build(quickStartCardBuilderParams))
         }
         cards.addAll(dashboardCardsBuilder.build(dashboardCardsBuilderParams))
+        if (domainRegistrationCardBuilderParams.isDomainCreditAvailable) {
+            cards.add(trackAndBuildDomainRegistrationCard(domainRegistrationCardBuilderParams))
+        }
         return cards
     }
 


### PR DESCRIPTION
Fixes #19674

According to this reasearch (pcdRpT-4nr-p2#comment-7550) the Google Domain Transfer card has changed its position on the list below the key dashboard cards such as prompts, blaze, stats, draft posts, and social.

| Before | After |
| ------ | ------|
|![Screenshot_20231127_132550](https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/523a610e-0a12-44e1-9e74-c307cc7664f5)|![Screenshot_20231127_132507](https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/569e69fc-427f-4e1b-aae7-a011177ea41f)|

-----

## To Test:

- Go to `My Site` tab
- [ ] Make sure you can see the `Reclaim your Google Domains` card is below `Today's Stats`, `Draft posts`, `Scheduled posts`, `Pages`, `Activity Log`, and `Blogging prompts` cards. It should be just above the `Personalize home tab` card

-----

## Regression Notes

1. Potential unintended areas of impact

    - The dashboard on the My Site tab

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)