### PR TITLE
[Bloganuary] Implement Dashboard Nudge card analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTracker.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.bloganuary
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import javax.inject.Inject
+
+class BloganuaryNudgeAnalyticsTracker @Inject constructor(
+    private val analyticsTracker: AnalyticsTrackerWrapper,
+    private val cardsTracker: CardsTracker,
+) {
+    fun trackMySiteCardLearnMoreTapped(isPromptsEnabled: Boolean) = analyticsTracker.track(
+        Stat.BLOGANUARY_NUDGE_MY_SITE_CARD_LEARN_MORE_TAPPED,
+        mapOf("prompts_enabled" to isPromptsEnabled.toString())
+    )
+
+    fun trackMySiteCardMoreMenuTapped() = cardsTracker.trackCardMoreMenuClicked(
+        CardsTracker.Type.BLOGANUARY_NUDGE.label
+    )
+
+    fun trackMySiteCardMoreMenuItemTapped(item: MySiteCardMenuItemType) = cardsTracker.trackCardMoreMenuItemClicked(
+        CardsTracker.Type.BLOGANUARY_NUDGE.label,
+        item.label
+    )
+
+    enum class MySiteCardMenuItemType(val label: String) {
+        HIDE_THIS("hide_this"),
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTracker.kt
@@ -18,12 +18,13 @@ class BloganuaryNudgeAnalyticsTracker @Inject constructor(
         CardsTracker.Type.BLOGANUARY_NUDGE.label
     )
 
-    fun trackMySiteCardMoreMenuItemTapped(item: MySiteCardMenuItemType) = cardsTracker.trackCardMoreMenuItemClicked(
-        CardsTracker.Type.BLOGANUARY_NUDGE.label,
-        item.label
-    )
+    fun trackMySiteCardMoreMenuItemTapped(item: BloganuaryNudgeCardMenuItem) = cardsTracker
+        .trackCardMoreMenuItemClicked(
+            CardsTracker.Type.BLOGANUARY_NUDGE.label,
+            item.label
+        )
 
-    enum class MySiteCardMenuItemType(val label: String) {
+    enum class BloganuaryNudgeCardMenuItem(val label: String) {
         HIDE_THIS("hide_this"),
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -26,7 +26,7 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
 
     private val _refresh = MutableLiveData<Event<Boolean>>()
-    val refresh = _refresh
+    val refresh = _refresh as LiveData<Event<Boolean>>
 
     private lateinit var scope: CoroutineScope
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker
+import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker.BloganuaryNudgeCardMenuItem
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
@@ -18,6 +20,7 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     private val bloggingPromptsSettingsHelper: BloggingPromptsSettingsHelper,
     private val selectedSiteRepository: SelectedSiteRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val tracker: BloganuaryNudgeAnalyticsTracker,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -51,19 +54,19 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     }
 
     private fun onLearnMoreClick() {
-        // TODO thomashortadev: track analytics for this action
         scope.launch {
             val isPromptsEnabled = bloggingPromptsSettingsHelper.isPromptsSettingEnabled()
+            tracker.trackMySiteCardLearnMoreTapped(isPromptsEnabled)
             _onNavigation.value = Event(SiteNavigationAction.OpenBloganuaryNudgeOverlay(isPromptsEnabled))
         }
     }
 
     private fun onMoreMenuClick() {
-        // TODO thomashortadev: track analytics for this action
+        tracker.trackMySiteCardMoreMenuTapped()
     }
 
     private fun onHideMenuItemClick() {
-        // TODO thomashortadev: track analytics for this action
+        tracker.trackMySiteCardMoreMenuItemTapped(BloganuaryNudgeCardMenuItem.HIDE_THIS)
         scope.launch {
             val siteId = selectedSiteRepository.getSelectedSite()?.siteId ?: return@launch
             appPrefsWrapper.setShouldHideBloganuaryNudgeCard(siteId, true)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTrackerTest.kt
@@ -7,6 +7,7 @@ import org.mockito.Mock
 import org.mockito.kotlin.verify
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker.BloganuaryNudgeCardMenuItem
 import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
@@ -48,7 +49,7 @@ class BloganuaryNudgeAnalyticsTrackerTest : BaseUnitTest() {
 
     @Test
     fun `WHEN trackMySiteCardMoreMenuItemTapped is called THEN cardsTracker is called correctly`() {
-        BloganuaryNudgeAnalyticsTracker.MySiteCardMenuItemType.entries.forEach {
+        BloganuaryNudgeCardMenuItem.entries.forEach {
             tracker.trackMySiteCardMoreMenuItemTapped(it)
 
             verify(cardsTracker).trackCardMoreMenuItemClicked(

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/BloganuaryNudgeAnalyticsTrackerTest.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.bloganuary
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.ui.mysite.cards.dashboard.CardsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BloganuaryNudgeAnalyticsTrackerTest : BaseUnitTest() {
+    @Mock
+    lateinit var analyticsTracker: AnalyticsTrackerWrapper
+
+    @Mock
+    lateinit var cardsTracker: CardsTracker
+
+    lateinit var tracker: BloganuaryNudgeAnalyticsTracker
+
+    @Before
+    fun setUp() {
+        tracker = BloganuaryNudgeAnalyticsTracker(analyticsTracker, cardsTracker)
+    }
+
+    @Test
+    fun `WHEN trackMySiteCardLearnMoreTapped is called THEN analyticsTracker is called correctly`() {
+        listOf(true, false).forEach { isPromptsEnabled ->
+            tracker.trackMySiteCardLearnMoreTapped(isPromptsEnabled)
+
+            verify(analyticsTracker).track(
+                Stat.BLOGANUARY_NUDGE_MY_SITE_CARD_LEARN_MORE_TAPPED,
+                mapOf("prompts_enabled" to isPromptsEnabled.toString())
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN trackMySiteCardMoreMenuTapped is called THEN cardsTracker is called correctly`() {
+        tracker.trackMySiteCardMoreMenuTapped()
+
+        verify(cardsTracker).trackCardMoreMenuClicked(
+            CardsTracker.Type.BLOGANUARY_NUDGE.label
+        )
+    }
+
+    @Test
+    fun `WHEN trackMySiteCardMoreMenuItemTapped is called THEN cardsTracker is called correctly`() {
+        BloganuaryNudgeAnalyticsTracker.MySiteCardMenuItemType.entries.forEach {
+            tracker.trackMySiteCardMoreMenuItemTapped(it)
+
+            verify(cardsTracker).trackCardMoreMenuItemClicked(
+                CardsTracker.Type.BLOGANUARY_NUDGE.label,
+                it.label
+            )
+        }
+    }
+}

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1096,6 +1096,7 @@ public final class AnalyticsTracker {
         BARCODE_SCANNING_SUCCESS,
         BARCODE_SCANNING_FAILURE,
         QRLOGIN_SCANNER_DISMISSED_CAMERA_PERMISSION_DENIED,
+        BLOGANUARY_NUDGE_MY_SITE_CARD_LEARN_MORE_TAPPED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2677,6 +2677,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "barcode_scanning_failure";
             case QRLOGIN_SCANNER_DISMISSED_CAMERA_PERMISSION_DENIED:
                 return "qrlogin_scanner_dismissed_camera_permission_denied";
+            case BLOGANUARY_NUDGE_MY_SITE_CARD_LEARN_MORE_TAPPED:
+                return "bloganuary_nudge_my_site_card_learn_more_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Part of #19663

Implements the remaining analytics events for the Dashboard Nudge card. Specs: pctCYC-16J-p2

-----

## To Test:
1. Install and log into JP app with an account + site that has Prompts available
2. Make sure the `bloganuary_dashboard_nudge` Feature Flag is ON in Debug Settings
3. Make sure Analytics tracking is enabled in `Me` -> `App Settings` -> `Privacy Settings` -> `Collect Information`
4. Go to My Site Dashboard
5. **Verify** log is shown: `🔵 Tracked: my_site_dashboard_card_shown, Properties: {"type":"bloganuary_nudge","subtype":"bloganuary_nudge"}`
6. Tap "Learn more" button in Bloganuary Nudge card
7. **Verify** log is shown: `🔵 Tracked: bloganuary_nudge_my_site_card_learn_more_tapped, Properties: {"prompts_enabled":["true" if prompts is enabled in settings | "false" if it's not]}`
8. Tap the Context menu in Bloganuary Nudge card
9. **Verify** log is shown: `🔵 Tracked: my_site_dashboard_contextual_menu_accessed, Properties: {"card":"bloganuary_nudge"}`
10. Tap "Hide this" button in context menu
11. **Verify** log is shown: `🔵 Tracked: my_site_dashboard_card_menu_item_tapped, Properties: {"card":"bloganuary_nudge","item":"hide_this"}`

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

12. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

13. What automated tests I added (or what prevented me from doing so)

    - Tracker and ViewModelSlice new tests for analytics.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes made.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)