### PR TITLE
[Gutenberg] Add isNetworkConnected capability

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2475,6 +2475,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         boolean isFreeWPCom = mSite.isWPCom() && SiteUtils.onFreePlan(mSite);
         boolean isWPComSite = mSite.isWPCom() || mSite.isWPComAtomic();
         boolean shouldUseFastImage = !mSite.isPrivate() && !mSite.isPrivateWPComAtomic();
+        boolean isNetworkConnected = true;
 
         String hostAppNamespace = mBuildConfigWrapper.isJetpackApp() ? "Jetpack" : "WordPress";
 
@@ -2504,7 +2505,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                     postType,
                     hostAppNamespace,
                     featuredImageId,
-                    themeBundle
+                    themeBundle,
+                    isNetworkConnected
             );
         }
 
@@ -2531,7 +2533,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 postType,
                 hostAppNamespace,
                 featuredImageId,
-                themeBundle
+                themeBundle,
+                isNetworkConnected
         );
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.109.0'
+    gutenbergMobileVersion = '6415-f9dfaf7c64b481905f67ced3a754101ce79895c4'
     wordPressAztecVersion = 'v1.8.0'
     wordPressFluxCVersion = '2.57.0'
     wordPressLoginVersion = '1.10.0'

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergPropsBuilder.kt
@@ -32,7 +32,8 @@ data class GutenbergPropsBuilder(
     private val postType: String,
     private val hostAppNamespace: String,
     private val featuredImageId: Int,
-    private val editorTheme: Bundle?
+    private val editorTheme: Bundle?,
+    private val isNetworkConnected: Boolean,
 ) : Parcelable {
     fun build(activity: Activity, isHtmlModeEnabled: Boolean) = GutenbergProps(
         enableContactInfoBlock = enableContactInfoBlock,
@@ -60,6 +61,7 @@ data class GutenbergPropsBuilder(
         editorTheme = editorTheme,
         translations = GutenbergUtils.getTranslations(activity),
         isDarkMode = GutenbergUtils.isDarkMode(activity),
-        htmlModeEnabled = isHtmlModeEnabled
+        htmlModeEnabled = isHtmlModeEnabled,
+        isNetworkConnected = isNetworkConnected,
     )
 }


### PR DESCRIPTION
WIP to test sending network connectivity status to the Editor:

* https://github.com/WordPress/gutenberg/pull/56583
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6415

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
