### PR TITLE
Fix register domain feature-related copy

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2328,7 +2328,7 @@
     <string name="my_site_create_new_site">Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.</string>
     <string name="my_site_create_new_site_title">You don\'t have any sites</string>
     <string name="my_site_add_new_site">Add new site</string>
-    <string name="my_site_custom_domain_name">All WordPress.com plans include a custom domain name. Register your free premium domain now.</string>
+    <string name="my_site_custom_domain_name">All WordPress.com annual plans include a custom domain name. Register your free domain now.</string>
     <string name="my_site_verify_your_email">Verify your email address - instructions sent to %s</string>
     <string name="my_site_verify_your_email_without_email">Verify your email address - instructions sent to your email</string>
     <string name="my_site_icon_dialog_title">Site Icon</string>
@@ -2660,7 +2660,7 @@
     <string name="register_domain">Register Domain</string>
     <string name="domains_suggestions_select_domain">Select domain</string>
     <string name="domains_suggestions_empty_list">No suggestions found</string>
-    <string name="domains_suggestions_intro_title">Choose a premium domain name</string>
+    <string name="domains_suggestions_intro_title">Choose a custom domain name</string>
     <string name="domains_suggestions_intro_description">This is where people will find you on the internet.</string>
     <string name="domain_suggestions_search_hint">Type a keyword for more ideas</string>
     <string name="domain_suggestions_list_item_cost">%s&lt;span style="color:#50575e;"&gt; /year&lt;/span&gt;</string>


### PR DESCRIPTION
Convo: p1702527756668429-slack-C0JJ0C1UL

This PR replaces "premium" keyword with "custom" for the Register Domain card and screen.

**⚠️ Please, let me know if I should initialize the change for all other translations. I'm not sure if I can edit existing resources in this way.**

-----

## To Test:

**Natural steps:**
The "Register Domain" card appears when the user.
* Has a Free Dotcom site.
* Purchases a Paid Plan.
* The Paid Plan comes with a credit to redeem a custom domain.

**Quick steps:**
* Apply this patch: [quickpatch.patch](https://github.com/wordpress-mobile/WordPress-Android/files/13677560/quickpatch.patch).
* Build the app and select any WP site.

- [ ] Make sure that you can see `Register Domain` card on a dashboard with the following copy: _"All WordPress.com annual plans include a custom domain name. Register your free domain now."_
- [ ] Tap on the card and verify that the `Register Domain` screen's copy has: _"Choose a custom domain name"_ line.


-----

## Regression Notes

1. Potential unintended areas of impact

    - My site dashboard, Register domain screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)