### PR TITLE
[Upload] Add UploadService and UploadWorker logs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1094,7 +1094,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
             return;
         }
 
-        UploadService.uploadMedia(this, mediaModels);
+        UploadService.uploadMedia(this, mediaModels, "MediaBrowserActivity#addMediaToUploadService");
         AppRatingDialog.INSTANCE.incrementInteractions(APP_REVIEWS_EVENT_INCREMENTED_BY_UPLOADING_MEDIA);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -420,7 +420,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             )
             showSnackbar(SnackbarMessageHolder(UiString.UiStringText(message)))
         }
-        viewModel.onMediaUpload.observeEvent(viewLifecycleOwner) { UploadService.uploadMedia(requireActivity(), it) }
+        viewModel.onMediaUpload.observeEvent(viewLifecycleOwner) {
+            UploadService.uploadMedia(requireActivity(), it, "MySiteFragment onMediaUpload")
+        }
         dialogViewModel.onInteraction.observeEvent(viewLifecycleOwner) { viewModel.onDialogInteraction(it) }
         viewModel.onUploadedItem.observeEvent(viewLifecycleOwner) { handleUploadedItem(it) }
         viewModel.onOpenJetpackInstallFullPluginOnboarding.observeEvent(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/FeaturedImageHelper.kt
@@ -75,7 +75,7 @@ class FeaturedImageHelper @Inject constructor(
     private fun startUploadService(media: MediaModel) {
         val mediaList = ArrayList<MediaModel>()
         mediaList.add(media)
-        uploadServiceFacade.uploadMedia(mediaList)
+        uploadServiceFacade.uploadMedia(mediaList, "FeaturedImageHelper#startUploadService")
     }
 
     fun queueFeaturedImageForUpload(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListAction.kt
@@ -89,7 +89,8 @@ fun handlePostListAction(
             val intent = UploadService.getRetryUploadServiceIntent(
                 activity,
                 action.post,
-                action.trackAnalytics
+                action.trackAnalytics,
+                "PostListAction.RetryUpload"
             )
             activity.startService(intent)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PreviewStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PreviewStateHelper.kt
@@ -56,7 +56,10 @@ class PreviewStateHelper @Inject constructor() {
                     PostInfoType.PostNoInfo
                 )
                 if (!UploadService.isPostUploadingOrQueued(post)) {
-                    UploadService.uploadPost(activity, post.id, false)
+                    UploadService.uploadPost(
+                        activity, post.id, false,
+                        "PreviewStateHelper#startUploading, isRemoteAutoSave: true"
+                    )
                 } else {
                     AppLog.d(
                         AppLog.T.POSTS,
@@ -69,7 +72,10 @@ class PreviewStateHelper @Inject constructor() {
                     PostInfoType.PostNoInfo
                 )
                 if (!UploadService.isPostUploadingOrQueued(post)) {
-                    UploadService.uploadPost(activity, post.id, false)
+                    UploadService.uploadPost(
+                        activity, post.id, false,
+                        "PreviewStateHelper#startUploading, isRemoteAutoSave: false"
+                    )
                 } else {
                     AppLog.d(
                         AppLog.T.POSTS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -85,7 +85,10 @@ class StorePostViewModel
                 editPostRepository.getPost(),
                 requireNotNull(siteStore.getSiteByLocalId(editPostRepository.localSiteId))
             )
-            uploadService.uploadPost(context, editPostRepository.id, isFirstTimePublish)
+            uploadService.uploadPost(
+                context, editPostRepository.id, isFirstTimePublish,
+                "StorePostViewModel#savePostOnline"
+            )
             SAVED_ONLINE
         } else {
             SAVED_LOCALLY

--- a/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stories/media/StoryMediaSaveUploadBridge.kt
@@ -216,7 +216,10 @@ class StoryMediaSaveUploadBridge @Inject constructor(
                         editPostRepository.getPost(),
                         site
                     )
-                    uploadService.uploadPost(appContext, editPostRepository.id, true)
+                    uploadService.uploadPost(
+                        appContext, editPostRepository.id, true,
+                        "StoryMediaSaveUploadBridge#addNewMediaItemsInStoryFramesToPostAsync"
+                    )
                     // SAVED_ONLINE
                     storiesTrackerHelper.trackStoryPostSavedEvent(uriList.size, site, false)
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -370,7 +370,8 @@ class PostUploadNotifier {
 
         // add draft Publish action for drafts
         if (PostStatus.fromPost(post) == PostStatus.DRAFT || PostStatus.fromPost(post) == PostStatus.PENDING) {
-            Intent publishIntent = UploadService.getPublishPostServiceIntent(mContext, post, isFirstTimePublish);
+            Intent publishIntent = UploadService.getPublishPostServiceIntent(mContext, post,
+                    isFirstTimePublish, "draft success notification publish action");
             PendingIntent pendingIntent = PendingIntent.getService(mContext, 0, publishIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
             notificationBuilder.addAction(R.drawable.ic_posts_white_24dp, mContext.getString(R.string.button_publish),

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -531,7 +531,7 @@ class PostUploadNotifier {
         // Add RETRY action - only available on Aztec
         if (AppPrefs.isAztecEditorEnabled()) {
             Intent publishIntent = UploadService.getRetryUploadServiceIntent(mContext, post,
-                    PostUtils.isFirstTimePublish(post));
+                    PostUtils.isFirstTimePublish(post), "error notification retry action");
             PendingIntent actionPendingIntent = PendingIntent.getService(mContext, 0, publishIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
             notificationBuilder.addAction(0, mContext.getString(R.string.retry),

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -532,7 +532,7 @@ class PostUploadNotifier {
         // Add RETRY action - only available on Aztec
         if (AppPrefs.isAztecEditorEnabled()) {
             Intent publishIntent = UploadService.getRetryUploadServiceIntent(mContext, post,
-                    PostUtils.isFirstTimePublish(post), "error notification retry action");
+                    PostUtils.isFirstTimePublish(post), "post error notification retry action");
             PendingIntent actionPendingIntent = PendingIntent.getService(mContext, 0, publishIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
             notificationBuilder.addAction(0, mContext.getString(R.string.retry),
@@ -625,7 +625,8 @@ class PostUploadNotifier {
         if (mediaList != null && !mediaList.isEmpty()) {
             ArrayList<MediaModel> mediaListToRetry = new ArrayList<>();
             mediaListToRetry.addAll(mediaList);
-            Intent publishIntent = UploadService.getUploadMediaServiceIntent(mContext, mediaListToRetry, true);
+            Intent publishIntent = UploadService.getUploadMediaServiceIntent(mContext, mediaListToRetry,
+                    true, "media error notification retry action");
             PendingIntent actionPendingIntent = PendingIntent.getService(mContext, 1, publishIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
             notificationBuilder.addAction(0, mContext.getString(R.string.retry),

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -344,11 +344,12 @@ public class UploadService extends Service {
     }
 
     public static Intent getRetryUploadServiceIntent(Context context, @NonNull PostImmutableModel post,
-                                                     boolean trackAnalytics) {
+                                                     boolean trackAnalytics, String sourceForLogging) {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(KEY_LOCAL_POST_ID, post.getId());
         intent.putExtra(KEY_SHOULD_TRACK_ANALYTICS, trackAnalytics);
         intent.putExtra(KEY_SHOULD_RETRY, true);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, sourceForLogging);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -66,6 +66,7 @@ public class UploadService extends Service {
     private static final String KEY_UPLOAD_MEDIA_FROM_EDITOR = "mediaFromEditor";
     private static final String KEY_LOCAL_POST_ID = "localPostId";
     private static final String KEY_SHOULD_TRACK_ANALYTICS = "shouldTrackPostAnalytics";
+    private static final String KEY_SOURCE_FOR_LOGGING = "sourceForLogging";
 
     private static @Nullable UploadService sInstance;
 
@@ -148,6 +149,13 @@ public class UploadService extends Service {
             AppLog.e(T.MAIN, "UploadService > Killed and restarted with an empty intent");
             stopServiceIfUploadsComplete();
             return START_NOT_STICKY;
+        }
+
+        if (intent.hasExtra(KEY_SOURCE_FOR_LOGGING)) {
+            String sourceForLogging = intent.getStringExtra(KEY_SOURCE_FOR_LOGGING);
+            if (sourceForLogging != null && !sourceForLogging.isEmpty()) {
+                AppLog.i(T.MAIN, "UploadService > Started from " + sourceForLogging);
+            }
         }
 
         if (intent.hasExtra(KEY_MEDIA_LIST)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -394,20 +394,21 @@ public class UploadService extends Service {
         context.startService(intent);
     }
 
-    public static void uploadMedia(Context context, @NonNull MediaModel media) {
+    public static void uploadMedia(Context context, @NonNull MediaModel media, String sourceForLogging) {
         ArrayList<MediaModel> list = new ArrayList<>();
         list.add(media);
 
-        uploadMedia(context, list);
+        uploadMedia(context, list, sourceForLogging);
     }
 
-    public static void uploadMedia(Context context, @NonNull ArrayList<MediaModel> mediaList) {
+    public static void uploadMedia(Context context, @NonNull ArrayList<MediaModel> mediaList, String sourceForLogging) {
         if (context == null) {
             return;
         }
 
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(UploadService.KEY_MEDIA_LIST, mediaList);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, sourceForLogging);
         context.startService(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -372,10 +372,11 @@ public class UploadService extends Service {
     }
 
     public static Intent getUploadMediaServiceIntent(Context context, @NonNull ArrayList<MediaModel> mediaList,
-                                                     boolean isRetry) {
+                                                     boolean isRetry, String sourceForLogging) {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(UploadService.KEY_MEDIA_LIST, mediaList);
         intent.putExtra(KEY_SHOULD_RETRY, isRetry);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, sourceForLogging);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -362,11 +362,12 @@ public class UploadService extends Service {
      * UploadUtils.publishPost(..) instead.
      */
     public static Intent getPublishPostServiceIntent(Context context, @NonNull PostImmutableModel post,
-                                                     boolean trackAnalytics) {
+                                                     boolean trackAnalytics, String sourceForLogging) {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(KEY_LOCAL_POST_ID, post.getId());
         intent.putExtra(KEY_SHOULD_TRACK_ANALYTICS, trackAnalytics);
         intent.putExtra(KEY_CHANGE_STATUS_TO_PUBLISH, true);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, sourceForLogging);
         return intent;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -384,11 +384,13 @@ public class UploadService extends Service {
      * Adds a post to the queue.
      * @param postId
      * @param isFirstTimePublish true when its status changes from local draft or remote draft to published.
+     * @param sourceForLogging the source of the request for logging purposes.
      */
-    public static void uploadPost(Context context, int postId, boolean isFirstTimePublish) {
+    public static void uploadPost(Context context, int postId, boolean isFirstTimePublish, String sourceForLogging) {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(KEY_LOCAL_POST_ID, postId);
         intent.putExtra(KEY_SHOULD_TRACK_ANALYTICS, isFirstTimePublish);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, sourceForLogging);
         context.startService(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -420,6 +420,7 @@ public class UploadService extends Service {
         Intent intent = new Intent(context, UploadService.class);
         intent.putExtra(UploadService.KEY_MEDIA_LIST, mediaList);
         intent.putExtra(UploadService.KEY_UPLOAD_MEDIA_FROM_EDITOR, true);
+        intent.putExtra(KEY_SOURCE_FOR_LOGGING, "UploadService#uploadMediaFromEditor");
         context.startService(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -31,8 +31,8 @@ class UploadServiceFacade @Inject constructor(private val appContext: Context) {
     fun cancelFinalNotificationForMedia(site: SiteModel) =
         UploadService.cancelFinalNotificationForMedia(appContext, site)
 
-    fun uploadMedia(mediaList: ArrayList<MediaModel>) =
-        UploadService.uploadMedia(appContext, mediaList)
+    fun uploadMedia(mediaList: ArrayList<MediaModel>, sourceForLogging: String = "") =
+        UploadService.uploadMedia(appContext, mediaList, sourceForLogging)
 
     fun getPendingOrInProgressFeaturedImageUploadForPost(post: PostImmutableModel): MediaModel? =
         UploadService.getPendingOrInProgressFeaturedImageUploadForPost(post)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -14,8 +14,8 @@ import javax.inject.Inject
  * contain any static methods.
  */
 class UploadServiceFacade @Inject constructor(private val appContext: Context) {
-    fun uploadPost(context: Context, post: PostModel, trackAnalytics: Boolean) {
-        val intent = UploadService.getRetryUploadServiceIntent(context, post, trackAnalytics)
+    fun uploadPost(context: Context, post: PostModel, trackAnalytics: Boolean, sourceForLogging: String = "") {
+        val intent = UploadService.getRetryUploadServiceIntent(context, post, trackAnalytics, sourceForLogging)
         context.startService(intent)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadServiceFacade.kt
@@ -19,8 +19,8 @@ class UploadServiceFacade @Inject constructor(private val appContext: Context) {
         context.startService(intent)
     }
 
-    fun uploadPost(context: Context, postId: Int, isFirstTimePublish: Boolean) =
-        UploadService.uploadPost(context, postId, isFirstTimePublish)
+    fun uploadPost(context: Context, postId: Int, isFirstTimePublish: Boolean, sourceForLogging: String = "") =
+        UploadService.uploadPost(context, postId, isFirstTimePublish, sourceForLogging)
 
     fun isPostUploadingOrQueued(post: PostImmutableModel) =
         UploadService.isPostUploadingOrQueued(post)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadStarter.kt
@@ -175,7 +175,8 @@ class UploadStarter @Inject constructor(
                         uploadServiceFacade.uploadPost(
                             context = context,
                             post = post,
-                            trackAnalytics = false
+                            trackAnalytics = false,
+                            sourceForLogging = "UploadStarter#upload"
                         )
                     }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -486,15 +486,15 @@ public class UploadUtils {
                 // RETRY only available for Aztec
                 if (AppPrefs.isAztecEditorEnabled()) {
                     UploadUtils.showSnackbarError(snackbarAttachView, errorMessage, R.string.retry,
-                                                  new View.OnClickListener() {
-                                                      @Override
-                                                      public void onClick(View view) {
-                                                          Intent intent = UploadService.getRetryUploadServiceIntent(
-                                                                  activity, post, false,
-                                                                  "error snack bar retry action");
-                                                          activity.startService(intent);
-                                                      }
-                                                  }, sequencer);
+                            new View.OnClickListener() {
+                                @Override
+                                public void onClick(View view) {
+                                    Intent intent = UploadService.getRetryUploadServiceIntent(
+                                            activity, post, false,
+                                            "post error snack bar retry action");
+                                    activity.startService(intent);
+                                }
+                            }, sequencer);
                 } else {
                     UploadUtils.showSnackbarError(snackbarAttachView, errorMessage, sequencer);
                 }
@@ -568,17 +568,18 @@ public class UploadUtils {
                 // RETRY only available for Aztec
                 if (mediaList != null && !mediaList.isEmpty()) {
                     UploadUtils.showSnackbarError(snackbarAttachView, messageForUser, R.string.retry,
-                                                  new View.OnClickListener() {
-                                                      @Override
-                                                      public void onClick(View view) {
-                                                          ArrayList<MediaModel> mediaListToRetry = new ArrayList<>();
-                                                          mediaListToRetry.addAll(mediaList);
-                                                          Intent retryIntent = UploadService
-                                                                  .getUploadMediaServiceIntent(activity,
-                                                                                               mediaListToRetry, true);
-                                                          activity.startService(retryIntent);
-                                                      }
-                                                  }, sequencer);
+                            new View.OnClickListener() {
+                                @Override
+                                public void onClick(View view) {
+                                    ArrayList<MediaModel> mediaListToRetry = new ArrayList<>();
+                                    mediaListToRetry.addAll(mediaList);
+                                    Intent retryIntent = UploadService
+                                            .getUploadMediaServiceIntent(activity,
+                                                    mediaListToRetry, true,
+                                                    "media error snack bar retry action");
+                                    activity.startService(retryIntent);
+                                }
+                            }, sequencer);
                 } else {
                     UploadUtils.showSnackbarError(snackbarAttachView, messageForUser, sequencer);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -456,7 +456,7 @@ public class UploadUtils {
         dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(post));
 
         if (NetworkUtils.isNetworkAvailable(activity)) {
-            UploadService.uploadPost(activity, post.getId(), isFirstTimePublish);
+            UploadService.uploadPost(activity, post.getId(), isFirstTimePublish, "UploadUtils#publishPost");
             if (onPublishingCallback != null) {
                 onPublishingCallback.onPublishing(isFirstTimePublish);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -490,7 +490,8 @@ public class UploadUtils {
                                                       @Override
                                                       public void onClick(View view) {
                                                           Intent intent = UploadService.getRetryUploadServiceIntent(
-                                                                  activity, post, false);
+                                                                  activity, post, false,
+                                                                  "error snack bar retry action");
                                                           activity.startService(intent);
                                                       }
                                                   }, sequencer);

--- a/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/UploadWorker.kt
@@ -33,6 +33,7 @@ class UploadWorker(
     }
 
     override fun doWork(): Result {
+        AppLog.i(AppLog.T.MAIN, "UploadWorker started")
         runBlocking {
             val job = when (val localSiteId = inputData.getInt(WordPress.LOCAL_SITE_ID, UPLOAD_FROM_ALL_SITES)) {
                 UPLOAD_FROM_ALL_SITES -> uploadStarter.queueUploadFromAllSites()
@@ -40,6 +41,7 @@ class UploadWorker(
             }
             job?.join()
         }
+        AppLog.i(AppLog.T.MAIN, "UploadWorker finished")
         return Result.success()
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/FeaturedImageHelperTest.kt
@@ -120,7 +120,7 @@ class FeaturedImageHelperTest {
         // Act
         val mediaModel = featuredImageHelper.retryFeaturedImageUpload(mock(), mock())
         // Assert
-        verify(uploadServiceFacade).uploadMedia(argThat { this[0] == mediaModel })
+        verify(uploadServiceFacade).uploadMedia(argThat { this[0] == mediaModel }, any())
     }
 
     @Test
@@ -189,7 +189,7 @@ class FeaturedImageHelperTest {
         // Act
         featuredImageHelper.queueFeaturedImageForUpload(0, createSiteModel(), mock(), "")
         // Assert
-        verify(uploadServiceFacade).uploadMedia(argThat { this[0] == mediaModel })
+        verify(uploadServiceFacade).uploadMedia(argThat { this[0] == mediaModel }, any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
@@ -8,6 +8,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -249,7 +250,7 @@ class StorePostViewModelTest : BaseUnitTest() {
         verify(savePostToDbUseCase).savePostToDb(postRepository, site)
         assertThat(result).isEqualTo(SAVED_ONLINE)
         verify(postUtils).trackSavePostAnalytics(postModel, site)
-        verify(uploadService).uploadPost(context, postId, isFirstTimePublish)
+        verify(uploadService).uploadPost(eq(context), eq(postId), eq(isFirstTimePublish), any())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterConcurrentTest.kt
@@ -61,7 +61,8 @@ class UploadStarterConcurrentTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(draftPosts.size)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any()
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterMutexTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterMutexTest.kt
@@ -113,7 +113,7 @@ class UploadStarterMutexTest : BaseUnitTest() {
             .thenReturn(UploadActionUseCase.UploadAction.UPLOAD)
 
         // throw IllegalStateException when uploading post (emulate trying to start background service)
-        whenever(uploadServiceFacade.uploadPost(any(), any<PostModel>(), any()))
+        whenever(uploadServiceFacade.uploadPost(any(), any<PostModel>(), any(), any()))
             .thenThrow(IllegalStateException("FAKE: Not allowed to start service intent"))
 
         // ACT

--- a/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/uploads/UploadStarterTest.kt
@@ -143,7 +143,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(draftPosts.size + draftPages.size)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -166,7 +167,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(0)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -188,7 +190,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(draftPosts.size + draftPages.size)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -211,7 +214,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -241,7 +245,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(expectedUploadPostExecutions)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -283,7 +288,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(expectedUploadPostsAndPages.size)).uploadPost(
             context = any(),
             post = argWhere { expectedUploadPostsAndPages.contains(it) },
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
         verify(
             uploadServiceFacade,
@@ -315,7 +321,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -333,7 +340,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -351,7 +359,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(1)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -373,7 +382,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -395,7 +405,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, times(1)).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -416,7 +427,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -436,7 +448,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 
@@ -463,7 +476,8 @@ class UploadStarterTest : BaseUnitTest() {
         verify(uploadServiceFacade, never()).uploadPost(
             context = any(),
             post = any(),
-            trackAnalytics = any()
+            trackAnalytics = any(),
+            sourceForLogging = any(),
         )
     }
 


### PR DESCRIPTION
This is an attempt to add more information for properly debugging the crash described in https://github.com/wordpress-mobile/WordPress-Android/issues/18714 by adding some logs displaying the caller/source of the `UploadService` start and when `UploadWorker` is used.

Even though we should ideally move away from using services for uploading posts and media (as mentioned in https://github.com/wordpress-mobile/WordPress-Android/issues/18714#issuecomment-1688477268), the real issue causing the crash is trying to start a foreground service from the background and without the information about the caller/source, it's being pretty challenging to understand which part of the code is trying to start such service from the background.

These logs should help us understand what is going on and aid us when we go ahead with refactoring the service to use only WorkManager.

-----

## To Test:

There are no specific instructions here, but you can try some app flows that result in `UploadService` and/or `UploadWorker` being called and verify that the logs are being shown accordingly.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.