### PR TITLE
Fixed Like button Attributes

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post_new.xml
@@ -191,7 +191,6 @@
             android:text="@string/like"
             app:drawableStartCompat="@drawable/ic_like_new_selector"
             app:layout_goneMarginStart="0dp"
-            app:layout_constraintWidth_max="80dp"
             app:layout_constraintStart_toEndOf="@id/comment"
             app:layout_constraintEnd_toStartOf="@id/more_menu"
             app:layout_constraintTop_toBottomOf="@id/reader_card_interactions_bottom_barrier"


### PR DESCRIPTION

Fixes #

Updated Like button text view in XML layout So that i does not go out of bound in Spanish Language
[Localization](https://github.com/wordpress-mobile/WordPress-Android/labels/Localization)
[[Pri] Medium](https://github.com/wordpress-mobile/WordPress-Android/labels/%5BPri%5D%20Medium)
[Reader](https://github.com/wordpress-mobile/WordPress-Android/labels/Reader)
[[Type] Bug](https://github.com/wordpress-mobile/WordPress-Android/labels/%5BType%5D%20Bug)

-----

What I did :- Remove max width Attribute from like textview

![Screenshot 2023-12-24 145649](https://github.com/wordpress-mobile/WordPress-Android/assets/152642367/a2267f4b-3402-47e5-a23d-dd48c394b75d)

Here's the proof !!...

