### PR TITLE
Use `trackWithSiteDetails` to track media upload events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -21,6 +21,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.config.Mp4ComposerVideoOptimizationFeatureConfig;
 
@@ -395,7 +396,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         if (properties != null) {
             mediaProperties.putAll(properties);
         }
-        AnalyticsTracker.track(stat, mediaProperties);
+        SiteModel site = mSiteStore.getSiteByLocalId(media.getLocalSiteId());
+        AnalyticsUtils.trackWithSiteDetails(stat, site, mediaProperties);
     }
 
     private boolean mediaAlreadyQueuedOrUploading(MediaModel mediaModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -21,7 +21,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
-import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.config.Mp4ComposerVideoOptimizationFeatureConfig;
 


### PR DESCRIPTION
This uses `AnalyticsUtils.trackWithSiteDetails` to track media upload events so that we can better diagnosis failure events.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Add a some media to a blog via the editor and via the media library 
- Notice that the media related tracking log messages now include `site_type`, `blog_id`, and `is_jetpack` properties 

-----

## Regression Notes

1. Potential unintended areas of impact

    Change in metric tracking 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Verified that only new keys are added to the tracking event
    - Verified that the event ids are unchanged 

3. What automated tests I added (or what prevented me from doing so)

    No additional test coverage is needed.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
