### PR TITLE
🤖 [Dynamic Cards] Implement card display logic according to the remote feature flags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsSource.kt
@@ -118,7 +118,7 @@ class CardsSource @Inject constructor(
     }
 
     private fun shouldRequestDynamicCards(): Boolean {
-        return dynamicDashboardCardsFeatureConfig.isEnabled() // TODO We should also add check for hidden cards here
+        return dynamicDashboardCardsFeatureConfig.isEnabled()
     }
 
     private fun MediatorLiveData<CardsUpdate>.postErrorState() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
@@ -32,7 +32,7 @@ class DynamicCardsBuilder @Inject constructor(
     }
 
     private fun convertToDynamicCards(params: DynamicCardsBuilderParams, order: CardOrder): List<Dynamic> {
-        val cards = params.dynamicCards?.dynamicCards?.filter { it.order == order && it.isEnabled()} ?: emptyList()
+        val cards = params.dynamicCards?.dynamicCards?.filter { it.order == order && it.isEnabled()}.orEmpty()
         return cards.map { card ->
             Dynamic(
                 id = card.id,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
@@ -51,8 +51,11 @@ class DynamicCardsBuilder @Inject constructor(
     }
 
     fun DynamicCardModel.isEnabled(): Boolean {
-        if (remoteFeatureFlag.isNullOrEmpty()) return true // If there is no feature flag, then the card is enabled
-        return featureFlagConfig.getFeatureState(requireNotNull(remoteFeatureFlag), false).isEnabled
+        // If there is no feature flag or there is no such remote feature flag, then the card is enabled
+        if (remoteFeatureFlag.isNullOrEmpty() ||
+            featureFlagConfig.getString(requireNotNull(remoteFeatureFlag)).isEmpty()
+        ) return true
+        return featureFlagConfig.isEnabled(requireNotNull(remoteFeatureFlag))
     }
 
     private fun getActionSource(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
@@ -27,8 +27,7 @@ class DynamicCardsBuilder @Inject constructor(
     }
 
     private fun shouldBuildCard(params: DynamicCardsBuilderParams, order: CardOrder): Boolean {
-        if (params.dynamicCards == null || params.dynamicCards.dynamicCards.none { it.order == order }) return false
-        return true
+        return !(params.dynamicCards == null || params.dynamicCards.dynamicCards.none { it.order == order })
     }
 
     private fun convertToDynamicCards(params: DynamicCardsBuilderParams, order: CardOrder): List<Dynamic> {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -140,7 +140,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuild() {
+    fun `WHEN the parameters contain an eligible card THEN all the card fields are copied to the card ui`() {
         val expectedCards = listOf(
             MySiteCardAndItem.Card.Dynamic(
                 id = DYNAMIC_CARD_ID,
@@ -184,7 +184,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithInvalidActionTitle() {
+    fun `WHEN the card has invalid action title THEN the card has no action button but is actionable`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE)
@@ -201,7 +201,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithInvalidActionTitleAndUrl() {
+    fun `WHEN the card has invalid action title and url THEN the card is not actionable`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
@@ -216,7 +216,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithInvalidUrl() {
+    fun `WHEN the card has invalid url THEN the card is not actionable`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_URL)
@@ -231,10 +231,10 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithEmptyPosition() {
+    fun `WHEN there are no cards for the requested order position THEN no cards are shown`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
-                dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
+                dynamicCards = listOf(DYNAMIC_CARD_MODEL)
             ),
             onActionClick = mock(),
             onMoreMenuClick = mock(),
@@ -245,7 +245,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithInvalidParams() {
+    fun `WHEN the dynamic cards are null THEN then no dynamic cards are shown`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = null,
             onActionClick = mock(),
@@ -257,7 +257,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithDisabledRemoteFlag() {
+    fun `WHEN the card remote feature flag is disabled THEN the card is not visible`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_DISABLED_REMOTELY)
@@ -271,7 +271,7 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     }
 
     @Test
-    fun testBuildWithEmptyRemoteFlag() {
+    fun `WHEN the card remote feature flag is empty THEN the card is visible`() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = CardModel.DynamicCardsModel(
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_WITH_EMPTY_REMOTE_FLAG)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -13,6 +14,9 @@ import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.config.AppConfig
+import org.wordpress.android.util.config.DynamicDashboardCardsFeatureConfig
+import org.wordpress.android.util.config.FeatureFlagConfig
 import kotlin.test.assertEquals
 
 /* DYNAMIC CARDS */
@@ -87,10 +91,23 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
     @Mock
     private lateinit var deepLinkHandlers: DeepLinkHandlers
 
+    @Mock
+    private lateinit var dynamicDashboardCardsFeatureConfig: DynamicDashboardCardsFeatureConfig
+
+    @Mock
+    private lateinit var featureFlagConfig: FeatureFlagConfig
+
+    @Mock
+    private lateinit var featureState: AppConfig.FeatureState
+
     @Before
     fun setUp() {
-        dynamicCardsBuilder = DynamicCardsBuilder(urlUtils, deepLinkHandlers)
+        dynamicCardsBuilder =
+            DynamicCardsBuilder(urlUtils, deepLinkHandlers, dynamicDashboardCardsFeatureConfig, featureFlagConfig)
         whenever(urlUtils.isValidUrlAndHostNotNull(DYNAMIC_CARD_URL)).thenReturn(true)
+        whenever(dynamicDashboardCardsFeatureConfig.isEnabled()).thenReturn(true)
+        whenever(featureState.isEnabled).thenReturn(true)
+        whenever(featureFlagConfig.getFeatureState(any(), any())).thenReturn(featureState)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -141,11 +141,11 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
-        assertThat(requireNotNull(dynamicCards).size).isEqualTo(1)
+        assertEquals(requireNotNull(dynamicCards).size, 1)
         assertEquals(expectedCards[0].id, dynamicCards[0].id)
         assertEquals(expectedCards[0].title, dynamicCards[0].title)
         assertEquals(expectedCards[0].image, dynamicCards[0].image)
-        assertThat(expectedCards[0].rows.size).isEqualTo(1)
+        assertEquals(expectedCards[0].rows.size, 1)
         assertEquals(expectedCards[0].rows, dynamicCards[0].rows)
         assertThat(dynamicCards[0].action).isInstanceOf(MySiteCardAndItem.Card.Dynamic.ActionSource.Button::class.java)
         val expected = expectedCards[0].action as? MySiteCardAndItem.Card.Dynamic.ActionSource.Button


### PR DESCRIPTION
Fixes #19797

## Description
This PR checks the remote feature flag key of each card returned from the endpoint and:
* If the key exists in the remote feature flags endpoint response, the remote flag value controls the card visibility
* If the key doesn’t exist, it means there are no restrictions, and the card is shown

-----

## To Test:
- Apply the [remotecards.patch](https://github.com/wordpress-mobile/WordPress-Android/files/13703174/remotecards.patch) and run the app.
- **Verify** that the cards with the following titles are visible:
  - `Enabled remote feature flag`
  - `Non existent remote feature flag`
  - `Empty feature flag`
 - **Verify** that the card with title `Disabled by remote feature flag` is not visible


https://github.com/wordpress-mobile/WordPress-Android/assets/304044/a297d83f-c43b-416f-b78b-6f8298792a5a

-----

## Regression Notes

1. Potential unintended areas of impact

    My Site Dashboard screen and a dynamic dashboard card

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing

3. What automated tests I added (or what prevented me from doing so)

    Added new test cases in the `DynamicCardsBuilderTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
