### PR TITLE
[Prompts] Fix response list paging regression

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [*] Block Editor: In the deeply nested block warning, only display the ungroup option for blocks that support it [https://github.com/WordPress/gutenberg/pull/56445]
 * [**] Enable Optimize Image setting (via Me → App Settings) by default, and change default compression and resolution values. [https://github.com/wordpress-mobile/WordPress-Android/pull/19581]
 * [*] Fixed an issue that prevented theme installation on atomic sites [https://github.com/wordpress-mobile/WordPress-Android/pull/19668]
+* [*] Fixed an issue with the pagination of the Blogging Prompts response list [https://github.com/wordpress-mobile/WordPress-Android/pull/19730]
 
 23.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.bloggingprompts
 
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.ui.reader.services.post.ReaderPostLogic
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import javax.inject.Inject
 
@@ -16,10 +17,16 @@ class BloggingPromptsPostTagProvider @Inject constructor(
 
     fun promptIdSearchReaderTag(
         tagUrl: String
-    ): ReaderTag = readerUtilsWrapper.getTagFromTagName(
-        promptIdTag(tagUrl),
-        ReaderTagType.FOLLOWED,
-    )
+    ): ReaderTag {
+        val promptIdTag = promptIdTag(tagUrl)
+        return ReaderTag(
+            promptIdTag,
+            promptIdTag,
+            promptIdTag,
+            ReaderPostLogic.formatFullEndpointForTag(promptIdTag),
+            ReaderTagType.FOLLOWED,
+        )
+    }
 
     companion object {
         const val BLOGGING_PROMPT_TAG = "dailyprompt"

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
@@ -5,12 +5,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.ui.reader.services.post.ReaderPostLogic
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import kotlin.test.assertEquals
 
@@ -23,9 +23,6 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        whenever(readerUtilsWrapper.getTagFromTagName(BLOGGING_PROMPT_ID_TAG, ReaderTagType.FOLLOWED))
-            .thenReturn(BLOGGING_PROMPT_ID_READER_TAG)
-
         tagProvider = BloggingPromptsPostTagProvider(readerUtilsWrapper)
     }
 
@@ -50,14 +47,18 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
     @Test
     fun `Should return the expected ReaderTag when promptIdSearchReaderTag is called`() {
         whenever(readerUtilsWrapper.getTagFromTagUrl(any())).thenReturn(BLOGGING_PROMPT_ID_TAG)
-
+        val expected = ReaderTag(
+            BLOGGING_PROMPT_ID_TAG,
+            BLOGGING_PROMPT_ID_TAG,
+            BLOGGING_PROMPT_ID_TAG,
+            ReaderPostLogic.formatFullEndpointForTag(BLOGGING_PROMPT_ID_TAG),
+            ReaderTagType.FOLLOWED,
+        )
         val actual = tagProvider.promptIdSearchReaderTag("valid-url")
-
-        assertEquals(BLOGGING_PROMPT_ID_READER_TAG, actual)
+        assertEquals(expected, actual)
     }
 
     companion object {
         private const val BLOGGING_PROMPT_ID_TAG = "dailyprompt-1234"
-        private val BLOGGING_PROMPT_ID_READER_TAG = mock<ReaderTag>()
     }
 }


### PR DESCRIPTION
Fixes #19728

The correct code was already in production until the release of 23.7, when it was removed because of an old PR (created before the correct code fix was merged in the past) that was rebased and I didn't realize it reverted to the wrong behavior.

PR that introduced the regression: https://github.com/wordpress-mobile/WordPress-Android/pull/18340

This PR basically reintroduces the fix made by #18276 that was reverted by the culprit PR above:

-----

## To Test:
1. Install and log into the Jetpack app
2. Make sure the `dailyprompt-XXXX` tag for the current day IS NOT FOLLOWED
3. Go to the dashboard
4. Tap `View all responses` on the Prompts card
5. Scroll the prompt tag responses list for a while
6. **Verify** pagination is working properly (posts are not shifting around, just being added at the end)
7. **Verify** posts keep loading when reaching the end of the feed as long as there are posts available

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Update relevant unit test.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
