### PR TITLE
Fix a crash on the design preview screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -127,7 +127,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
         binding?.webView?.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)
-                if (view == null) return
+                if (!isAdded || view == null) return
                 val width = viewModel.selectedPreviewMode().previewWidth
                 setWebViewWidth(view, width)
                 val widthScript = context?.getString(R.string.web_preview_width_script, width)

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -75,7 +75,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
     private fun initViewModel() {
         this.viewModel = getViewModel()
 
-        viewModel.previewState.observe(viewLifecycleOwner, { state ->
+        viewModel.previewState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is Loading -> {
                     binding?.desktopPreviewHint?.setVisible(false)
@@ -84,6 +84,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
                     binding?.errorView?.setVisible(false)
                     binding?.webView?.loadUrl(state.url)
                 }
+
                 is Loaded -> {
                     binding?.progressBar?.setVisible(false)
                     binding?.webView?.setVisible(true)
@@ -97,6 +98,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
                     )
                     AniUtils.animateBottomBar(binding?.desktopPreviewHint, true)
                 }
+
                 is Error -> {
                     binding?.progressBar?.setVisible(false)
                     binding?.webView?.setVisible(false)
@@ -104,14 +106,14 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
                     state.toast?.let { ToastUtils.showToast(requireContext(), it) }
                 }
             }
-        })
+        }
 
         // We're skipping the first emitted value since it derives from the view model initialization (`start` method)
-        viewModel.previewMode.skip(1).observe(viewLifecycleOwner, { load() })
+        viewModel.previewMode.skip(1).observe(viewLifecycleOwner) { load() }
 
-        viewModel.onPreviewModeButtonPressed.observe(viewLifecycleOwner, {
+        viewModel.onPreviewModeButtonPressed.observe(viewLifecycleOwner) {
             previewModeSelectorPopup.show(viewModel)
-        })
+        }
 
         binding?.previewTypeSelectorButton?.let {
             previewModeSelectorPopup = PreviewModeSelectorPopup(requireActivity(), it)


### PR DESCRIPTION
Fixes #19336

I couldn't reproduce the crash, but it appears that the crash occurs after changing themes and their mode on the preview screen multiple times. The reason seems to be that `WebViewClient.onPageFinished()` is triggered after the fragment has been killed. We were already checking if the `view` is null; I've added another check, if the fragment `isAdded`. I believe this change should fix the crash without introducing a worse state. 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Since it's not reproducible, testing is not possible.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

3. What automated tests I added (or what prevented me from doing so)

    - This is a fix for a rare case in the UI. It is not suitable for a UI test.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
