### PR TITLE
[Bloganuary] Implement Dashboard Nudge card hide button functionality

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -245,7 +245,8 @@ class MySiteViewModel @Inject constructor(
             pagesCardViewModelSlice.refresh,
             todaysStatsViewModelSlice.refresh,
             postsCardViewModelSlice.refresh,
-            activityLogCardViewModelSlice.refresh
+            activityLogCardViewModelSlice.refresh,
+            bloganuaryNudgeCardViewModelSlice.refresh,
         )
     val domainTransferCardRefresh = domainTransferCardViewModel.refresh
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -206,6 +206,7 @@ public class AppPrefs {
 
         SHOULD_SHOW_SITE_ITEM_AS_QUICK_LINK_IN_DASHBOARD,
         SHOULD_SHOW_DEFAULT_QUICK_LINK_IN_DASHBOARD,
+        SHOULD_HIDE_BLOGANUARY_NUDGE_CARD,
     }
 
     /**
@@ -1806,5 +1807,18 @@ public class AppPrefs {
 
     public static Boolean getShouldShowDefaultQuickLink(String siteItem, final long siteId) {
         return prefs().getBoolean(getShouldShowDefaultQuickLinkKey(siteItem, siteId), true);
+    }
+
+    @NonNull
+    private static String getSiteIdHideBloganuaryNudgeCardKey(long siteId) {
+        return DeletablePrefKey.SHOULD_HIDE_BLOGANUARY_NUDGE_CARD.name() + siteId;
+    }
+
+    public static void setShouldHideBloganuaryNudgeCard(final long siteId, final boolean isHidden) {
+        prefs().edit().putBoolean(getSiteIdHideBloganuaryNudgeCardKey(siteId), isHidden).apply();
+    }
+
+    public static boolean getShouldHideBloganuaryNudgeCard(final long siteId) {
+        return prefs().getBoolean(getSiteIdHideBloganuaryNudgeCardKey(siteId), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -412,6 +412,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldShowDefaultQuickLink(siteItem: String, siteId: Long): Boolean =
         AppPrefs.getShouldShowDefaultQuickLink(siteItem, siteId)
 
+    fun setShouldHideBloganuaryNudgeCard(siteId: Long, isHidden: Boolean) =
+        AppPrefs.setShouldHideBloganuaryNudgeCard(siteId, isHidden)
+
+    fun getShouldHideBloganuaryNudgeCard(siteId: Long): Boolean =
+        AppPrefs.getShouldHideBloganuaryNudgeCard(siteId)
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
@@ -5,10 +5,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -19,13 +25,21 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper
 
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
     lateinit var viewModel: BloganuaryNudgeCardViewModelSlice
 
     @Before
     fun setUp() {
         viewModel = BloganuaryNudgeCardViewModelSlice(
             bloganuaryNudgeFeatureConfig,
-            bloggingPromptsSettingsHelper
+            bloggingPromptsSettingsHelper,
+            selectedSiteRepository,
+            appPrefsWrapper,
         )
         viewModel.initialize(testScope())
     }
@@ -50,9 +64,34 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `GIVEN FF enabled and prompts available, WHEN getting builder params, THEN eligible`() {
+    fun `GIVEN no selected site, WHEN getting builder params, THEN not eligible`() {
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.isEligible).isFalse
+    }
+
+    @Test
+    fun `GIVEN card was hidden by user, WHEN getting builder params, THEN not eligible`() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(true)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.isEligible).isFalse
+    }
+
+    @Test
+    fun `GIVEN FF enabled, prompts available, and card not hidden, WHEN getting builder params, THEN eligible`() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
 
         val params = viewModel.getBuilderParams()
 
@@ -66,6 +105,8 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
 
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
 
         val params = viewModel.getBuilderParams()
         params.onLearnMoreClick.invoke()
@@ -76,5 +117,27 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         )
     }
 
-    // TODO thomashortadev: test onMoreMenuClick and onHideMenuItemClick when they are implemented
+    @Test
+    fun `GIVEN builder params, WHEN calling onHideMenuItemClick, THEN hide card in AppPrefs and refresh`() = test {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+
+        val params = viewModel.getBuilderParams()
+        params.onHideMenuItemClick.invoke()
+
+        advanceUntilIdle()
+        verify(appPrefsWrapper).setShouldHideBloganuaryNudgeCard(SITE_ID, true)
+        assertThat(viewModel.refresh.value?.peekContent()).isTrue
+    }
+
+    // TODO thomashortadev: test onHideMenuItemClick when it is implemented
+
+    companion object {
+        private const val SITE_ID = 1L
+        private val mockSiteModel: SiteModel = mock {
+            on { siteId } doReturn SITE_ID
+        }
+    }
 }


### PR DESCRIPTION
Part of #19663

Implement the "Hide this" button functionality for hiding the Bloganuary Nudge card from the dashboard.


https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/6c95681c-2114-4dfc-977d-1f9ce9c72f4a

-----

## To Test:

1. Install and log into the Jetpack app (with a site that has blogging prompts available)
2. Make sure the `bloganuary_dashboard_nudge` FF is active in Debug Settings
3. Go to My Site dashboard
4. **Verify** the Bloganuary card is showing
5. Tap the context menu (three-dots)
6. Tap "Hide this"
7. **Verify** the Bloganuary card is hidden for this site
8. Select a different site that also has blogging prompts available
9. **Verify** the Bloganuary card is still shown for the other site

The only way to reset this "hidden" state is to clear the app settings / reinstall the app.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

11. What automated tests I added (or what prevented me from doing so)

    - Updated Bloganuary unit tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
