### PR TITLE
[Dynamic Card] Make a dynamic card featured image height flexible

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardFeatureImage.kt
@@ -6,12 +6,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.ui.compose.theme.AppColor
+
 
 @Composable
 fun DynamicCardFeatureImage(imageUrl: String, modifier: Modifier = Modifier) {
@@ -24,6 +27,10 @@ fun DynamicCardFeatureImage(imageUrl: String, modifier: Modifier = Modifier) {
             .padding(start = 16.dp, end = 16.dp)
             .clip(RoundedCornerShape(6.dp))
             .fillMaxWidth()
-            .aspectRatio(2f)
+            .previewAspectRatio(2f)
     )
+}
+
+private fun Modifier.previewAspectRatio(ratio: Float): Modifier = composed {
+    if (LocalInspectionMode.current) aspectRatio(ratio) else this
 }


### PR DESCRIPTION
Fixes #19819

-----

This PR removes a dynamic card featured image's aspect ratio that was equal to 2:1. The aspect ratio is used for previews only, which prevents breaking the previews' UI due to unmeasurable async images.

![ezgif-2-7f179e85f8](https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/3fde74a0-32bb-45ed-bf2a-98773765be6f)

## To Test:
* Apply this patch: [featureimages.patch](https://github.com/wordpress-mobile/WordPress-Android/files/13730302/featureimages.patch)
* Run the app and ensure the two top cards have feature images with different aspect ratios. Play with the sizes of generated images ("https://picsum.photos/*width*/*height*") of the test cards from `CardSource` to make sure the images' size is unlimited.

-----

## Regression Notes

1. Potential unintended areas of impact

    - My Site Dashboard and dynamic cards

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual tests

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
