### PR TITLE
[SotW 2023] Implement card UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.TodaysStatsCard.TodaysStatsCardWithData
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryEmptyHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
@@ -51,6 +52,7 @@ import org.wordpress.android.ui.mysite.cards.nocards.NoCardsMessageViewHolder
 import org.wordpress.android.ui.mysite.cards.personalize.PersonalizeCardViewHolder
 import org.wordpress.android.ui.mysite.cards.quicklinksitem.QuickLinkRibbonViewHolder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardViewHolder
+import org.wordpress.android.ui.mysite.cards.sotw2023.WpSotw2023NudgeCardViewHolder
 import org.wordpress.android.ui.mysite.items.categoryheader.MySiteCategoryItemEmptyViewHolder
 import org.wordpress.android.ui.mysite.items.categoryheader.MySiteCategoryItemViewHolder
 import org.wordpress.android.ui.mysite.items.infoitem.MySiteInfoItemViewHolder
@@ -123,6 +125,7 @@ class MySiteAdapter(
             )
             MySiteCardAndItem.Type.NO_CARDS_MESSAGE.ordinal -> NoCardsMessageViewHolder(parent)
             MySiteCardAndItem.Type.PERSONALIZE_CARD.ordinal -> PersonalizeCardViewHolder(parent)
+            MySiteCardAndItem.Type.WP_SOTW_2023_NUDGE_CARD.ordinal -> WpSotw2023NudgeCardViewHolder(parent)
             else -> throw IllegalArgumentException("Unexpected view type")
         }
     }
@@ -156,6 +159,7 @@ class MySiteAdapter(
             is JetpackInstallFullPluginCardViewHolder -> holder.bind(getItem(position) as JetpackInstallFullPluginCard)
             is NoCardsMessageViewHolder -> holder.bind(getItem(position) as MySiteCardAndItem.Card.NoCardsMessage)
             is PersonalizeCardViewHolder -> holder.bind(getItem(position) as PersonalizeCardModel)
+            is WpSotw2023NudgeCardViewHolder -> holder.bind(getItem(position) as WpSotw2023NudgeCardModel)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapterDiffCallback.kt
@@ -20,6 +20,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.PostCard.PostCardW
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.TodaysStatsCard.TodaysStatsCardWithData
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryEmptyHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.CategoryHeaderItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
@@ -64,6 +65,7 @@ object MySiteAdapterDiffCallback : DiffUtil.ItemCallback<MySiteCardAndItem>() {
             oldItem is MySiteCardAndItem.Card.NoCardsMessage && updatedItem is
                     MySiteCardAndItem.Card.NoCardsMessage -> true
             oldItem is PersonalizeCardModel && updatedItem is PersonalizeCardModel -> true
+            oldItem is WpSotw2023NudgeCardModel && updatedItem is WpSotw2023NudgeCardModel -> true
             else -> throw UnsupportedOperationException("Diff not implemented yet")
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -59,6 +59,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         JETPACK_INSTALL_FULL_PLUGIN_CARD,
         NO_CARDS_MESSAGE,
         PERSONALIZE_CARD,
+        SOTW_2023_NUDGE_CARD,
     }
 
     data class SiteInfoHeaderCard(
@@ -384,7 +385,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onMoreMenuClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,
             val onCtaClick: ListItemInteraction,
-        )
+        ) : Card(type = Type.SOTW_2023_NUDGE_CARD)
 
         data class NoCardsMessage(val title: UiString, val message: UiString)  : Card(Type.NO_CARDS_MESSAGE)
         data class PersonalizeCardModel(val onClick: () -> Unit) : Card(Type.PERSONALIZE_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -380,6 +380,12 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onMoreMenuClick: ListItemInteraction,
         ) : Card(type = Type.DASHBOARD_PLANS_CARD)
 
+        data class WpSotw2023NudgeCardModel(
+            val onMoreMenuClick: ListItemInteraction,
+            val onHideMenuItemClick: ListItemInteraction,
+            val onCtaClick: ListItemInteraction,
+        )
+
         data class NoCardsMessage(val title: UiString, val message: UiString)  : Card(Type.NO_CARDS_MESSAGE)
         data class PersonalizeCardModel(val onClick: () -> Unit) : Card(Type.PERSONALIZE_CARD)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -385,7 +385,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val title: UiString,
             val text: UiString,
             val ctaText: UiString,
-            val onMoreMenuClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,
             val onCtaClick: ListItemInteraction,
         ) : Card(type = Type.WP_SOTW_2023_NUDGE_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -59,7 +59,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         JETPACK_INSTALL_FULL_PLUGIN_CARD,
         NO_CARDS_MESSAGE,
         PERSONALIZE_CARD,
-        SOTW_2023_NUDGE_CARD,
+        WP_SOTW_2023_NUDGE_CARD,
     }
 
     data class SiteInfoHeaderCard(
@@ -385,7 +385,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onMoreMenuClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,
             val onCtaClick: ListItemInteraction,
-        ) : Card(type = Type.SOTW_2023_NUDGE_CARD)
+        ) : Card(type = Type.WP_SOTW_2023_NUDGE_CARD)
 
         data class NoCardsMessage(val title: UiString, val message: UiString)  : Card(Type.NO_CARDS_MESSAGE)
         data class PersonalizeCardModel(val onClick: () -> Unit) : Card(Type.PERSONALIZE_CARD)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -382,6 +382,9 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         ) : Card(type = Type.DASHBOARD_PLANS_CARD)
 
         data class WpSotw2023NudgeCardModel(
+            val title: UiString,
+            val text: UiString,
+            val ctaText: UiString,
             val onMoreMenuClick: ListItemInteraction,
             val onHideMenuItemClick: ListItemInteraction,
             val onCtaClick: ListItemInteraction,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -84,6 +84,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardBuilder
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardViewModelSlice
+import org.wordpress.android.ui.mysite.cards.sotw2023.WpSotw2023NudgeCardViewModelSlice
 import org.wordpress.android.ui.mysite.items.infoitem.MySiteInfoItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsViewModelSlice
@@ -169,6 +170,7 @@ class MySiteViewModel @Inject constructor(
     private val siteInfoHeaderCardViewModelSlice: SiteInfoHeaderCardViewModelSlice,
     private val quickLinksItemViewModelSlice: QuickLinksItemViewModelSlice,
     private val bloganuaryNudgeCardViewModelSlice: BloganuaryNudgeCardViewModelSlice,
+    private val sotw2023NudgeCardViewModelSlice: WpSotw2023NudgeCardViewModelSlice,
 ) : ScopedViewModel(mainDispatcher) {
     private val _onSnackbarMessage = MutableLiveData<Event<SnackbarMessageHolder>>()
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
@@ -423,8 +425,11 @@ class MySiteViewModel @Inject constructor(
 
         val siteItems = getSiteItems(site, activeTask, backupAvailable, scanAvailable)
 
+        val sotw2023Card = sotw2023NudgeCardViewModelSlice.buildCard()
+
         return mutableListOf<MySiteCardAndItem>().apply {
             infoItem?.let { add(infoItem) }
+            sotw2023Card?.let { add(it) }
             addAll(siteItems)
             jetpackSwitchMenu?.let { add(jetpackSwitchMenu) }
             if (jetpackFeatureCardHelper.shouldShowFeatureCardAtTop())
@@ -988,6 +993,7 @@ class MySiteViewModel @Inject constructor(
             .forEach { personalizeCardViewModelSlice.trackShown(it.type) }
         siteSelected.dashboardData.filterIsInstance<MySiteCardAndItem.Card.NoCardsMessage>()
             .forEach { noCardsMessageViewModelSlice.trackShown(it.type) }
+        // TODO thomashortadev add shown tracking for SotW card here
     }
 
     private fun resetShownTrackers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
@@ -66,7 +66,6 @@ private fun CardToolbar(
     model: WpSotw2023NudgeCardModel
 ) {
     MySiteCardToolbar(
-        onContextMenuClick = { model.onMoreMenuClick.click() },
         contextMenuItems = listOf(
             MySiteCardToolbarContextMenuItem.Option(
                 text = stringResource(R.string.my_site_dashboard_card_more_menu_hide_card),
@@ -93,7 +92,6 @@ fun WpSotw2023NudgeCardPreview() {
                 title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),
                 text = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_text),
                 ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
-                onMoreMenuClick = ListItemInteraction.create {},
                 onHideMenuItemClick = ListItemInteraction.create {},
                 onCtaClick = ListItemInteraction.create {},
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.mysite.cards.sotw2023
+
+import android.content.res.Configuration
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
+import org.wordpress.android.ui.utils.ListItemInteraction
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+fun WpSotw2023NudgeCard(
+    model: WpSotw2023NudgeCardModel,
+    modifier: Modifier = Modifier,
+) {
+    UnelevatedCard(
+        modifier = modifier,
+    ) {
+        Text("SOTW 2023")
+    }
+}
+
+@Preview(name = "Light Mode")
+@Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun WpSotw2023NudgeCardPreview() {
+    AppTheme {
+        WpSotw2023NudgeCard(
+            model = WpSotw2023NudgeCardModel(
+                onMoreMenuClick = ListItemInteraction.create {},
+                onHideMenuItemClick = ListItemInteraction.create {},
+                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,7 +32,7 @@ fun WpSotw2023NudgeCard(
     modifier: Modifier = Modifier,
 ) {
     UnelevatedCard(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
     ) {
         Column(
             modifier = Modifier.padding(bottom = Margin.Medium.value)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
@@ -1,16 +1,30 @@
 package org.wordpress.android.ui.mysite.cards.sotw2023
 
 import android.content.res.Configuration
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbar
+import org.wordpress.android.ui.mysite.cards.compose.MySiteCardToolbarContextMenuItem
 import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 
-@Suppress("UNUSED_PARAMETER")
 @Composable
 fun WpSotw2023NudgeCard(
     model: WpSotw2023NudgeCardModel,
@@ -19,7 +33,53 @@ fun WpSotw2023NudgeCard(
     UnelevatedCard(
         modifier = modifier,
     ) {
-        Text("SOTW 2023")
+        Column(
+            modifier = Modifier.padding(bottom = Margin.Medium.value)
+        ) {
+            CardToolbar(model)
+
+            Spacer(Modifier.height(Margin.Medium.value))
+
+            Text(
+                text = uiStringText(model.text),
+                style = DashboardCardTypography.detailText,
+                modifier = Modifier.padding(horizontal = Margin.ExtraLarge.value),
+            )
+
+            Spacer(Modifier.height(Margin.Small.value))
+
+            TextButton(
+                onClick = { model.onCtaClick.click() },
+                modifier = Modifier.padding(horizontal = Margin.Small.value)
+            ) {
+                Text(
+                    text = uiStringText(model.ctaText),
+                    style = DashboardCardTypography.footerCTA,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CardToolbar(
+    model: WpSotw2023NudgeCardModel
+) {
+    MySiteCardToolbar(
+        onContextMenuClick = { model.onMoreMenuClick.click() },
+        contextMenuItems = listOf(
+            MySiteCardToolbarContextMenuItem.Option(
+                text = stringResource(R.string.my_site_dashboard_card_more_menu_hide_card),
+                onClick = { model.onHideMenuItemClick.click() },
+            )
+        ),
+    ) {
+        Text(
+            text = uiStringText(uiString = model.title),
+            style = DashboardCardTypography.smallTitle,
+            textAlign = TextAlign.Start,
+            fontWeight = FontWeight.Medium,
+        )
     }
 }
 
@@ -30,6 +90,9 @@ fun WpSotw2023NudgeCardPreview() {
     AppTheme {
         WpSotw2023NudgeCard(
             model = WpSotw2023NudgeCardModel(
+                title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),
+                text = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_text),
+                ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
                 onMoreMenuClick = ListItemInteraction.create {},
                 onHideMenuItemClick = ListItemInteraction.create {},
                 onCtaClick = ListItemInteraction.create {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewHolder.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.mysite.cards.sotw2023
+
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import org.wordpress.android.databinding.WpSotw20223NudgeCardBinding
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
+import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
+import org.wordpress.android.util.extensions.viewBinding
+
+class WpSotw2023NudgeCardViewHolder(parent: ViewGroup) :
+    MySiteCardAndItemViewHolder<WpSotw20223NudgeCardBinding>(parent.viewBinding(WpSotw20223NudgeCardBinding::inflate)) {
+    fun bind(cardModel: WpSotw2023NudgeCardModel) = with(binding.wpSotw2023NudgeCard) {
+        // Dispose of the Composition when the view's LifecycleOwner is destroyed
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool)
+        setContent {
+            AppTheme {
+                WpSotw2023NudgeCard(
+                    model = cardModel,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -1,14 +1,19 @@
 package org.wordpress.android.ui.mysite.cards.sotw2023
 
+import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
 import javax.inject.Inject
 
 class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     private val featureConfig: WpSotw2023NudgeFeatureConfig,
 ) {
-    fun buildCard() : WpSotw2023NudgeCardModel? = WpSotw2023NudgeCardModel(
+    fun buildCard(): WpSotw2023NudgeCardModel? = WpSotw2023NudgeCardModel(
+        title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),
+        text = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_text),
+        ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
         onMoreMenuClick = ListItemInteraction.create(::onMoreMenuClick),
         onHideMenuItemClick = ListItemInteraction.create(::onHideMenuItemClick),
         onCtaClick = ListItemInteraction.create(::onCtaClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -1,0 +1,30 @@
+package org.wordpress.android.ui.mysite.cards.sotw2023
+
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
+import org.wordpress.android.ui.utils.ListItemInteraction
+import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
+import javax.inject.Inject
+
+class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
+    private val featureConfig: WpSotw2023NudgeFeatureConfig,
+) {
+    fun buildCard() : WpSotw2023NudgeCardModel? = WpSotw2023NudgeCardModel(
+        onMoreMenuClick = ListItemInteraction.create(::onMoreMenuClick),
+        onHideMenuItemClick = ListItemInteraction.create(::onHideMenuItemClick),
+        onCtaClick = ListItemInteraction.create(::onCtaClick),
+    ).takeIf { featureConfig.isEnabled() }
+
+    private fun onMoreMenuClick() {
+        // TODO analytics
+    }
+
+    private fun onHideMenuItemClick() {
+        // TODO analytics
+        // TODO hide card and refresh
+    }
+
+    private fun onCtaClick() {
+        // TODO analytics
+        // TODO navigation event to open SotW recording URL
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -14,14 +14,9 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
         title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),
         text = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_text),
         ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
-        onMoreMenuClick = ListItemInteraction.create(::onMoreMenuClick),
         onHideMenuItemClick = ListItemInteraction.create(::onHideMenuItemClick),
         onCtaClick = ListItemInteraction.create(::onCtaClick),
     ).takeIf { featureConfig.isEnabled() }
-
-    private fun onMoreMenuClick() {
-        // TODO analytics
-    }
 
     private fun onHideMenuItemClick() {
         // TODO analytics

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -19,12 +19,12 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     ).takeIf { featureConfig.isEnabled() }
 
     private fun onHideMenuItemClick() {
-        // TODO analytics
-        // TODO hide card and refresh
+        // TODO thomashortadev analytics
+        // TODO thomashortadev hide card and refresh
     }
 
     private fun onCtaClick() {
-        // TODO analytics
-        // TODO navigation event to open SotW recording URL
+        // TODO thomashortadev analytics
+        // TODO thomashortadev navigation event to open SotW recording URL
     }
 }

--- a/WordPress/src/main/res/layout/wp_sotw_20223_nudge_card.xml
+++ b/WordPress/src/main/res/layout/wp_sotw_20223_nudge_card.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/wp_sotw_2023_nudge_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:composableName="org.wordpress.android.ui.mysite.cards.sotw2023.WpSotw2023NudgeCardKt.WpSotw2023NudgeCardPreview"
+        tools:ignore="RtlSymmetry" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4833,4 +4833,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="bloganuary_dashboard_nudge_overlay_note_prompts_enabled">Bloganuary will use Daily Blogging Prompts to send you topics for the month of January.</string>
     <string name="bloganuary_dashboard_nudge_overlay_action_turn_on_prompts">Turn on blogging prompts</string>
     <string name="bloganuary_dashboard_nudge_overlay_action_dismiss">Let’s go!</string>
+
+
+    <!-- State of the Word 2023 -->
+    <string name="wp_sotw_2023_dashboard_nudge_title">State of the Word 2023</string>
+    <string name="wp_sotw_2023_dashboard_nudge_text">Check out WordPress co-founder Matt Mullenweg’s annual keynote to stay on top of what’s coming in 2024 and beyond.</string>
+    <string name="wp_sotw_2023_dashboard_nudge_cta">Watch now</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.ErrorCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackFeatureCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickStartCard.QuickStartTaskTypeItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.InfoItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.ListItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Item.SingleActionCard
@@ -97,6 +98,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardBuilder
 import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardViewModelSlice
+import org.wordpress.android.ui.mysite.cards.sotw2023.WpSotw2023NudgeCardViewModelSlice
 import org.wordpress.android.ui.mysite.items.infoitem.MySiteInfoItemBuilder
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.mysite.items.listitem.SiteItemsBuilder
@@ -281,6 +283,9 @@ class MySiteViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var bloganuaryNudgeViewModelSlice: BloganuaryNudgeCardViewModelSlice
 
+    @Mock
+    lateinit var wpSotw2023NudgeCardViewModelSlice: WpSotw2023NudgeCardViewModelSlice
+
     private lateinit var viewModel: MySiteViewModel
     private lateinit var uiModels: MutableList<MySiteViewModel.State>
     private lateinit var snackbars: MutableList<SnackbarMessageHolder>
@@ -420,6 +425,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         whenever(bloggingPromptCardViewModelSlice.getBuilderParams(anyOrNull())).thenReturn(mock())
         whenever(quickLinksItemViewModelSlice.uiState).thenReturn(mock())
         whenever(quickStartRepository.quickStartMenuStep).thenReturn(mock())
+        whenever(wpSotw2023NudgeCardViewModelSlice.buildCard()).thenReturn(null)
 
         viewModel = MySiteViewModel(
             testDispatcher(),
@@ -474,6 +480,7 @@ class MySiteViewModelTest : BaseUnitTest() {
             siteInfoHeaderCardViewModelSlice,
             quickLinksItemViewModelSlice,
             bloganuaryNudgeViewModelSlice,
+            wpSotw2023NudgeCardViewModelSlice,
         )
         uiModels = mutableListOf()
         snackbars = mutableListOf()
@@ -1429,6 +1436,24 @@ class MySiteViewModelTest : BaseUnitTest() {
 
             assertThat(viewModel.onShowJetpackIndividualPluginOverlay.value?.peekContent()).isNull()
         }
+
+    @Test
+    fun `when sotw card is not null then it is shown in the site menu`() {
+        whenever(wpSotw2023NudgeCardViewModelSlice.buildCard()).thenReturn(mock())
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().filterIsInstance(WpSotw2023NudgeCardModel::class.java)).isNotEmpty
+    }
+
+    @Test
+    fun `when sotw card is null then it is not shown in the site menu`() {
+        whenever(wpSotw2023NudgeCardViewModelSlice.buildCard()).thenReturn(null)
+
+        initSelectedSite()
+
+        assertThat(getSiteMenuTabLastItems().filterIsInstance(WpSotw2023NudgeCardModel::class.java)).isEmpty()
+    }
 
     private fun findDomainRegistrationCard() =
         getLastItems().find { it is DomainRegistrationCard } as DomainRegistrationCard?

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.mysite.cards.sotw2023
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Ignore
+
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
+    @Mock
+    lateinit var featureConfig: WpSotw2023NudgeFeatureConfig
+
+    private lateinit var viewModelSlice: WpSotw2023NudgeCardViewModelSlice
+
+    @Before
+    fun setUp() {
+        viewModelSlice = WpSotw2023NudgeCardViewModelSlice(featureConfig)
+    }
+
+    @Test
+    fun `WHEN feature is disabled THEN buildCard returns null `() {
+        whenever(featureConfig.isEnabled()).thenReturn(false)
+
+        val card = viewModelSlice.buildCard()
+
+        assertThat(card).isNull()
+    }
+
+    @Test
+    fun `WHEN feature is enabled THEN buildCard returns card `() {
+        whenever(featureConfig.isEnabled()).thenReturn(true)
+
+        val card = viewModelSlice.buildCard()
+
+        assertThat(card!!).isNotNull
+    }
+
+    @Ignore("TODO thomashortadev")
+    @Test
+    fun `WHEN card onHideMenuItemClick is clicked THEN hide card in app prefs and refresh`() {
+        // TODO thomashortadev implement when done
+    }
+
+    @Ignore("TODO thomashortadev")
+    @Test
+    fun `WHEN card onCtaClick is clicked THEN navigate to URL`() {
+        // TODO thomashortadev implement when done
+    }
+
+    // region Analytics
+    @Ignore("TODO thomashortadev")
+    @Test
+    fun `WHEN card onHideMenuItemClick is clicked THEN analytics is tracked`() {
+        // TODO thomashortadev implement when done
+    }
+
+    @Ignore("TODO thomashortadev")
+    @Test
+    fun `WHEN card onCtaClick is clicked THEN analytics is tracked`() {
+        // TODO thomashortadev implement when done
+    }
+    // endregion Analytics
+}


### PR DESCRIPTION
Part of #19709

Implement the UI for the WordPress State of the Word nudge card. Note: It is only available in the WordPress app. It currently doesn't have the implementation for the user interactions, callbacks, and analytics, but the code has some TODOs as I will be tackling them next.

![sotw-card-ui](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/40b4a208-53b4-4e44-a242-f188c206af94)

-----

## To Test:

1. Install and log into the WordPress app
2. Disable the `wp_sotw_2023_nudge` FF in Debug Settings
3. **Verify** the card is not shown
4. Enable the FF in Debug Settings
5. Go to `My Site`
6. **Verify** the card is shown.

Make sure the card doesn't appear in the Jetpack app even with the FF on.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

9. What automated tests I added (or what prevented me from doing so)

    - Added unit tests for new code.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
