### PR TITLE
🤖 [Dynamic Cards] Adds domain management feature deep linking support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -86,6 +86,7 @@ class DeepLinkNavigator
                 ActivityLauncher.showJetpackStaticPoster(activity)
             is NavigateAction.OpenMediaForSite -> activityNavigator.openMediaInNewStack(activity, navigateAction.site)
             NavigateAction.OpenMedia -> activityNavigator.openMediaInNewStack(activity)
+            NavigateAction.DomainManagement -> ActivityLauncher.openDomainManagement(activity)
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -119,5 +120,6 @@ class DeepLinkNavigator
         object OpenJetpackStaticPosterView : NavigateAction()
         data class OpenMediaForSite(val site: SiteModel) : NavigateAction()
         object OpenMedia : NavigateAction()
+        object DomainManagement : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -17,7 +17,8 @@ class DeepLinkHandlers
     notificationsLinkHandler: NotificationsLinkHandler,
     qrCodeAuthLinkHandler: QRCodeAuthLinkHandler,
     homeLinkHandler: HomeLinkHandler,
-    mediaLinkHandler: MediaLinkHandler
+    mediaLinkHandler: MediaLinkHandler,
+    domainManagementLinkHandler: DomainManagementLinkHandler,
 ) {
     private val handlers = listOf(
         editorLinkHandler,
@@ -28,7 +29,8 @@ class DeepLinkHandlers
         notificationsLinkHandler,
         qrCodeAuthLinkHandler,
         homeLinkHandler,
-        mediaLinkHandler
+        mediaLinkHandler,
+        domainManagementLinkHandler,
     )
 
     private val _toast by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DomainManagementLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DomainManagementLinkHandler.kt
@@ -1,0 +1,44 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.DomainManagement
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel.Companion.HOST_WORDPRESS_COM
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class DomainManagementLinkHandler
+@Inject constructor() : DeepLinkHandler {
+    /**
+     * Returns true if the URI looks like `https://wordpress.com/me/domains` or `https://wordpress.com/domains/manage`
+     */
+    override fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        return (uri.host == HOST_WORDPRESS_COM &&
+                (uri.pathSegments.isMeDomainsScheme() || uri.pathSegments.isDomainsManagementScheme()))
+    }
+
+    private fun List<String>.isMeDomainsScheme() =
+        size == 2 && this[0] == ME_DOMAINS_SEGMENT1 && this[1] == ME_DOMAINS_SEGMENT2
+
+    private fun List<String>.isDomainsManagementScheme() =
+        size == 2 && this[0] == DOMAINS_MANAGE_SEGMENT1 && this[1] == DOMAINS_MANAGE_SEGMENT2
+
+    override fun buildNavigateAction(uri: UriWrapper): NavigateAction = DomainManagement
+
+    override fun stripUrl(uri: UriWrapper): String {
+        return buildString {
+            append("$HOST_WORDPRESS_COM/")
+            if (uri.pathSegments.isMeDomainsScheme()) {
+                append("$ME_DOMAINS_SEGMENT1/$ME_DOMAINS_SEGMENT2")
+            } else {
+                append("$DOMAINS_MANAGE_SEGMENT1/$DOMAINS_MANAGE_SEGMENT2")
+            }
+        }
+    }
+
+    companion object {
+        private const val ME_DOMAINS_SEGMENT1 = "me"
+        private const val ME_DOMAINS_SEGMENT2 = "domains"
+        private const val DOMAINS_MANAGE_SEGMENT1 = "domains"
+        private const val DOMAINS_MANAGE_SEGMENT2 = "manage"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
@@ -43,6 +43,9 @@ class DeepLinkHandlersTest : BaseUnitTest() {
     lateinit var mediaLinkHandler: MediaLinkHandler
 
     @Mock
+    lateinit var domainManagementLinkHandler: DomainManagementLinkHandler
+
+    @Mock
     lateinit var uri: UriWrapper
     private lateinit var deepLinkHandlers: DeepLinkHandlers
     private lateinit var handlers: List<DeepLinkHandler>
@@ -58,7 +61,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             notificationsLinkHandler,
             qrCodeAuthLinkHandler,
             homeLinkHandler,
-            mediaLinkHandler
+            mediaLinkHandler,
+            domainManagementLinkHandler,
         )
         initDeepLinkHandlers()
     }
@@ -73,7 +77,8 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             notificationsLinkHandler,
             qrCodeAuthLinkHandler,
             homeLinkHandler,
-            mediaLinkHandler
+            mediaLinkHandler,
+            domainManagementLinkHandler,
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DomainManagementLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DomainManagementLinkHandlerTest.kt
@@ -1,0 +1,82 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator
+import org.wordpress.android.ui.deeplinks.buildUri
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class DomainManagementLinkHandlerTest {
+    private lateinit var handler: DomainManagementLinkHandler
+
+    @Before
+    fun setUp() {
+        handler = DomainManagementLinkHandler()
+    }
+
+    @Test
+    fun `WHEN the me domains scheme is passed THEN the url is handled`() {
+        val uri = buildUri("wordpress.com", "me", "domains")
+
+        val handled = handler.shouldHandleUrl(uri)
+
+        assertThat(handled).isTrue()
+    }
+
+    @Test
+    fun `WHEN the domains manage scheme is passed THEN the url is handled`() {
+        val uri = buildUri("wordpress.com", "domains", "manage")
+
+        val handled = handler.shouldHandleUrl(uri)
+
+        assertThat(handled).isTrue()
+    }
+
+    @Test
+    fun `WHEN a different host is passed THEN the url is not handled`() {
+        val uri = buildUri("wordpress.org", "domains", "manage")
+
+        val handled = handler.shouldHandleUrl(uri)
+
+        assertThat(handled).isFalse()
+    }
+
+    @Test
+    fun `WHEN a different path is passed THEN the url is not handled`() {
+        val uri = buildUri("wordpress.com", "different")
+
+        val handled = handler.shouldHandleUrl(uri)
+
+        assertThat(handled).isFalse()
+    }
+
+    @Test
+    fun `WHEN the navigation action is requested THEN the DomainManagement is returned`() {
+        val navigateAction = handler.buildNavigateAction(mock())
+
+        assertEquals(navigateAction, DeepLinkNavigator.NavigateAction.DomainManagement)
+    }
+
+    @Test
+    fun `WHEN the domains manage scheme is used THEN the correct url for tracking is returned`() {
+        val uri = buildUri("wordpress.com", "domains", "manage")
+
+        val strippedUrl = handler.stripUrl(uri)
+
+        assertThat(strippedUrl).isEqualTo("wordpress.com/domains/manage")
+    }
+
+    @Test
+    fun `WHEN the me domains scheme is used THEN the correct url for tracking is returned`() {
+        val uri = buildUri("wordpress.com", "me", "domains")
+
+        val strippedUrl = handler.stripUrl(uri)
+
+        assertThat(strippedUrl).isEqualTo("wordpress.com/me/domains")
+    }
+}


### PR DESCRIPTION
Fixes #19815

**Based on: https://github.com/wordpress-mobile/WordPress-Android/pull/19810**

-----
## Description
This PR adds deeplinking support for the domains management feature handling urls the following urls:
* `https://wordpress.com/me/domains`
* `https://wordpress.com/domains/manage`

Note: I added both schemes discussed in p1702979252140089/1702973027.394549-slack-C067H36F011

## To Test:

- Sandbox your emulator with D132479-code (instructions paqN3M-5m-p2)
- Tap on the *Check it out* button
- **Verify** that the domain management screen opens

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/c373277d-a81d-4e27-b7a3-eb55a685ad32

-----

## Regression Notes

1. Potential unintended areas of impact

    Dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing

3. What automated tests I added (or what prevented me from doing so)

    Adapted `DeepLinkHandlersTest` and added `DomainManagementLinkHandlerTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)