### PR TITLE
🤖 [Dynamic Cards] Card Actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.deeplinks;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -151,5 +152,12 @@ public class DeepLinkingIntentReceiverActivity extends LocaleAwareActivity {
         } else {
             finish();
         }
+    }
+
+    public static void openDeepLinkUrl(@NonNull Context context, @NonNull String url) {
+        Intent intent = new Intent(context, DeepLinkingIntentReceiverActivity.class);
+        intent.setData(Uri.parse(url));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        getContext().startActivity(intent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -50,6 +50,10 @@ class DeepLinkHandlers
         return handlers.firstOrNull { it.shouldHandleUrl(uri) }?.buildNavigateAction(uri)
     }
 
+    fun isDeepLink(url: String): Boolean {
+        return handlers.any { it.shouldHandleUrl(UriWrapper(url)) }
+    }
+
     fun stripUrl(uri: UriWrapper): String? {
         return handlers.firstOrNull { it.shouldHandleUrl(uri) }?.stripUrl(uri)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -163,7 +163,6 @@ sealed class MySiteCardAndItemBuilderParams {
     data class DynamicCardsBuilderParams(
         val dynamicCards: DynamicCardsModel?,
         val onActionClick: (actionUrl: String) -> Unit,
-        val onMoreMenuClick: (cardId: String) -> Unit,
         val onHideMenuItemClick: (cardId: String) -> Unit
     ) : MySiteCardAndItemBuilderParams()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.TextInputDialogFragment
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity
 import org.wordpress.android.ui.bloganuary.learnmore.BloganuaryNudgeLearnMoreOverlayFragment
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverActivity
 import org.wordpress.android.ui.domains.DomainRegistrationActivity
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
@@ -66,6 +67,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.util.PackageManagerWrapper
 import org.wordpress.android.util.QuickStartUtilsWrapper
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
@@ -130,6 +132,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
 
     @Inject
     lateinit var activityNavigator: ActivityNavigator
+
+    @Inject
+    lateinit var packageManagerWrapper: PackageManagerWrapper
 
     private lateinit var viewModel: MySiteViewModel
     private lateinit var dialogViewModel: BasicDialogViewModel
@@ -668,6 +673,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             ActivityLauncher.openUrlExternal(requireActivity(), action.url)
         is SiteNavigationAction.OpenUrlInWebView ->
             WPWebViewActivity.openURL(requireActivity(), action.url)
+        is SiteNavigationAction.OpenDeepLink ->
+            DeepLinkingIntentReceiverActivity.openDeepLinkUrl(requireActivity(), action.url)
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
         is SiteNavigationAction.OpenJetpackMigrationDeleteWP -> showJetpackMigrationDeleteWP()
         is SiteNavigationAction.OpenJetpackFeatureOverlay -> showJetpackFeatureOverlay(action.source)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.FullScreenDialogFragment
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.TextInputDialogFragment
+import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity
 import org.wordpress.android.ui.bloganuary.learnmore.BloganuaryNudgeLearnMoreOverlayFragment
 import org.wordpress.android.ui.domains.DomainRegistrationActivity
@@ -665,6 +666,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.INSIGHTS)
         is SiteNavigationAction.OpenExternalUrl ->
             ActivityLauncher.openUrlExternal(requireActivity(), action.url)
+        is SiteNavigationAction.OpenUrlInWebView ->
+            WPWebViewActivity.openURL(requireActivity(), action.url)
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
         is SiteNavigationAction.OpenJetpackMigrationDeleteWP -> showJetpackMigrationDeleteWP()
         is SiteNavigationAction.OpenJetpackFeatureOverlay -> showJetpackFeatureOverlay(action.source)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -234,6 +234,7 @@ class MySiteViewModel @Inject constructor(
         siteInfoHeaderCardViewModelSlice.onNavigation,
         quickLinksItemViewModelSlice.navigation,
         sotw2023NudgeCardViewModelSlice.onNavigation,
+        dynamicCardsViewModelSlice.onNavigation,
     )
 
     val onMediaUpload = siteInfoHeaderCardViewModelSlice.onMediaUpload

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -87,6 +87,7 @@ sealed class SiteNavigationAction {
     data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
     data class OpenExternalUrl(val url: String) : SiteNavigationAction()
     data class OpenUrlInWebView(val url: String) : SiteNavigationAction()
+    data class OpenDeepLink(val url: String) : SiteNavigationAction()
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -86,6 +86,7 @@ sealed class SiteNavigationAction {
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
     data class OpenExternalUrl(val url: String) : SiteNavigationAction()
+    data class OpenUrlInWebView(val url: String) : SiteNavigationAction()
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
     object OpenJetpackMigrationDeleteWP : SiteNavigationAction()
     data class OpenJetpackFeatureOverlay(val source: JetpackFeatureCollectionOverlaySource) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilder.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.Dynamic
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction.Companion.create
-import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.UrlUtilsWrapper
 import javax.inject.Inject
 
@@ -64,7 +63,7 @@ class DynamicCardsBuilder @Inject constructor(
 
     private fun isValidUrlOrDeeplink(url: String?): Boolean {
         return !url.isNullOrEmpty() && (urlUtils.isValidUrlAndHostNotNull(url)
-                || deepLinkHandlers.buildNavigateAction(UriWrapper(url)) != null)
+                || deepLinkHandlers.isDeepLink(url))
     }
 
     private fun isValidActionTitle(title: String?): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
@@ -22,18 +22,12 @@ class DynamicCardsViewModelSlice @Inject constructor(
         return DynamicCardsBuilderParams(
             dynamicCards = dynamicCards?.filterVisible(),
             onActionClick = this::onActionClick,
-            onMoreMenuClick = this::onMoreMenuClick,
             onHideMenuItemClick = this::onHideMenuItemClick
         )
     }
 
     private fun onActionClick(actionUrl: String) {
         AppLog.d(AppLog.T.MY_SITE_DASHBOARD, "Dynamic dashboard card action clicked: $actionUrl")
-        // TODO
-    }
-
-    private fun onMoreMenuClick(cardId: String) {
-        AppLog.d(AppLog.T.MY_SITE_DASHBOARD, "Dynamic dashboard card action more menu click: $cardId")
         // TODO
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.mysite.cards.dynamiccard
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.wordpress.android.fluxc.model.dashboard.CardModel
+import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -10,7 +11,8 @@ import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
 class DynamicCardsViewModelSlice @Inject constructor(
-    private val appPrefsWrapper: AppPrefsWrapper
+    private val appPrefsWrapper: AppPrefsWrapper,
+    private val deepLinkHandlers: DeepLinkHandlers,
 ) {
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
     val onNavigation = _onNavigation as LiveData<Event<SiteNavigationAction>>
@@ -26,7 +28,11 @@ class DynamicCardsViewModelSlice @Inject constructor(
     }
 
     private fun onActionClick(actionUrl: String) {
-        _onNavigation.value = Event(SiteNavigationAction.OpenUrlInWebView(actionUrl))
+        if (deepLinkHandlers.isDeepLink(actionUrl)) {
+            _onNavigation.value = Event(SiteNavigationAction.OpenDeepLink(actionUrl))
+        } else {
+            _onNavigation.value = Event(SiteNavigationAction.OpenUrlInWebView(actionUrl))
+        }
     }
 
     private fun onHideMenuItemClick(cardId: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSlice.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.util.AppLog
 import org.wordpress.android.viewmodel.Event
 import javax.inject.Inject
 
@@ -27,8 +26,7 @@ class DynamicCardsViewModelSlice @Inject constructor(
     }
 
     private fun onActionClick(actionUrl: String) {
-        AppLog.d(AppLog.T.MY_SITE_DASHBOARD, "Dynamic dashboard card action clicked: $actionUrl")
-        // TODO
+        _onNavigation.value = Event(SiteNavigationAction.OpenUrlInWebView(actionUrl))
     }
 
     private fun onHideMenuItemClick(cardId: String) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -426,7 +426,6 @@ class MySiteViewModelTest : BaseUnitTest() {
                 mock(),
                 mock(),
                 mock(),
-                mock()
             )
         )
         whenever(bloganuaryNudgeViewModelSlice.getBuilderParams()).thenReturn(mock())

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -158,7 +158,7 @@ class CardsBuilderTest {
                 ),
                 pagesCardBuilderParams = PagesCardBuilderParams(mock(), mock(), mock(), mock()),
                 activityCardBuilderParams = ActivityCardBuilderParams(mock(), mock(), mock(), mock(), mock()),
-                dynamicCardsBuilderParams = DynamicCardsBuilderParams(mock(), mock(), mock(), mock()),
+                dynamicCardsBuilderParams = DynamicCardsBuilderParams(mock(), mock(), mock()),
             ),
             jetpackInstallFullPluginCardBuilderParams = JetpackInstallFullPluginCardBuilderParams(
                 site = site,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -362,7 +362,6 @@ class CardsBuilderTest : BaseUnitTest() {
                     mock(),
                     mock(),
                     mock(),
-                    mock()
                 )
             )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -262,7 +262,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_DISABLED_REMOTELY)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -276,7 +275,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_WITH_EMPTY_REMOTE_FLAG)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -290,7 +288,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_WITH_UNKNOWN_REMOTE_FLAG)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsBuilderTest.kt
@@ -120,7 +120,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -144,7 +143,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -161,7 +159,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -176,7 +173,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_URL)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)
@@ -191,7 +187,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
                 dynamicCards = listOf(DYNAMIC_CARD_MODEL_INVALID_ACTION_TITLE_AND_URL)
             ),
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.BOTTOM)
@@ -203,7 +198,6 @@ class DynamicCardsBuilderTest : BaseUnitTest() {
         val builderParams = MySiteCardAndItemBuilderParams.DynamicCardsBuilderParams(
             dynamicCards = null,
             onActionClick = mock(),
-            onMoreMenuClick = mock(),
             onHideMenuItemClick = mock(),
         )
         val dynamicCards = dynamicCardsBuilder.build(builderParams, CardModel.DynamicCardsModel.CardOrder.TOP)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.DynamicCardsModel.DynamicCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.DynamicCardsModel.DynamicCardRowModel
+import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
 /* DYNAMIC CARDS */
@@ -94,5 +95,14 @@ class DynamicCardsViewModelSliceTest : BaseUnitTest() {
 
         verify(appPrefsWrapper).setShouldHideDynamicCard(DYNAMIC_CARD_ID_FIRST, true)
         assertThat(viewModelSlice.refresh.value?.peekContent()).isTrue
+    }
+
+    @Test
+    fun `WHEN the card action is triggered THEN open the URL in a webview`() {
+        val builderParams = viewModelSlice.getBuilderParams(dynamicCardsModel)
+        builderParams.onActionClick.invoke(DYNAMIC_CARD_URL)
+        assertThat(viewModelSlice.onNavigation.value?.peekContent()).isEqualTo(
+            SiteNavigationAction.OpenUrlInWebView(DYNAMIC_CARD_URL)
+        )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardsViewModelSliceTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.dashboard.CardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.DynamicCardsModel.DynamicCardModel
 import org.wordpress.android.fluxc.model.dashboard.CardModel.DynamicCardsModel.DynamicCardRowModel
+import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 
@@ -22,6 +23,7 @@ private const val DYNAMIC_CARD_TITLE = "News"
 private const val DYNAMIC_CARD_REMOTE_FEATURE_FLAG = "dynamic_dashboard_cards"
 private const val DYNAMIC_CARD_FEATURED_IMAGE = "https://path/to/image"
 private const val DYNAMIC_CARD_URL = "https://wordpress.com"
+private const val SOME_DEEP_LINK = "some_deep_link"
 private const val DYNAMIC_CARD_ACTION = "Call to action"
 private const val DYNAMIC_CARD_ORDER = "top"
 private const val DYNAMIC_CARD_ROW_ICON = "https://path/to/image"
@@ -68,12 +70,16 @@ private val filteredDynamicCardsModel = CardModel.DynamicCardsModel(
 class DynamicCardsViewModelSliceTest : BaseUnitTest() {
     @Mock
     private lateinit var appPrefsWrapper: AppPrefsWrapper
+
+    @Mock
+    private lateinit var deepLinkHandlers: DeepLinkHandlers
+
     private lateinit var viewModelSlice: DynamicCardsViewModelSlice
 
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        viewModelSlice = DynamicCardsViewModelSlice(appPrefsWrapper)
+        viewModelSlice = DynamicCardsViewModelSlice(appPrefsWrapper, deepLinkHandlers)
     }
 
     @Test
@@ -98,11 +104,22 @@ class DynamicCardsViewModelSliceTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN the card action is triggered THEN open the URL in a webview`() {
+    fun `WHEN the card action is triggered with a url THEN open the URL in a webview`() {
+        whenever(deepLinkHandlers.isDeepLink(DYNAMIC_CARD_URL)).thenReturn(false)
         val builderParams = viewModelSlice.getBuilderParams(dynamicCardsModel)
         builderParams.onActionClick.invoke(DYNAMIC_CARD_URL)
         assertThat(viewModelSlice.onNavigation.value?.peekContent()).isEqualTo(
             SiteNavigationAction.OpenUrlInWebView(DYNAMIC_CARD_URL)
+        )
+    }
+
+    @Test
+    fun `WHEN the card action is triggered for a deep link THEN the deep link is handled`() {
+        whenever(deepLinkHandlers.isDeepLink(SOME_DEEP_LINK)).thenReturn(true)
+        val builderParams = viewModelSlice.getBuilderParams(dynamicCardsModel)
+        builderParams.onActionClick.invoke(SOME_DEEP_LINK)
+        assertThat(viewModelSlice.onNavigation.value?.peekContent()).isEqualTo(
+            SiteNavigationAction.OpenDeepLink(SOME_DEEP_LINK)
         )
     }
 }


### PR DESCRIPTION
Fixes #19746

## Description
This PR adds card actions based on the provided url.
* If the url is a deep link the proper screen is opened inside the app
* If the url is not a deep link a webview opend

-----

## To Test:
### With a response patch
- Apply the [cardactions.patch](https://github.com/wordpress-mobile/WordPress-Android/files/13712576/cardactions.patch) and run the app.
- Tap on the first card action button
- **Verify** that a webview opens with the provided url
- Tap on the second action card
- **Verify** that the reader opens with the linked post

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/02ecc2a4-eb48-42a5-a04b-9f6aa73ffec4

### With a sandbox (url testing only)
- Sandbox your emulator with D132479-code (instructions paqN3M-5m-p2)
- Tap on the *Check it out* button
- **Verify** that a webview opens (Note you can use the follow up PR to test deep link handling https://github.com/wordpress-mobile/WordPress-Android/pull/19821)

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/304044/07867808-08f8-497c-a54e-a7fea6a03494" width=320 />


-----

## Regression Notes

1. Potential unintended areas of impact

    My Site Dashboard screen and a dynamic dashboard card

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing

3. What automated tests I added (or what prevented me from doing so)

    Added test cases in the `DynamicCardsViewModelSliceTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)