### PR TITLE
[Bloganuary] Replace hyphen with em dash in Bloganuary Nudge text

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4822,7 +4822,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Bloganuary -->
     <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
-    <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.</string>
+    <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.</string>
     <string name="bloganuary_dashboard_nudge_learn_more" translatable="false">@string/learn_more</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">Join our month-long writing challenge</string>


### PR DESCRIPTION
Use the appropriate character in the Bloganuary text for US English, it should be an `em` and not a `hyphen`. This should target a hotfix branch for the 23.8 release, likely `release/23.8.1`.

-----

## To Test:

Check that the Bloganuary card on My Site dashboard shows the correct character for US English.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

3. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.