### PR TITLE
Fix NPE in Site Settings on Blogging Reminders

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1304,7 +1304,14 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mBloggingRemindersPref == null || !isAdded()) {
             return;
         }
-        mBloggingRemindersViewModel.onBlogSettingsItemClicked(mSite.getId());
+        if (mBloggingRemindersViewModel != null) {
+            mBloggingRemindersViewModel.onBlogSettingsItemClicked(mSite.getId());
+        } else {
+            AppLog.d(AppLog.T.SETTINGS, "BloggingRemindersViewModel is null, creating new instance");
+            mBloggingRemindersViewModel = new ViewModelProvider(getAppCompatActivity(), mViewModelFactory)
+                    .get(BloggingRemindersViewModel.class);
+            mBloggingRemindersViewModel.onBlogSettingsItemClicked(mSite.getId());
+        }
     }
 
     private void initBloggingPrompts() {


### PR DESCRIPTION
Fixes #19766

This NPE is occurring only on Emulator, and mostly on ~ v23.4 and after, probably during testing with a local or self-hosted site on WordPress app. 

A hard to reproduce crash, may be occurring on particular setup, emulator or network issues.

-----

## To Test:

- Create a self-hosted site or use a local site if you have sandbox
- Launch WordPress App 
- Go to Site Settings
- Find `Reminders` under **Blogging** section
- See if crash occurs
- May need to explore with/without Jetpack plugin given migration settings.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing

3. What automated tests I added (or what prevented me from doing so)

    Existing unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
