### PR TITLE
[SotW 2023] Set strings as translatable=false

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4836,7 +4836,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
 
     <!-- State of the Word 2023 -->
-    <string name="wp_sotw_2023_dashboard_nudge_title">State of the Word 2023</string>
-    <string name="wp_sotw_2023_dashboard_nudge_text">Check out WordPress co-founder Matt Mullenweg’s annual keynote to stay on top of what’s coming in 2024 and beyond.</string>
-    <string name="wp_sotw_2023_dashboard_nudge_cta">Watch now</string>
+    <string name="wp_sotw_2023_dashboard_nudge_title" translatable="false">State of the Word 2023</string>
+    <string name="wp_sotw_2023_dashboard_nudge_text" translatable="false">Check out WordPress co-founder Matt Mullenweg’s annual keynote to stay on top of what’s coming in 2024 and beyond.</string>
+    <string name="wp_sotw_2023_dashboard_nudge_cta" translatable="false">Watch now</string>
 </resources>


### PR DESCRIPTION
Part of #19709

Since we're targeting only English-speaking users, there's no reason for localizing the Strings used in the card.

-----

## To Test:

N/A

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
