### PR TITLE
Adds: Missing tracking for Copy Link in Pages More Menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesListActions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesListActions.kt
@@ -56,7 +56,7 @@ enum class PagesListAction(
         actionGroup = ActionGroup.TAKE_AN_ACTION,
         positionInGroup = 7,
     ),
-    COPY_LINK(
+    SHARE(
         R.string.button_share,
         R.drawable.gb_ic_share,
         actionGroup = ActionGroup.SHARE_AND_PROMOTE,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCase.kt
@@ -5,7 +5,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.pages.PagesListAction
 import org.wordpress.android.ui.pages.PagesListAction.CANCEL_AUTO_UPLOAD
 import org.wordpress.android.ui.pages.PagesListAction.COPY
-import org.wordpress.android.ui.pages.PagesListAction.COPY_LINK
 import org.wordpress.android.ui.pages.PagesListAction.DELETE_PERMANENTLY
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_DRAFT
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_TRASH
@@ -14,6 +13,7 @@ import org.wordpress.android.ui.pages.PagesListAction.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_HOMEPAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_POSTS_PAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_PARENT
+import org.wordpress.android.ui.pages.PagesListAction.SHARE
 import org.wordpress.android.ui.pages.PagesListAction.VIEW_PAGE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
@@ -57,7 +57,7 @@ class CreatePageListItemActionsUseCase @Inject constructor() {
         return mutableListOf(
             VIEW_PAGE,
             SET_PARENT,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_DRAFT,
             MOVE_TO_TRASH
         ).apply {
@@ -81,7 +81,7 @@ class CreatePageListItemActionsUseCase @Inject constructor() {
         return mutableListOf(
             VIEW_PAGE,
             COPY,
-            COPY_LINK,
+            SHARE,
             SET_PARENT
         ).apply {
             if (siteModel.isUsingWpComRestApi &&
@@ -112,7 +112,7 @@ class CreatePageListItemActionsUseCase @Inject constructor() {
     }
 
     private fun getDraftsPageActions(uploadUiState: PostUploadUiState): List<PagesListAction> {
-        return mutableListOf(VIEW_PAGE, SET_PARENT, PUBLISH_NOW, MOVE_TO_TRASH, COPY, COPY_LINK).apply {
+        return mutableListOf(VIEW_PAGE, SET_PARENT, PUBLISH_NOW, MOVE_TO_TRASH, COPY, SHARE).apply {
             if (canCancelPendingAutoUpload(uploadUiState)) {
                 add(CANCEL_AUTO_UPLOAD)
             }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -659,7 +659,7 @@ class PagesViewModel
             MOVE_TO_DRAFT -> "move_to_draft"
             DELETE_PERMANENTLY -> "delete_permanently"
             MOVE_TO_TRASH -> "move_to_bin"
-            COPY_LINK -> "copy_link"
+            COPY_LINK -> "share"
             PROMOTE_WITH_BLAZE -> "promote_with_blaze"
         }
         val properties = mutableMapOf("option_name" to menu as Any)

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -572,6 +572,7 @@ class PagesViewModel
 
     private fun copyPageLink(page: Page, context: Context) {
         // Get the link to the page
+        trackMenuSelectionEvent(COPY_LINK)
         val pageLink = postStore.getPostByLocalPostId(page.localId)?.link ?: return
         ActivityLauncher.openShareIntent(
             context,

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PagesViewModel.kt
@@ -43,7 +43,6 @@ import org.wordpress.android.ui.pages.PagesAuthorFilterUIState
 import org.wordpress.android.ui.pages.PagesListAction
 import org.wordpress.android.ui.pages.PagesListAction.CANCEL_AUTO_UPLOAD
 import org.wordpress.android.ui.pages.PagesListAction.COPY
-import org.wordpress.android.ui.pages.PagesListAction.COPY_LINK
 import org.wordpress.android.ui.pages.PagesListAction.DELETE_PERMANENTLY
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_DRAFT
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_TRASH
@@ -52,6 +51,7 @@ import org.wordpress.android.ui.pages.PagesListAction.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_HOMEPAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_POSTS_PAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_PARENT
+import org.wordpress.android.ui.pages.PagesListAction.SHARE
 import org.wordpress.android.ui.pages.PagesListAction.VIEW_PAGE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.AuthorFilterListItemUIState
@@ -473,7 +473,7 @@ class PagesViewModel
             SET_AS_HOMEPAGE -> setHomepage(page.remoteId)
             SET_AS_POSTS_PAGE -> setPostsPage(page.remoteId)
             COPY -> onCopyPage(page)
-            COPY_LINK -> context?.let { copyPageLink(page, it) }
+            SHARE -> context?.let { copyPageLink(page, it) }
             PROMOTE_WITH_BLAZE -> navigateToBlazeOverlay(page.remoteId)
         }
         return true
@@ -572,7 +572,7 @@ class PagesViewModel
 
     private fun copyPageLink(page: Page, context: Context) {
         // Get the link to the page
-        trackMenuSelectionEvent(COPY_LINK)
+        trackMenuSelectionEvent(SHARE)
         val pageLink = postStore.getPostByLocalPostId(page.localId)?.link ?: return
         ActivityLauncher.openShareIntent(
             context,
@@ -659,7 +659,7 @@ class PagesViewModel
             MOVE_TO_DRAFT -> "move_to_draft"
             DELETE_PERMANENTLY -> "delete_permanently"
             MOVE_TO_TRASH -> "move_to_bin"
-            COPY_LINK -> "share"
+            SHARE -> "share"
             PROMOTE_WITH_BLAZE -> "promote_with_blaze"
         }
         val properties = mutableMapOf("option_name" to menu as Any)

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/CreatePageListItemActionsUseCaseTest.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.SiteModel.ORIGIN_WPCOM_REST
 import org.wordpress.android.ui.pages.PagesListAction.CANCEL_AUTO_UPLOAD
 import org.wordpress.android.ui.pages.PagesListAction.COPY
-import org.wordpress.android.ui.pages.PagesListAction.COPY_LINK
 import org.wordpress.android.ui.pages.PagesListAction.DELETE_PERMANENTLY
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_DRAFT
 import org.wordpress.android.ui.pages.PagesListAction.MOVE_TO_TRASH
@@ -20,6 +19,7 @@ import org.wordpress.android.ui.pages.PagesListAction.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_HOMEPAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_POSTS_PAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_PARENT
+import org.wordpress.android.ui.pages.PagesListAction.SHARE
 import org.wordpress.android.ui.pages.PagesListAction.VIEW_PAGE
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.DRAFTS
 import org.wordpress.android.viewmodel.pages.PageListViewModel.PageListType.PUBLISHED
@@ -48,7 +48,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_PARENT,
             PUBLISH_NOW,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH
         )
 
@@ -79,7 +79,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_PARENT,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH,
         )
 
@@ -100,7 +100,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_AS_POSTS_PAGE,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH
         )
         site.showOnFront = ShowOnFront.PAGE.value
@@ -123,7 +123,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_AS_POSTS_PAGE,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH,
         )
         site.showOnFront = ShowOnFront.PAGE.value
@@ -145,7 +145,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_PARENT,
             SET_AS_POSTS_PAGE,
             COPY,
-            COPY_LINK
+            SHARE
         )
         site.showOnFront = ShowOnFront.PAGE.value
         site.pageOnFront = defaultRemoteId
@@ -167,7 +167,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_AS_HOMEPAGE,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH
         )
         site.showOnFront = ShowOnFront.PAGE.value
@@ -188,7 +188,7 @@ class CreatePageListItemActionsUseCaseTest {
             VIEW_PAGE,
             SET_PARENT,
             COPY,
-            COPY_LINK
+            SHARE
         )
         site.showOnFront = ShowOnFront.PAGE.value
         val remoteId = -1L
@@ -208,7 +208,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_PARENT,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH
         )
         site.showOnFront = ShowOnFront.PAGE.value
@@ -229,7 +229,7 @@ class CreatePageListItemActionsUseCaseTest {
             VIEW_PAGE,
             SET_PARENT,
             MOVE_TO_DRAFT,
-            COPY_LINK,
+            SHARE,
             MOVE_TO_TRASH
         )
 
@@ -274,7 +274,7 @@ class CreatePageListItemActionsUseCaseTest {
             SET_AS_POSTS_PAGE,
             MOVE_TO_DRAFT,
             COPY,
-            COPY_LINK,
+            SHARE,
             PROMOTE_WITH_BLAZE,
             MOVE_TO_TRASH
         )

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/pages/PagesViewModelTest.kt
@@ -46,10 +46,10 @@ import org.wordpress.android.ui.pages.PageItem
 import org.wordpress.android.ui.pages.PageItem.PublishedPage
 import org.wordpress.android.ui.pages.PagesAuthorFilterUIState
 import org.wordpress.android.ui.pages.PagesListAction.COPY
-import org.wordpress.android.ui.pages.PagesListAction.COPY_LINK
 import org.wordpress.android.ui.pages.PagesListAction.PUBLISH_NOW
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_HOMEPAGE
 import org.wordpress.android.ui.pages.PagesListAction.SET_AS_POSTS_PAGE
+import org.wordpress.android.ui.pages.PagesListAction.SHARE
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.AuthorFilterSelection
 import org.wordpress.android.ui.posts.AuthorFilterSelection.EVERYONE
@@ -310,7 +310,7 @@ class PagesViewModelTest : BaseUnitTest() {
         whenever(pageStore.getPagesFromDb(anyOrNull())).thenReturn(listOf(pageModel))
         viewModel.start(site)
 
-        val returnVal = viewModel.onMenuAction(COPY_LINK, page)
+        val returnVal = viewModel.onMenuAction(SHARE, page)
         assertThat(returnVal).isEqualTo(true)
     }
 


### PR DESCRIPTION
## Fixes 
This PR
1. fixes the missing tracking when clicking on Share in Pages → More Button → Share
2. Updates the `PagesListActions` to use **Share** instead of **Copy Link** In tracking and code

## To Test:
1. Go to Jetpack app 
3. Login with a site having published pages 
4. Go to dashboard  → pages → published pages 
5. Click on More(⁞) 
6. Click on Copy Link
7. Verify that the copy link triggers a bottom sheet for sharing 
8. Verify the tracking event `site_pages_options_pressed, Properties: {"option_name":"share","blog_id":{site id},"is_jetpack":true,"site_type":"blog"}`


## Regression Notes

1. Potential unintended areas of impact
Copy link click is not tracked 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
