### PR TITLE
🤖 [Dynamic Cards] Adds domain management feature web link support

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -428,45 +428,45 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/post/..*"
-                android:scheme="https" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/post/..*"
+                    android:scheme="https" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/post/..*"
-                android:scheme="http" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/post/..*"
+                    android:scheme="http" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/stats/..*"
-                android:scheme="https" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/stats/..*"
+                    android:scheme="https" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/stats/..*"
-                android:scheme="http" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/stats/..*"
+                    android:scheme="http" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/pages/..*"
-                android:scheme="https" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/pages/..*"
+                    android:scheme="https" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/pages/..*"
-                android:scheme="http" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/pages/..*"
+                    android:scheme="http" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/notifications/.*"
-                android:scheme="https" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/notifications/.*"
+                    android:scheme="https" />
 
-            <data
-                android:host="wordpress.com"
-                android:pathPattern="/notifications/.*"
-                android:scheme="http" />
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/notifications/.*"
+                    android:scheme="http" />
 
                 <data
                     android:host="wordpress.com"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -478,7 +478,10 @@
                     android:pathPattern="/media/.*"
                     android:scheme="http" />
 
-
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/domains/manage"
+                    android:scheme="https" />
 
             </intent-filter>
         </activity-alias>


### PR DESCRIPTION
## Description

This PR enhances the implementation of https://github.com/wordpress-mobile/WordPress-Android/pull/19821 by adding domain management feature web link support (internal ref: p1703056247263069/1702997046.577089-slack-C067H36F011)

### Before
The wordpress.com/domains/manage link is not handled by the app while other (eg. reader) links are handled

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/53ccdcbc-de1c-4eea-9c6a-5c83c46b19e2

### After
The wordpress.com/domains/manage link is handled and the user is directed to the proper screen

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/108d4444-924f-411a-b004-c83fd8fde115

-----

## To Test:

1. Install a Jetpack Jalapeno (prealpha) version from this PR (note: [only the production and prealpha apps handle links](https://wordpress.com/.well-known/assetlinks.json))
2. Tap on a `https://wordpress.com/domains/manage` link
3. **Verify** that the app handles the link


## Note

I considered fixing the `IntentFilterUniqueDataAttributes` warning (check below) but thought that it would be better to handle this in a separate PR to be tested properly.

> Consider splitting data tag into multiple tags with individual attributes to avoid confusion More... (⌘F1) 
Inspection info:<intent-filter> <data> tags should only declare a single unique attribute (i.e. scheme OR host, but not both). This better matches the runtime behavior of intent filters, as they combine all of the declared data attributes into a single matcher which is allowed to handle any combination across attribute types.  For example, the following two <intent-filter> declarations are the same:
<intent-filter>    <data android:scheme="http" android:host="example.com" />    <data android:scheme="https" android:host="example.org" /></intent-filter>
<intent-filter>    <data android:scheme="http"/>    <data android:scheme="https"/>    <data android:host="example.com" />    <data android:host="example.org" /></intent-filter>
 They both handle all of the following: * http://example.com * https://example.com * http://example.org * https://example.org  The second one better communicates the combining behavior and is clearer to an external reader that one should not rely on the scheme/host being self contained. It is not obvious in the first that http://example.org is also matched, which can lead to confusion (or incorrect behavior) with a more complex set of schemes/hosts.  Note that this does not apply to host + port, as those must be declared in the same <data> tag and are only associated with each other.  Issue id: IntentFilterUniqueDataAttributes  More info: https://developer.android.com/guide/components/intents-filters  Vendor: Android Open Source Project Contact: https://groups.google.com/g/lint-dev Feedback: https://issuetracker.google.com/issues/new?component=192708 

-----

## Regression Notes

1. Potential unintended areas of impact

Deep linking

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

This involved only a manifest change

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)