### PR TITLE
Add feature flag for in-app reviews

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -143,6 +143,7 @@ android {
         buildConfigField "boolean", "PLANS_IN_SITE_CREATION", "false"
         buildConfigField "boolean", "READER_IMPROVEMENTS", "false"
         buildConfigField "boolean", "BLOGANUARY_DASHBOARD_NUDGE", "false"
+        buildConfigField "boolean", "IN_APP_REVIEWS", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/InAppReviewsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/InAppReviewsFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val IN_APP_REVIEWS_REMOTE_FIELD = "in_app_reviews"
+
+@Feature(IN_APP_REVIEWS_REMOTE_FIELD, false)
+class InAppReviewsFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.IN_APP_REVIEWS,
+    IN_APP_REVIEWS_REMOTE_FIELD
+)


### PR DESCRIPTION
This adds a new feature flag for the upcoming project, in-app reviews.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/be2d3354-93bc-4208-9cff-d8253bcc97d1" width=300>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Launch the app.
2. Log in.
3. Open Me → Debug Settings.
4. Verify `in_app_reviews` is on the list.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

6. What automated tests I added (or what prevented me from doing so)

    - We don't add tests for feature flags.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
