### PR TITLE
feat: Provide Gutenberg editor network connection status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -121,6 +121,7 @@ import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData;
+import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.support.ZendeskHelper;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -3821,6 +3822,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
                 mEditorMediaUploadListener.onMediaUploadRetry(localMediaId, mediaType);
             }
         }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onEventMainThread(ConnectionChangeReceiver.ConnectionChangeEvent event) {
+        ((GutenbergEditorFragment) mEditorFragment).onConnectionStatusChange(event.isConnected());
     }
 
     private void refreshEditorTheme() {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.109.2'
+    gutenbergMobileVersion = '6417-edd96cff628dbd6403807e256e2c0fda9b7a6932'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.59.0'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6417-edd96cff628dbd6403807e256e2c0fda9b7a6932'
+    gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.59.0'
     wordPressLoginVersion = '1.10.0'

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -23,6 +23,7 @@ import org.wordpress.mobile.WPAndroidGlue.Media;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnAuthHeaderRequestedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnBlockTypeImpressionsEventListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnConnectionStatusEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnContentInfoReceivedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnCustomerSupportOptionsListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorAutosaveListener;
@@ -95,6 +96,7 @@ public class GutenbergContainerFragment extends Fragment {
                                   OnSendEventToHostListener onSendEventToHostListener,
                                   OnToggleUndoButtonListener onToggleUndoButtonListener,
                                   OnToggleRedoButtonListener onToggleRedoButtonListener,
+                                  OnConnectionStatusEventListener onConnectionStatusEventListener,
                                   boolean isDarkMode) {
             mWPAndroidGlueCode.attachToContainer(
                     viewGroup,
@@ -120,6 +122,7 @@ public class GutenbergContainerFragment extends Fragment {
                     onSendEventToHostListener,
                     onToggleUndoButtonListener,
                     onToggleRedoButtonListener,
+                    onConnectionStatusEventListener,
                     isDarkMode);
     }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -320,4 +320,8 @@ public class GutenbergContainerFragment extends Fragment {
     public void sendToJSFeaturedImageId(int mediaId) {
         mWPAndroidGlueCode.sendToJSFeaturedImageId(mediaId);
     }
+
+    public void onConnectionStatusChange(boolean isConnected) {
+        mWPAndroidGlueCode.connectionStatusChange(isConnected);
+    }
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -54,6 +54,7 @@ import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergD
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.StringUtils;
@@ -68,6 +69,7 @@ import org.wordpress.mobile.WPAndroidGlue.RequestExecutor;
 import org.wordpress.mobile.WPAndroidGlue.ShowSuggestionsUtil;
 import org.wordpress.mobile.WPAndroidGlue.UnsupportedBlock;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnBlockTypeImpressionsEventListener;
+import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnConnectionStatusEventListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnContentInfoReceivedListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnCustomerSupportOptionsListener;
 import org.wordpress.mobile.WPAndroidGlue.WPAndroidGlueCode.OnEditorMountListener;
@@ -425,6 +427,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                                                   Consumer<Bundle> onError) {
                         mEditorFragmentListener.onPerformFetch(path, enableCaching, onSuccess, onError);
                     }
+
                     @Override
                     public void performPostRequest(
                             String path,
@@ -586,6 +589,12 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 mEditorFragmentListener::onToggleUndo,
 
                 mEditorFragmentListener::onToggleRedo,
+
+                new OnConnectionStatusEventListener() {
+                    @Override public boolean onRequestConnectionStatus() {
+                        return NetworkUtils.isNetworkAvailable(getActivity());
+                    }
+                },
 
                 GutenbergUtils.isDarkMode(getActivity()));
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -99,7 +99,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         EditorThemeUpdateListener,
         StorySaveMediaListener,
         GutenbergDialogPositiveClickInterface,
-        GutenbergDialogNegativeClickInterface {
+        GutenbergDialogNegativeClickInterface,
+        GutenbergNetworkConnectionListener {
     private static final String GUTENBERG_EDITOR_NAME = "gutenberg";
     private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
     private static final String KEY_EDITOR_DID_MOUNT = "KEY_EDITOR_DID_MOUNT";
@@ -1568,5 +1569,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 // Dismiss dialog with no action.
                 break;
         }
+    }
+
+    @Override
+    public void onConnectionStatusChange(boolean isConnected) {
+        getGutenbergContainerFragment().onConnectionStatusChange(isConnected);
     }
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergNetworkConnectionListener.kt
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergNetworkConnectionListener.kt
@@ -1,0 +1,5 @@
+package org.wordpress.android.editor.gutenberg
+
+interface GutenbergNetworkConnectionListener {
+    fun onConnectionStatusChange(isConnected: Boolean)
+}


### PR DESCRIPTION
## Related
- https://github.com/WordPress/gutenberg/pull/56861
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6417
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22112

## Description

Enable the block editor to request and respond to changes to the network
connection status within the host app.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

To test: Smoke test the editor, verify it does not crash. 

## Regression Notes

1. Potential unintended areas of impact
    The bridge changes could cause the editor to fail to load.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Smoke tested the editor.
5. What automated tests I added (or what prevented me from doing so)
    None. There is no existing test files for the bridge module. Historically,
    we focus tests on the JavaScript counterparts in Gutenberg.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
