### PR TITLE
New strings for popup for clear translations

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -163,10 +163,10 @@ public class WPMediaUtils {
         };
 
         AlertDialog.Builder builder = new MaterialAlertDialogBuilder(context);
-        builder.setTitle(R.string.image_optimization_promo_title);
-        builder.setMessage(R.string.image_optimization_promo_desc);
-        builder.setPositiveButton(R.string.turn_on, onClickListener);
-        builder.setNegativeButton(R.string.leave_off, onClickListener);
+        builder.setTitle(R.string.image_optimization_popup_title);
+        builder.setMessage(R.string.image_optimization_popup_desc);
+        builder.setPositiveButton(R.string.leave_on, onClickListener);
+        builder.setNegativeButton(R.string.turn_off, onClickListener);
         builder.setOnCancelListener(onCancelListener);
         builder.show();
         // Do not ask again

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2975,10 +2975,10 @@
     <string name="permission_microphone">Microphone</string>
 
     <!-- Image Optimization promo -->
-    <string name="turn_on">Yes, leave on</string>
-    <string name="leave_off">No, turn off</string>
-    <string name="image_optimization_promo_title">Keep optimizing images?</string>
-    <string name="image_optimization_promo_desc">Image optimization shrinks images for faster uploading.\n\nThis option is enabled by default, but you can change it in the app settings at any time.</string>
+    <string name="leave_on">Yes, leave on</string>
+    <string name="turn_off">No, turn off</string>
+    <string name="image_optimization_popup_title">Keep optimizing images?</string>
+    <string name="image_optimization_popup_desc">Image optimization shrinks images for faster uploading.\n\nThis option is enabled by default, but you can change it in the app settings at any time.</string>
 
     <!-- Login -->
     <!-- If any of these appear unused, be sure to check the same string in the login library -


### PR DESCRIPTION
## Description

The strings originally associated with the image optimization popup were updated in https://github.com/wordpress-mobile/WordPress-Android/pull/19581. Instead of informing users that optimization is off by default, the popup should now inform users of the new on-by-default state.

However, as we only updated existing strings, the old message was still displaying in languages with outdated translations. This means the popup would display misleading and incorrect information for those with languages other than `English (United States)` selected. For example, the below compares the expected translation compared to what is currently displaying when `English (United Kingdom)` is selected. 

| Expected  | Actual |
| ------------- | ------------- |
| <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2998162/089f22f8-2bf7-41c2-8197-78ed3a3b256d" width="100%"> | <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2998162/94dd59d7-d39f-47bd-86e7-f7bf62b6ab95" width="100%"> |

With this PR, we now remove the old, now-redundant strings and replace them with completely new strings. As such, languages without translations will display the default English strings.

-----

## To Test

* Remove and install the app.
* Navigate to _Me_ → _App Settings_ and set any locale _other_ than `English (United States)`.
* Next, to upload media, navigate to either the My Site → Media or the post/page editor to add a media block. 
* Following the steps to add media from your screen of choice and select the choose from my device option.
* Select one or multiple images and add them.
* Verify that the image optimization popup is displayed with the correct wording.

-----

## Regression Notes

1. Potential unintended areas of impact

    - As we're changing strings, unintended impact should be minimal, but may include translations in general.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manually tested a number of different languages to confirm the default strings are used.

3. What automated tests I added (or what prevented me from doing so)

    - Not applicable, this PR only includes changes to strings.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
