### PR TITLE
Update Utils library hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.10.0'
+    wordPressUtilsVersion = '137-52a9327f4278f84f8a266f209e4da77ebb668594'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '137-52a9327f4278f84f8a266f209e4da77ebb668594'
+    wordPressUtilsVersion = '3.11.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha2'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
+    wordPressFluxCVersion = '2936-4239fa78afe57e3ba3ba677f927cf33ca048e589'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha2'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2936-4239fa78afe57e3ba3ba677f927cf33ca048e589'
+    wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.11.0'


### PR DESCRIPTION
Addresses https://github.com/Automattic/jetpack-mobile-roadmap/issues/45

This PR is the companion for https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/137 to support gravatar move from md5 to sha256. 

See pb6Nl-gyD-p2 for additional info

Merge Instructions
- [x] Wait for Utils release version to be published and update this PR
~~- [x] Wait for dependency-catalog PR test version to be available and associated FluxC PR hash has been applied to this PR~~
~~- [x] Test again after the FluxC hash has been applied~~
~~- [ ] Wait for dependency-catalog release version to be available and associated FluxC PR updated/merged to trunk~~
~~- [ ] Update the FluxC hash after the merge into trunk~~
- [ ] Merge this PR as normal

Note: Removed the FluxC steps based upon this conversation: p1704390087406499/1704207355.619229-slack-CC7L49W13


-----

## To Test:
I found it quite tricky to test, as if there is already a author profile url, the code to get the gravatar from email is not executed. The best way to test it to use the branch
- Download the branch
- Open `CommentDetailFragment.java`
- Make a change in `showCommentWhenNonNull` as follows:
**Add as line 816:**
`
boolean forceGravatar = comment.getAuthorEmail() != null && comment.getAuthorEmail().equalsIgnoreCase("yourgravataremail@wherever.com")
`
**Change old line 816 to** 
`if (comment.getAuthorProfileImageUrl() != null && !forceGravatar) {`
- You can add log lines to elseif branch to validate that you are calling the proper method
- Compile and launch the app
- Navigate to `Notifications` tab
- Select a conversation in which you are a participant (make sure the authorEmail matches what you provided in the statement above
- ✅ Verify your gravatar is shown as normal

Note: Launching comments via notifications is the only area that uses this logic. All other comments are handled via the reader post comment. If you want to do a cursory look for any other instances that use `gravatarFromEmail` or `blavatarFromUrl` that would be great.

-----

## Regression Notes

1. Potential unintended areas of impact
Gravatars do not load

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: N/A