### PR TITLE
Post List: Remove treeViewObserver

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -53,13 +53,13 @@ sealed class PostListItemViewHolder(
     private val uiHelpers: UiHelpers
 ) : RecyclerView.ViewHolder(LayoutInflater.from(parent.context).inflate(layout, parent, false)) {
     private val featuredImageView: ImageView = itemView.findViewById(R.id.image_featured)
-    private val titleTextView: TextView = itemView.findViewById(R.id.title)
+    private val titleTextView: PostListTitleExcerptTextView = itemView.findViewById(R.id.title)
     private val postInfoTextView: TextView = itemView.findViewById(R.id.post_info)
     private val statusesTextView: TextView = itemView.findViewById(R.id.statuses_label)
     private val uploadProgressBar: ProgressBar = itemView.findViewById(R.id.upload_progress)
     private val disabledOverlay: FrameLayout = itemView.findViewById(R.id.disabled_overlay)
     private val container: ConstraintLayout = itemView.findViewById(R.id.container)
-    private val excerptTextView: TextView = itemView.findViewById(R.id.excerpt)
+    private val excerptTextView: PostListTitleExcerptTextView = itemView.findViewById(R.id.excerpt)
     private val moreButton: ImageButton = itemView.findViewById(R.id.more)
 
     private val selectableBackground: Drawable? = parent.context.getDrawableFromAttribute(
@@ -125,27 +125,8 @@ sealed class PostListItemViewHolder(
         if ((data.title != null && data.title != noTitle) && data.excerpt != null) {
             titleTextView.maxLines = MAX_TITLE_EXCERPT_LINES
             excerptTextView.maxLines = MAX_TITLE_EXCERPT_LINES
-            titleTextView.viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
-                override fun onPreDraw(): Boolean {
-                    // Remove the listener to avoid multiple callbacks
-                    titleTextView.viewTreeObserver.removeOnPreDrawListener(this)
-
-                    // Get the layout of the title text
-                    val titleLayout: Layout? = titleTextView.layout
-
-                    // Check if the title occupies more than 2 lines
-                    when (titleLayout?.lineCount) {
-                        1 -> {
-                            excerptTextView.maxLines = 2
-                        }
-                        else -> {
-                            excerptTextView.maxLines = 1
-                            titleTextView.maxLines = 2
-                        }
-                    }
-                    return true
-                }
-            })
+            titleTextView.setTargetTextView(titleTextView, PostListTitleExcerptTextView.CallingTextView.TITLE)
+            excerptTextView.setTargetTextView(titleTextView, PostListTitleExcerptTextView.CallingTextView.EXCERPT)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListItemViewHolder.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.posts
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.text.Layout
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -11,7 +10,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.ImageView

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListTitleExcerptTextView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListTitleExcerptTextView.kt
@@ -1,0 +1,34 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Context
+import android.util.AttributeSet
+import com.google.android.material.textview.MaterialTextView
+import android.text.Layout
+
+class PostListTitleExcerptTextView(context: Context, attrs: AttributeSet) : MaterialTextView(context, attrs) {
+    private var targetTextView: MaterialTextView? = null
+
+    enum class CallingTextView {
+        TITLE, EXCERPT
+    }
+
+    fun setTargetTextView(targetTextView: MaterialTextView, callingTextView: CallingTextView) {
+        this.targetTextView = targetTextView
+
+        // Post a runnable to adjust maxLines after the layout is complete
+        post {
+            adjustMaxLines(callingTextView)
+        }
+    }
+
+    private fun adjustMaxLines(callingTextView: CallingTextView) {
+        // Adjust maxLines based on the target TextView's line count
+        val targetLayout: Layout? = targetTextView?.layout
+        targetLayout?.lineCount.let { lineCount ->
+            maxLines = when (callingTextView) {
+                CallingTextView.TITLE -> if (lineCount == 1) 1 else 2
+                CallingTextView.EXCERPT -> if (lineCount == 1) 2 else 1
+            }
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -76,7 +76,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <com.google.android.material.textview.MaterialTextView
+            <org.wordpress.android.ui.posts.PostListTitleExcerptTextView
                 android:id="@+id/title"
                 style="@style/PostList.Item.Title"
                 android:layout_width="0dp"
@@ -88,7 +88,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="My Title is super duper long and longer than the fox that is running into the area of large text and will have to cut off the remaining" />
 
-            <com.google.android.material.textview.MaterialTextView
+            <org.wordpress.android.ui.posts.PostListTitleExcerptTextView
                 android:id="@+id/excerpt"
                 style="@style/PostList.Item.Body"
                 android:layout_width="0dp"


### PR DESCRIPTION
This PR may or may not be a good idea. It replaces setting a treeViewObserver with a custom UI textView for title and excerpt. The custom text view posts a runnable to perform the "set max line count" action after the layout pass is complete.

IMHO, I don't see that much of a visible difference. In fact, the list may be more janky. There are other things at play here that I haven't sussed out yet and happen both in this branch and the current production version: The list freezes at times when loading next page, the shimmer effect sometimes overlaps with text, at times the list of posts doesn't gather all the posts. Some of this may be due to how the "lists" action works, but I can't be certain as of yet.

Would love to hear thoughts. Thanks!

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
