### PR TITLE
Renames dynamic cards list property for consistency

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
@@ -22,12 +22,12 @@ class DynamicCardsBuilder @Inject constructor(
     }
 
     private fun shouldBuildCard(params: DynamicCardsBuilderParams, order: CardOrder): Boolean {
-        if (params.dynamicCards == null || params.dynamicCards.pages.none { it.order == order }) return false
+        if (params.dynamicCards == null || params.dynamicCards.dynamicCards.none { it.order == order }) return false
         return true
     }
 
     private fun convertToDynamicCards(params: DynamicCardsBuilderParams, order: CardOrder): List<Dynamic> {
-        val cards = params.dynamicCards?.pages?.filter { it.order == order } ?: emptyList()
+        val cards = params.dynamicCards?.dynamicCards?.filter { it.order == order } ?: emptyList()
         return cards.map { card ->
             Dynamic(
                 id = card.id,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSourceTest.kt
@@ -145,7 +145,7 @@ private val DYNAMIC_CARD_MODEL = DynamicCardModel(
 )
 
 private val DYNAMIC_CARDS_MODEL = DynamicCardsModel(
-    pages = listOf(DYNAMIC_CARD_MODEL)
+    dynamicCards = listOf(DYNAMIC_CARD_MODEL)
 )
 
 private val ACTIVITY_LOG_MODEL = ActivityLogModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -117,7 +117,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
         )
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                pages = listOf(DYNAMIC_CARD_MODEL)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),
@@ -141,7 +141,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     fun testBuildWithInvalidActionTitle() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                pages = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),
@@ -158,7 +158,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     fun testBuildWithInvalidActionTitleAndUrl() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                pages = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),
@@ -173,7 +173,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     fun testBuildWithInvalidUrl() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                pages = listOf(DYNAMIC_CARD_MODEL_INVALID_URL)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_URL)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),
@@ -188,7 +188,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     fun testBuildWithEmptyPosition() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                pages = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
@@ -39,7 +39,7 @@ private val DYNAMIC_CARD_MODEL = DynamicCardModel(
 )
 
 private val DYNAMIC_CARDS_MODEL = CardModel.DynamicCardsModel(
-    pages = listOf(DYNAMIC_CARD_MODEL)
+    dynamicCards = listOf(DYNAMIC_CARD_MODEL)
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha2'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = 'trunk-a7668041a4e3e135b19dc3c52a90bd0c7259f133'
+    wordPressFluxCVersion = '2928-e0faeacb969813f8f1bc191abcad800ec415b0ba'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha2'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2928-e0faeacb969813f8f1bc191abcad800ec415b0ba'
+    wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/pull/19790#discussion_r1427007253

**Depends: on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2928**

**Based on: https://github.com/wordpress-mobile/WordPress-Android/pull/19790**

**Note:** Before merging:
* Verify that https://github.com/wordpress-mobile/WordPress-Android/pull/19790 is merged
* FluxC PR is merged https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2928 into `trunk`
* The `wordPressFluxCVersion` reference on this PR is updated to point to the latest FluxC `trunk`

-----

## To Test:

* Follow the steps in https://github.com/wordpress-mobile/WordPress-Android/pull/19790 and verify that nothing breaks

-----

## Regression Notes

1. Potential unintended areas of impact

N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)