### PR TITLE
[JP Social] Fix social share limit being shown Atomic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/usecase/social/GetJetpackSocialShareLimitStatusUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/usecase/social/GetJetpackSocialShareLimitStatusUseCase.kt
@@ -10,9 +10,9 @@ class GetJetpackSocialShareLimitStatusUseCase @Inject constructor(
     private val siteStore: SiteStore,
 ) {
     suspend fun execute(siteModel: SiteModel): ShareLimit {
-        val isShareLimitEnabled =
-            !siteModel.isHostedAtWPCom
-                    && (siteModel.planActiveFeatures?.split(",")?.doesNotContain(FEATURE_SOCIAL_SHARES_1000) != false)
+        val isWPComSite = siteModel.isWPCom || siteModel.isWPComAtomic
+        val isShareLimitEnabled = !isWPComSite &&
+                    (siteModel.planActiveFeatures?.split(",")?.doesNotContain(FEATURE_SOCIAL_SHARES_1000) != false)
         val result = siteStore.fetchJetpackSocial(siteModel)
         return if (isShareLimitEnabled && result is FetchedJetpackSocialResult.Success) {
             with(result.jetpackSocial) {

--- a/WordPress/src/test/java/org/wordpress/android/usecase/social/GetJetpackSocialShareLimitStatusUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/usecase/social/GetJetpackSocialShareLimitStatusUseCaseTest.kt
@@ -19,10 +19,11 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
     )
 
     @Test
-    fun `Should return Disabled if site is not self hosted`() = test {
+    fun `Should return Disabled if site is hosted at WPCom`() = test {
         val siteModel = SiteModel().apply {
             siteId = 1L
-            setIsJetpackInstalled(false)
+            setIsWPCom(true)
+            setIsWPComAtomic(false)
         }
         val expected = ShareLimit.Disabled
         val actual = classToTest.execute(siteModel)
@@ -30,10 +31,23 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should return Disabled if site has social-shares-1000 feature active`() = test {
+    fun `Should return Disabled if site is Atomic`() = test {
         val siteModel = SiteModel().apply {
             siteId = 1L
-            setIsJetpackInstalled(true)
+            setIsWPCom(false)
+            setIsWPComAtomic(true)
+        }
+        val expected = ShareLimit.Disabled
+        val actual = classToTest.execute(siteModel)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should return Disabled if site is self-hosted AND has social-shares-1000 feature active`() = test {
+        val siteModel = SiteModel().apply {
+            siteId = 1L
+            setIsWPCom(false)
+            setIsWPComAtomic(false)
             planActiveFeatures = "social-shares-1000"
         }
         val expected = ShareLimit.Disabled
@@ -42,7 +56,7 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should return Enabled if active features list is null AND is self hosted`() = test {
+    fun `Should return Enabled if site is self-hosted AND active features list is null`() = test {
         val jetpackSocial = JetpackSocial(
             isShareLimitEnabled = true,
             toBePublicizedCount = 10,
@@ -55,7 +69,8 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
         )
         val siteModel = SiteModel().apply {
             siteId = 1L
-            setIsJetpackInstalled(true)
+            setIsWPCom(false)
+            setIsWPComAtomic(false)
             planActiveFeatures = null
         }
         whenever(siteStore.fetchJetpackSocial(siteModel)).thenReturn(FetchedJetpackSocialResult.Success(jetpackSocial))
@@ -83,7 +98,8 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
         )
         val siteModel = SiteModel().apply {
             siteId = 1L
-            setIsJetpackInstalled(true)
+            setIsWPCom(false)
+            setIsWPComAtomic(false)
             planActiveFeatures = ""
         }
         whenever(siteStore.fetchJetpackSocial(siteModel)).thenReturn(FetchedJetpackSocialResult.Success(jetpackSocial))
@@ -101,7 +117,8 @@ class GetJetpackSocialShareLimitStatusUseCaseTest : BaseUnitTest() {
     fun `Should return Disabled if fetch site fails`() = test {
         val siteModel = SiteModel().apply {
             siteId = 1L
-            setIsJetpackInstalled(true)
+            setIsWPCom(false)
+            setIsWPComAtomic(false)
             planActiveFeatures = ""
         }
         whenever(siteStore.fetchJetpackSocial(siteModel)).thenReturn(


### PR DESCRIPTION
Fixes #19641 

We were only checking `isHostedAtWPCom` which checks if the site doesn't have Jetpack installed. It turns out that returns `false` for Atomic sites since they DO have Jetpack installed. The correct way to check if a site is a WPCom site, that is used in other places of the app, is by checking `isWPCom || isWPComAtomic` from `SIteModel`. So that's what this fix does.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/e83df1e3-4640-46cf-92fe-38c20b30e3ca

-----

## To Test:

### Requisites
You need an Atomic site to test the bug and the fix. For Automatticians, the easiest way I found to get an Atomic site, if I remember correctly, is:
1. Create a site
2. Buy an upgrade to a Creator plan (or any plan that supports installing plugins)
3. Install a plugin

### Steps
1. Open and log into Jetpack
2. Select an Atomic site
3. Connect a Social network account to it (`My Site` -> `More` option -> `Social`)
4. Go to your Posts
5. Create a new post
6. Hit Publish
7. **Verify** no text about share limits (like "30 shares remaining") is shown in the JP Social pre-publish item

If you want to go the extra mile you can also post and share over 30 posts and **verify** the JP Social item is always available and usable, and the posts are still shared as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Sharing functionality is broken on other types of sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Added unit tests covering the fix scenario (Atomic sites).

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
