### PR TITLE
In-app reviews

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -421,6 +421,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-process:$androidxLifecycleVersion"
     implementation "com.android.volley:volley:$androidVolleyVersion"
+    implementation "com.google.android.play:review:$googlePlayReviewVersion"
+    implementation "com.google.android.play:review-ktx:$googlePlayReviewVersion"
     implementation "com.google.android.gms:play-services-auth:$googlePlayServicesAuthVersion"
     implementation "com.google.android.gms:play-services-code-scanner:$googlePlayServicesCodeScannerVersion"
     implementation "com.google.mlkit:barcode-scanning-common:$googleMLKitBarcodeScanningVersion"

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -33,13 +33,13 @@ import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel;
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
-import org.wordpress.android.ui.posts.prepublishing.categories.addcategory.PrepublishingAddCategoryViewModel;
-import org.wordpress.android.ui.posts.prepublishing.categories.PrepublishingCategoriesViewModel;
-import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeViewModel;
-import org.wordpress.android.ui.posts.prepublishing.tags.PrepublishingTagsViewModel;
-import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel;
 import org.wordpress.android.ui.posts.editor.StorePostViewModel;
+import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel;
+import org.wordpress.android.ui.posts.prepublishing.categories.PrepublishingCategoriesViewModel;
+import org.wordpress.android.ui.posts.prepublishing.categories.addcategory.PrepublishingAddCategoryViewModel;
+import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeViewModel;
 import org.wordpress.android.ui.posts.prepublishing.publishsettings.PrepublishingPublishSettingsViewModel;
+import org.wordpress.android.ui.posts.prepublishing.tags.PrepublishingTagsViewModel;
 import org.wordpress.android.ui.prefs.accountsettings.AccountSettingsViewModel;
 import org.wordpress.android.ui.prefs.homepage.HomepageSettingsViewModel;
 import org.wordpress.android.ui.prefs.language.LocalePickerViewModel;
@@ -53,6 +53,7 @@ import org.wordpress.android.ui.reader.viewmodels.ConversationNotificationsViewM
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel;
 import org.wordpress.android.ui.reader.viewmodels.SubfilterPageViewModel;
+import org.wordpress.android.ui.review.ReviewViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.DaysListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.InsightsListViewModel;
@@ -464,6 +465,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(UnifiedCommentListViewModel.class)
     abstract ViewModel unifiedCommentListViewModel(UnifiedCommentListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(ReviewViewModel.class)
+    abstract ViewModel reviewViewModel(ReviewViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1369,12 +1369,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                             post,
                             site,
                             mUploadActionUseCase.getUploadAction(post),
-                            new View.OnClickListener() {
-                                @Override
-                                public void onClick(View v) {
-                                    UploadUtils.publishPost(WPMainActivity.this, post, site, mDispatcher);
-                                }
-                            },
+                            v -> UploadUtils.publishPost(WPMainActivity.this, post, site, mDispatcher),
                             isFirstTimePublishing -> {
                                 mBloggingRemindersViewModel.onPublishingPost(site.getId(), isFirstTimePublishing);
                                 mReviewViewModel.onPublishingPost(isFirstTimePublishing);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -171,6 +171,8 @@ public class AppPrefs {
         SITE_JETPACK_CAPABILITIES,
         REMOVED_QUICK_START_CARD_TYPE,
         PINNED_DYNAMIC_CARD,
+        // PUBLISHED_POST_COUNT will increase until it reaches ReviewViewModel.TARGET_COUNT_POST_PUBLISHED
+        PUBLISHED_POST_COUNT,
         BLOGGING_REMINDERS_SHOWN,
         SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION,
         SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
@@ -1362,6 +1364,14 @@ public class AppPrefs {
 
     @NonNull private static String getManualFeatureConfigKey(String featureKey) {
         return DeletablePrefKey.MANUAL_FEATURE_CONFIG.name() + featureKey;
+    }
+
+    public static void incrementPublishedPostCount() {
+        putInt(DeletablePrefKey.PUBLISHED_POST_COUNT, getPublishedPostCount() + 1);
+    }
+
+    public static int getPublishedPostCount() {
+        return prefs().getInt(DeletablePrefKey.PUBLISHED_POST_COUNT.name(), 0);
     }
 
     public static void setBloggingRemindersShown(int siteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -173,6 +173,7 @@ public class AppPrefs {
         PINNED_DYNAMIC_CARD,
         // PUBLISHED_POST_COUNT will increase until it reaches ReviewViewModel.TARGET_COUNT_POST_PUBLISHED
         PUBLISHED_POST_COUNT,
+        IN_APP_REVIEW_SHOWN,
         BLOGGING_REMINDERS_SHOWN,
         SHOULD_SCHEDULE_CREATE_SITE_NOTIFICATION,
         SHOULD_SHOW_WEEKLY_ROUNDUP_NOTIFICATION,
@@ -1372,6 +1373,14 @@ public class AppPrefs {
 
     public static int getPublishedPostCount() {
         return prefs().getInt(DeletablePrefKey.PUBLISHED_POST_COUNT.name(), 0);
+    }
+
+    public static void setInAppReviewsShown() {
+        putBoolean(DeletablePrefKey.IN_APP_REVIEW_SHOWN, true);
+    }
+
+    public static boolean isInAppReviewsShown() {
+        return prefs().getBoolean(DeletablePrefKey.IN_APP_REVIEW_SHOWN.name(), false);
     }
 
     public static void setBloggingRemindersShown(int siteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -191,6 +191,14 @@ class AppPrefsWrapper @Inject constructor() {
         return AppPrefs.getPublishedPostCount()
     }
 
+    fun setInAppReviewsShown() {
+        AppPrefs.setInAppReviewsShown()
+    }
+
+    fun isInAppReviewsShown(): Boolean {
+        return AppPrefs.isInAppReviewsShown()
+    }
+
     fun setBloggingRemindersShown(siteId: Int) {
         AppPrefs.setBloggingRemindersShown(siteId)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -183,6 +183,14 @@ class AppPrefsWrapper @Inject constructor() {
         return AppPrefs.getManualFeatureConfig(featureKey)
     }
 
+    fun incrementPublishedPostCount() {
+        AppPrefs.incrementPublishedPostCount()
+    }
+
+    fun getPublishedPostCount(): Int {
+        return AppPrefs.getPublishedPostCount()
+    }
+
     fun setBloggingRemindersShown(siteId: Int) {
         AppPrefs.setBloggingRemindersShown(siteId)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
@@ -4,15 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.InAppReviewsFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
-class ReviewViewModel @Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) : ViewModel() {
+class ReviewViewModel @Inject constructor(
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val inAppReviewsFeatureConfig: InAppReviewsFeatureConfig
+) : ViewModel() {
     private val _launchReview = MutableLiveData<Event<Unit>>()
     val launchReview = _launchReview as LiveData<Event<Unit>>
 
     fun onPublishingPost(isFirstTimePublishing: Boolean) {
-        if (!appPrefsWrapper.isInAppReviewsShown() && isFirstTimePublishing) {
+        if (inAppReviewsFeatureConfig.isEnabled() && !appPrefsWrapper.isInAppReviewsShown() && isFirstTimePublishing) {
             if (appPrefsWrapper.getPublishedPostCount() < TARGET_COUNT_POST_PUBLISHED) {
                 appPrefsWrapper.incrementPublishedPostCount()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.review
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+class ReviewViewModel @Inject constructor(private val appPrefsWrapper: AppPrefsWrapper) : ViewModel() {
+    private val _launchReview = MutableLiveData<Event<Unit>>()
+    val launchReview = _launchReview as LiveData<Event<Unit>>
+
+    fun onPublishingPost(isFirstTimePublishing: Boolean) {
+        if (!appPrefsWrapper.isInAppReviewsShown() && isFirstTimePublishing) {
+            if (appPrefsWrapper.getPublishedPostCount() < TARGET_COUNT_POST_PUBLISHED) {
+                appPrefsWrapper.incrementPublishedPostCount()
+            }
+            if (appPrefsWrapper.getPublishedPostCount() == TARGET_COUNT_POST_PUBLISHED) {
+                _launchReview.value = Event(Unit)
+                appPrefsWrapper.setInAppReviewsShown()
+            }
+        }
+    }
+
+    companion object {
+        private const val TARGET_COUNT_POST_PUBLISHED = 2
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/review/ReviewViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.review
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -28,6 +29,7 @@ class ReviewViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TARGET_COUNT_POST_PUBLISHED = 2
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val TARGET_COUNT_POST_PUBLISHED = 2
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/review/ReviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/review/ReviewViewModelTest.kt
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.review
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.eventToList
+import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.InAppReviewsFeatureConfig
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class ReviewViewModelTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+
+    @Mock
+    lateinit var inAppReviewsFeatureConfig: InAppReviewsFeatureConfig
+
+    @Mock
+    lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    private lateinit var viewModel: ReviewViewModel
+
+    private lateinit var events: MutableList<Unit>
+
+    @Before
+    fun setup() {
+        whenever(inAppReviewsFeatureConfig.isEnabled()).thenReturn(true)
+        viewModel = ReviewViewModel(appPrefsWrapper, inAppReviewsFeatureConfig)
+        events = mutableListOf()
+        events = viewModel.launchReview.eventToList()
+    }
+
+    @Test
+    fun onPublishingPost_whenPublishedCountIsLow_doNotLaunchInAppReviews() {
+        whenever(appPrefsWrapper.isInAppReviewsShown()).thenReturn(false)
+        whenever(appPrefsWrapper.getPublishedPostCount()).thenReturn(ReviewViewModel.TARGET_COUNT_POST_PUBLISHED - 1)
+
+        viewModel.onPublishingPost(true)
+
+        assertEquals(events.size, 0)
+    }
+
+    @Test
+    fun onPublishingPost_whenInAppReviewsAlreadyShown_doNotLaunchInAppReviews() {
+        whenever(appPrefsWrapper.isInAppReviewsShown()).thenReturn(true)
+
+        viewModel.onPublishingPost(true)
+
+        assertEquals(events.size, 0)
+    }
+
+    @Test
+    fun onPublishingPost_whenPublishedCountIsHigh_launchInAppReviews() {
+        whenever(appPrefsWrapper.isInAppReviewsShown()).thenReturn(false)
+        whenever(appPrefsWrapper.getPublishedPostCount()).thenReturn(ReviewViewModel.TARGET_COUNT_POST_PUBLISHED)
+
+        viewModel.onPublishingPost(true)
+
+        // Verify `launchReview` is triggered.
+        assertEquals(Unit, events.last())
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ ext {
     googleMaterialVersion = '1.9.0'
 
     googleMLKitBarcodeScanningVersion = '17.0.0'
+    googlePlayReviewVersion = '2.0.1'
     googlePlayServicesAuthVersion = '20.4.1'
     googlePlayServicesCodeScannerVersion = '16.0.0-beta3'
     jsoupVersion = '1.16.2'

--- a/docs/test_instructions_per_dependency_update.md
+++ b/docs/test_instructions_per_dependency_update.md
@@ -428,7 +428,7 @@ Step.3:
     <summary>1. In app reviews</summary>
 
 - Perform a clean install.
-- Publish three (`ReviewViewModel.TARGET_COUNT_POST_PUBLISHED`) new posts or stories.
+- Publish three (`ReviewViewModel.TARGET_COUNT_POST_PUBLISHED + 1`) new posts or stories.
 - Verify that there are no crashes.
 
 </details>

--- a/docs/test_instructions_per_dependency_update.md
+++ b/docs/test_instructions_per_dependency_update.md
@@ -54,6 +54,7 @@ rather than strict requirements.
     3. [MLKitBarcodeScanning](#mlkitbarcodescanning)
     4. [PlayServicesAuth](#playservicesauth)
     5. [PlayServicesCoreScanner](#playservicescodescanner)
+    6. [PlayReview](#playreview)
 5. Network
     1. [Okio](#okio)
 6. Tool
@@ -416,6 +417,19 @@ Step.3:
 - Scan the QR code on the web browser.
 - Follow the remaining prompts on your mobile to log in to WordPress on your web browser (desktop),
   verify that you have successfully logged-in and are able to use WordPress as expected.
+
+</details>
+
+-----
+
+### PlayReview [[googlePlayReviewVersion](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/build.gradle)] <a name="playreview"></a>
+
+<details>
+    <summary>1. In app reviews</summary>
+
+- Perform a clean install.
+- Publish three (`ReviewViewModel.TARGET_COUNT_POST_PUBLISHED`) new posts or stories.
+- Verify that there are no crashes.
 
 </details>
 


### PR DESCRIPTION
Fixes #12605 

This adds [in-app reviews feature](https://developer.android.com/guide/playcore/in-app-review). The prompt will display after the second successful publishing (post or story). It must be a new post, and editing doesn't count.  

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/4914894f-3819-4a89-96ed-a7af502611fe

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Testing this feature is not available within the PR. It will be tested outside of the PR.
Internal link: p1702317430036659-slack-C441E3YTS

1. Install the app from the link.
2. Log in.
3. Publish a post or story. 
4. Verify that the blogging reminder is displayed.
5. Publish another post or story.
6. Verify that the in-app previews prompt is displayed. (Submitting the review may not be available due to the testing environment.)

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

8. What automated tests I added (or what prevented me from doing so)

    - `ReviewViewModelTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)