### PR TITLE
[Bloganuary] Make Bloganuary Nudge only be eligible in December

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 
+import android.icu.util.Calendar
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
@@ -35,8 +36,8 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     }
 
     fun getBuilderParams(): BloganuaryNudgeCardBuilderParams {
-        // TODO thomashortadev: check if current device date is in December 2023
         val isEligible = bloganuaryNudgeFeatureConfig.isEnabled() &&
+                Calendar.getInstance().get(Calendar.MONTH) == Calendar.DECEMBER &&
                 bloggingPromptsSettingsHelper.isPromptsFeatureAvailable() &&
                 !isCardHiddenByUser()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.Bloganuary
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
@@ -22,6 +23,7 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     private val selectedSiteRepository: SelectedSiteRepository,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val tracker: BloganuaryNudgeAnalyticsTracker,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -36,8 +38,9 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     }
 
     fun getBuilderParams(): BloganuaryNudgeCardBuilderParams {
+        val now = dateTimeUtilsWrapper.getCalendarInstance()
         val isEligible = bloganuaryNudgeFeatureConfig.isEnabled() &&
-                Calendar.getInstance().get(Calendar.MONTH) == Calendar.DECEMBER &&
+                now.get(Calendar.MONTH) == Calendar.DECEMBER &&
                 bloggingPromptsSettingsHelper.isPromptsFeatureAvailable() &&
                 !isCardHiddenByUser()
 

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.util
 
+import android.icu.util.Calendar
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.viewmodel.ContextProvider
 import java.text.SimpleDateFormat
@@ -52,5 +53,9 @@ class DateTimeUtilsWrapper @Inject constructor(
     fun getRelativeTimeSpanString(date: Date): String {
         return DateUtils.getRelativeTimeSpanString(date.time, System.currentTimeMillis(), DateUtils.SECOND_IN_MILLIS)
             .toString()
+    }
+
+    fun getCalendarInstance(): Calendar {
+        return Calendar.getInstance()
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 
+import android.icu.util.Calendar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -17,6 +19,7 @@ import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -36,6 +39,9 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var tracker: BloganuaryNudgeAnalyticsTracker
 
+    @Mock
+    lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+
     lateinit var viewModel: BloganuaryNudgeCardViewModelSlice
 
     @Before
@@ -46,6 +52,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
             selectedSiteRepository,
             appPrefsWrapper,
             tracker,
+            dateTimeUtilsWrapper,
         )
         viewModel.initialize(testScope())
     }
@@ -60,8 +67,30 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
+    fun `GIVEN not December, WHEN getting builder params, THEN not eligible`() {
+        // need to use it to make sure that test will fail if other month meets the requirement incorrectly
+        val lenient = Mockito.lenient()
+
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        lenient.`when`(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        lenient.`when`(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        lenient.`when`(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+
+        // Test all months except December
+        (Calendar.JANUARY..Calendar.NOVEMBER).forEach { month ->
+            mockCalendarMonth(month)
+
+            val params = viewModel.getBuilderParams()
+
+            assertThat(params.isEligible).isFalse
+            Mockito.reset(dateTimeUtilsWrapper)
+        }
+    }
+
+    @Test
     fun `GIVEN prompts not available, WHEN getting builder params, THEN not eligible`() {
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        mockCalendarMonth(Calendar.DECEMBER)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(false)
 
         val params = viewModel.getBuilderParams()
@@ -72,6 +101,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     @Test
     fun `GIVEN no selected site, WHEN getting builder params, THEN not eligible`() {
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        mockCalendarMonth(Calendar.DECEMBER)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
 
@@ -83,6 +113,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     @Test
     fun `GIVEN card was hidden by user, WHEN getting builder params, THEN not eligible`() {
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        mockCalendarMonth(Calendar.DECEMBER)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
         whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(true)
@@ -93,11 +124,8 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `GIVEN FF enabled, prompts available, and card not hidden, WHEN getting builder params, THEN eligible`() {
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+    fun `GIVEN requirements met, WHEN getting builder params, THEN eligible`() {
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
 
@@ -109,10 +137,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         val isPromptsEnabled = true
         whenever(bloggingPromptsSettingsHelper.isPromptsSettingEnabled()).thenReturn(isPromptsEnabled)
 
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
         params.onLearnMoreClick.invoke()
@@ -125,10 +150,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `GIVEN builder params, WHEN calling onHideMenuItemClick, THEN hide card in AppPrefs and refresh`() = test {
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
         params.onHideMenuItemClick.invoke()
@@ -144,10 +166,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         val isPromptsEnabled = true
         whenever(bloggingPromptsSettingsHelper.isPromptsSettingEnabled()).thenReturn(isPromptsEnabled)
 
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
         params.onLearnMoreClick.invoke()
@@ -158,10 +177,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `GIVEN builder params, WHEN calling onMoreMenuClick, THEN track analytics`() = test {
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
         params.onMoreMenuClick.invoke()
@@ -172,10 +188,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `GIVEN builder params, WHEN calling onHideMenuItemClick, THEN track analytics`() = test {
-        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
-        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
-        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+        mockEligibleRequirements()
 
         val params = viewModel.getBuilderParams()
         params.onHideMenuItemClick.invoke()
@@ -184,6 +197,21 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         verify(tracker).trackMySiteCardMoreMenuItemTapped(BloganuaryNudgeCardMenuItem.HIDE_THIS)
     }
     // endregion
+
+    private fun mockCalendarMonth(month: Int) {
+        val mockCalendar: Calendar = mock {
+            on { get(Calendar.MONTH) } doReturn month
+        }
+        whenever(dateTimeUtilsWrapper.getCalendarInstance()).thenReturn(mockCalendar)
+    }
+
+    private fun mockEligibleRequirements() {
+        whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
+        mockCalendarMonth(Calendar.DECEMBER)
+        whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
+        whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
+    }
 
     companion object {
         private const val SITE_ID = 1L


### PR DESCRIPTION
Check if the current month is December for deciding if the Bloganuary Nudge should be shown.

-----

## To Test:

1. Install and log into the Jetpack app using a site that has prompts available
2. Make sure the `bloganuary_dashboard_nudge` FF is on in Debug Settings
3. Go to your device settings -> Date
4. Set the date to some month that is **not** December
5. Go back to Jetpack -> My Site Dashboard
6. **Verify** the Bloganuary card is not shown
7.  Go to your device settings -> Date
8. Set the date to December
9. **Verify** the Bloganuary card is shown

-----

## Regression Notes

1. Potential unintended areas of impact

    - Bloganuary card is shown for other months or if other requirements don't match.

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing, Unit tests.

10. What automated tests I added (or what prevented me from doing so)

    - Added/update unit tests for the ViewModelSlice.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
