### PR TITLE
[Reader IA] Make Filter slide in/out horizontally when animating

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -45,7 +45,7 @@ import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChipGrou
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterType
 import org.wordpress.android.ui.utils.UiString
 
-private const val ANIM_DURATION = 200
+private const val ANIM_DURATION = 300
 private val chipHeight = 36.dp
 
 @Composable
@@ -106,9 +106,9 @@ fun ReaderTopAppBar(
                 AnimatedVisibility(
                     visible = isFilterShown,
                     enter = fadeIn(tween(delayMillis = ANIM_DURATION)) +
-                            slideInVertically(tween(delayMillis = ANIM_DURATION)) { it / 2 },
+                            slideInHorizontally(tween(delayMillis = ANIM_DURATION)) { -it / 2 },
                     exit = fadeOut(tween(ANIM_DURATION)) +
-                            slideOutVertically(tween(ANIM_DURATION)) { it / 2 },
+                            slideOutHorizontally(tween(ANIM_DURATION)) { -it / 2 },
                 ) {
                     latestFilterState?.let { filterUiState ->
                         Filter(


### PR DESCRIPTION
Fixes #19861

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/a497047d-4e71-455f-8dca-21a5248a4813

-----

## To Test:

1. Install and log into Jetpack
2. Go to Reader
3. Select "Subscriptions"
4. **Verify** the enter animation now slides horizontally
5. Select another feed
6. **Verify** the exit animation also slides horizontally

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

8. What automated tests I added (or what prevented me from doing so)

    - N/A, UI only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
