### PR TITLE
Address `NullPointerException` crash in `AztecHeadingSpan`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.109.1'
-    wordPressAztecVersion = 'v1.8.0'
+    wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.57.1'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/18657

-----

## Related PRs

* `Gutenberg`: https://github.com/WordPress/gutenberg/pull/56757
* `Gutenberg Mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6435
* `Aztec Android`: https://github.com/wordpress-mobile/AztecEditor-Android/pull/1071

-----

## To Test

* Install the app using the installable build from this PR.
* Navigate to the post editor.
* Add some heading blocks and ensure there are no unexpected side effects when performing tasks. Example tasks to test include splitting the block, applying new font sizes and line heights, etc.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Although the changes shouldn't create unwanted side effects, we're still changing the `chooseHeight` override. As described [here](https://developer.android.com/reference/android/text/style/LineHeightSpan#chooseHeight(java.lang.CharSequence,%20int,%20int,%20int,%20int,%20android.graphics.Paint.FontMetricsInt)), that function defines the height for a given element. As such, changes to that override may impact how heights are calculated for heading blocks. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manually tested the heading block via the installable build.

3. What automated tests I added (or what prevented me from doing so)

    - As we're only adding safety checks to the code and the testing is visual, there aren't any obvious ways to implement automated tests.  
    
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----