### PR TITLE
[Fix] Danger warning about strings that reference other strings

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4823,7 +4823,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Bloganuary -->
     <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
-    <string name="bloganuary_dashboard_nudge_learn_more">@string/learn_more</string>
+    <string name="bloganuary_dashboard_nudge_learn_more" translatable="false">@string/learn_more</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">Join our month-long writing challenge</string>
     <string name="bloganuary_dashboard_nudge_overlay_text_one">Receive a new prompt to inspire you each day.</string>


### PR DESCRIPTION
Fix Danger warning (https://github.com/wordpress-mobile/WordPress-Android/pull/19727#issuecomment-1841146567) for `bloganuary_dashboard_nudge_learn_more` string which is pointing to another string reference.

> Warnings
> ⚠️	
> This PR adds a translatable entry to `strings.xml` which references another string resource: this usually causes issues with translations.Please make sure to set the `translatable="false"` attribute here:`+ <string name="bloganuary_dashboard_nudge_learn_more">@string/learn_more</string>`
> 
> Generated by 🚫 [dangerJS](https://danger.systems/js)

