### PR TITLE
Replace green-ish gradient colors to white on the login screen

### DIFF
--- a/WordPress/src/jetpack/res/values/colors.xml
+++ b/WordPress/src/jetpack/res/values/colors.xml
@@ -15,10 +15,10 @@
     <color name="bg_jetpack_login_splash_bottom_panel">#CCF1F3EC</color>
     <color name="border_top_jetpack_login_splash_bottom_panel">#0D000000</color>
 
-    <color name="bg_jetpack_login_splash_top_gradient_1">#FCF1F3EC</color>
-    <color name="bg_jetpack_login_splash_top_gradient_2">#FAF1F3EC</color>
-    <color name="bg_jetpack_login_splash_top_gradient_3">#D9F1F3EC</color>
-    <color name="bg_jetpack_login_splash_top_gradient_4">#00F1F3EC</color>
+    <color name="bg_jetpack_login_splash_top_gradient_1">#FCFFFFFF</color>
+    <color name="bg_jetpack_login_splash_top_gradient_2">#FAFFFFFF</color>
+    <color name="bg_jetpack_login_splash_top_gradient_3">#D9FFFFFF</color>
+    <color name="bg_jetpack_login_splash_top_gradient_4">#00FFFFFF</color>
 
     <color name="text_color_jetpack_login_label_primary">#3858E9</color>
     <color name="text_color_jetpack_login_label_secondary">@color/jetpack_green_40</color>

--- a/WordPress/src/jetpack/res/values/strings.xml
+++ b/WordPress/src/jetpack/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="login_prologue_revamped_jetpack_feature_text_13">Build an audience</string>
     <string name="login_prologue_revamped_jetpack_feature_text_14">Post a photo</string>
     <string name="login_prologue_revamped_jetpack_feature_text_15">Write from anywhere</string>
+    <string name="login_prologue_revamped_jetpack_feature_text_16">Manage your domains</string>
 
     <!-- Login Magic Link -->
     <string name="login_magic_links_sent_label">Check your email on this device and tap the link in the email you received from Jetpack.com.</string>

--- a/WordPress/src/jetpack/res/values/texts_login_prologue_jetpack_features.xml
+++ b/WordPress/src/jetpack/res/values/texts_login_prologue_jetpack_features.xml
@@ -16,5 +16,6 @@
         <item>@string/login_prologue_revamped_jetpack_feature_text_13</item>
         <item>@string/login_prologue_revamped_jetpack_feature_text_14</item>
         <item>@string/login_prologue_revamped_jetpack_feature_text_15</item>
+        <item>@string/login_prologue_revamped_jetpack_feature_text_16</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Convo: p1703256676462629-slack-C0JJ0C1UL

The outdated green-ish gradient colors have been replaced by white within this PR

| Before | After |
| -------| ----- |
|![Screenshot_20231221_114045](https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/d8c8d984-6175-432b-a86f-58e5b5db5d67)|![Screenshot_20231222_083402](https://github.com/wordpress-mobile/WordPress-Android/assets/16563318/f7b86536-edfa-42b3-9fd9-3210a8178599)|

-----

## To Test:

- Go to a login screen and make sure you can see a white gradient behind the WP/JP logo

-----

## Regression Notes

1. Potential unintended areas of impact

    - Login screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual tests

3. What automated tests I added (or what prevented me from doing so)

    - UI changes only

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)