### PR TITLE
Add nullability recommendation to the "Converting to Kotlin" documentation

### DIFF
--- a/docs/converting-to-kotlin.md
+++ b/docs/converting-to-kotlin.md
@@ -16,6 +16,12 @@ When converting a file from Java to Kotlin, ensure you enable this option in And
 
 **Reason**: Enabling this option helps the reviewer perform a diff on the second commit, showing precisely what changes occurred between the Java and Kotlin files. Otherwise, the PR will display a file deletion (`.java` file) and a file addition (`.kt` file), making it challenging for the reviewer to diff effectively.
 
+### Consider adding nullability annotations before initiating automatic conversion:
+
+Address the warnings of "Missing null annotation" before starting automatic conversion.
+
+**Reason:** This makes automatic conversion to handle nullability instead of setting everything to nullable.
+
 ### Depend on automatic conversion and commit immediately:
 
 When performing the conversion, rely on the automatic conversion tools and commit the changes promptly, even if the resulting Kotlin code doesn't compile. Subsequently, on another commit, you can refine the Kotlin code, making it more idiomatic or addressing any compilation issues, such as adding nullable checks (`!!` or `let`).

--- a/docs/converting-to-kotlin.md
+++ b/docs/converting-to-kotlin.md
@@ -14,7 +14,7 @@ When converting a file from Java to Kotlin, ensure you enable this option in And
 1. The first commit will involve a simple rename from `.java` to `.kt`.
 2. The second commit will rename the `.kt` extension back to .java, followed by the actual commit.
 
-**Reason**: Enabling this option helps the reviewer perform a diff on the second commit, showing precisely what changes occurred between the Java and Kotlin files. Otherwise, the PR will display a file deletion (`.java` file) and a file addition (`.kt` file), making it challenging for the reviewer to diff effectively.
+**Reason:** Enabling this option helps the reviewer perform a diff on the second commit, showing precisely what changes occurred between the Java and Kotlin files. Otherwise, the PR will display a file deletion (`.java` file) and a file addition (`.kt` file), making it challenging for the reviewer to diff effectively.
 
 ### Consider adding nullability annotations before initiating automatic conversion:
 
@@ -26,5 +26,5 @@ Address the warnings of "Missing null annotation" before starting automatic conv
 
 When performing the conversion, rely on the automatic conversion tools and commit the changes promptly, even if the resulting Kotlin code doesn't compile. Subsequently, on another commit, you can refine the Kotlin code, making it more idiomatic or addressing any compilation issues, such as adding nullable checks (`!!` or `let`).
 
-**Reason**: This approach informs the reviewer and other readers that the first commit involved an automated conversion without manual intervention. It helps establish that any code refinements occurred separately, providing clarity on the development process.
+**Reason:** This approach informs the reviewer and other readers that the first commit involved an automated conversion without manual intervention. It helps establish that any code refinements occurred separately, providing clarity on the development process.
 


### PR DESCRIPTION
A recommendation for addressing "Missing null annotation" warnings before initiating automatic conversion has been included in the "Converting to Kotlin" documentation.
