### PR TITLE
[Prompts/Crash] Fix crash on Prompts local table migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.108.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2.55.1'
+    wordPressFluxCVersion = '2914-04da18325ddbd74a85703142d510270bbde96310'
     wordPressLoginVersion = '1.8.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.108.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2914-04da18325ddbd74a85703142d510270bbde96310'
+    wordPressFluxCVersion = '2914-a6f12cfa50402d899ce0073d9be7dcf929f8c66d'
     wordPressLoginVersion = '1.8.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.108.0'
     wordPressAztecVersion = 'v1.8.0'
-    wordPressFluxCVersion = '2914-a6f12cfa50402d899ce0073d9be7dcf929f8c66d'
+    wordPressFluxCVersion = '2.55.2'
     wordPressLoginVersion = '1.8.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #19693 
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2914

The DB migration for the Prompts table in FluxC didn't account for cases where the local table had duplicate entries for certain dates (though it's unclear what could cause that). The fix in FluxC just removes the manual migration implementation, relying on the fallback to destructive migration, which is better for this scenario anyway since both schema AND backend response data changed with the update to Prompts V3, so it doesn't really make sense to keep old data.

-----

## To Test:

Since I was not able to find what would cause duplicate entries in normal app usage I had to come up with some steps to force multiple entries with the same date to reproduce the crash and confirm the fix. To test it, the test device needs to be connected to your computer and accessible for debugging in Android Studio.

1. Install a Jetpack app version based on 23.6 (e.g.: https://github.com/wordpress-mobile/WordPress-Android/pull/19601#issuecomment-1806059989)
2. Open the app and log into it with an account/site that has Blogging Prompts available
3. **Verify** the prompts card appears in the dashboard
4. On Android Studio, open the `App Inspection` tool
5. Select the device and process for the Jetpack app
6. Go to `Database Inspector`
7. Open the `wp-android-database`.`BloggingPrompts` table
8. Make some changes so a few entries have the same `date`
9. Install a Jetpack app version based on 23.7 (e.g.: https://github.com/wordpress-mobile/WordPress-Android/pull/19665#issuecomment-1825294789)
10. Open the app
11. **Verify** it crashes
12. Look at the crash logs to confirm the crash signature matches #19693
13. Install the Jetpack app version from this PR
14. Open the app
15. **Verify** it opens correctly and the Prompts card appears in the dashboard
16. On Android Studio, open the `App Inspection` tool
17. Select the device and process for the Jetpack app
18. Go to `Database Inspector`
19. Open the `wp-android-database`.`BloggingPrompts` table
20. **Verify** that the duplicate entries were not added to the table

_Important: do not uninstall the app between installs as we want to make sure the migrations are being executed to confirm the crash AND the fix, similar to what would happen with our users._

_Note: these steps don't work on all Android versions as Database Inspector only works on SDK 26 and higher._

Here's a video showing the testing process, as it is not very straightforward:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/05649905-c36f-44c9-b55c-05b5dd86e644

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

17. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

18. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)