### PR TITLE
[Boganuary] Implement Modal action to enable prompts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
@@ -8,15 +8,24 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.extensions.fillScreen
+import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class BloganuaryNudgeLearnMoreOverlayFragment : BottomSheetDialogFragment() {
     private val viewModel: BloganuaryNudgeLearnMoreOverlayViewModel by viewModels()
+
+    @Inject
+    lateinit var viewModelFactory: ViewModelProvider.Factory
+    private val wpMainActivityViewModel by lazy {
+        ViewModelProvider(requireActivity(), viewModelFactory)[WPMainActivityViewModel::class.java]
+    }
 
     private val isPromptsEnabled: Boolean by lazy {
         arguments?.getBoolean(ARG_IS_PROMPTS_ENABLED) ?: false
@@ -44,7 +53,10 @@ class BloganuaryNudgeLearnMoreOverlayFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.dismissDialog.observe(viewLifecycleOwner) { dismiss() }
+        viewModel.dismissDialog.observe(viewLifecycleOwner) {
+            dismiss()
+            if (it.refreshDashboard) wpMainActivityViewModel.requestMySiteDashboardRefresh()
+        }
         viewModel.onDialogShown()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayViewModel.kt
@@ -2,17 +2,24 @@ package org.wordpress.android.ui.bloganuary.learnmore
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 
 @HiltViewModel
-class BloganuaryNudgeLearnMoreOverlayViewModel @Inject constructor() : ViewModel() {
-    private val _dismissDialog = SingleLiveEvent<Unit>()
-    val dismissDialog = _dismissDialog as LiveData<Unit>
+class BloganuaryNudgeLearnMoreOverlayViewModel @Inject constructor(
+    private val promptsSettingsHelper: BloggingPromptsSettingsHelper,
+) : ViewModel() {
+    data class DismissEvent(val refreshDashboard: Boolean = false)
+
+    private val _dismissDialog = SingleLiveEvent<DismissEvent>()
+    val dismissDialog = _dismissDialog as LiveData<DismissEvent>
 
     fun getUiState(isPromptsEnabled: Boolean): BloganuaryNudgeLearnMoreOverlayUiState {
         val noteText: UiString
@@ -40,18 +47,18 @@ class BloganuaryNudgeLearnMoreOverlayViewModel @Inject constructor() : ViewModel
         // TODO thomashortadev add analytics
         when (action) {
             BloganuaryNudgeLearnMoreOverlayAction.DISMISS -> {
-                _dismissDialog.value = Unit
+                _dismissDialog.value = DismissEvent()
             }
 
-            BloganuaryNudgeLearnMoreOverlayAction.TURN_ON_PROMPTS -> {
-                // TODO thomashortadev add action to turn on prompts
-                _dismissDialog.value = Unit
+            BloganuaryNudgeLearnMoreOverlayAction.TURN_ON_PROMPTS -> viewModelScope.launch {
+                promptsSettingsHelper.updatePromptsCardEnabledForCurrentSite(true)
+                _dismissDialog.postValue(DismissEvent(refreshDashboard = true))
             }
         }
     }
 
     fun onCloseClick() {
-        _dismissDialog.value = Unit
+        _dismissDialog.value = DismissEvent()
     }
 
     fun onDialogDismissed() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelper.kt
@@ -44,6 +44,13 @@ class BloggingPromptsSettingsHelper @Inject constructor(
         bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
     }
 
+    suspend fun updatePromptsCardEnabledForCurrentSite(isEnabled: Boolean) {
+        val siteId = selectedSiteRepository.getSelectedSite()?.localId()?.value ?: return
+        val current = bloggingRemindersStore.bloggingRemindersModel(siteId).firstOrNull() ?: return
+        bloggingRemindersStore.updateBloggingReminders(current.copy(isPromptsCardEnabled = isEnabled))
+    }
+
+
     fun isPromptsFeatureAvailable(): Boolean {
         val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
         return bloggingPromptsFeature.isEnabled() && selectedSite.isUsingWpComRestApi

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -450,8 +450,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             if (quickStartScrollPosition > 0) recyclerView.scrollToPosition(quickStartScrollPosition)
             else appbarMain.setExpanded(true)
         }
-    }
 
+        wpMainActivityViewModel.mySiteDashboardRefreshRequested.observeEvent(viewLifecycleOwner) {
+            viewModel.refresh()
+        }
+    }
 
     private fun MySiteFragmentBinding.hideRefreshIndicatorIfNeeded() {
         swipeRefreshLayout.postDelayed({

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModel.kt
@@ -137,6 +137,9 @@ class WPMainActivityViewModel @Inject constructor(
     private val _showPrivacySettingsWithError = SingleLiveEvent<Boolean?>()
     val showPrivacySettingsWithError: LiveData<Boolean?> = _showPrivacySettingsWithError
 
+    private val _mySiteDashboardRefreshRequested = MutableLiveData<Event<Unit>>()
+    val mySiteDashboardRefreshRequested: LiveData<Event<Unit>> = _mySiteDashboardRefreshRequested
+
     val onFocusPointVisibilityChange = quickStartRepository.activeTask
         .mapNullable { getExternalFocusPointInfo(it) }
         .distinctUntilChanged()
@@ -408,6 +411,10 @@ class WPMainActivityViewModel @Inject constructor(
 
     fun onSettingsPrivacyPreferenceUpdateFailed(requestedAnalyticsPreference: Boolean?) {
         _showPrivacySettingsWithError.value = requestedAnalyticsPreference
+    }
+
+    fun requestMySiteDashboardRefresh() {
+        this._mySiteDashboardRefreshRequested.value = Event(Unit)
     }
 
     data class FocusPointInfo(

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayViewModelTest.kt
@@ -5,17 +5,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.verify
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
+import org.wordpress.android.ui.bloganuary.learnmore.BloganuaryNudgeLearnMoreOverlayViewModel.DismissEvent
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BloganuaryNudgeLearnMoreOverlayViewModelTest : BaseUnitTest() {
+    @Mock
+    lateinit var promptsSettingsHelper: BloggingPromptsSettingsHelper
+
     lateinit var viewModel: BloganuaryNudgeLearnMoreOverlayViewModel
 
     @Before
     fun setUp() {
-        viewModel = BloganuaryNudgeLearnMoreOverlayViewModel()
+        viewModel = BloganuaryNudgeLearnMoreOverlayViewModel(promptsSettingsHelper)
     }
 
     @Test
@@ -46,29 +53,28 @@ class BloganuaryNudgeLearnMoreOverlayViewModelTest : BaseUnitTest() {
     fun `onActionClick should dismiss dialog when action is DISMISS`() {
         viewModel.onActionClick(BloganuaryNudgeLearnMoreOverlayAction.DISMISS)
 
-        assertThat(viewModel.dismissDialog.value).isEqualTo(Unit)
+        assertThat(viewModel.dismissDialog.value).isEqualTo(DismissEvent())
     }
 
     @Test
-    @Ignore("WIP")
-    fun `onActionClick should turn on blogging prompts when action is TURN_ON_PROMPTS`() {
+    fun `onActionClick should turn on blogging prompts when action is TURN_ON_PROMPTS`() = test {
         viewModel.onActionClick(BloganuaryNudgeLearnMoreOverlayAction.TURN_ON_PROMPTS)
 
-        // TODO thomashortadev implement this when we have the action to turn on prompts
+        verify(promptsSettingsHelper).updatePromptsCardEnabledForCurrentSite(true)
     }
 
     @Test
-    fun `onActionClick should dismiss dialog when action is TURN_ON_PROMPTS`() {
+    fun `onActionClick should dismiss dialog requesting refresh when action is TURN_ON_PROMPTS`() {
         viewModel.onActionClick(BloganuaryNudgeLearnMoreOverlayAction.TURN_ON_PROMPTS)
 
-        assertThat(viewModel.dismissDialog.value).isEqualTo(Unit)
+        assertThat(viewModel.dismissDialog.value).isEqualTo(DismissEvent(refreshDashboard = true))
     }
 
     @Test
     fun `onCloseClick should dismiss dialog`() {
         viewModel.onCloseClick()
 
-        assertThat(viewModel.dismissDialog.value).isEqualTo(Unit)
+        assertThat(viewModel.dismissDialog.value).isEqualTo(DismissEvent())
     }
 
     // region Analytics

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsSettingsHelperTest.kt
@@ -99,6 +99,22 @@ class BloggingPromptsSettingsHelperTest : BaseUnitTest() {
     }
 
     @Test
+    fun `when updatePromptsCardEnabledForCurrentSite, then updates the store model`() = test {
+        val expectedState = true
+        val model = createRemindersModel(isPromptsCardEnabled = false)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())
+        whenever(bloggingRemindersStore.bloggingRemindersModel(any())).doAnswer {
+            flowOf(model)
+        }
+
+        helper.updatePromptsCardEnabledForCurrentSite(isEnabled = expectedState)
+
+        verify(bloggingRemindersStore).updateBloggingReminders(
+            argThat { siteId == 123 && isPromptsCardEnabled == expectedState }
+        )
+    }
+
+    @Test
     fun `given prompts FF is off and site is wpcom site, when isPromptsFeatureAvailable, then returns false`() {
         whenever(bloggingPromptsFeature.isEnabled()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(createSiteModel())

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -785,6 +785,20 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
         verify(observer, times(1)).onChanged(anyOrNull())
     }
 
+    @Test
+    fun `requests my site dashboard refresh when requestMySiteDashboardRefresh is called`() {
+        startViewModelWithDefaultParameters()
+
+        var observerCalledCount = 0
+        viewModel.mySiteDashboardRefreshRequested.observeForever {
+            observerCalledCount++
+        }
+
+        viewModel.requestMySiteDashboardRefresh()
+
+        assertThat(observerCalledCount).isEqualTo(1)
+    }
+
     private fun startViewModelWithDefaultParameters(
         isWhatsNewFeatureEnabled: Boolean = true,
         isCreateFabEnabled: Boolean = true,


### PR DESCRIPTION
Part of #19685 

Implements the CTA action of enabling the prompts from the Bloganuary Learn More modal and refresh the dashboard to show the prompts card when closing the overlay.


https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/f8db173a-1b07-4351-a234-a8f33ac28e59

-----

## To Test:

1. Install and log into the app with a site that has Blogging Prompts available
2. Go to the My Site dashboard
3. Make sure the Prompts card is turn off / disabled
4. Tap "Learn More" on the Bloganuary card
5. **Verify** the overlay modal shows up with the correct copy
8. Tap the "Turn on blogging prompts" CTA
9. **Verify** it closes the modal
10. **Verify** the dashboard refreshes
11. **Verify** the Prompts card is shown

-----

## Regression Notes

1. Potential unintended areas of impact

    - Refreshing the dashboard when no needed.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and unit tests.
  
3. What automated tests I added (or what prevented me from doing so)

    - Unit tests for the new functionality and added code.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes were made.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
