### PR TITLE
Fix crash when creating new post with Atomic/SH site 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = 'trunk-01d386ea4c0a9dbda7c06432e555300a97a231f5'
+    wordPressFluxCVersion = '2925-2f53da00e43d368eac9e7223662d0a27cd0342fe'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2925-2f53da00e43d368eac9e7223662d0a27cd0342fe'
+    wordPressFluxCVersion = '2925-4581e6060433b92c4655fb2ac4b305154b87ffe9'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha1'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2925-4581e6060433b92c4655fb2ac4b305154b87ffe9'
+    wordPressFluxCVersion = 'trunk-a7668041a4e3e135b19dc3c52a90bd0c7259f133'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes #19646 

This PR is the WP companion app to FluxC PR  - https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2925
It prevents the NullPointerException when `site.username` is null.

There is a scenario where a self-hosted site, initially added to the app and subsequently connected to a JP standalone plugin, might undergo a transition where the full-JP plugin is deactivated. During this process, the database entry associated with the original username and password undergoes an update, resulting in the removal of credentials. (This happens when the site or site list is refreshed in the app). However, when the site reverts to an unconnected state, the credentials are not reinstated. Consequently, querying the SiteModel at this point returns null for username/password.

Furthermore, a similar situation can arise even if the self-hosted site is not initially added to the app. In such cases, the SiteModel can end up without a username/password entry."

**Merge Instructions**
- Test using the instructions in this PR
- Merge the FluxC PR
- Wait for CI to finish 
- Grab the FluxC hash from CI
- Update `build.gradle` and commit
- Remove the not ready for merge label
- Merge as normal

-----

## To Test:
**There are a combination off App and Web actions for testing**

- Install the JP from this PR
- [App action] - Log into the app using a WP.com account (I used a non-a8c acct)
- Create a JN self-hosted site - with only a single JP plugin (I used social). Wait for the site to be created and launch it in the browser
- [App action] - Add the newly created self hosted to your app via Sites List > More Menu > Add self-hosted site and make it the selected site)
- [Optional] - Use Android Studio:App Inspector to view the SiteModel entry and note there is a username/psw combo for the self-hosted site and origin=2
- [Web action] - Connect social to a WP account by navigating to `plugins > social > settings` (the settings link is underneath the social plugin line)
- [Web action] - Tap "get started"
- [Web action] - When the approve box is shown, tap "signin as a different user" and use the same account that you have used in the earlier step
- [Web action] - Tap approve
- [App action] - Navigation to My Site > sites selector drop down to launch the sites list and pull-to-refresh 
- [Optional] Use Android Studio:App Inspector to view the SiteModel entry and note the username/psw are both null for the self-hosted site and origin=1
- [Web action] - Navigate to `WP admin` for the self-hosted site and disconnect the Jetpack plugin (leave the social plugin activated)
- [App action] - Go back to app > sites list and pull-to-refresh 
- [Optional] Use Android Studio:App Inspector to view the SiteModel entry and note the username/psw are both null for the self-hosted site and origin=1
- [App action] - If the  `please install the full jp plugin` overlay is shown, click cancel "X"
- [App action] - Navigate to My Site > FAB > Blog Post
- ✅ Verify the app does not crash


Note: Since the site does not have the full-JP plugin installed, publishing a post (among other features) will not work. The web has the same issue, however they show a banner at the top of every page that notifying the user "We can't communicate with your site because the Jetpack plugin is deactivated".

-----

## Regression Notes

1. Potential unintended areas of impact
The Unknown nonce is not handled properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran test suites and manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A
-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A
