### PR TITLE
[Reader IA] Fix RTL drop-down menu not being shown 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -67,9 +66,9 @@ fun JetpackDropdownMenu(
         val cascadeMenuWidth = 200.dp
         CascadeDropdownMenu(
             modifier = Modifier
-                .background(MenuColors.itemBackgroundColor())
-                .width(cascadeMenuWidth),
+                .background(MenuColors.itemBackgroundColor()),
             expanded = isMenuVisible,
+            fixedWidth = cascadeMenuWidth,
             onDismissRequest = { isMenuVisible = false },
             offset = if (LocalLayoutDirection.current == LayoutDirection.Rtl) DpOffset(
                 cascadeMenuWidth,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -70,10 +70,10 @@ fun JetpackDropdownMenu(
             expanded = isMenuVisible,
             fixedWidth = cascadeMenuWidth,
             onDismissRequest = { isMenuVisible = false },
-            offset = if (LocalLayoutDirection.current == LayoutDirection.Rtl) DpOffset(
-                cascadeMenuWidth,
-                0.dp
-            ) else DpOffset.Zero,
+            offset = DpOffset(
+                x = if (LocalLayoutDirection.current == LayoutDirection.Rtl) cascadeMenuWidth else 0.dp,
+                y = 0.dp
+            )
         ) {
             val onMenuItemSingleClick: (MenuElementData.Item.Single) -> Unit = { clickedItem ->
                 isMenuVisible = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -169,8 +169,13 @@ private fun CascadeColumnScope.SubMenuHeader(
             LocalTextStyle provides MaterialTheme.typography.bodyLarge
         ) {
             if (this@SubMenuHeader.hasParentMenu) {
+                val backIconResource = if(LocalLayoutDirection.current == LayoutDirection.Rtl) {
+                    R.drawable.ic_arrow_right_white_24dp
+                } else {
+                    R.drawable.ic_arrow_left_white_24dp
+                }
                 Image(
-                    painter = painterResource(R.drawable.ic_arrow_left_white_24dp),
+                    painter = painterResource(backIconResource),
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(MenuColors.itemContentColor()),
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
@@ -30,12 +31,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import me.saket.cascade.CascadeColumnScope
 import me.saket.cascade.CascadeDropdownMenu
@@ -60,10 +64,17 @@ fun JetpackDropdownMenu(
                 isMenuVisible = !isMenuVisible
             }
         )
+        val cascadeMenuWidth = 200.dp
         CascadeDropdownMenu(
-            modifier = Modifier.background(MenuColors.itemBackgroundColor()),
+            modifier = Modifier
+                .background(MenuColors.itemBackgroundColor())
+                .width(cascadeMenuWidth),
             expanded = isMenuVisible,
             onDismissRequest = { isMenuVisible = false },
+            offset = if (LocalLayoutDirection.current == LayoutDirection.Rtl) DpOffset(
+                cascadeMenuWidth,
+                0.dp
+            ) else DpOffset.Zero,
         ) {
             val onMenuItemSingleClick: (MenuElementData.Item.Single) -> Unit = { clickedItem ->
                 isMenuVisible = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -157,7 +157,7 @@ private fun Filter(
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun ReaderScreenPreview() {
+fun ReaderTopAppBarPreview() {
     val menuItems = mutableListOf<MenuElementData>(
         MenuElementData.Item.Single(
             id = "discover",
@@ -179,6 +179,20 @@ fun ReaderScreenPreview() {
             text = UiString.UiStringRes(R.string.reader_dropdown_menu_liked),
             leadingIcon = R.drawable.ic_reader_liked_24dp,
         ),
+        MenuElementData.Item.SubMenu(
+            id = "subMenu1",
+            text = UiString.UiStringText("Funny Blogs"),
+            children = listOf(
+                MenuElementData.Item.Single(
+                    id = "funnyBlog1",
+                    text = UiString.UiStringText("Funny Blog 1"),
+                ),
+                MenuElementData.Item.Single(
+                    id = "funnyBlog2",
+                    text = UiString.UiStringText("Funny Blog 2"),
+                ),
+            ),
+        )
     )
 
     var topBarUiState by remember {


### PR DESCRIPTION
Fixes #19839

> [!CAUTION]
> Should not be merged before https://github.com/wordpress-mobile/WordPress-Android/pull/19805

Also fixed back icon in sub-menu considering layout direction.

### LTR
https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/f7c9c413-cf74-4085-89be-1513a8fa94ba

### RTL
https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/db76a523-8616-4a60-bd8e-04df8d50b6ae

-----

## To Test:

Run the `JetpackDropdownMenu` in RTL and LTR. A way to test it is to run `ReaderTopAppBarPreview` forcing RTL and then LTR. You can do so by wrapping the view with this `CompositionLocalProvider`:

```
CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl ) {
     // Add menu view here
}
```

-----

## Regression Notes

1. Potential unintended areas of impact
 None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
UI only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
