### PR TITLE
Updates: the logic of updating the post revisions in a background thread.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/history/HistoryViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
@@ -90,20 +89,20 @@ class HistoryViewModel @Inject constructor(
         }
         isStarted = true
         this.site = site
-        connectionStatus.observe(lifecycleOwner, Observer {
+        connectionStatus.observe(lifecycleOwner) {
             if (it == AVAILABLE) {
                 fetchRevisions()
             }
-        })
+        }
         launch {
             val post: PostModel? = withContext(bgDispatcher) {
                 postStore.getPostByLocalPostId(localPostId)
             }
 
             revisionsList.clear()
-            _revisions.value = emptyList()
+            _revisions.postValue(emptyList())
 
-            this@HistoryViewModel._post.value = post
+            this@HistoryViewModel._post.postValue(post)
 
             fetchRevisions()
 
@@ -120,7 +119,7 @@ class HistoryViewModel @Inject constructor(
         }
 
         revisionAuthorsId = ArrayList(revisionAuthorsId.distinct())
-        _revisions.value = getHistoryListItemsFromRevisionModels(revisions)
+        _revisions.postValue(getHistoryListItemsFromRevisionModels(revisions))
 
         if (revisionAuthorsId.isNotEmpty()) {
             fetchRevisionAuthorDetails(revisionAuthorsId)
@@ -243,10 +242,12 @@ class HistoryViewModel @Inject constructor(
                 _listStatus.value = HistoryListStatus.NO_NETWORK
             }
         } else {
-            _listStatus.value = HistoryListStatus.DONE
-            createRevisionsList(event.revisionsModel.revisions)
-            removeRevisionsFromLocalDB(event.post)
-            saveRevisionsToLocalDB(event.post, event.revisionsModel.revisions)
+           launch(bgDispatcher) {
+               _listStatus.postValue(HistoryListStatus.DONE)
+               createRevisionsList(event.revisionsModel.revisions)
+               removeRevisionsFromLocalDB(event.post)
+               saveRevisionsToLocalDB(event.post, event.revisionsModel.revisions)
+           }
         }
     }
 }


### PR DESCRIPTION
## Fixes 
#18690 

### Description 
This PR wraps the logic of inserting the post revisions in a background thread. 


## To Test:
Note: I couldn't reproduce the crash, but the way I checked was to put a log in the `HistoryViewModel → onRevisionsFetched` method and check the thread.

Testing requires a change in the code

1. Add a log `Log.e("Thread", Thread.currentThread().name)` in `HistoryViewModel → onRevisionsFetched` to check the current thread
2. Login to the jetpack app 
3. Go to the posts → Click on a post 
4. Verify that the current thread is background thread
5. Verify that the post revisions are fetched as expected

## Regression Notes

1. Potential unintended areas of impact
Post is not updated in the app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Manual

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
