### PR TITLE
Integrate gutenberg-mobile release v1.109.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.109.2'
+    gutenbergMobileVersion = '6466-367ba28fed66550343fa15124600d00d300bbae7'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.59.0'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6466-367ba28fed66550343fa15124600d00d300bbae7'
+    gutenbergMobileVersion = 'v1.109.3'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.59.0'
     wordPressLoginVersion = '1.10.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.109.3 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6466

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.