### PR TITLE
Do not launch share intent for a page that is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -572,7 +572,7 @@ class PagesViewModel
 
     private fun copyPageLink(page: Page, context: Context) {
         // Get the link to the page
-        val pageLink = postStore.getPostByLocalPostId(page.localId).link
+        val pageLink = postStore.getPostByLocalPostId(page.localId)?.link ?: return
         ActivityLauncher.openShareIntent(
             context,
             pageLink,


### PR DESCRIPTION
Fixes #19748

The problem seems to be occurred when the user tries to share a draft post that hasn't been saved to our local database - `PageStore`, so it returns null for the selected post id. I couldn't reproduce it, though.

## To Test:

I haven't found a way to reproduce this bug since there should be a page on a drafts list that is not saved in the `PostStore`.
Please smoke test a page draft creation and generating a share link for the draft page.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Pages screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
