### PR TITLE
Fix NumberFormatException crash in ImageBlockProcessor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
@@ -5,7 +5,10 @@ import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.MediaFile;
+
+import static org.wordpress.android.util.AppLog.T.MEDIA;
 
 public class ImageBlockProcessor extends BlockProcessor {
     public ImageBlockProcessor(String localId, MediaFile mediaFile) {
@@ -34,7 +37,11 @@ public class ImageBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
+            try {
+                jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
+            } catch (NumberFormatException e) {
+                AppLog.e(MEDIA, e.getMessage());
+            }
             return true;
         }
 


### PR DESCRIPTION
This is not an actual fix for this hard to trace issue.  Added a **try, catch** block around parsing to avoid crash, not ideal but prevents crash.  Also considered adding a null check on **mRemoteId**.

Fixes #17021 

-----

## To Test:

Please see comments on the issue #17021. This is a hard to reproduce bug.  
- Try with a low end device by 
- Create a new post using Gutenberg
- Add a gallery block with some images
- While the images are still uploading press publish
- Wait outside the editor for the post to be published
- Open the post again
- Check that the gallery block is working
- Switch to HTML mode and see if the link and id are pointing to the server/remote values.

Also, please test this same flow for image and media-text blocks.


-----

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A
3. What automated tests I added (or what prevented me from doing so)

N/A
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----
