### PR TITLE
Integrate gutenberg-mobile release v1.109.1 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.109.0'
+    gutenbergMobileVersion = '6421-f3c448f3bbf07ba3ea5d7289d9d2fef396e1549c'
     wordPressAztecVersion = 'v1.8.0'
     wordPressFluxCVersion = '2.57.0'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6421-f3c448f3bbf07ba3ea5d7289d9d2fef396e1549c'
+    gutenbergMobileVersion = 'v1.109.1'
     wordPressAztecVersion = 'v1.8.0'
     wordPressFluxCVersion = '2.57.0'
     wordPressLoginVersion = '1.10.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.109.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6421

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.