### PR TITLE
[SotW 2023] Implement card visibility/eligibility logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import java.time.Instant
@@ -20,6 +21,7 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     private val featureConfig: WpSotw2023NudgeFeatureConfig,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val localeManagerWrapper: LocaleManagerWrapper,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -57,14 +59,19 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
         val now = dateTimeUtilsWrapper.getInstantNow()
         val isDateEligible = now.isAfter(eventTime)
 
+        val currentLanguage = localeManagerWrapper.getLanguage()
+        val isLanguageEligible = currentLanguage.startsWith(TARGET_LANGUAGE, ignoreCase = true)
+
         return featureConfig.isEnabled() &&
                 !appPrefsWrapper.getShouldHideSotw2023NudgeCard() &&
-                isDateEligible
+                isDateEligible &&
+                isLanguageEligible
     }
 
     companion object {
         private const val URL = "https://wordpress.org/state-of-the-word/" +
                 "?utm_source=mobile&utm_medium=appnudge&utm_campaign=sotw2023"
         private const val EVENT_DATE = "2023-12-11T15:00:00.00Z"
+        private const val TARGET_LANGUAGE = "en"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -10,13 +10,18 @@ import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenExternalUrl
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
 import org.wordpress.android.viewmodel.Event
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     private val featureConfig: WpSotw2023NudgeFeatureConfig,
     private val appPrefsWrapper: AppPrefsWrapper,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -51,8 +56,19 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
         _onNavigation.value = Event(OpenExternalUrl(URL))
     }
 
+    private fun isEligible(): Boolean {
+        val eventTime = Instant.parse(EVENT_DATE)
+        val now = dateTimeUtilsWrapper.getInstantNow()
+        val isDateEligible = now.isAfter(eventTime)
+
+        return featureConfig.isEnabled() &&
+                !appPrefsWrapper.getShouldHideSotw2023NudgeCard() &&
+                isDateEligible
+    }
+
     companion object {
         private const val URL = "https://wordpress.org/state-of-the-word/" +
                 "?utm_source=mobile&utm_medium=appnudge&utm_campaign=sotw2023"
+        private const val EVENT_DATE = "2023-12-11T15:00:00.00Z"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -14,8 +14,6 @@ import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
@@ -41,9 +39,7 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
         ctaText = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_cta),
         onHideMenuItemClick = ListItemInteraction.create(::onHideMenuItemClick),
         onCtaClick = ListItemInteraction.create(::onCtaClick),
-    ).takeIf {
-        featureConfig.isEnabled() && !appPrefsWrapper.getShouldHideSotw2023NudgeCard()
-    }
+    ).takeIf { isEligible() }
 
     private fun onHideMenuItemClick() {
         // TODO thomashortadev analytics

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSlice.kt
@@ -55,7 +55,7 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     }
 
     private fun isEligible(): Boolean {
-        val eventTime = Instant.parse(EVENT_DATE)
+        val eventTime = Instant.parse(POST_EVENT_START)
         val now = dateTimeUtilsWrapper.getInstantNow()
         val isDateEligible = now.isAfter(eventTime)
 
@@ -71,7 +71,7 @@ class WpSotw2023NudgeCardViewModelSlice @Inject constructor(
     companion object {
         private const val URL = "https://wordpress.org/state-of-the-word/" +
                 "?utm_source=mobile&utm_medium=appnudge&utm_campaign=sotw2023"
-        private const val EVENT_DATE = "2023-12-11T15:00:00.00Z"
+        private const val POST_EVENT_START = "2023-12-12T00:00:00.00Z"
         private const val TARGET_LANGUAGE = "en"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -10,6 +10,7 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 import android.text.format.DateUtils
+import java.time.Instant
 
 class DateTimeUtilsWrapper @Inject constructor(
     private val localeManagerWrapper: LocaleManagerWrapper,
@@ -58,4 +59,6 @@ class DateTimeUtilsWrapper @Inject constructor(
     fun getCalendarInstance(): Calendar {
         return Calendar.getInstance()
     }
+
+    fun getInstantNow(): Instant = Instant.now()
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/WpSotw2023NudgeFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/WpSotw2023NudgeFeatureConfig.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 
 private const val WP_SOTW_2023_NUDGE_REMOTE_FIELD = "wp_sotw_2023_nudge"
 
-@Feature(WP_SOTW_2023_NUDGE_REMOTE_FIELD, false)
+@Feature(WP_SOTW_2023_NUDGE_REMOTE_FIELD, true)
 class WpSotw2023NudgeFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -133,7 +133,7 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
         with (Mockito.lenient()) {
             whenever(featureConfig.isEnabled()).thenReturn(isFeatureEnabled)
             whenever(appPrefsWrapper.getShouldHideSotw2023NudgeCard()).thenReturn(isCardHidden)
-            val date = if (isDateAfterEvent) "2023-12-12T00:00:00Z" else "2021-12-11T00:00:00Z"
+            val date = if (isDateAfterEvent) "2023-12-12T00:00:01Z" else "2021-12-11T00:00:00Z"
             whenever(dateTimeUtilsWrapper.getInstantNow()).thenReturn(Instant.parse(date))
             val language = if (isLanguageEnglish) "en_US" else "fr_FR"
             whenever(localeManagerWrapper.getLanguage()).thenReturn(language)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewModelSliceTest.kt
@@ -6,12 +6,16 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.mysite.SiteNavigationAction.OpenExternalUrl
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.config.WpSotw2023NudgeFeatureConfig
+import java.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
@@ -21,17 +25,28 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
+    @Mock
+    lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
+
+    @Mock
+    lateinit var localeManagerWrapper: LocaleManagerWrapper
+
     private lateinit var viewModelSlice: WpSotw2023NudgeCardViewModelSlice
 
     @Before
     fun setUp() {
-        viewModelSlice = WpSotw2023NudgeCardViewModelSlice(featureConfig, appPrefsWrapper)
+        viewModelSlice = WpSotw2023NudgeCardViewModelSlice(
+            featureConfig,
+            appPrefsWrapper,
+            dateTimeUtilsWrapper,
+            localeManagerWrapper
+        )
         viewModelSlice.initialize(testScope())
     }
 
     @Test
     fun `WHEN feature is disabled THEN buildCard returns null `() {
-        whenever(featureConfig.isEnabled()).thenReturn(false)
+        mockCardRequisites(isFeatureEnabled = false)
 
         val card = viewModelSlice.buildCard()
 
@@ -40,8 +55,25 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `WHEN card is hidden in app prefs THEN buildCard returns null`() {
-        whenever(featureConfig.isEnabled()).thenReturn(true)
-        whenever(appPrefsWrapper.getShouldHideSotw2023NudgeCard()).thenReturn(true)
+        mockCardRequisites(isCardHidden = true)
+
+        val card = viewModelSlice.buildCard()
+
+        assertThat(card).isNull()
+    }
+
+    @Test
+    fun `WHEN date is before event THEN buildCard returns null`() {
+        mockCardRequisites(isDateAfterEvent = false)
+
+        val card = viewModelSlice.buildCard()
+
+        assertThat(card).isNull()
+    }
+
+    @Test
+    fun `WHEN language is not english THEN buildCard returns null`() {
+        mockCardRequisites(isLanguageEnglish = false)
 
         val card = viewModelSlice.buildCard()
 
@@ -92,9 +124,20 @@ class WpSotw2023NudgeCardViewModelSliceTest : BaseUnitTest() {
     }
     // endregion Analytics
 
-    private fun mockCardRequisites() {
-        whenever(featureConfig.isEnabled()).thenReturn(true)
-        whenever(appPrefsWrapper.getShouldHideSotw2023NudgeCard()).thenReturn(false)
+    private fun mockCardRequisites(
+        isFeatureEnabled: Boolean = true,
+        isCardHidden: Boolean = false,
+        isDateAfterEvent: Boolean = true,
+        isLanguageEnglish: Boolean = true
+    ) {
+        with (Mockito.lenient()) {
+            whenever(featureConfig.isEnabled()).thenReturn(isFeatureEnabled)
+            whenever(appPrefsWrapper.getShouldHideSotw2023NudgeCard()).thenReturn(isCardHidden)
+            val date = if (isDateAfterEvent) "2023-12-12T00:00:00Z" else "2021-12-11T00:00:00Z"
+            whenever(dateTimeUtilsWrapper.getInstantNow()).thenReturn(Instant.parse(date))
+            val language = if (isLanguageEnglish) "en_US" else "fr_FR"
+            whenever(localeManagerWrapper.getLanguage()).thenReturn(language)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Part of #19709

This implements the full logic for figuring out if the card can be shown or not in the My Site dashboard. It also sets the FeatureConfig for `wp_sotw_2023_nudge` to `true` by default, since we now have the other client-side logic to avoid it showing by mistake.

The logic consists of:
- The app is WordPress (part of the `WpSotw2023NudgeFeatureConfig` logic)
- The `wp_sotw_2023_nudge` flag is ON (`WpSotw2023NudgeFeatureConfig`)
- The user did not hide the card (App Pref set by user interaction with `hide this` card button)
- The device's current date is at least one day after the event date (2023-12-11)
- The user app language is English (`en`)

-----

## To Test:

The step-by-step for all possible combinations is a bit large, but basically, the device / WordPress app should be set in such a way that all requirements above are `true` except ONE at a time, so each requirement "false" scenario is tested individually, leading to the card not being shown. After that, you should set everything so all requirements are true and **verify** the card is shown.

Tips:
- To set up the Date requirement, FIRST log into the app, then change the device date from the system settings.
- The language can be set in the app in `App Settings`.
- After hiding the card by tapping `hide this` you need to clear app data and log in again.
- The feature config can be set in `Debug Settings`.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Added/Updated unit tests related to card visibility scenarios.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
