### PR TITLE
Adds XMLRPCRequest missing accept header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.109.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2.57.0'
+    wordPressFluxCVersion = '2911-115f8b738d8aa5c3cca37a5feae24aa7f0e399ff'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #7846

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2911

## Description
This PR adds the `Accept: */*` header to all XMLRPC Requests and aligns with the behaviour of the iOS app https://github.com/wordpress-mobile/WordPress-Android/issues/7846#issuecomment-811776264

-----

## To Test:

Follow the steps in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2911

-----

## Regression Notes

1. Potential unintended areas of impact

    - Self-hosted sites

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - This was a network layer change

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
