### PR TITLE
[SotW 2023] Implement card interactions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -704,7 +704,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
         is SiteNavigationAction.OpenStatsInsights ->
             ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.INSIGHTS)
-        is SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl ->
+        is SiteNavigationAction.OpenExternalUrl ->
             ActivityLauncher.openUrlExternal(requireActivity(), action.url)
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
         is SiteNavigationAction.OpenJetpackMigrationDeleteWP -> showJetpackMigrationDeleteWP()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -233,7 +233,8 @@ class MySiteViewModel @Inject constructor(
         bloganuaryNudgeCardViewModelSlice.onNavigation,
         personalizeCardViewModelSlice.onNavigation,
         siteInfoHeaderCardViewModelSlice.onNavigation,
-        quickLinksItemViewModelSlice.navigation
+        quickLinksItemViewModelSlice.navigation,
+        sotw2023NudgeCardViewModelSlice.onNavigation,
     )
 
     val onMediaUpload = siteInfoHeaderCardViewModelSlice.onMediaUpload
@@ -249,6 +250,7 @@ class MySiteViewModel @Inject constructor(
             postsCardViewModelSlice.refresh,
             activityLogCardViewModelSlice.refresh,
             bloganuaryNudgeCardViewModelSlice.refresh,
+            sotw2023NudgeCardViewModelSlice.refresh,
         )
     val domainTransferCardRefresh = domainTransferCardViewModel.refresh
 
@@ -324,6 +326,7 @@ class MySiteViewModel @Inject constructor(
         siteInfoHeaderCardViewModelSlice.initialize(viewModelScope)
         quickLinksItemViewModelSlice.initialization(viewModelScope)
         quickLinksItemViewModelSlice.start()
+        sotw2023NudgeCardViewModelSlice.initialize(viewModelScope)
     }
 
     @Suppress("LongParameterList")

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -85,7 +85,7 @@ sealed class SiteNavigationAction {
     data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
-    data class OpenTodaysStatsGetMoreViewsExternalUrl(val url: String) : SiteNavigationAction()
+    data class OpenExternalUrl(val url: String) : SiteNavigationAction()
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -50,7 +50,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
             _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
         } else {
             _onNavigation.value = Event(
-                SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(
+                SiteNavigationAction.OpenExternalUrl(
                     TodaysStatsCardBuilder.URL_GET_MORE_VIEWS_AND_TRAFFIC
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenExternalUrl
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
@@ -42,6 +43,11 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
 
     private fun onCtaClick() {
         // TODO thomashortadev analytics
-        // TODO thomashortadev navigation event to open SotW recording URL
+        _onNavigation.value = Event(OpenExternalUrl(URL))
+    }
+
+    companion object {
+        private const val URL = "https://wordpress.org/state-of-the-word/" +
+                "?utm_source=mobile&utm_medium=appnudge&utm_campaign=sotw2023"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -1,15 +1,32 @@
 package org.wordpress.android.ui.mysite.cards.sotw2023
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
 import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
+import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
+import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     private val featureConfig: WpSotw2023NudgeFeatureConfig,
 ) {
+    private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
+    val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
+
+    private val _refresh = MutableLiveData<Event<Boolean>>()
+    val refresh = _refresh as LiveData<Event<Boolean>>
+
+    private lateinit var scope: CoroutineScope
+
+    fun initialize(scope: CoroutineScope) {
+        this.scope = scope
+    }
+
     fun buildCard(): WpSotw2023NudgeCardModel? = WpSotw2023NudgeCardModel(
         title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),
         text = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_text),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -7,6 +7,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenExternalUrl
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
@@ -15,6 +16,7 @@ import javax.inject.Inject
 
 class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     private val featureConfig: WpSotw2023NudgeFeatureConfig,
+    private val appPrefsWrapper: AppPrefsWrapper,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -34,11 +36,14 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
         ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
         onHideMenuItemClick = ListItemInteraction.create(::onHideMenuItemClick),
         onCtaClick = ListItemInteraction.create(::onCtaClick),
-    ).takeIf { featureConfig.isEnabled() }
+    ).takeIf {
+        featureConfig.isEnabled() && !appPrefsWrapper.getShouldHideSotw2023NudgeCard()
+    }
 
     private fun onHideMenuItemClick() {
         // TODO thomashortadev analytics
-        // TODO thomashortadev hide card and refresh
+        appPrefsWrapper.setShouldHideSotw2023NudgeCard(true)
+        _refresh.value = Event(true)
     }
 
     private fun onCtaClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -207,6 +207,7 @@ public class AppPrefs {
         SHOULD_SHOW_SITE_ITEM_AS_QUICK_LINK_IN_DASHBOARD,
         SHOULD_SHOW_DEFAULT_QUICK_LINK_IN_DASHBOARD,
         SHOULD_HIDE_BLOGANUARY_NUDGE_CARD,
+        SHOULD_HIDE_SOTW2023_NUDGE_CARD,
     }
 
     /**
@@ -1820,5 +1821,13 @@ public class AppPrefs {
 
     public static boolean getShouldHideBloganuaryNudgeCard(final long siteId) {
         return prefs().getBoolean(getSiteIdHideBloganuaryNudgeCardKey(siteId), false);
+    }
+
+    public static void setShouldHideSotw2023NudgeCard(boolean isHidden) {
+        prefs().edit().putBoolean(DeletablePrefKey.SHOULD_HIDE_SOTW2023_NUDGE_CARD.name(), isHidden).apply();
+    }
+
+    public static boolean getShouldHideSotw2023NudgeCard() {
+        return prefs().getBoolean(DeletablePrefKey.SHOULD_HIDE_SOTW2023_NUDGE_CARD.name(), false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -418,6 +418,12 @@ class AppPrefsWrapper @Inject constructor() {
     fun getShouldHideBloganuaryNudgeCard(siteId: Long): Boolean =
         AppPrefs.getShouldHideBloganuaryNudgeCard(siteId)
 
+    fun setShouldHideSotw2023NudgeCard(isHidden: Boolean): Unit =
+        AppPrefs.setShouldHideSotw2023NudgeCard(isHidden)
+
+    fun getShouldHideSotw2023NudgeCard(): Boolean =
+        AppPrefs.getShouldHideSotw2023NudgeCard()
+
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
 
     fun setString(prefKey: PrefKey, value: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -87,7 +87,7 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
 
             assertThat(navigationActions)
                 .containsOnly(
-                    SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl(
+                    SiteNavigationAction.OpenExternalUrl(
                         TodaysStatsCardBuilder.URL_GET_MORE_VIEWS_AND_TRAFFIC
                     )
                 )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -4,11 +4,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Ignore
-
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenExternalUrl
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,7 +39,17 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
 
         val card = viewModelSlice.buildCard()
 
-        assertThat(card!!).isNotNull
+        assertThat(card).isNotNull
+    }
+
+    @Test
+    fun `WHEN card onCtaClick is clicked THEN navigate to URL`() {
+        whenever(featureConfig.isEnabled()).thenReturn(true)
+
+        val card = viewModelSlice.buildCard()!!
+
+        card.onCtaClick.click()
+        assertThat(viewModelSlice.onNavigation.value?.peekContent()).isInstanceOf(OpenExternalUrl::class.java)
     }
 
     @Ignore("TODO thomashortadev")
@@ -48,22 +58,16 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
         // TODO thomashortadev implement when done
     }
 
-    @Ignore("TODO thomashortadev")
-    @Test
-    fun `WHEN card onCtaClick is clicked THEN navigate to URL`() {
-        // TODO thomashortadev implement when done
-    }
-
     // region Analytics
     @Ignore("TODO thomashortadev")
     @Test
-    fun `WHEN card onHideMenuItemClick is clicked THEN analytics is tracked`() {
+    fun `WHEN card onCtaClick is clicked THEN analytics is tracked`() {
         // TODO thomashortadev implement when done
     }
 
     @Ignore("TODO thomashortadev")
     @Test
-    fun `WHEN card onCtaClick is clicked THEN analytics is tracked`() {
+    fun `WHEN card onHideMenuItemClick is clicked THEN analytics is tracked`() {
         // TODO thomashortadev implement when done
     }
     // endregion Analytics

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -64,7 +64,7 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
         val card = viewModelSlice.buildCard()!!
 
         card.onCtaClick.click()
-        assertThat(viewModelSlice.onNavigation.value?.peekContent()).isInstanceOf(OpenExternalUrl::class.java)
+        assertThat(viewModelSlice.onNavigation.value?.peekContent()).isEqualTo(OpenExternalUrl(EXPECTED_URL))
     }
 
     @Test
@@ -95,5 +95,10 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
     private fun mockCardRequisites() {
         whenever(featureConfig.isEnabled()).thenReturn(true)
         whenever(appPrefsWrapper.getShouldHideSotw2023NudgeCard()).thenReturn(false)
+    }
+
+    companion object {
+        private const val EXPECTED_URL = "https://wordpress.org/state-of-the-word/" +
+                "?utm_source=mobile&utm_medium=appnudge&utm_campaign=sotw2023"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -21,6 +21,7 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
     @Before
     fun setUp() {
         viewModelSlice = WpSotw2023NudgeCardViewModelSlice(featureConfig)
+        viewModelSlice.initialize(testScope())
     }
 
     @Test


### PR DESCRIPTION
Part of #19709 

Implement the card "Watch now" and "Hide this" button interactions.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/92be457e-6b45-4e88-aad5-bd69e77b90cd

-----

## To Test:

1. Install and log into the WordPress app
2. Enable the `wp_sotw_2023_nudge` FF in Debug Settings
3. **Verify** the SotW card is shown
4. Tap "Watch now"
5. **Verify** the SotW event page opens on an External Browser
6. Go back to the app
7. Tap "Hide this"
8. **Verify** the card is hidden for the user (all sites)

The card will only be shown again if the user logouts or clear the app data.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Add unit tests for the interactions.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
