### PR TITLE
[Dynamic Cards] Update Endpoint Response

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.mysite.MySiteUiState.PartialState.CardsUpdate
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.cards.dashboard.activity.DashboardActivityLogCardFeatureUtils
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.util.config.DynamicDashboardCardsFeatureConfig
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -27,7 +28,8 @@ class CardsSource @Inject constructor(
     private val cardsStore: CardsStore,
     private val dashboardActivityLogCardFeatureUtils: DashboardActivityLogCardFeatureUtils,
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val dynamicDashboardCardsFeatureConfig: DynamicDashboardCardsFeatureConfig,
 ) : MySiteRefreshSource<CardsUpdate> {
     override val refresh = MutableLiveData(false)
 
@@ -103,6 +105,7 @@ class CardsSource @Inject constructor(
         if (shouldRequestPagesCard(selectedSite)) add(Type.PAGES)
         if (dashboardActivityLogCardFeatureUtils.shouldRequestActivityCard(selectedSite)) add(Type.ACTIVITY)
         add(Type.POSTS)
+        if (shouldRequestDynamicCards()) add(Type.DYNAMIC)
     }.toList()
 
     private fun shouldRequestPagesCard(selectedSite: SiteModel): Boolean {
@@ -112,6 +115,10 @@ class CardsSource @Inject constructor(
 
     private fun shouldRequestStatsCard(selectedSite: SiteModel): Boolean {
         return !appPrefsWrapper.getShouldHideTodaysStatsDashboardCard(selectedSite.siteId)
+    }
+
+    private fun shouldRequestDynamicCards(): Boolean {
+        return dynamicDashboardCardsFeatureConfig.isEnabled() // TODO We should also add check for hidden cards here
     }
 
     private fun MediatorLiveData<CardsUpdate>.postErrorState() {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2.59.0'
+    wordPressFluxCVersion = '2923-2585cec528a39b36f6d96bb60e08fcf6722e644d'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2923-6ab4d13c36f7f9fc3a0960d20ae6227a92a58e81'
+    wordPressFluxCVersion = 'trunk-01d386ea4c0a9dbda7c06432e555300a97a231f5'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2923-2585cec528a39b36f6d96bb60e08fcf6722e644d'
+    wordPressFluxCVersion = '2923-6ab4d13c36f7f9fc3a0960d20ae6227a92a58e81'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #19734

-----

## Description
This PR adds Dynamic Cards support in the dashboard/cards-data Endpoint Response.

Note:
* Adding the `Not Ready for Merge` status till we test with the backend, merge the accompanying FluxC PR and update the reference to point to `trunk` 

## To Test:
* Enable https://github.com/wordpress-mobile/WordPress-Android/pull/19765
* Verify that the existing dashboard cards appear as expected
* TODO: Test with a sandbox

-----

## Regression Notes

1. Potential unintended areas of impact

Jetpack app dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)

 Manual testing

3. What automated tests I added (or what prevented me from doing so)

 Added new test case

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
