### PR TITLE
Super Fast Media Uploads: Add support for QR Code Media Links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -17,7 +17,8 @@ class DeepLinkHandlers
     notificationsLinkHandler: NotificationsLinkHandler,
     qrCodeAuthLinkHandler: QRCodeAuthLinkHandler,
     homeLinkHandler: HomeLinkHandler,
-    mediaLinkHandler: MediaLinkHandler
+    mediaLinkHandler: MediaLinkHandler,
+    qrCodeMediaLinkHandler: QRCodeMediaLinkHandler
 ) {
     private val handlers = listOf(
         editorLinkHandler,
@@ -28,7 +29,8 @@ class DeepLinkHandlers
         notificationsLinkHandler,
         qrCodeAuthLinkHandler,
         homeLinkHandler,
-        mediaLinkHandler
+        mediaLinkHandler,
+        qrCodeMediaLinkHandler
     )
 
     private val _toast by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandler.kt
@@ -12,7 +12,8 @@ class QRCodeAuthLinkHandler @Inject constructor() : DeepLinkHandler {
     override fun shouldHandleUrl(uri: UriWrapper): Boolean {
         // https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX
         return uri.host == HOST_APPS_WORDPRESS_COM &&
-                uri.pathSegments.firstOrNull() == GET_PATH
+                uri.pathSegments.firstOrNull() == GET_PATH &&
+                uri.getQueryParameter(CAMPAIGN) == CAMPAIGN_TYPE
     }
 
     override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
@@ -28,5 +29,7 @@ class QRCodeAuthLinkHandler @Inject constructor() : DeepLinkHandler {
     companion object {
         private const val GET_PATH = "get"
         private const val HOST_APPS_WORDPRESS_COM = "apps.wordpress.com"
+        private const val CAMPAIGN = "campaign"
+        private const val CAMPAIGN_TYPE = "login-qr-code"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class QRCodeMediaLinkHandler @Inject constructor(
+    private val deepLinkUriUtils: DeepLinkUriUtils
+) : DeepLinkHandler {
+    /**
+     * Returns true if the URI looks like `apps.wordpress.com/get`
+     */
+    override fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        // https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:227148183
+        return uri.host == HOST_APPS_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == GET_PATH &&
+                uri.getQueryParameter("campaign") == CAMPAIGN_TYPE
+    }
+
+    override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
+        val extractedSiteId = extractSiteIdFromUrl(uri)
+        return when (val siteModel = extractedSiteId?.let { siteId -> deepLinkUriUtils.blogIdToSite(siteId) }) {
+            null -> {
+                NavigateAction.OpenMySite
+            }
+            else -> {
+                NavigateAction.OpenMediaForSite(siteModel)
+            }
+        }
+    }
+
+    override fun stripUrl(uri: UriWrapper): String {
+        return buildString {
+            append("$HOST_APPS_WORDPRESS_COM/$GET_PATH")
+        }
+    }
+
+    private fun extractSiteIdFromUrl(uri: UriWrapper): String? {
+        uri.getQueryParameter("data")?.let { data ->
+            val siteIdPair = data.split(",").find { it.startsWith("site_id:") }
+            return siteIdPair?.substringAfter(":")
+        }
+        return null
+    }
+
+    companion object {
+        private const val GET_PATH = "get"
+        private const val HOST_APPS_WORDPRESS_COM = "apps.wordpress.com"
+        private const val CAMPAIGN_TYPE = "qr-code-media"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
@@ -15,7 +15,7 @@ class QRCodeMediaLinkHandler @Inject constructor(
         // https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:227148183
         return uri.host == HOST_APPS_WORDPRESS_COM &&
                 uri.pathSegments.firstOrNull() == GET_PATH &&
-                uri.getQueryParameter("campaign") == CAMPAIGN_TYPE
+                uri.getQueryParameter(CAMPAIGN) == CAMPAIGN_TYPE
     }
 
     override fun buildNavigateAction(uri: UriWrapper): NavigateAction {
@@ -47,6 +47,7 @@ class QRCodeMediaLinkHandler @Inject constructor(
     companion object {
         private const val GET_PATH = "get"
         private const val HOST_APPS_WORDPRESS_COM = "apps.wordpress.com"
+        private const val CAMPAIGN = "campaign"
         private const val CAMPAIGN_TYPE = "qr-code-media"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
@@ -36,7 +36,6 @@ fun buildUri(
 fun buildUri(
     host: String? = null,
     queryParams: Map<String, String>? = null,
-    fragment: String? = null,
     vararg path: String
 ): UriWrapper {
     val uri = mock<UriWrapper>()
@@ -45,9 +44,6 @@ fun buildUri(
     }
     if (path.isNotEmpty()) {
         whenever(uri.pathSegments).thenReturn(path.toList())
-    }
-    if (fragment != null) {
-        whenever(uri.fragment).thenReturn(fragment)
     }
     if (queryParams != null) {
         for ((key, value) in queryParams) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/UriTestHelper.kt
@@ -32,3 +32,27 @@ fun buildUri(
     }
     return uri
 }
+
+fun buildUri(
+    host: String? = null,
+    queryParams: Map<String, String>? = null,
+    fragment: String? = null,
+    vararg path: String
+): UriWrapper {
+    val uri = mock<UriWrapper>()
+    if (host != null) {
+        whenever(uri.host).thenReturn(host)
+    }
+    if (path.isNotEmpty()) {
+        whenever(uri.pathSegments).thenReturn(path.toList())
+    }
+    if (fragment != null) {
+        whenever(uri.fragment).thenReturn(fragment)
+    }
+    if (queryParams != null) {
+        for ((key, value) in queryParams) {
+            whenever(uri.getQueryParameter(key)).thenReturn(value)
+        }
+    }
+    return uri
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
@@ -43,6 +43,9 @@ class DeepLinkHandlersTest : BaseUnitTest() {
     lateinit var mediaLinkHandler: MediaLinkHandler
 
     @Mock
+    lateinit var qrCodeMediaLinkHandler: QRCodeMediaLinkHandler
+
+    @Mock
     lateinit var uri: UriWrapper
     private lateinit var deepLinkHandlers: DeepLinkHandlers
     private lateinit var handlers: List<DeepLinkHandler>
@@ -58,7 +61,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             notificationsLinkHandler,
             qrCodeAuthLinkHandler,
             homeLinkHandler,
-            mediaLinkHandler
+            mediaLinkHandler,
+            qrCodeMediaLinkHandler
         )
         initDeepLinkHandlers()
     }
@@ -73,7 +77,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             notificationsLinkHandler,
             qrCodeAuthLinkHandler,
             homeLinkHandler,
-            mediaLinkHandler
+            mediaLinkHandler,
+            qrCodeMediaLinkHandler
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandlerTest.kt
@@ -1,0 +1,79 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.buildUri
+
+@RunWith(MockitoJUnitRunner::class)
+class QRCodeAuthLinkHandlerTest {
+    @Mock
+    lateinit var site: SiteModel
+    private lateinit var qrCodeAuthLinkHandler: QRCodeAuthLinkHandler
+
+    @Before
+    fun setUp() {
+        qrCodeAuthLinkHandler = QRCodeAuthLinkHandler()
+    }
+
+    // https://apps.wordpress.com/get/?campaign=login-qr-code#qr-code-login?token=XXXX&data=XXXXX
+    @Test
+    fun `given proper auth url, when deep linked, then handles URI`() {
+        val authUri = buildUri(
+            host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "login-qr-code", "token" to "XXX", "data" to "XXX"),
+            fragment = "qr-code-login",
+            "get",
+        )
+
+        val isAuthUri = qrCodeAuthLinkHandler.shouldHandleUrl(authUri)
+
+        assertThat(isAuthUri).isTrue()
+    }
+
+    @Test
+    fun `given improper auth host, when deep linked, then URI is not handled`() {
+        val authUri = buildUri(host = "apps.wordpress.org", "get")
+
+        val isAuthUri = qrCodeAuthLinkHandler.shouldHandleUrl(authUri)
+
+        assertThat(isAuthUri).isFalse()
+    }
+
+    @Test
+    fun `given improper media query params, when deep linked, then handles URI`() {
+        val authUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "login-qr-no-good", "token" to "XXX", "data" to "XXX"),
+            "get", )
+
+        val isAuthUri = qrCodeAuthLinkHandler.shouldHandleUrl(authUri)
+
+        assertThat(isAuthUri).isFalse()
+    }
+
+    @Test
+    fun `given improper auth path, when deep linked, then URI is not handled`() {
+        val authUri = buildUri(host = "apps.wordpress.com", "invalid")
+
+        val isMediaQrCodeUri = qrCodeAuthLinkHandler.shouldHandleUrl(authUri)
+
+        assertThat(isMediaQrCodeUri).isFalse()
+    }
+
+    @Test
+    fun `given proper auth url, when deep linked, then opens qr code auth flow`() {
+        val authUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "login-qr-no-good", "token" to "token", "data" to "data"),
+            fragment = "qr-code-login",
+            "get", )
+
+        val navigateAction = qrCodeAuthLinkHandler.buildNavigateAction(authUri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenQRCodeAuthFlow(authUri.toString()))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeAuthLinkHandlerTest.kt
@@ -27,8 +27,7 @@ class QRCodeAuthLinkHandlerTest {
         val authUri = buildUri(
             host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "login-qr-code", "token" to "XXX", "data" to "XXX"),
-            fragment = "qr-code-login",
-            "get",
+            path = arrayOf("get"),
         )
 
         val isAuthUri = qrCodeAuthLinkHandler.shouldHandleUrl(authUri)
@@ -69,7 +68,6 @@ class QRCodeAuthLinkHandlerTest {
     fun `given proper auth url, when deep linked, then opens qr code auth flow`() {
         val authUri = buildUri(host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "login-qr-no-good", "token" to "token", "data" to "data"),
-            fragment = "qr-code-login",
             "get", )
 
         val navigateAction = qrCodeAuthLinkHandler.buildNavigateAction(authUri)

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
@@ -1,0 +1,100 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
+import org.wordpress.android.ui.deeplinks.buildUri
+
+@RunWith(MockitoJUnitRunner::class)
+class QRCodeMediaLinkHandlerTest {
+    @Mock
+    lateinit var deepLinkUriUtils: DeepLinkUriUtils
+
+    @Mock
+    lateinit var site: SiteModel
+    private lateinit var qrCodeMediaLinkHandler: QRCodeMediaLinkHandler
+
+    @Before
+    fun setUp() {
+        qrCodeMediaLinkHandler = QRCodeMediaLinkHandler(deepLinkUriUtils)
+    }
+
+    // https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:227148183
+    @Test
+    fun `given proper media url, when deep linked, then handles URI`() {
+        val mediaUri = buildUri(
+            host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
+            "get",
+        )
+
+        val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
+
+        assertThat(isMediaQrCodeUri).isTrue()
+    }
+
+    @Test
+    fun `given improper media host, when deep linked, then URI is not handled`() {
+        val mediaUri = buildUri(host = "apps.wordpress.org", "get")
+
+        val isPagesUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
+
+        assertThat(isPagesUri).isFalse()
+    }
+
+    @Test
+    fun `given improper media query params, when deep linked, then handles URI`() {
+        val mediaUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "qr-code-no-good", "data" to "post_id:6,site_id:227148183"),
+            "get", )
+
+        val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
+
+        assertThat(isMediaQrCodeUri).isFalse()
+    }
+
+    @Test
+    fun `given improper media path, when deep linked, then URI is not handled`() {
+        val mediaUri = buildUri(host = "apps.wordpress.com", "invalid")
+
+        val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
+
+        assertThat(isMediaQrCodeUri).isFalse()
+    }
+
+    @Test
+    fun `given unrecognized siteId, when deep linked, then opens my site view`() {
+        val mediaUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
+            "get", )
+
+        whenever(mediaUri.getQueryParameter("data")).thenReturn(null)
+
+        val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenMySite)
+    }
+
+    @Test
+    fun `given recognized siteId, when deep linked, then opens media view`() {
+        val siteId = "227148183"
+        val data = "post_id:6,site_id:227148183"
+        val mediaUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
+            "get", )
+
+        whenever(mediaUri.getQueryParameter("data")).thenReturn(data)
+        whenever(deepLinkUriUtils.blogIdToSite(siteId)).thenReturn(site)
+
+        val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
+
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenMediaForSite(site))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
@@ -32,7 +32,7 @@ class QRCodeMediaLinkHandlerTest {
         val mediaUri = buildUri(
             host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
-            "get",
+            path = arrayOf("get")
         )
 
         val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
@@ -53,7 +53,7 @@ class QRCodeMediaLinkHandlerTest {
     fun `given improper media query params, when deep linked, then handles URI`() {
         val mediaUri = buildUri(host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "qr-code-no-good", "data" to "post_id:6,site_id:227148183"),
-            "get", )
+            path = arrayOf("get"), )
 
         val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
 
@@ -73,7 +73,7 @@ class QRCodeMediaLinkHandlerTest {
     fun `given unrecognized siteId, when deep linked, then opens my site view`() {
         val mediaUri = buildUri(host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
-            "get", )
+            path = arrayOf("get"), )
 
         whenever(mediaUri.getQueryParameter("data")).thenReturn(null)
 
@@ -88,7 +88,7 @@ class QRCodeMediaLinkHandlerTest {
         val data = "post_id:6,site_id:227148183"
         val mediaUri = buildUri(host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
-            "get", )
+            path = arrayOf("get"), )
 
         whenever(mediaUri.getQueryParameter("data")).thenReturn(data)
         whenever(deepLinkUriUtils.blogIdToSite(siteId)).thenReturn(site)


### PR DESCRIPTION
This PR adds support for QR Code Media Links handling

- Updates the `QRCodeAuthLinkHandler.shouldHandleUrl` to include a check for a specific `campaign` query parameter
- Adds `QRCodeMediaLinkHandler` to support media qr code scans. 

Note: This PR does not include showing an error message if siteId scanned is not valid for the user. At this moment, the user will be pushed to the MySite as happens will all other invalid deep link requests.

-----

## To Test:
#### Prerequisites: 
- Find a siteId for a site associated with a WP.com account that you will run these tests with. Jot this number down.
- Generate two test QR Codes [ I used `https://qr.io/` ]
-- Replace the "{your site id}" in the following URL with the valid site id from above. `https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:{your site id}`
-- Replace the "{invalid site id}" in the following URL with an invalid site id. `https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:{invalid site id}`
- Download and install JP from this PR
- Login with the account that includes the valid siteId you captured above

#### Test Media Link 
- Close or background the JP app
- Open the device camera
- Scan the QR Code with the valid site
- ✅ Verify the app launches and the media grid is opened
- Close or background the JP ap
- Scan the QR Code with the invalid site
- ✅ Verify the app launches and the my site view is opened

#### Test QR Code Login still works when scanned from ME
- Open a browser on the web in incognito mode (if you are already logged in to WP.com)
- Navigate to `https://wordpress.com/log-in/` > Login via the mobile app
- STOP
- Go back to the app
- Navigate to Me > Scan Login Code
- Scan the login code shown on the web browser
- ✅ Verify the qr code login flow is launched

#### Test QR Code Login still works when scanned from camera
- Close or background the JP app
- Open a browser on the web in incognito mode (if you are already logged in to WP.com)
- Navigate to `https://wordpress.com/log-in/` > Login via the mobile app
- STOP
- Open the camera on your device
- Scan the login code shown on the web browser
- ✅ Verify the app is opened and the qr code login flow is launched
-----

## Regression Notes

1. Potential unintended areas of impact
QR Code Auth login breaks

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Adds `QRCodeAuthLinkHandlerTest` and `QRCodeMediaLinkHandlerTest`

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: N/A
 