### PR TITLE
Fixes: Personalization viewmodel start crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -68,6 +68,7 @@ class PersonalizationActivity : AppCompatActivity() {
                 PersonalizationScreen()
             }
         }
+        viewModel.onSelectedSiteMissing.observe(this) { finish() }
     }
 
     @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.mysite.personalization
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -27,9 +29,14 @@ class PersonalizationViewModel @Inject constructor(
     }
 
     fun start() {
-        val siteId = selectedSiteRepository.getSelectedSite()!!.siteId
-        dashboardCardPersonalizationViewModelSlice.start(siteId)
-        shortcutsPersonalizationViewModelSlice.start(selectedSiteRepository.getSelectedSite()!!)
+        val site = selectedSiteRepository.getSelectedSite()
+        if (site == null) {
+            //todo pass a state to the ui
+            return
+        }
+
+        dashboardCardPersonalizationViewModelSlice.start(site.siteId)
+        shortcutsPersonalizationViewModelSlice.start(site)
     }
 
     fun onCardToggled(cardType: CardType, enabled: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationViewModel.kt
@@ -23,6 +23,9 @@ class PersonalizationViewModel @Inject constructor(
     val uiState = dashboardCardPersonalizationViewModelSlice.uiState
     val shortcutsState = shortcutsPersonalizationViewModelSlice.uiState
 
+    private val _onSelectedSiteMissing = MutableLiveData<Unit>()
+    val onSelectedSiteMissing = _onSelectedSiteMissing as LiveData<Unit>
+
     init {
         shortcutsPersonalizationViewModelSlice.initialize(viewModelScope)
         dashboardCardPersonalizationViewModelSlice.initialize(viewModelScope)
@@ -31,7 +34,7 @@ class PersonalizationViewModel @Inject constructor(
     fun start() {
         val site = selectedSiteRepository.getSelectedSite()
         if (site == null) {
-            //todo pass a state to the ui
+            _onSelectedSiteMissing.value = Unit
             return
         }
 


### PR DESCRIPTION
## Fixes 
Issue #19335

## Description
This PR fixes the crash in `PersonalizationViewmodel` when the selected site repository returns a null site. This happens when the system frees the app's memory and the user returns to the app. The system may free up the memory due to low memory, app being in the background for many days or there may be some optimizations in the system to kill the background process. One way to emulate this behaviour is to set backgroung process limit through developer options. 

In the case when the system frees up the memory, the system directly launches the `PersonalizationActivity` instead of launching the `WpMainActivity` which sets the site in `SelectedSiteRepository`. The PersonalizationViewModel tries to get the selected site and crashes 🎆 

## Explanation of changes 
In this PR, added a check for the condition in which selected site is null then finish the activity to return to the WPMainActivity. 

## To Test:

#### Prerequisite
<details><summary>◐ Apply background limit</code> flag</summary>

1. Enable Developer options 
2. Go to `Developer Options` → `Background Process limit` → `Set 1 as background process limit`

| Developer options → Background process limit |  Set 1 as background process limit | 
|---|---|
| ![Screenshot_20231206_173732](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/339aa441-c39c-4dcf-a836-f404ecc66ffd)  | ![Screenshot_20231206_173712](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/4712c532-9f86-4e0e-ad09-6c2b379ee3bc) |  

</details>

1. Apply background process limit 
2. Install a build from the `trunk`
3. Go to the personalization screen from dashboard
4. Move the app to background and use 2+ other apps 
5. Launch the app from app launcher
6. Notice that the app crashes and the crash log is similar to the one in the linked issue
7. Launch the app from this PR 
8. Repeat steps 3-5. Verify there is no crash. 

-----

## Regression Notes

1. Potential unintended areas of impact
Personalization screen doesn't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
