### PR TITLE
[SotW 2023] Feature Flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/WpSotw2023NudgeFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WpSotw2023NudgeFeatureConfig.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val WP_SOTW_2023_NUDGE_REMOTE_FIELD = "wp_sotw_2023_nudge"
+
+@Feature(WP_SOTW_2023_NUDGE_REMOTE_FIELD, false)
+class WpSotw2023NudgeFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.BLOGANUARY_DASHBOARD_NUDGE,
+    WP_SOTW_2023_NUDGE_REMOTE_FIELD
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && !BuildConfig.IS_JETPACK_APP
+    }
+}


### PR DESCRIPTION
Part of #19709 

Creates the Feature Flag for SotW 2023 nudge, which will only be available in the WP app.

-----

## To Test:

Not much to test, but you can check it shows up properly in the debug menu as `wp_sotw_2023_nudge`.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
