### PR TITLE
Add remote feature flag for Dynamic Dashboard Cards

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -144,6 +144,7 @@ android {
         buildConfigField "boolean", "READER_IMPROVEMENTS", "false"
         buildConfigField "boolean", "BLOGANUARY_DASHBOARD_NUDGE", "false"
         buildConfigField "boolean", "IN_APP_REVIEWS", "false"
+        buildConfigField "boolean", "DYNAMIC_DASHBOARD_CARDS", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/DynamicDashboardCardsFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/DynamicDashboardCardsFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val DYNAMIC_DASHBOARD_CARDS_FEATURE_REMOTE_FIELD = "dynamic_dashboard_cards"
+
+@Feature(DYNAMIC_DASHBOARD_CARDS_FEATURE_REMOTE_FIELD, false)
+class DynamicDashboardCardsFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.DYNAMIC_DASHBOARD_CARDS,
+    DYNAMIC_DASHBOARD_CARDS_FEATURE_REMOTE_FIELD,
+)


### PR DESCRIPTION
Fixes #19733

## Description
This PR adds a remote feature flag `dynamic_dashboard_cards` for the Dynamic Dashboard Cards feature.

-----

## To Test:

* Go to _Me > Debug Settings_ and verify that the new flag is present in the remote settings
* Sandbox the emulator (or physical device), with the remote flag `dynamic_dashboard_cards` set to `true` and verify that the value is passed in the app.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/304044/6b51d32b-dcde-46a4-9fc3-1321a94223a1" width= 320/>

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

4. What automated tests I added (or what prevented me from doing so)

N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
