### PR TITLE
If the step index saved in the instance state is invalid reset the wizard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -169,7 +169,12 @@ class SiteCreationMainVM @Inject constructor(
         } else {
             siteCreationState = requireNotNull(savedInstanceState.getParcelableCompat(KEY_SITE_CREATION_STATE))
             val currentStepIndex = savedInstanceState.getInt(KEY_CURRENT_STEP)
-            wizardManager.setCurrentStepIndex(currentStepIndex)
+            try {
+                wizardManager.setCurrentStepIndex(currentStepIndex)
+            } catch (e: IllegalStateException) {
+                // If the current step index is invalid, we reset the wizard
+                wizardManager.setCurrentStepIndex(0)
+            }
         }
         isStarted = true
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -174,6 +174,7 @@ class SiteCreationMainVM @Inject constructor(
             } catch (e: IllegalStateException) {
                 // If the current step index is invalid, we reset the wizard
                 wizardManager.setCurrentStepIndex(0)
+                AppLog.e(T.THEMES, "Resetting site creation wizard: ${e.message}")
             }
         }
         isStarted = true

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -364,6 +364,19 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         verify(tracker, times(1)).trackSiteCreationAccessed(SiteCreationSource.UNSPECIFIED)
     }
 
+    @Test
+    fun `given instance state returns an invalid step, when start, then site creation is reset`() {
+        val expectedState = SiteCreationState(segmentId = SEGMENT_ID)
+        whenever(savedInstanceState.getParcelableCompat<SiteCreationState>(KEY_SITE_CREATION_STATE))
+            .thenReturn(expectedState)
+        whenever(savedInstanceState.getInt(KEY_CURRENT_STEP)).thenReturn(-1) // Invalid step
+
+        val newViewModel = getNewViewModel()
+        newViewModel.start(savedInstanceState, SiteCreationSource.UNSPECIFIED)
+
+        verify(wizardManager).setCurrentStepIndex(0)
+    }
+
     private fun currentWizardState(vm: SiteCreationMainVM) = vm.navigationTargetObservable.lastEvent!!.wizardState
 
     private fun getNewViewModel() = SiteCreationMainVM(

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVMTest.kt
@@ -374,7 +374,7 @@ class SiteCreationMainVMTest : BaseUnitTest() {
         val newViewModel = getNewViewModel()
         newViewModel.start(savedInstanceState, SiteCreationSource.UNSPECIFIED)
 
-        verify(wizardManager).setCurrentStepIndex(0)
+        assertEquals(0, wizardManager.currentStep)
     }
 
     private fun currentWizardState(vm: SiteCreationMainVM) = vm.navigationTargetObservable.lastEvent!!.wizardState


### PR DESCRIPTION
Fixes #19758

## Description
Under undefined conditions the Site Creation flow is resumed [with an invalid step retrieved from the saved instance state](https://github.com/wordpress-mobile/WordPress-Android/blob/93e4b7e827f25ba0d94f82b545d0dd5a0f66e161/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt#L171). This results in a crash due to an [unhandled exception thrown in the step validation](https://github.com/wordpress-mobile/WordPress-Android/blob/93e4b7e827f25ba0d94f82b545d0dd5a0f66e161/WordPress/src/main/java/org/wordpress/android/util/wizard/WizardManager.kt#L52). This PR adds exception handling and resets the site creation flow in this edge case.
```
IllegalStateException: Invalid index.
    at org.wordpress.android.util.wizard.WizardManager.setCurrentStepIndex(WizardManager.kt:52)
    at org.wordpress.android.ui.sitecreation.SiteCreationMainVM.start(SiteCreationMainVM.kt:172)
    at org.wordpress.android.ui.sitecreation.SiteCreationActivity.onCreate(SiteCreationActivity.kt:11
```

-----

## To Test:
* I wasn't able to reproduce the crash thus a sanity check on the flow is recommended.

-----

## Regression Notes

1. Potential unintended areas of impact

Site Creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)

 Manual testing

3. What automated tests I added (or what prevented me from doing so)

New test with in the `SiteCreationMainVMTest.kt`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)