### PR TITLE
[Reader Improvements] Show "View in browser" and "Share" actions in reader post details toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -106,6 +106,8 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryActi
 import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
+import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_POST_DETAIL
+import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_POST_DETAIL_TOOLBAR
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
@@ -1069,7 +1071,15 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
             true
         }
         R.id.menu_share -> {
-            readerTracker.track(AnalyticsTracker.Stat.SHARED_ITEM)
+            viewModel.post?.let {
+                readerTracker.trackBlog(
+                    AnalyticsTracker.Stat.SHARED_ITEM_READER,
+                    it.blogId,
+                    it.feedId,
+                    it.isFollowedByCurrentUser,
+                    SOURCE_POST_DETAIL_TOOLBAR,
+                )
+            }
             ReaderActivityLauncher.sharePost(context, viewModel.post)
             true
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1046,21 +1046,13 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     }
 
     override fun onPrepareMenu(menu: Menu) {
-        val isReaderImprovementsEnabled = readerImprovementsFeatureConfig.isEnabled()
-
         val postHasUrl = viewModel.post?.hasUrl() == true
         val menuBrowse = menu.findItem(R.id.menu_browse)
-        menuBrowse?.isVisible = if (!isReaderImprovementsEnabled) {
-            // browse require the post to have a URL (some feed-based posts don't have one) or an intercepted URI
-            postHasUrl || viewModel.interceptedUri != null
-        } else {
-            // in the Reader improvements we are only showing this as a fallback for posts with intercepted URI only
-            !postHasUrl && viewModel.interceptedUri != null
-        }
-
+        // browse require the post to have a URL (some feed-based posts don't have one) or an intercepted URI
+        menuBrowse?.isVisible = postHasUrl || viewModel.interceptedUri != null
+        // share require the post to have a URL
         val menuShare = menu.findItem(R.id.menu_share)
-        // share should not be shown as a TopBar item after Reader improvements (only in the "more" menu)
-        menuShare?.isVisible = postHasUrl && !isReaderImprovementsEnabled
+        menuShare?.isVisible = postHasUrl
     }
 
     override fun onMenuItemSelected(menuItem: MenuItem) = when (menuItem.itemId) {
@@ -1074,6 +1066,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 ReaderActivityLauncher.openUrl(activity, interceptedUri, OpenUrlType.EXTERNAL)
                 requireActivity().finish()
             }
+            true
+        }
+        R.id.menu_share -> {
+            readerTracker.track(AnalyticsTracker.Stat.SHARED_ITEM)
+            ReaderActivityLauncher.sharePost(context, viewModel.post)
             true
         }
         R.id.menu_more -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -415,6 +415,7 @@ class ReaderTracker @Inject constructor(
         const val SOURCE_SITE_PREVIEW = "site_preview"
         const val SOURCE_TAG_PREVIEW = "tag_preview"
         const val SOURCE_POST_DETAIL = "post_detail"
+        const val SOURCE_POST_DETAIL_TOOLBAR = "post_detail_toolbar"
         const val SOURCE_POST_DETAIL_COMMENT_SNIPPET = "post_detail_comment_snippet"
         const val SOURCE_COMMENT = "comment"
         const val SOURCE_USER = "user"

--- a/WordPress/src/main/res/menu/reader_detail.xml
+++ b/WordPress/src/main/res/menu/reader_detail.xml
@@ -6,14 +6,12 @@
         android:id="@+id/menu_browse"
         android:icon="@drawable/ic_globe_white_24dp"
         android:title="@string/view_in_browser"
-        android:visible="false"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_share"
         android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share_action"
-        android:visible="false"
         app:showAsAction="always" />
 
     <item

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -379,7 +379,6 @@ public final class AnalyticsTracker {
         CLOSE_ACCOUNT_FAILED,
         CLOSED_ACCOUNT,
         ACCOUNT_LOGOUT,
-        SHARED_ITEM,
         SHARED_ITEM_READER,
         ADDED_SELF_HOSTED_SITE,
         SIGNED_IN,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1031,8 +1031,6 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "close_account_failed";
             case CLOSED_ACCOUNT:
                 return "closed_account";
-            case SHARED_ITEM:
-                return "item_shared";
             case SHARED_ITEM_READER:
                 return "item_shared_reader";
             case ADDED_SELF_HOSTED_SITE:


### PR DESCRIPTION
Fixes #19729 

-----

## To Test:

1 - Install JP and sign in
2 - Open reader
3 - Tap on any post in any tab
4 - Verify that the "View in browser" and "Share" actions are shown in the toolbar
5 - Verify that both actions work as expected, including their analytics events. The analytics event for share action was changed and should look like this:
```
Tracked: item_shared_reader, Properties: {"blog_id":123,"feed_id":123,"follow":true,"source":"post_detail_toolbar"}
```
Discussion: p1701731047457609/1701688108.191079-slack-C01CW1VMLAF

-----

## Regression Notes

1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
--

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)