### PR TITLE
Catches `ExecutionException` thrown during thumbnail preload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.image.ImageType.VIDEO
 import java.io.File
 import java.util.Locale
+import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -308,11 +309,16 @@ class ImageManager @Inject constructor(
      */
     fun preload(context: Context, design: MShot) {
         if (!context.isAvailable()) return
-        GlideApp.with(context)
-            .downloadOnly()
-            .load(design)
-            .submit()
-            .get() // This makes each call blocking, so subsequent calls can be cancelled if needed.
+        try {
+            GlideApp.with(context)
+                .downloadOnly()
+                .load(design)
+                .submit()
+                .get() // This makes each call blocking, so subsequent calls can be cancelled if needed.
+        } catch (e: ExecutionException) {
+            // This is a best effort preload, so we don't want to crash the app if an `ExecutionException` is thrown.
+            AppLog.e(AppLog.T.UTILS, "Error preloading MShot: $e")
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #17154

## Description
This PR adds exception handling on site creation image preloading after a regression was detected https://github.com/wordpress-mobile/WordPress-Android/issues/17154#issuecomment-1841039191

The applied fix shallows the exception with just a log. Given that the site creation thumbnail preloading is a best effort process to speedup the thumbnail load later in the flow, we don't want to crash the app if an `ExecutionException` is thrown.

```
java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
There was 1 root cause:
com.android.volley.NoConnectionError(java.net.SocketException: Connection reset)
 call GlideException#logRootCauses(String) for more detail
    at com.bumptech.glide.request.RequestFutureTarget.doGet(RequestFutureTarget.java:217)
    at com.bumptech.glide.request.RequestFutureTarget.get(RequestFutureTarget.java:130)
    at org.wordpress.android.util.image.ImageManager.preload(ImageManager.kt:315)
    at org.wordpress.android.ui.sitecreation.SiteCreationMainVM$preloadThumbnails$1.invokeSuspend(SiteCreationMainVM.kt:202)
```

-----

## To Test:

I wasn't able to figure out a way to reproduce the issue since [there is already a network connection check in place before the preload call](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt#L191) and simulating a network error wasn't possible.
I think a sanity check that the site creation theme thumbnail preloading works in the Jetpack app would be enough.

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

The applied fix adds exception handling for an edge case crash

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
