### PR TITLE
[Reader IA] Subscription filter chip group

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
@@ -39,11 +40,12 @@ import androidx.compose.material3.MaterialTheme as Material3Theme
 fun DropdownMenuButton(
     selectedItem: Item,
     onClick: () -> Unit,
+    height: Dp = 36.dp,
     contentSizeAnimation: FiniteAnimationSpec<IntSize> = spring(),
 ) {
     Button(
         onClick = onClick,
-        modifier = Modifier.height(32.dp),
+        modifier = Modifier.height(height),
         elevation = ButtonDefaults.elevation(
             defaultElevation = 0.dp,
             pressedElevation = 0.dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -27,6 +27,8 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData.Item
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.utils.UiString.UiStringText
 import androidx.compose.material3.MaterialTheme as Material3Theme
 
 @Composable
@@ -73,7 +75,7 @@ fun DropdownMenuButton(
                     ),
                 style = Material3Theme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
-                text = selectedItem.text,
+                text = uiStringText(selectedItem.text),
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
             )
@@ -99,14 +101,14 @@ private fun JetpackDropdownMenuButtonPreview() {
             DropdownMenuButton(
                 selectedItem = Item.Single(
                     id = "text-only",
-                    text = "Text only",
+                    text = UiStringText("Text only"),
                 ),
                 onClick = {}
             )
             DropdownMenuButton(
                 selectedItem = Item.Single(
                     id = "text-and-icon",
-                    text = "Text and Icon",
+                    text = UiStringText("Text and Icon"),
                     leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
                 ),
                 onClick = {},
@@ -114,14 +116,14 @@ private fun JetpackDropdownMenuButtonPreview() {
             DropdownMenuButton(
                 selectedItem = Item.Single(
                     id = "text-with-a-really-long-text-as-the-button-label",
-                    text = "Text type with a really long text as the button label",
+                    text = UiStringText("Text type with a really long text as the button label"),
                 ),
                 onClick = {},
             )
             DropdownMenuButton(
                 selectedItem = Item.Single(
                     id = "text-with-a-really-long-text-as-the-button-label-and-icon",
-                    text = "Text type with a really long text as the button label",
+                    text = UiStringText("Text type with a really long text as the button label"),
                     leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
                 ),
                 onClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -69,10 +70,7 @@ fun DropdownMenuButton(
             Text(
                 modifier = Modifier
                     .align(Alignment.CenterVertically)
-                    .weight(
-                        weight = 1f,
-                        fill = false,
-                    ),
+                    .widthIn(max = 280.dp),
                 style = Material3Theme.typography.titleMedium,
                 fontWeight = FontWeight.Medium,
                 text = uiStringText(selectedItem.text),

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.compose.components.menu.dropdown
 
 import android.content.res.Configuration
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -23,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData.Item
@@ -36,6 +39,7 @@ import androidx.compose.material3.MaterialTheme as Material3Theme
 fun DropdownMenuButton(
     selectedItem: Item,
     onClick: () -> Unit,
+    contentSizeAnimation: FiniteAnimationSpec<IntSize> = spring(),
 ) {
     Button(
         onClick = onClick,
@@ -57,7 +61,7 @@ fun DropdownMenuButton(
         )
     ) {
         Row(
-            modifier = Modifier.animateContentSize(),
+            modifier = Modifier.animateContentSize(contentSizeAnimation),
         ) {
             if (selectedItem is Item.Single && selectedItem.leadingIcon != NO_ICON) {
                 Icon(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -98,30 +98,30 @@ private fun JetpackDropdownMenuButtonPreview() {
         ) {
             DropdownMenuButton(
                 selectedItem = Item.Single(
+                    id = "text-only",
                     text = "Text only",
-                    onClick = {},
                 ),
                 onClick = {}
             )
             DropdownMenuButton(
                 selectedItem = Item.Single(
+                    id = "text-and-icon",
                     text = "Text and Icon",
-                    onClick = {},
                     leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
                 ),
                 onClick = {},
             )
             DropdownMenuButton(
                 selectedItem = Item.Single(
+                    id = "text-with-a-really-long-text-as-the-button-label",
                     text = "Text type with a really long text as the button label",
-                    onClick = {},
                 ),
                 onClick = {},
             )
             DropdownMenuButton(
                 selectedItem = Item.Single(
+                    id = "text-with-a-really-long-text-as-the-button-label-and-icon",
                     text = "Text type with a really long text as the button label",
-                    onClick = {},
                     leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
                 ),
                 onClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -1,6 +1,8 @@
 package org.wordpress.android.ui.compose.components.menu.dropdown
 
 import android.content.res.Configuration
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -33,6 +35,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import me.saket.cascade.CascadeColumnScope
 import me.saket.cascade.CascadeDropdownMenu
@@ -46,10 +49,12 @@ fun JetpackDropdownMenu(
     menuItems: List<MenuElementData>,
     selectedItem: MenuElementData.Item.Single,
     onSingleItemClick: (MenuElementData.Item.Single) -> Unit,
+    contentSizeAnimation: FiniteAnimationSpec<IntSize> = spring(),
 ) {
     Column {
         var isMenuVisible by remember { mutableStateOf(false) }
         DropdownMenuButton(
+            contentSizeAnimation = contentSizeAnimation,
             selectedItem = selectedItem,
             onClick = {
                 isMenuVisible = !isMenuVisible

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -38,6 +38,8 @@ import me.saket.cascade.CascadeColumnScope
 import me.saket.cascade.CascadeDropdownMenu
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.utils.UiString.UiStringText
 
 @Composable
 fun JetpackDropdownMenu(
@@ -111,7 +113,7 @@ private fun Single(
         ),
         text = {
             Text(
-                text = element.text,
+                text = uiStringText(element.text),
                 style = MaterialTheme.typography.bodyLarge,
                 overflow = TextOverflow.Ellipsis,
                 fontWeight = FontWeight.Normal,
@@ -184,7 +186,7 @@ private fun CascadeColumnScope.SubMenu(
         ),
         text = {
             Text(
-                text = element.text,
+                text = uiStringText(element.text),
                 style = MaterialTheme.typography.bodyLarge,
                 overflow = TextOverflow.Ellipsis,
                 fontWeight = FontWeight.Normal,
@@ -209,25 +211,25 @@ fun JetpackDropdownMenuPreview() {
     val menuItems = listOf(
         MenuElementData.Item.Single(
             id = "text-only",
-            text = "Text only",
+            text = UiStringText("Text only"),
         ),
         MenuElementData.Item.Single(
             id = "text-and-icon",
-            text = "Text and leading icon",
+            text = UiStringText("Text and leading icon"),
             leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
         ),
         MenuElementData.Divider,
         MenuElementData.Item.SubMenu(
             id = "text-and-sub-menu",
-            text = "Text and sub-menu",
+            text = UiStringText("Text and sub-menu"),
             children = listOf(
                 MenuElementData.Item.Single(
                     id = "text-sub-menu-1",
-                    text = "Text sub-menu 1",
+                    text = UiStringText("Text sub-menu 1"),
                 ),
                 MenuElementData.Item.Single(
                     id = "text-sub-menu-2",
-                    text = "Text sub-menu 2",
+                    text = UiStringText("Text sub-menu 2"),
                 )
             )
         ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import me.saket.cascade.CascadeColumnScope
@@ -49,11 +50,13 @@ fun JetpackDropdownMenu(
     menuItems: List<MenuElementData>,
     selectedItem: MenuElementData.Item.Single,
     onSingleItemClick: (MenuElementData.Item.Single) -> Unit,
+    menuButtonHeight: Dp = 36.dp,
     contentSizeAnimation: FiniteAnimationSpec<IntSize> = spring(),
 ) {
     Column {
         var isMenuVisible by remember { mutableStateOf(false) }
         DropdownMenuButton(
+            height = menuButtonHeight,
             contentSizeAnimation = contentSizeAnimation,
             selectedItem = selectedItem,
             onClick = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -42,13 +42,11 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 @Composable
 fun JetpackDropdownMenu(
     menuItems: List<MenuElementData>,
-    defaultItem: MenuElementData.Item.Single = menuItems.first() as MenuElementData.Item.Single,
+    selectedItem: MenuElementData.Item.Single,
+    onSingleItemClick: (MenuElementData.Item.Single) -> Unit,
 ) {
     Column {
         var isMenuVisible by remember { mutableStateOf(false) }
-        // TODO selected item logic will be moved to VM in another PR. This will make sure the selected item stays the
-        // same on orientation change.
-        var selectedItem by remember { mutableStateOf(defaultItem) }
         DropdownMenuButton(
             selectedItem = selectedItem,
             onClick = {
@@ -61,8 +59,8 @@ fun JetpackDropdownMenu(
             onDismissRequest = { isMenuVisible = false },
         ) {
             val onMenuItemSingleClick: (MenuElementData.Item.Single) -> Unit = { clickedItem ->
-                selectedItem = clickedItem
                 isMenuVisible = false
+                onSingleItemClick(clickedItem)
             }
             menuItems.forEach { element ->
                 MenuElementComposable(element = element, onMenuItemSingleClick = onMenuItemSingleClick)
@@ -102,7 +100,6 @@ private fun Single(
             .background(MenuColors.itemBackgroundColor()),
         onClick = {
             onMenuItemSingleClick(element)
-            element.onClick()
         },
         colors = MenuDefaults.itemColors(
             textColor = enabledContentColor,
@@ -209,6 +206,34 @@ private fun CascadeColumnScope.SubMenu(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun JetpackDropdownMenuPreview() {
+    val menuItems = listOf(
+        MenuElementData.Item.Single(
+            id = "text-only",
+            text = "Text only",
+        ),
+        MenuElementData.Item.Single(
+            id = "text-and-icon",
+            text = "Text and leading icon",
+            leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
+        ),
+        MenuElementData.Divider,
+        MenuElementData.Item.SubMenu(
+            id = "text-and-sub-menu",
+            text = "Text and sub-menu",
+            children = listOf(
+                MenuElementData.Item.Single(
+                    id = "text-sub-menu-1",
+                    text = "Text sub-menu 1",
+                ),
+                MenuElementData.Item.Single(
+                    id = "text-sub-menu-2",
+                    text = "Text sub-menu 2",
+                )
+            )
+        ),
+    )
+    var selectedItem by remember { mutableStateOf(menuItems.first() as MenuElementData.Item.Single) }
+
     AppTheme {
         Box(
             modifier = Modifier
@@ -216,34 +241,10 @@ fun JetpackDropdownMenuPreview() {
                 .fillMaxWidth()
                 .fillMaxHeight()
         ) {
-            val menuItems = listOf(
-                MenuElementData.Item.Single(
-                    text = "Text only",
-                    onClick = {}
-                ),
-                MenuElementData.Item.Single(
-                    text = "Text and leading icon",
-                    onClick = {},
-                    leadingIcon = R.drawable.ic_jetpack_logo_white_24dp,
-                ),
-                MenuElementData.Divider,
-                MenuElementData.Item.SubMenu(
-                    text = "Text and sub-menu",
-                    children = listOf(
-                        MenuElementData.Item.Single(
-                            text = "Text sub-menu 1",
-                            onClick = {}
-                        ),
-                        MenuElementData.Item.Single(
-                            text = "Text sub-menu 2",
-                            onClick = {}
-                        )
-                    )
-                ),
-            )
             JetpackDropdownMenu(
-                defaultItem = menuItems.first() as MenuElementData.Item.Single,
-                menuItems = menuItems
+                selectedItem = selectedItem,
+                menuItems = menuItems,
+                onSingleItemClick = { selectedItem = it }
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/MenuElementData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/MenuElementData.kt
@@ -6,22 +6,24 @@ sealed interface MenuElementData {
     data object Divider : MenuElementData
 
     sealed class Item(
+        open val id: String,
         open val text: String,
         @DrawableRes open val leadingIcon: Int,
     ) : MenuElementData {
         // Item element that closes the menu when clicked
         data class Single(
+            override val id: String,
             override val text: String,
-            val onClick: () -> Unit,
             @DrawableRes override val leadingIcon: Int = NO_ICON,
-        ) : Item(text, leadingIcon)
+        ) : Item(id, text, leadingIcon)
 
         // Sub-menu element that opens a sub-menu when clicked
         data class SubMenu(
+            override val id: String,
             override val text: String,
             val children: List<MenuElementData>,
             @DrawableRes override val leadingIcon: Int = NO_ICON,
-        ) : Item(text, leadingIcon)
+        ) : Item(id, text, leadingIcon)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/MenuElementData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/MenuElementData.kt
@@ -1,26 +1,27 @@
 package org.wordpress.android.ui.compose.components.menu.dropdown
 
 import androidx.annotation.DrawableRes
+import org.wordpress.android.ui.utils.UiString
 
 sealed interface MenuElementData {
     data object Divider : MenuElementData
 
     sealed class Item(
         open val id: String,
-        open val text: String,
+        open val text: UiString,
         @DrawableRes open val leadingIcon: Int,
     ) : MenuElementData {
         // Item element that closes the menu when clicked
         data class Single(
             override val id: String,
-            override val text: String,
+            override val text: UiString,
             @DrawableRes override val leadingIcon: Int = NO_ICON,
         ) : Item(id, text, leadingIcon)
 
         // Sub-menu element that opens a sub-menu when clicked
         data class SubMenu(
             override val id: String,
-            override val text: String,
+            override val text: UiString,
             val children: List<MenuElementData>,
             @DrawableRes override val leadingIcon: Int = NO_ICON,
         ) : Item(id, text, leadingIcon)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/FadingEdgesModifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/FadingEdgesModifier.kt
@@ -25,16 +25,18 @@ import kotlin.math.min
  * Adds vertical fading edges to a scrollable container, usually a [Column].
  * It needs to be used right after the scrollable modifier [verticalScroll].
  *
- * The [edgeSize] defines the maximum size of the fading edge effect, which is used when that same amount of the
+ * The [topEdgeSize] defines the maximum size of the fading edge effect, which is used when that same amount of the
  * content is outside the scrollable area.
  *
  * @param scrollState the scroll state of the scrollable container (same used in [Modifier.verticalScroll])
- * @param edgeSize the size of the fading edge
+ * @param topEdgeSize the size of the fading edge on the top
+ * @param bottomEdgeSize the size of the fading edge on the bottom
  */
 @Suppress("MagicNumber", "Unused")
 fun Modifier.verticalFadingEdges(
     scrollState: ScrollState,
-    edgeSize: Dp = 72.dp,
+    topEdgeSize: Dp = 72.dp,
+    bottomEdgeSize: Dp = 72.dp,
 ): Modifier = this
     // adding layer fixes issue with blending gradient and content
     .graphicsLayer { alpha = 0.999F }
@@ -46,21 +48,23 @@ fun Modifier.verticalFadingEdges(
         val scrollAreaBottomY = scrollAreaTopY + scrollAreaHeight
 
         // gradient size is equivalent to how much content is outside of the area in each side limited by edgeSize
-        val topGradientHeight = min(edgeSize.toPx(), scrollState.value.toFloat())
-        val bottomGradientHeight = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+        val topGradientHeight = min(topEdgeSize.toPx(), scrollState.value.toFloat())
+        val bottomGradientHeight = min(bottomEdgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
 
         // wherever the rectangle is drawn (green), the content will be transparent, creating the fading effect
         val topColors = listOf(Color.Green, Color.Transparent)
         val bottomColors = listOf(Color.Transparent, Color.Green)
 
-        drawRect(
-            brush = Brush.verticalGradient(
-                colors = topColors,
-                startY = scrollAreaTopY,
-                endY = scrollAreaTopY + topGradientHeight
-            ),
-            blendMode = BlendMode.DstOut
-        )
+        if (topGradientHeight != 0f) {
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colors = topColors,
+                    startY = scrollAreaTopY,
+                    endY = scrollAreaTopY + topGradientHeight
+                ),
+                blendMode = BlendMode.DstOut
+            )
+        }
 
         if (bottomGradientHeight != 0f) {
             drawRect(
@@ -82,12 +86,14 @@ fun Modifier.verticalFadingEdges(
  * content is outside the scrollable area.
  *
  * @param scrollState the scroll state of the scrollable container (same used in [Modifier.horizontalScroll])
- * @param edgeSize the size of the fading edge
+ * @param startEdgeSize the size of the fading edge on the start
+ * @param endEdgeSize the size of the fading edge on the end
  */
 @Suppress("MagicNumber", "Unused")
 fun Modifier.horizontalFadingEdges(
     scrollState: ScrollState,
-    edgeSize: Dp = 24.dp,
+    startEdgeSize: Dp = 24.dp,
+    endEdgeSize: Dp = 24.dp,
 ): Modifier = this
     // adding layer fixes issue with blending gradient and content
     .graphicsLayer { alpha = 0.99F }
@@ -106,13 +112,13 @@ fun Modifier.horizontalFadingEdges(
             if (!isRtl) {
                 scrollAreaLeftX = scrollState.value.toFloat()
                 scrollAreaRightX = scrollAreaLeftX + scrollAreaWidth
-                leftGradientWidth = min(edgeSize.toPx(), scrollState.value.toFloat())
-                rightGradientWidth = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+                leftGradientWidth = min(startEdgeSize.toPx(), scrollState.value.toFloat())
+                rightGradientWidth = min(endEdgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
             } else {
                 scrollAreaRightX = size.width - scrollState.value.toFloat()
                 scrollAreaLeftX = scrollAreaRightX - scrollAreaWidth
-                leftGradientWidth = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
-                rightGradientWidth = min(edgeSize.toPx(), scrollState.value.toFloat())
+                leftGradientWidth = min(endEdgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+                rightGradientWidth = min(startEdgeSize.toPx(), scrollState.value.toFloat())
             }
 
             val leftColors = listOf(Color.Green, Color.Transparent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/FadingEdgesModifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/utils/FadingEdgesModifier.kt
@@ -1,0 +1,143 @@
+package org.wordpress.android.ui.compose.utils
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.min
+
+// Fading edges for scrollable containers based on
+// https://medium.com/@helmersebastian/fading-edges-modifier-in-jetpack-compose-af94159fdf1f
+
+/**
+ * Adds vertical fading edges to a scrollable container, usually a [Column].
+ * It needs to be used right after the scrollable modifier [verticalScroll].
+ *
+ * The [edgeSize] defines the maximum size of the fading edge effect, which is used when that same amount of the
+ * content is outside the scrollable area.
+ *
+ * @param scrollState the scroll state of the scrollable container (same used in [Modifier.verticalScroll])
+ * @param edgeSize the size of the fading edge
+ */
+@Suppress("MagicNumber", "Unused")
+fun Modifier.verticalFadingEdges(
+    scrollState: ScrollState,
+    edgeSize: Dp = 72.dp,
+): Modifier = this
+    // adding layer fixes issue with blending gradient and content
+    .graphicsLayer { alpha = 0.999F }
+    .drawWithContent {
+        drawContent()
+
+        val scrollAreaHeight = size.height - scrollState.maxValue
+        val scrollAreaTopY = scrollState.value.toFloat()
+        val scrollAreaBottomY = scrollAreaTopY + scrollAreaHeight
+
+        // gradient size is equivalent to how much content is outside of the area in each side limited by edgeSize
+        val topGradientHeight = min(edgeSize.toPx(), scrollState.value.toFloat())
+        val bottomGradientHeight = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+
+        // wherever the rectangle is drawn (green), the content will be transparent, creating the fading effect
+        val topColors = listOf(Color.Green, Color.Transparent)
+        val bottomColors = listOf(Color.Transparent, Color.Green)
+
+        drawRect(
+            brush = Brush.verticalGradient(
+                colors = topColors,
+                startY = scrollAreaTopY,
+                endY = scrollAreaTopY + topGradientHeight
+            ),
+            blendMode = BlendMode.DstOut
+        )
+
+        if (bottomGradientHeight != 0f) {
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colors = bottomColors,
+                    startY = scrollAreaBottomY - bottomGradientHeight,
+                    endY = scrollAreaBottomY
+                ),
+                blendMode = BlendMode.DstOut
+            )
+        }
+    }
+
+/**
+ * Adds horizontal fading edges to a scrollable container, usually a [Row].
+ * It needs to be used right after the scrollable modifier [horizontalScroll].
+ *
+ * The [edgeSize] defines the maximum size of the fading edge effect, which is used when that same amount of the
+ * content is outside the scrollable area.
+ *
+ * @param scrollState the scroll state of the scrollable container (same used in [Modifier.horizontalScroll])
+ * @param edgeSize the size of the fading edge
+ */
+@Suppress("MagicNumber", "Unused")
+fun Modifier.horizontalFadingEdges(
+    scrollState: ScrollState,
+    edgeSize: Dp = 24.dp,
+): Modifier = this
+    // adding layer fixes issue with blending gradient and content
+    .graphicsLayer { alpha = 0.99F }
+    .composed {
+        val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+
+        drawWithContent {
+            drawContent()
+
+            val scrollAreaWidth = size.width - scrollState.maxValue
+            val scrollAreaLeftX: Float
+            val scrollAreaRightX: Float
+            val leftGradientWidth: Float
+            val rightGradientWidth: Float
+
+            if (!isRtl) {
+                scrollAreaLeftX = scrollState.value.toFloat()
+                scrollAreaRightX = scrollAreaLeftX + scrollAreaWidth
+                leftGradientWidth = min(edgeSize.toPx(), scrollState.value.toFloat())
+                rightGradientWidth = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+            } else {
+                scrollAreaRightX = size.width - scrollState.value.toFloat()
+                scrollAreaLeftX = scrollAreaRightX - scrollAreaWidth
+                leftGradientWidth = min(edgeSize.toPx(), scrollState.maxValue.toFloat() - scrollState.value)
+                rightGradientWidth = min(edgeSize.toPx(), scrollState.value.toFloat())
+            }
+
+            val leftColors = listOf(Color.Green, Color.Transparent)
+            val rightColors = listOf(Color.Transparent, Color.Green)
+
+            if (leftGradientWidth != 0f) {
+                drawRect(
+                    brush = Brush.horizontalGradient(
+                        colors = leftColors,
+                        startX = scrollAreaLeftX,
+                        endX = scrollAreaLeftX + leftGradientWidth
+                    ),
+                    blendMode = BlendMode.DstOut,
+                )
+            }
+
+            if (rightGradientWidth != 0f) {
+                drawRect(
+                    brush = Brush.horizontalGradient(
+                        colors = rightColors,
+                        startX = scrollAreaRightX - rightGradientWidth,
+                        endX = scrollAreaRightX
+                    ),
+                    blendMode = BlendMode.DstOut,
+                )
+            }
+        }
+    }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderFilterChipGroup.kt
@@ -1,0 +1,186 @@
+package org.wordpress.android.ui.reader.views.compose
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.utils.uiStringText
+import org.wordpress.android.ui.utils.UiString
+import androidx.compose.material3.MaterialTheme as Material3Theme
+
+@Composable
+fun ReaderFilterChipGroup(
+    modifier: Modifier = Modifier,
+    filterCategories: List<ReaderFilterChipType.FilterCategory>,
+    selectedFilterChoice: ReaderFilterChipType.SelectedFilterChoice? = null,
+) {
+    var currentSelectedFilterChoice by remember { mutableStateOf(selectedFilterChoice) }
+    val showSelectedFilter = selectedFilterChoice != null
+
+    if (selectedFilterChoice != null) {
+        currentSelectedFilterChoice = selectedFilterChoice
+    }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        filterCategories.forEach { filterCategory ->
+            AnimatedVisibility(visible = !showSelectedFilter) {
+                ReaderFilterChip(
+                    text = filterCategory.text,
+                    onClick = filterCategory.onClick,
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = showSelectedFilter) {
+            currentSelectedFilterChoice?.let { selectedFilterChoice ->
+                ReaderFilterChip(
+                    text = selectedFilterChoice.text,
+                    onClick = selectedFilterChoice.onClick,
+                    onDismissClick = selectedFilterChoice.onDismissClick,
+                    invertColors = true,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ReaderFilterChip(
+    text: UiString,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    invertColors: Boolean = false,
+    onDismissClick: (() -> Unit)? = null,
+) {
+    val padding = PaddingValues(
+        top = 8.dp,
+        bottom = 8.dp,
+        start = 24.dp,
+        end = if (onDismissClick != null) 12.dp else 24.dp,
+    )
+
+    CompositionLocalProvider(
+        LocalContentColor provides if (invertColors) {
+            MaterialTheme.colors.surface
+        } else {
+            MaterialTheme.colors.onSurface
+        },
+    ) {
+        Box(
+            modifier = modifier
+                .background(
+                    color = if (invertColors) {
+                        MaterialTheme.colors.onSurface
+                    } else {
+                        MaterialTheme.colors.onSurface.copy(alpha = 0.1f)
+                    },
+                    shape = RoundedCornerShape(50),
+                )
+                .clip(RoundedCornerShape(50))
+                .clickable(onClick = onClick),
+        ) {
+            Row(
+                modifier = Modifier.padding(padding),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    uiStringText(text),
+                    style = Material3Theme.typography.titleSmall,
+                )
+
+                if (onDismissClick != null) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = null, // TODO thomashorta clear or dismiss?
+                        modifier = Modifier
+                            .size(24.dp)
+                            .padding(4.dp)
+                            .clickable(onClick = onDismissClick),
+                    )
+                }
+            }
+        }
+    }
+}
+
+sealed class ReaderFilterChipType(
+    open val text: UiString,
+    open val onClick: () -> Unit,
+) {
+    data class FilterCategory(
+        override val text: UiString,
+        override val onClick: () -> Unit,
+    ) : ReaderFilterChipType(text, onClick)
+
+    data class SelectedFilterChoice(
+        override val text: UiString,
+        override val onClick: () -> Unit,
+        val onDismissClick: () -> Unit,
+    ) : ReaderFilterChipType(text, onClick)
+}
+
+@Preview(name = "Light Mode", showBackground = true)
+@Preview(name = "Dark Mode", showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun ReaderFilterChipGroupPreview() {
+    var selectedTag: ReaderFilterChipType.SelectedFilterChoice? by remember { mutableStateOf(null) }
+    val clearSelection = { selectedTag = null }
+
+    AppThemeWithoutBackground {
+        ReaderFilterChipGroup(
+            modifier = Modifier.padding(8.dp),
+            filterCategories = listOf(
+                ReaderFilterChipType.FilterCategory(
+                    text = UiString.UiStringText("23 Blogs"),
+                    onClick = {
+                        selectedTag = ReaderFilterChipType.SelectedFilterChoice(
+                            text = UiString.UiStringText("Amazing Blog"),
+                            onClick = clearSelection,
+                            onDismissClick = clearSelection,
+                        )
+                    },
+                ),
+                ReaderFilterChipType.FilterCategory(
+                    text = UiString.UiStringText("41 Tags"),
+                    onClick = {
+                        selectedTag = ReaderFilterChipType.SelectedFilterChoice(
+                            text = UiString.UiStringText("Amazing Tag"),
+                            onClick = clearSelection,
+                            onDismissClick = clearSelection,
+                        )
+                    },
+                ),
+            ),
+            selectedFilterChoice = selectedTag,
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -28,6 +28,8 @@ import org.wordpress.android.ui.compose.components.menu.dropdown.JetpackDropdown
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.utils.UiString.UiStringRes
+import org.wordpress.android.ui.utils.UiString.UiStringText
 
 @Composable
 fun ReaderTopAppBar(
@@ -37,22 +39,22 @@ fun ReaderTopAppBar(
     val menuItems = mutableListOf<MenuElementData>(
         MenuElementData.Item.Single(
             id = "discover",
-            text = stringResource(id = R.string.reader_dropdown_menu_discover),
+            text = UiStringRes(R.string.reader_dropdown_menu_discover),
             leadingIcon = R.drawable.ic_reader_discover_24dp,
         ),
         MenuElementData.Item.Single(
             id = "subscriptions",
-            text = stringResource(id = R.string.reader_dropdown_menu_subscriptions),
+            text = UiStringRes(R.string.reader_dropdown_menu_subscriptions),
             leadingIcon = R.drawable.ic_reader_subscriptions_24dp,
         ),
         MenuElementData.Item.Single(
             id = "notifications",
-            text = stringResource(id = R.string.reader_dropdown_menu_saved),
+            text = UiStringRes(R.string.reader_dropdown_menu_saved),
             leadingIcon = R.drawable.ic_reader_saved_24dp,
         ),
         MenuElementData.Item.Single(
             id = "notifications",
-            text = stringResource(id = R.string.reader_dropdown_menu_liked),
+            text = UiStringRes(R.string.reader_dropdown_menu_liked),
             leadingIcon = R.drawable.ic_reader_liked_24dp,
         ),
     ).apply {
@@ -60,7 +62,7 @@ fun ReaderTopAppBar(
             add(MenuElementData.Divider)
             MenuElementData.Item.SubMenu(
                 id = "lists",
-                text = stringResource(id = R.string.reader_dropdown_menu_lists),
+                text = UiStringRes(R.string.reader_dropdown_menu_lists),
                 children = readerLists,
             )
         }
@@ -120,11 +122,11 @@ fun ReaderScreenPreview() {
                 readerLists = listOf(
                     MenuElementData.Item.Single(
                         id = "funny-blog-1",
-                        text = "Funny Blog 1",
+                        text = UiStringText("Funny Blog 1"),
                     ),
                     MenuElementData.Item.Single(
                         id = "funny-blog-2",
-                        text = "Funny Blog 2",
+                        text = UiStringText("Funny Blog 2"),
                     ),
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -1,74 +1,77 @@
 package org.wordpress.android.ui.reader.views.compose
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.menu.dropdown.JetpackDropdownMenu
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.ui.utils.UiString.UiStringText
+import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
+import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChipGroup
+import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterType
+import org.wordpress.android.ui.utils.UiString
+
+private const val ANIM_DURATION = 200
 
 @Composable
 fun ReaderTopAppBar(
+    topBarUiState: ReaderViewModel.TopBarUiState,
+    onMenuItemClick: (MenuElementData.Item.Single) -> Unit,
+    onFilterClick: (ReaderFilterType) -> Unit,
+    onClearFilterClick: () -> Unit,
     onSearchClick: () -> Unit,
-    readerLists: List<MenuElementData.Item> = emptyList(),
 ) {
-    val menuItems = mutableListOf<MenuElementData>(
-        MenuElementData.Item.Single(
-            id = "discover",
-            text = UiStringRes(R.string.reader_dropdown_menu_discover),
-            leadingIcon = R.drawable.ic_reader_discover_24dp,
-        ),
-        MenuElementData.Item.Single(
-            id = "subscriptions",
-            text = UiStringRes(R.string.reader_dropdown_menu_subscriptions),
-            leadingIcon = R.drawable.ic_reader_subscriptions_24dp,
-        ),
-        MenuElementData.Item.Single(
-            id = "notifications",
-            text = UiStringRes(R.string.reader_dropdown_menu_saved),
-            leadingIcon = R.drawable.ic_reader_saved_24dp,
-        ),
-        MenuElementData.Item.Single(
-            id = "notifications",
-            text = UiStringRes(R.string.reader_dropdown_menu_liked),
-            leadingIcon = R.drawable.ic_reader_liked_24dp,
-        ),
-    ).apply {
-        if (readerLists.isNotEmpty()) {
-            add(MenuElementData.Divider)
-            MenuElementData.Item.SubMenu(
-                id = "lists",
-                text = UiStringRes(R.string.reader_dropdown_menu_lists),
-                children = readerLists,
-            )
+    var selectedItem by remember { mutableStateOf(topBarUiState.selectedItem) }
+    var isFilterShown by remember { mutableStateOf(topBarUiState.filterUiState != null) }
+    var latestFilterState by remember { mutableStateOf(topBarUiState.filterUiState) }
+
+    // Coordinate filter enter and exit animations with the dropdown menu (delays are required for a nice experience)
+    val shouldShowFilter = topBarUiState.filterUiState != null
+    LaunchedEffect(shouldShowFilter, topBarUiState.selectedItem) {
+        if (isFilterShown != shouldShowFilter) {
+            isFilterShown = shouldShowFilter
+            if (!shouldShowFilter) delay(ANIM_DURATION.toLong())
         }
+        selectedItem = topBarUiState.selectedItem
     }
-    var selectedItem by remember {
-        mutableStateOf(menuItems.filterIsInstance<MenuElementData.Item.Single>().first())
+
+    // Update filter state when it changes to non-null value. We need to keep it non-null so that the exit animation
+    // works properly.
+    if (topBarUiState.filterUiState != null) {
+        latestFilterState = topBarUiState.filterUiState
     }
 
     Row(
@@ -79,17 +82,43 @@ fun ReaderTopAppBar(
                 start = Margin.ExtraLarge.value,
             )
     ) {
-        Row(
+        Box(
             modifier = Modifier
                 .fillMaxHeight()
-                .weight(1f),
-            verticalAlignment = Alignment.CenterVertically,
+                .weight(1f)
         ) {
-            JetpackDropdownMenu(
-                selectedItem = selectedItem,
-                menuItems = menuItems,
-                onSingleItemClick = { selectedItem = it },
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .horizontalScroll(rememberScrollState()),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                JetpackDropdownMenu(
+                    selectedItem = selectedItem,
+                    menuItems = topBarUiState.menuItems,
+                    onSingleItemClick = onMenuItemClick,
+                    contentSizeAnimation = tween(ANIM_DURATION),
+                )
+
+                AnimatedVisibility(
+                    visible = isFilterShown,
+                    enter = fadeIn(tween(delayMillis = ANIM_DURATION)) +
+                            slideInVertically(tween(delayMillis = ANIM_DURATION)) { it / 2 },
+                    exit = fadeOut(tween(ANIM_DURATION)) +
+                            slideOutVertically(tween(ANIM_DURATION)) { it / 2 },
+                ) {
+                    latestFilterState?.let { filterUiState ->
+                        Filter(
+                            filterUiState = filterUiState,
+                            onFilterClick = onFilterClick,
+                            onClearFilterClick = onClearFilterClick,
+                            modifier = Modifier
+                                // use padding instead of Spacer for nicer animation
+                                .padding(start = Margin.Medium.value),
+                        )
+                    }
+                }
+            }
         }
         Spacer(Modifier.width(Margin.ExtraLarge.value))
         IconButton(
@@ -107,10 +136,60 @@ fun ReaderTopAppBar(
     }
 }
 
+@Composable
+private fun Filter(
+    filterUiState: ReaderViewModel.TopBarUiState.FilterUiState,
+    onFilterClick: (ReaderFilterType) -> Unit,
+    onClearFilterClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ReaderFilterChipGroup(
+        modifier = modifier,
+        selectedItem = filterUiState.selectedItem,
+        followedBlogsCount = filterUiState.followedBlogsCount,
+        followedTagsCount = filterUiState.followedTagsCount,
+        onFilterClick = onFilterClick,
+        onSelectedItemClick = onClearFilterClick,
+        onSelectedItemDismissClick = onClearFilterClick,
+    )
+}
+
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderScreenPreview() {
+    val menuItems = mutableListOf<MenuElementData>(
+        MenuElementData.Item.Single(
+            id = "discover",
+            text = UiString.UiStringRes(R.string.reader_dropdown_menu_discover),
+            leadingIcon = R.drawable.ic_reader_discover_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "subscriptions",
+            text = UiString.UiStringRes(R.string.reader_dropdown_menu_subscriptions),
+            leadingIcon = R.drawable.ic_reader_subscriptions_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "saved",
+            text = UiString.UiStringRes(R.string.reader_dropdown_menu_saved),
+            leadingIcon = R.drawable.ic_reader_saved_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "liked",
+            text = UiString.UiStringRes(R.string.reader_dropdown_menu_liked),
+            leadingIcon = R.drawable.ic_reader_liked_24dp,
+        ),
+    )
+
+    var topBarUiState by remember {
+        mutableStateOf(
+            ReaderViewModel.TopBarUiState(
+                menuItems = menuItems,
+                selectedItem = menuItems.first() as MenuElementData.Item.Single,
+            )
+        )
+    }
+
     AppTheme {
         Box(
             modifier = Modifier
@@ -118,17 +197,15 @@ fun ReaderScreenPreview() {
                 .fillMaxHeight()
         ) {
             ReaderTopAppBar(
-                {},
-                readerLists = listOf(
-                    MenuElementData.Item.Single(
-                        id = "funny-blog-1",
-                        text = UiStringText("Funny Blog 1"),
-                    ),
-                    MenuElementData.Item.Single(
-                        id = "funny-blog-2",
-                        text = UiStringText("Funny Blog 2"),
-                    ),
-                )
+                topBarUiState = topBarUiState,
+                onMenuItemClick = {
+                    topBarUiState = topBarUiState.copy(
+                        selectedItem = it
+                    )
+                },
+                onFilterClick = {},
+                onClearFilterClick = {},
+                onSearchClick = {},
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterType
 import org.wordpress.android.ui.utils.UiString
 
 private const val ANIM_DURATION = 200
+private val chipHeight = 36.dp
 
 @Composable
 fun ReaderTopAppBar(
@@ -78,10 +79,7 @@ fun ReaderTopAppBar(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
-            .padding(
-                start = Margin.ExtraLarge.value,
-            )
+            .height(52.dp)
     ) {
         Box(
             modifier = Modifier
@@ -93,13 +91,15 @@ fun ReaderTopAppBar(
                 modifier = Modifier
                     .fillMaxSize()
                     .horizontalScroll(scrollState)
-                    .horizontalFadingEdges(scrollState),
+                    .horizontalFadingEdges(scrollState, startEdgeSize = 0.dp)
+                    .padding(start = Margin.ExtraLarge.value),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 JetpackDropdownMenu(
                     selectedItem = selectedItem,
                     menuItems = topBarUiState.menuItems,
                     onSingleItemClick = onMenuItemClick,
+                    menuButtonHeight = chipHeight,
                     contentSizeAnimation = tween(ANIM_DURATION),
                 )
 
@@ -116,14 +116,14 @@ fun ReaderTopAppBar(
                             onFilterClick = onFilterClick,
                             onClearFilterClick = onClearFilterClick,
                             modifier = Modifier
-                                // use padding instead of Spacer for nicer animation
+                                // use padding instead of Spacer for a nicer animation
                                 .padding(start = Margin.Medium.value),
                         )
                     }
                 }
             }
         }
-        Spacer(Modifier.width(Margin.ExtraLarge.value))
+        Spacer(Modifier.width(Margin.ExtraSmall.value))
         IconButton(
             modifier = Modifier.align(Alignment.CenterVertically),
             onClick = { onSearchClick() }
@@ -154,6 +154,7 @@ private fun Filter(
         onFilterClick = onFilterClick,
         onSelectedItemClick = onClearFilterClick,
         onSelectedItemDismissClick = onClearFilterClick,
+        chipHeight = chipHeight,
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.ui.compose.unit.Margin
 @Composable
 fun ReaderTopAppBar(
     onSearchClick: () -> Unit,
-    readerLists: List<MenuElementData.Item.SubMenu> = emptyList(),
+    readerLists: List<MenuElementData.Item> = emptyList(),
 ) {
     Row(
         modifier = Modifier
@@ -69,7 +69,10 @@ fun ReaderTopAppBar(
                 ).apply {
                     if (readerLists.isNotEmpty()) {
                         add(MenuElementData.Divider)
-                        addAll(readerLists)
+                        MenuElementData.Item.SubMenu(
+                            text = stringResource(id = R.string.reader_dropdown_menu_lists),
+                            children = readerLists,
+                        )
                     }
                 }
             )
@@ -103,19 +106,14 @@ fun ReaderScreenPreview() {
             ReaderTopAppBar(
                 {},
                 readerLists = listOf(
-                    MenuElementData.Item.SubMenu(
-                        text = "Funny Blogs",
-                        children = listOf(
-                            MenuElementData.Item.Single(
-                                text = "Funny Blog 1",
-                                onClick = {},
-                            ),
-                            MenuElementData.Item.Single(
-                                text = "Funny Blog 2",
-                                onClick = {},
-                            ),
-                        ),
-                    )
+                    MenuElementData.Item.Single(
+                        text = "Funny Blog 1",
+                        onClick = {},
+                    ),
+                    MenuElementData.Item.Single(
+                        text = "Funny Blog 2",
+                        onClick = {},
+                    ),
                 )
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -14,6 +14,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,6 +34,41 @@ fun ReaderTopAppBar(
     onSearchClick: () -> Unit,
     readerLists: List<MenuElementData.Item> = emptyList(),
 ) {
+    val menuItems = mutableListOf<MenuElementData>(
+        MenuElementData.Item.Single(
+            id = "discover",
+            text = stringResource(id = R.string.reader_dropdown_menu_discover),
+            leadingIcon = R.drawable.ic_reader_discover_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "subscriptions",
+            text = stringResource(id = R.string.reader_dropdown_menu_subscriptions),
+            leadingIcon = R.drawable.ic_reader_subscriptions_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "notifications",
+            text = stringResource(id = R.string.reader_dropdown_menu_saved),
+            leadingIcon = R.drawable.ic_reader_saved_24dp,
+        ),
+        MenuElementData.Item.Single(
+            id = "notifications",
+            text = stringResource(id = R.string.reader_dropdown_menu_liked),
+            leadingIcon = R.drawable.ic_reader_liked_24dp,
+        ),
+    ).apply {
+        if (readerLists.isNotEmpty()) {
+            add(MenuElementData.Divider)
+            MenuElementData.Item.SubMenu(
+                id = "lists",
+                text = stringResource(id = R.string.reader_dropdown_menu_lists),
+                children = readerLists,
+            )
+        }
+    }
+    var selectedItem by remember {
+        mutableStateOf(menuItems.filterIsInstance<MenuElementData.Item.Single>().first())
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,36 +84,9 @@ fun ReaderTopAppBar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             JetpackDropdownMenu(
-                menuItems = mutableListOf<MenuElementData>(
-                    MenuElementData.Item.Single(
-                        text = stringResource(id = R.string.reader_dropdown_menu_discover),
-                        onClick = {},
-                        leadingIcon = R.drawable.ic_reader_discover_24dp,
-                    ),
-                    MenuElementData.Item.Single(
-                        text = stringResource(id = R.string.reader_dropdown_menu_subscriptions),
-                        onClick = {},
-                        leadingIcon = R.drawable.ic_reader_subscriptions_24dp,
-                    ),
-                    MenuElementData.Item.Single(
-                        text = stringResource(id = R.string.reader_dropdown_menu_saved),
-                        onClick = {},
-                        leadingIcon = R.drawable.ic_reader_saved_24dp,
-                    ),
-                    MenuElementData.Item.Single(
-                        text = stringResource(id = R.string.reader_dropdown_menu_liked),
-                        onClick = {},
-                        leadingIcon = R.drawable.ic_reader_liked_24dp,
-                    ),
-                ).apply {
-                    if (readerLists.isNotEmpty()) {
-                        add(MenuElementData.Divider)
-                        MenuElementData.Item.SubMenu(
-                            text = stringResource(id = R.string.reader_dropdown_menu_lists),
-                            children = readerLists,
-                        )
-                    }
-                }
+                selectedItem = selectedItem,
+                menuItems = menuItems,
+                onSingleItemClick = { selectedItem = it },
             )
         }
         Spacer(Modifier.width(Margin.ExtraLarge.value))
@@ -107,12 +119,12 @@ fun ReaderScreenPreview() {
                 {},
                 readerLists = listOf(
                     MenuElementData.Item.Single(
+                        id = "funny-blog-1",
                         text = "Funny Blog 1",
-                        onClick = {},
                     ),
                     MenuElementData.Item.Single(
+                        id = "funny-blog-2",
                         text = "Funny Blog 2",
-                        onClick = {},
                     ),
                 )
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.compose.components.menu.dropdown.JetpackDropdown
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.compose.utils.horizontalFadingEdges
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChipGroup
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterType
@@ -87,10 +88,12 @@ fun ReaderTopAppBar(
                 .fillMaxHeight()
                 .weight(1f)
         ) {
+            val scrollState = rememberScrollState()
             Row(
                 modifier = Modifier
                     .fillMaxSize()
-                    .horizontalScroll(rememberScrollState()),
+                    .horizontalScroll(scrollState)
+                    .horizontalFadingEdges(scrollState),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 JetpackDropdownMenu(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -33,10 +34,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString
 import androidx.compose.material3.MaterialTheme as Material3Theme
@@ -102,7 +106,7 @@ fun ReaderFilterChipGroup(
         }
 
         AnimatedVisibility(visible = blogChipVisible && tagChipVisible) {
-            Spacer(Modifier.width(8.dp))
+            Spacer(Modifier.width(Margin.Medium.value))
         }
 
         // tags filter chip
@@ -148,11 +152,12 @@ fun ReaderFilterChip(
 
     val endPadding by animateDpAsState(
         label = "ReaderFilterChip endPadding",
-        targetValue = if (onDismissClick != null) 12.dp else 24.dp
+        targetValue = if (onDismissClick != null) Margin.Large.value else Margin.ExtraLarge.value,
     )
 
     CompositionLocalProvider(
         LocalContentColor provides contentColor,
+        LocalContentAlpha provides 1f,
     ) {
         Row(
             modifier = modifier
@@ -161,22 +166,20 @@ fun ReaderFilterChip(
                     shape = roundedShape,
                 )
                 .clip(roundedShape)
+                .height(32.dp)
                 .clickable(onClick = onClick)
                 .padding(
-                    top = 8.dp,
-                    bottom = 8.dp,
-                    start = 24.dp,
+                    start = Margin.ExtraLarge.value,
                     end = endPadding,
                 )
                 .animateContentSize(),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(Margin.Small.value),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 uiStringText(text),
-                style = Material3Theme.typography.titleSmall,
+                style = Material3Theme.typography.titleMedium,
                 modifier = Modifier
-                    .height(20.dp)
                     .align(Alignment.CenterVertically),
             )
 
@@ -186,7 +189,7 @@ fun ReaderFilterChip(
                     contentDescription = stringResource(R.string.dismiss),
                     modifier = Modifier
                         .size(20.dp)
-                        .padding(2.dp)
+                        .padding(Margin.ExtraSmall.value)
                         .clickable(
                             onClick = onDismissClick,
                             role = Role.Button,
@@ -215,7 +218,7 @@ fun ReaderFilterChipGroupPreview() {
 
     AppThemeWithoutBackground {
         ReaderFilterChipGroup(
-            modifier = Modifier.padding(8.dp),
+            modifier = Modifier.padding(Margin.Medium.value),
             selectedItem = selectedItem,
             followedBlogsCount = 23,
             followedTagsCount = 41,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -34,10 +34,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.compose.unit.Margin

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
@@ -54,6 +55,7 @@ fun ReaderFilterChipGroup(
     onSelectedItemDismissClick: () -> Unit,
     modifier: Modifier = Modifier,
     selectedItem: ReaderFilterSelectedItem? = null,
+    chipHeight: Dp = 36.dp,
 ) {
     Row(
         modifier = modifier,
@@ -100,6 +102,7 @@ fun ReaderFilterChipGroup(
                 onClick = if (blogSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.BLOG) }),
                 onDismissClick = if (blogSelected) onSelectedItemDismissClick else null,
                 isSelectedItem = blogSelected,
+                height = chipHeight,
             )
         }
 
@@ -117,6 +120,7 @@ fun ReaderFilterChipGroup(
                 onClick = if (tagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
                 onDismissClick = if (tagSelected) onSelectedItemDismissClick else null,
                 isSelectedItem = tagSelected,
+                height = chipHeight,
             )
         }
     }
@@ -126,6 +130,7 @@ fun ReaderFilterChipGroup(
 fun ReaderFilterChip(
     text: UiString,
     onClick: () -> Unit,
+    height: Dp,
     modifier: Modifier = Modifier,
     isSelectedItem: Boolean = false,
     onDismissClick: (() -> Unit)? = null,
@@ -164,7 +169,7 @@ fun ReaderFilterChip(
                     shape = roundedShape,
                 )
                 .clip(roundedShape)
-                .height(32.dp)
+                .height(height)
                 .clickable(onClick = onClick)
                 .padding(
                     start = Margin.ExtraLarge.value,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.reader.views.compose
+package org.wordpress.android.ui.reader.views.compose.filter
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.animation.AnimatedVisibility
@@ -31,9 +31,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString
@@ -64,8 +66,12 @@ fun ReaderFilterChipGroup(
             if (blogSelected) {
                 selectedItem?.text ?: UiString.UiStringText("")
             } else {
-                // TODO thomashortadev move this to string resources and use pluralization
-                UiString.UiStringText("$followedBlogsCount Blogs")
+                UiString.UiStringPluralRes(
+                    zeroRes = R.string.reader_filter_chip_blog_zero,
+                    oneRes = R.string.reader_filter_chip_blog_one,
+                    otherRes = R.string.reader_filter_chip_blog_other,
+                    count = followedBlogsCount,
+                )
             }
         }
 
@@ -73,8 +79,12 @@ fun ReaderFilterChipGroup(
             if (tagSelected) {
                 selectedItem?.text ?: UiString.UiStringText("")
             } else {
-                // TODO thomashortadev move this to string resources and use pluralization
-                UiString.UiStringText("$followedTagsCount Tags")
+                UiString.UiStringPluralRes(
+                    zeroRes = R.string.reader_filter_chip_tag_zero,
+                    oneRes = R.string.reader_filter_chip_tag_one,
+                    otherRes = R.string.reader_filter_chip_tag_other,
+                    count = followedTagsCount,
+                )
             }
         }
 
@@ -173,7 +183,7 @@ fun ReaderFilterChip(
             if (onDismissClick != null) {
                 Icon(
                     Icons.Default.Close,
-                    contentDescription = null, // TODO thomashorta clear or dismiss?
+                    contentDescription = stringResource(R.string.dismiss),
                     modifier = Modifier
                         .size(20.dp)
                         .padding(2.dp)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1673,6 +1673,12 @@
     <string name="reader_dropdown_menu_subscriptions">Subscriptions</string>
     <string name="reader_dropdown_menu_saved">Saved</string>
     <string name="reader_dropdown_menu_liked">Liked</string>
+    <string name="reader_filter_chip_blog_zero">0 Blogs</string>
+    <string name="reader_filter_chip_blog_one">1 Blog</string>
+    <string name="reader_filter_chip_blog_other">%d Blogs</string>
+    <string name="reader_filter_chip_tag_zero">0 Tags</string>
+    <string name="reader_filter_chip_tag_one">1 Tag</string>
+    <string name="reader_filter_chip_tag_other">%d Tags</string>
 
     <!-- editor -->
     <string name="editor_post_saved_online">Post saved online</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1673,6 +1673,7 @@
     <string name="reader_dropdown_menu_subscriptions">Subscriptions</string>
     <string name="reader_dropdown_menu_saved">Saved</string>
     <string name="reader_dropdown_menu_liked">Liked</string>
+    <string name="reader_dropdown_menu_lists">Lists</string>
     <string name="reader_filter_chip_blog_zero">0 Blogs</string>
     <string name="reader_filter_chip_blog_one">1 Blog</string>
     <string name="reader_filter_chip_blog_other">%d Blogs</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/compose/components/menu/MenuElementDataTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/compose/components/menu/MenuElementDataTest.kt
@@ -4,18 +4,19 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
 import org.wordpress.android.ui.compose.components.menu.dropdown.NO_ICON
+import org.wordpress.android.ui.utils.UiString.UiStringText
 
 class MenuElementDataTest {
     @Test
     fun `Single should have the correct leadingIcon default value`() {
-        val actual = MenuElementData.Item.Single("id", "").leadingIcon
+        val actual = MenuElementData.Item.Single("id", UiStringText("")).leadingIcon
         val expected = NO_ICON
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `SubMenu should have the correct leadingIcon value`() {
-        val actual = MenuElementData.Item.SubMenu("id", "", emptyList()).leadingIcon
+        val actual = MenuElementData.Item.SubMenu("id", UiStringText(""), emptyList()).leadingIcon
         val expected = NO_ICON
         assertThat(actual).isEqualTo(expected)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/compose/components/menu/MenuElementDataTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/compose/components/menu/MenuElementDataTest.kt
@@ -8,14 +8,14 @@ import org.wordpress.android.ui.compose.components.menu.dropdown.NO_ICON
 class MenuElementDataTest {
     @Test
     fun `Single should have the correct leadingIcon default value`() {
-        val actual = MenuElementData.Item.Single("", {}).leadingIcon
+        val actual = MenuElementData.Item.Single("id", "").leadingIcon
         val expected = NO_ICON
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `SubMenu should have the correct leadingIcon value`() {
-        val actual = MenuElementData.Item.SubMenu("", emptyList()).leadingIcon
+        val actual = MenuElementData.Item.SubMenu("id", "", emptyList()).leadingIcon
         val expected = NO_ICON
         assertThat(actual).isEqualTo(expected)
     }


### PR DESCRIPTION
Fixes #19606
Fixes #19611

This adds the UI part of the Subscription Filters chips/pills, both for Tags and Blogs. The content and behavior are just placeholders for now, and it's there mainly to review from a UI/Design perspective as well (specs, animations, etc).

Even so, the code for the TopBar Filter group should be final or only require minor changes when integrated with the business logic in the future.

Demo:

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/28f72243-6ddd-4743-bfdc-628811c77b18

-----

## To Test:

1. Install and log into the Jetpack app
2. Go to Reader
3. Play around with the top bar menu and the filter pills, under `Subscriptions`
4. **Verify** it works as designed

-----

## Regression Notes

1. Potential unintended areas of impact

    - UI regressions in the Reader top bar menu.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing.

5. What automated tests I added (or what prevented me from doing so)

    - Updated broken unit tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
