### PR TITLE
Add `is_free` property to the `jpandroid_enhanced_site_creation_domains_selected` event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -133,7 +133,7 @@ class SiteCreationDomainsViewModel @Inject constructor(
         val domain = requireNotNull(selectedDomain) {
             "Create site button should not be visible if a domain is not selected"
         }
-        tracker.trackDomainSelected(domain.domainName, currentQuery?.value.orEmpty(), domain.cost)
+        tracker.trackDomainSelected(domain.domainName, currentQuery?.value.orEmpty(), domain.cost, domain.isFree)
         _createSiteBtnClicked.value = domain
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationTracker.kt
@@ -47,6 +47,7 @@ class SiteCreationTracker @Inject constructor(
         SITE_NAME("site_name"),
         RECOMMENDED("recommended"),
         DOMAIN_COST("domain_cost"),
+        IS_FREE("is_free"),
     }
 
     private var designSelectionSkipped: Boolean = false
@@ -62,7 +63,7 @@ class SiteCreationTracker @Inject constructor(
         tracker.track(AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_DOMAINS_ACCESSED)
     }
 
-    fun trackDomainSelected(chosenDomain: String, searchTerm: String, domainCost: String = "free") {
+    fun trackDomainSelected(chosenDomain: String, searchTerm: String, domainCost: String = "free", isFree: Boolean) {
         if(plansInSiteCreationFeatureConfig.isEnabled()) {
             tracker.track(
                 AnalyticsTracker.Stat.ENHANCED_SITE_CREATION_DOMAINS_SELECTED,
@@ -70,6 +71,7 @@ class SiteCreationTracker @Inject constructor(
                     CHOSEN_DOMAIN.key to chosenDomain,
                     SEARCH_TERM.key to searchTerm,
                     PROPERTY.DOMAIN_COST.key to domainCost.lowercase(), // Homogenize data (e.g. "Free" becomes "free")
+                    PROPERTY.IS_FREE.key to isFree,
                 )
             )
         } else {

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModelTest.kt
@@ -312,7 +312,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
         viewModel.onCreateSiteBtnClicked()
 
-        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost)
+        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost, true)
     }
 
     @Test
@@ -324,7 +324,7 @@ class SiteCreationDomainsViewModelTest : BaseUnitTest() {
 
         viewModel.onCreateSiteBtnClicked()
 
-        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost)
+        verify(tracker).trackDomainSelected(selectedDomain.domainName, "", expectedCost, false)
     }
 
     @Test


### PR DESCRIPTION
`is_free` property was added to the `jpandroid_enhanced_site_creation_domains_selected` event.
More context: pcdRpT-3RO-p2#comment-7769

Fixes #19743

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Launch the JP app.
2. Log in.
4. Tap the ⌄ button near the site name.
5. Tap the + button and Create WordPress.com site.
6. Skip the topic screen.
7. Skip the theme screen.
8. Search for a domain name.
9. Select a free domain.
10. Check app logs and verify that `jpandroid_enhanced_site_creation_domains_selected` has `"is_free":true` property.
11. Navigate back to the domain selection screen.
12. Select a paid domain.
13. Check app logs and verify that `jpandroid_enhanced_site_creation_domains_selected` has `"is_free":false` property.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Sending `enhanced_site_creation_domains_selected` event`.

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested on "Tracks Live View"/

5. What automated tests I added (or what prevented me from doing so)

    - Updated `SiteCreationDomainsViewModelTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)