### PR TITLE
Implement composable UI for Dynamic Dashboard Cards

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/card/UnelevatedCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/card/UnelevatedCard.kt
@@ -6,21 +6,23 @@ import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun UnelevatedCard(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
+    val shape = RoundedCornerShape(10.dp)
     Card(
-        modifier = modifier,
+        modifier = Modifier.clip(shape).then(modifier),
         border = BorderStroke(
             width = 1.dp,
             color = MaterialTheme.colors.onSurface.copy(alpha = 0.12f)
         ),
         elevation = 0.dp,
-        shape = RoundedCornerShape(10.dp)
+        shape = shape,
     ) {
         content()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/styles/DashboardCardTypography.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/styles/DashboardCardTypography.kt
@@ -10,6 +10,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 object DashboardCardTypography {
+    val title: TextStyle
+        @Composable
+        get() = MaterialTheme.typography.bodyLarge.copy(
+            fontWeight = FontWeight.SemiBold,
+            color = colors.onSurface.copy(alpha = ContentAlpha.high)
+        )
+
     val smallTitle: TextStyle
         @Composable
         get() = MaterialTheme.typography.bodyLarge.copy(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -396,7 +396,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
 
         data class Dynamic(
             val id: String,
-            val order: Order,
             val rows: List<Row>,
             val title: String?,
             val image: String?,
@@ -424,8 +423,6 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                     val title: String
                 ) : ActionSource()
             }
-
-            enum class Order { TOP, BOTTOM }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.ui.avatars.TrainOfAvatarsItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.CATEGORY_EMPTY_HEADER_ITEM
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.CATEGORY_HEADER_ITEM
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.DOMAIN_REGISTRATION_CARD
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.DYNAMIC_DASHBOARD_CARD
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.INFO_ITEM
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.JETPACK_BADGE
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Type.JETPACK_FEATURE_CARD
@@ -60,6 +61,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         NO_CARDS_MESSAGE,
         PERSONALIZE_CARD,
         WP_SOTW_2023_NUDGE_CARD,
+        DYNAMIC_DASHBOARD_CARD,
     }
 
     data class SiteInfoHeaderCard(
@@ -89,7 +91,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
     ) : MySiteCardAndItem(type, activeQuickStartItem) {
         data class QuickLinksItem(
             val quickLinkItems: List<QuickLinkItem>,
-            val showMoreFocusPoint : Boolean = false
+            val showMoreFocusPoint: Boolean = false
         ) : Card(
             QUICK_LINK_RIBBON,
             activeQuickStartItem = showMoreFocusPoint
@@ -163,7 +165,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         }
 
         sealed class TodaysStatsCard(
-             override val type: Type
+            override val type: Type
         ) : Card(type) {
             data class Error(
                 override val title: UiString
@@ -194,7 +196,7 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
         }
 
         sealed class PagesCard(
-             override val type: Type,
+            override val type: Type,
         ) : Card(type) {
             data class Error(
                 override val title: UiString
@@ -389,8 +391,27 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val onCtaClick: ListItemInteraction,
         ) : Card(type = Type.WP_SOTW_2023_NUDGE_CARD)
 
-        data class NoCardsMessage(val title: UiString, val message: UiString)  : Card(Type.NO_CARDS_MESSAGE)
+        data class NoCardsMessage(val title: UiString, val message: UiString) : Card(Type.NO_CARDS_MESSAGE)
         data class PersonalizeCardModel(val onClick: () -> Unit) : Card(Type.PERSONALIZE_CARD)
+
+        data class Dynamic(
+            val id: String,
+            val order: Order,
+            val rows: List<Row>,
+            val title: String?,
+            val image: String?,
+            val action: String?,
+            val onHideMenuItemClick: ListItemInteraction,
+            val onCtaClick: ListItemInteraction,
+        ) : Card(type = DYNAMIC_DASHBOARD_CARD) {
+            data class Row(
+                val iconUrl: String?,
+                val title: String?,
+                val description: String?,
+            )
+
+            enum class Order { TOP, BOTTOM }
+        }
     }
 
     sealed class Item(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -400,15 +400,30 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
             val rows: List<Row>,
             val title: String?,
             val image: String?,
-            val action: String?,
+            val action: ActionSource?,
             val onHideMenuItemClick: ListItemInteraction,
-            val onCtaClick: ListItemInteraction,
         ) : Card(type = DYNAMIC_DASHBOARD_CARD) {
             data class Row(
                 val iconUrl: String?,
                 val title: String?,
                 val description: String?,
             )
+
+            sealed class ActionSource {
+                abstract val url: String
+                abstract val onCtaClick: ListItemInteraction
+
+                data class Card(
+                    override val url: String,
+                    override val onCtaClick: ListItemInteraction
+                ) : ActionSource()
+
+                data class Button(
+                    override val url: String,
+                    override val onCtaClick: ListItemInteraction,
+                    val title: String
+                ) : ActionSource()
+            }
 
             enum class Order { TOP, BOTTOM }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
@@ -11,10 +11,11 @@ import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 @Composable
 fun DynamicCardCallToActionButton(
     text: String,
-    onClicked: () -> Unit
+    onClicked: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     TextButton(
-        modifier = Modifier.padding(start = 8.dp),
+        modifier = modifier.padding(start = 8.dp),
         onClick = onClicked,
     ) {
         Text(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.mysite.cards.dynamiccard
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.domains.management.success
+
+@Composable
+fun DynamicCardCallToActionButton(
+    text: String,
+    onClicked: () -> Unit
+) {
+    TextButton(
+        modifier = Modifier.padding(start = 4.dp),
+        onClick = onClicked,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.success
+            ),
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardCallToActionButton.kt
@@ -1,13 +1,12 @@
 package org.wordpress.android.ui.mysite.cards.dynamiccard
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.wordpress.android.ui.domains.management.success
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 
 @Composable
 fun DynamicCardCallToActionButton(
@@ -15,14 +14,12 @@ fun DynamicCardCallToActionButton(
     onClicked: () -> Unit
 ) {
     TextButton(
-        modifier = Modifier.padding(start = 4.dp),
+        modifier = Modifier.padding(start = 8.dp),
         onClick = onClicked,
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = MaterialTheme.colorScheme.success
-            ),
+            style = DashboardCardTypography.footerCTA,
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
@@ -63,7 +63,6 @@ fun DynamicDashboardCardPreview() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = "Card Title",
                 image = "https://picsum.photos/200/300",
                 action = ActionSource.Button(
@@ -95,7 +94,6 @@ fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
                 action = ActionSource.Button(
@@ -124,7 +122,6 @@ fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
                 action = ActionSource.Button(
@@ -153,7 +150,6 @@ fun DynamicDashboardCardWithNoCta() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
                 action = ActionSource.Card(
@@ -181,7 +177,6 @@ fun DynamicDashboardWithFeatureImageOnly() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
                 action = ActionSource.Card(
@@ -202,7 +197,6 @@ fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
-                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = "What's New in Jetpack",
                 image = null,
                 action = ActionSource.Button(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dynamiccard
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -7,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
-import org.wordpress.android.ui.domains.management.M3Theme
+import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.utils.ListItemInteraction
 
@@ -41,9 +42,10 @@ fun DynamicDashboardCard(
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DynamicDashboardCardPreview() {
-    M3Theme {
+    AppTheme {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -73,7 +75,7 @@ fun DynamicDashboardCardPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
-    M3Theme {
+    AppTheme {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -99,7 +101,7 @@ fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
-    M3Theme {
+    AppTheme {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -125,7 +127,7 @@ fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
-    M3Theme {
+    AppTheme {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
@@ -1,40 +1,13 @@
 package org.wordpress.android.ui.mysite.cards.dynamiccard
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
-import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.domains.management.M3Theme
-import org.wordpress.android.ui.domains.management.success
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.utils.ListItemInteraction
 
@@ -49,127 +22,22 @@ fun DynamicDashboardCard(
             Column(
                 Modifier.padding(top = 8.dp, bottom = 8.dp)
             ) {
-                CardHeader(
+                DynamicCardHeader(
                     title = card.title,
                     onHideMenuClicked = { card.onHideMenuItemClick.click() }
                 )
-                card.image?.let { imageUrl -> CardFeatureImage(imageUrl) }
-                if (card.rows.isNotEmpty()) CardRow(card.rows)
+                card.image?.let { imageUrl ->
+                    DynamicCardFeatureImage(imageUrl)
+                }
+                if (card.rows.isNotEmpty()) {
+                    DynamicCardRows(card.rows)
+                }
                 card.action?.let { action ->
-                    TextButton(
-                        modifier = Modifier.padding(start = 4.dp),
-                        onClick = { card.onCtaClick.click() },
-                    ) {
-                        Text(
-                            text = action,
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                color = MaterialTheme.colorScheme.success
-                            ),
-                        )
-                    }
+                    DynamicCardCallToActionButton(text = action, onClicked = { card.onCtaClick.click() })
                 }
             }
         }
     )
-}
-
-@Composable
-private fun CardHeader(
-    title: String?,
-    onHideMenuClicked: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .padding(end = 16.dp),
-            content = {
-                title?.let { title ->
-                    Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        ),
-                    )
-                }
-            }
-        )
-        IconButton(
-            modifier = Modifier.size(32.dp), // to match the icon in my_site_card_toolbar.xml
-            onClick = onHideMenuClicked
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.MoreVert,
-                contentDescription = stringResource(id = R.string.more),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium),
-            )
-        }
-    }
-}
-
-@Composable
-private fun CardFeatureImage(imageUrl: String) {
-    AsyncImage(
-        model = imageUrl,
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
-        placeholder = ColorPainter(AppColor.Gray30),
-        modifier = Modifier
-            .padding(start = 16.dp, end = 16.dp)
-            .clip(RoundedCornerShape(6.dp))
-            .fillMaxWidth()
-            .aspectRatio(2f)
-    )
-}
-
-@Composable
-private fun CardRow(rows: List<MySiteCardAndItem.Card.Dynamic.Row>) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
-    ) {
-        items(items = rows) { row -> CardRow(row) }
-    }
-}
-
-@Composable
-private fun CardRow(row: MySiteCardAndItem.Card.Dynamic.Row) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        row.iconUrl?.let { iconUrl ->
-            AsyncImage(
-                model = iconUrl,
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
-                placeholder = ColorPainter(AppColor.Gray30),
-                modifier = Modifier.size(48.dp),
-            )
-        }
-        Column(modifier = Modifier.padding(start = row.iconUrl?.run { 12.dp } ?: 0.dp)) {
-            row.title?.let { title ->
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                )
-            }
-            row.description?.let { description ->
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        fontWeight = FontWeight.Light,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium)
-                    )
-                )
-            }
-        }
-    }
 }
 
 @Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.cards.dynamiccard
 
 import android.content.res.Configuration
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -10,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.Dynamic.ActionSource
 import org.wordpress.android.ui.utils.ListItemInteraction
 
 @Composable
@@ -18,23 +20,35 @@ fun DynamicDashboardCard(
     modifier: Modifier = Modifier,
 ) {
     UnelevatedCard(
-        modifier = modifier,
+        modifier = modifier
+            .run {
+                if (card.action is ActionSource.Card) clickable { card.action.onCtaClick.click() } else this
+            },
         content = {
             Column(
                 Modifier.padding(top = 8.dp, bottom = 8.dp)
             ) {
+                val isCtaInvisible = card.action !is ActionSource.Button
                 DynamicCardHeader(
                     title = card.title,
                     onHideMenuClicked = { card.onHideMenuItemClick.click() }
                 )
                 card.image?.let { imageUrl ->
-                    DynamicCardFeatureImage(imageUrl)
+                    DynamicCardFeatureImage(
+                        imageUrl,
+                        modifier = Modifier.run {
+                            if (isCtaInvisible && card.rows.isEmpty()) padding(bottom = 8.dp) else this
+                        }
+                    )
                 }
                 if (card.rows.isNotEmpty()) {
-                    DynamicCardRows(card.rows)
+                    DynamicCardRows(
+                        rows = card.rows,
+                        modifier = Modifier.run { if (isCtaInvisible) padding(bottom = 8.dp) else this }
+                    )
                 }
-                card.action?.let { action ->
-                    DynamicCardCallToActionButton(text = action, onClicked = { card.onCtaClick.click() })
+                (card.action as? ActionSource.Button)?.title?.let { title ->
+                    DynamicCardCallToActionButton(text = title, onClicked = { card.action.onCtaClick.click() })
                 }
             }
         }
@@ -52,7 +66,10 @@ fun DynamicDashboardCardPreview() {
                 order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = "Card Title",
                 image = "https://picsum.photos/200/300",
-                action = "Call to Action",
+                action = ActionSource.Button(
+                    title = "Call to Action", url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
                 rows = listOf(
                     MySiteCardAndItem.Card.Dynamic.Row(
                         iconUrl = "",
@@ -66,7 +83,6 @@ fun DynamicDashboardCardPreview() {
                     ),
                 ),
                 onHideMenuItemClick = ListItemInteraction.create {},
-                onCtaClick = ListItemInteraction.create {},
             )
         )
     }
@@ -82,7 +98,11 @@ fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
                 order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
-                action = "See yours now",
+                action = ActionSource.Button(
+                    title = "See yours now",
+                    url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
                 rows = listOf(
                     MySiteCardAndItem.Card.Dynamic.Row(
                         iconUrl = null,
@@ -92,7 +112,6 @@ fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
                     )
                 ),
                 onHideMenuItemClick = ListItemInteraction.create {},
-                onCtaClick = ListItemInteraction.create {},
             )
         )
     }
@@ -108,7 +127,11 @@ fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
                 order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = null,
                 image = "https://picsum.photos/200/300",
-                action = "Find out more",
+                action = ActionSource.Button(
+                    title = "Find out more",
+                    url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
                 rows = listOf(
                     MySiteCardAndItem.Card.Dynamic.Row(
                         iconUrl = null,
@@ -118,7 +141,55 @@ fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
                     )
                 ),
                 onHideMenuItemClick = ListItemInteraction.create {},
-                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardCardWithNoCta() {
+    AppTheme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = null,
+                image = "https://picsum.photos/200/300",
+                action = ActionSource.Card(
+                    url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
+                rows = listOf(
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = null,
+                        title = "New and Improved\nJetpack Mobile Editor",
+                        description = "Updated colours and icons, streamlined typing" +
+                                ", unified block controls, drag and drop."
+                    )
+                ),
+                onHideMenuItemClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardWithFeatureImageOnly() {
+    AppTheme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = null,
+                image = "https://picsum.photos/200/300",
+                action = ActionSource.Card(
+                    url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
+                rows = listOf(),
+                onHideMenuItemClick = ListItemInteraction.create {},
             )
         )
     }
@@ -134,7 +205,10 @@ fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
                 order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
                 title = "What's New in Jetpack",
                 image = null,
-                action = "Find out more",
+                action = ActionSource.Button(
+                    title = "Find out more", url = "",
+                    onCtaClick = ListItemInteraction.create {},
+                ),
                 rows = listOf(
                     MySiteCardAndItem.Card.Dynamic.Row(
                         iconUrl = "url",
@@ -153,7 +227,6 @@ fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
                     ),
                 ),
                 onHideMenuItemClick = ListItemInteraction.create {},
-                onCtaClick = ListItemInteraction.create {},
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.mysite.cards.dynamiccard
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.wordpress.android.ui.compose.theme.AppColor
+
+@Composable
+fun DynamicCardFeatureImage(imageUrl: String) {
+    AsyncImage(
+        model = imageUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        placeholder = ColorPainter(AppColor.Gray30),
+        modifier = Modifier
+            .padding(start = 16.dp, end = 16.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .fillMaxWidth()
+            .aspectRatio(2f)
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
@@ -14,13 +14,13 @@ import coil.compose.AsyncImage
 import org.wordpress.android.ui.compose.theme.AppColor
 
 @Composable
-fun DynamicCardFeatureImage(imageUrl: String) {
+fun DynamicCardFeatureImage(imageUrl: String, modifier: Modifier = Modifier) {
     AsyncImage(
         model = imageUrl,
         contentDescription = null,
         contentScale = ContentScale.Crop,
         placeholder = ColorPainter(AppColor.Gray30),
-        modifier = Modifier
+        modifier = modifier
             .padding(start = 16.dp, end = 16.dp)
             .clip(RoundedCornerShape(6.dp))
             .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardHeader.kt
@@ -7,17 +7,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 
 @Composable
 fun DynamicCardHeader(
@@ -40,13 +40,7 @@ private fun Title(title: String?, modifier: Modifier = Modifier) {
         modifier = modifier.padding(end = 16.dp),
         content = {
             title?.let { title ->
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    ),
-                )
+                Text(text = title, style = DashboardCardTypography.subTitle)
             }
         }
     )
@@ -55,13 +49,13 @@ private fun Title(title: String?, modifier: Modifier = Modifier) {
 @Composable
 private fun Menu(onHideMenuClicked: () -> Unit) {
     IconButton(
-        modifier = Modifier.size(32.dp), // to match the icon in my_site_card_toolbar.xml
+        modifier = Modifier.size(32.dp),
         onClick = onHideMenuClicked
     ) {
         Icon(
             imageVector = Icons.Rounded.MoreVert,
             contentDescription = stringResource(id = R.string.more),
-            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium),
+            tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardHeader.kt
@@ -1,0 +1,67 @@
+package org.wordpress.android.ui.mysite.cards.dynamiccard
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+
+@Composable
+fun DynamicCardHeader(
+    title: String?,
+    onHideMenuClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Title(title = title, modifier = Modifier.weight(1f))
+        Menu(onHideMenuClicked)
+    }
+}
+
+@Composable
+private fun Title(title: String?, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.padding(end = 16.dp),
+        content = {
+            title?.let { title ->
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun Menu(onHideMenuClicked: () -> Unit) {
+    IconButton(
+        modifier = Modifier.size(32.dp), // to match the icon in my_site_card_toolbar.xml
+        onClick = onHideMenuClicked
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.MoreVert,
+            contentDescription = stringResource(id = R.string.more),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium),
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
@@ -7,17 +7,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import org.wordpress.android.ui.compose.styles.DashboardCardTypography
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 
@@ -39,10 +37,10 @@ private fun Item(row: MySiteCardAndItem.Card.Dynamic.Row) {
         }
         Column(modifier = Modifier.padding(start = row.iconUrl?.run { 12.dp } ?: 0.dp)) {
             row.title?.let { title ->
-                Title(title)
+                Text(text = title, style = DashboardCardTypography.title)
             }
             row.description?.let { description ->
-                Description(description)
+                Text(text = description, style = DashboardCardTypography.detailText)
             }
         }
     }
@@ -56,27 +54,5 @@ private fun Icon(iconUrl: String) {
         contentScale = ContentScale.Fit,
         placeholder = ColorPainter(AppColor.Gray30),
         modifier = Modifier.size(48.dp),
-    )
-}
-
-@Composable
-private fun Title(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.bodyLarge.copy(
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-    )
-}
-
-@Composable
-private fun Description(description: String) {
-    Text(
-        text = description,
-        style = MaterialTheme.typography.bodyMedium.copy(
-            fontWeight = FontWeight.Light,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium)
-        )
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.ui.mysite.cards.dynamiccard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+
+@Composable
+fun DynamicCardRows(rows: List<MySiteCardAndItem.Card.Dynamic.Row>) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
+    ) {
+        items(items = rows) { row -> Item(row) }
+    }
+}
+
+@Composable
+private fun Item(row: MySiteCardAndItem.Card.Dynamic.Row) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        row.iconUrl?.let { iconUrl ->
+            Icon(iconUrl)
+        }
+        Column(modifier = Modifier.padding(start = row.iconUrl?.run { 12.dp } ?: 0.dp)) {
+            row.title?.let { title ->
+                Title(title)
+            }
+            row.description?.let { description ->
+                Description(description)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Icon(iconUrl: String) {
+    AsyncImage(
+        model = iconUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Fit,
+        placeholder = ColorPainter(AppColor.Gray30),
+        modifier = Modifier.size(48.dp),
+    )
+}
+
+@Composable
+private fun Title(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.bodyLarge.copy(
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    )
+}
+
+@Composable
+private fun Description(description: String) {
+    Text(
+        text = description,
+        style = MaterialTheme.typography.bodyMedium.copy(
+            fontWeight = FontWeight.Light,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium)
+        )
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardRows.kt
@@ -20,18 +20,18 @@ import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 
 @Composable
-fun DynamicCardRows(rows: List<MySiteCardAndItem.Card.Dynamic.Row>) {
+fun DynamicCardRows(rows: List<MySiteCardAndItem.Card.Dynamic.Row>, modifier: Modifier = Modifier) {
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
+        modifier = modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
     ) {
         items(items = rows) { row -> Item(row) }
     }
 }
 
 @Composable
-private fun Item(row: MySiteCardAndItem.Card.Dynamic.Row) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+private fun Item(row: MySiteCardAndItem.Card.Dynamic.Row, modifier: Modifier = Modifier) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
         row.iconUrl?.let { iconUrl ->
             Icon(iconUrl)
         }
@@ -47,12 +47,12 @@ private fun Item(row: MySiteCardAndItem.Card.Dynamic.Row) {
 }
 
 @Composable
-private fun Icon(iconUrl: String) {
+private fun Icon(iconUrl: String, modifier: Modifier = Modifier) {
     AsyncImage(
         model = iconUrl,
         contentDescription = null,
         contentScale = ContentScale.Fit,
         placeholder = ColorPainter(AppColor.Gray30),
-        modifier = Modifier.size(48.dp),
+        modifier = modifier.size(48.dp),
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicDashboardCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicDashboardCardComposable.kt
@@ -1,0 +1,290 @@
+package org.wordpress.android.ui.mysite.cards.dynamiccard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.card.UnelevatedCard
+import org.wordpress.android.ui.compose.theme.AppColor
+import org.wordpress.android.ui.domains.management.M3Theme
+import org.wordpress.android.ui.domains.management.success
+import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.utils.ListItemInteraction
+
+@Composable
+fun DynamicDashboardCard(
+    card: MySiteCardAndItem.Card.Dynamic,
+    modifier: Modifier = Modifier,
+) {
+    UnelevatedCard(
+        modifier = modifier,
+        content = {
+            Column(
+                Modifier.padding(top = 8.dp, bottom = 8.dp)
+            ) {
+                CardHeader(
+                    title = card.title,
+                    onHideMenuClicked = { card.onHideMenuItemClick.click() }
+                )
+                card.image?.let { imageUrl -> CardFeatureImage(imageUrl) }
+                if (card.rows.isNotEmpty()) CardRow(card.rows)
+                card.action?.let { action ->
+                    TextButton(
+                        modifier = Modifier.padding(start = 4.dp),
+                        onClick = { card.onCtaClick.click() },
+                    ) {
+                        Text(
+                            text = action,
+                            style = MaterialTheme.typography.bodyMedium.copy(
+                                color = MaterialTheme.colorScheme.success
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun CardHeader(
+    title: String?,
+    onHideMenuClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 16.dp),
+            content = {
+                title?.let { title ->
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        ),
+                    )
+                }
+            }
+        )
+        IconButton(
+            modifier = Modifier.size(32.dp), // to match the icon in my_site_card_toolbar.xml
+            onClick = onHideMenuClicked
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.MoreVert,
+                contentDescription = stringResource(id = R.string.more),
+                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CardFeatureImage(imageUrl: String) {
+    AsyncImage(
+        model = imageUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        placeholder = ColorPainter(AppColor.Gray30),
+        modifier = Modifier
+            .padding(start = 16.dp, end = 16.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .fillMaxWidth()
+            .aspectRatio(2f)
+    )
+}
+
+@Composable
+private fun CardRow(rows: List<MySiteCardAndItem.Card.Dynamic.Row>) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp)
+    ) {
+        items(items = rows) { row -> CardRow(row) }
+    }
+}
+
+@Composable
+private fun CardRow(row: MySiteCardAndItem.Card.Dynamic.Row) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        row.iconUrl?.let { iconUrl ->
+            AsyncImage(
+                model = iconUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                placeholder = ColorPainter(AppColor.Gray30),
+                modifier = Modifier.size(48.dp),
+            )
+        }
+        Column(modifier = Modifier.padding(start = row.iconUrl?.run { 12.dp } ?: 0.dp)) {
+            row.title?.let { title ->
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                )
+            }
+            row.description?.let { description ->
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.Light,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.medium)
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardCardPreview() {
+    M3Theme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = "Card Title",
+                image = "https://picsum.photos/200/300",
+                action = "Call to Action",
+                rows = listOf(
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = "",
+                        title = "Title first",
+                        description = "Description first"
+                    ),
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = "",
+                        title = "Title second",
+                        description = "Description second"
+                    ),
+                ),
+                onHideMenuItemClick = ListItemInteraction.create {},
+                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
+    M3Theme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = null,
+                image = "https://picsum.photos/200/300",
+                action = "See yours now",
+                rows = listOf(
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = null,
+                        title = null,
+                        description = "Review your blog's impactful year with key \n" +
+                                "stats on viewership, engagement, and community growth."
+                    )
+                ),
+                onHideMenuItemClick = ListItemInteraction.create {},
+                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
+    M3Theme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = null,
+                image = "https://picsum.photos/200/300",
+                action = "Find out more",
+                rows = listOf(
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = null,
+                        title = "New and Improved\nJetpack Mobile Editor",
+                        description = "Updated colours and icons, streamlined typing" +
+                                ", unified block controls, drag and drop."
+                    )
+                ),
+                onHideMenuItemClick = ListItemInteraction.create {},
+                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
+    M3Theme {
+        DynamicDashboardCard(
+            card = MySiteCardAndItem.Card.Dynamic(
+                id = "id",
+                order = MySiteCardAndItem.Card.Dynamic.Order.TOP,
+                title = "What's New in Jetpack",
+                image = null,
+                action = "Find out more",
+                rows = listOf(
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = "url",
+                        title = "Domain Management",
+                        description = "We added a space for all your domains in the ‘Me’ tab."
+                    ),
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = "url",
+                        title = "Media Enhancements",
+                        description = "Rebuilt for improved performance and new interactions."
+                    ),
+                    MySiteCardAndItem.Card.Dynamic.Row(
+                        iconUrl = "url",
+                        title = "Posts and Pages",
+                        description = "Streamlined design and improved options menus."
+                    ),
+                ),
+                onHideMenuItemClick = ListItemInteraction.create {},
+                onCtaClick = ListItemInteraction.create {},
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes #19735

This PR includes composable UI for the dynamic dashboard cards feature only. Unfortunately, there is no way to load images in the preview mode, so I created placeholders for icons and feature images. To test with  We should consider if we are good to have such placeholders or modify them.

<img width="650" alt="Screenshot 2023-12-12 at 3 06 34 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/ed1cb35d-06ca-44f2-a1c6-ebbf6573e99b">

-----

## To Test:

Go to `org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt` file in AndroidStudio and make sure the cards preview look accordingly to the designs: YSMw2nbFAgPpjZLLbYvTfT-fi-1281_3822

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)