### PR TITLE
[Reader IA] Update blog item UI in Filter sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
 import org.wordpress.android.util.extensions.getSerializableCompat
+import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.widgets.WPTextView
 import java.lang.ref.WeakReference
 import javax.inject.Inject
@@ -46,6 +47,9 @@ class SubfilterPageFragment : Fragment() {
 
     @Inject
     lateinit var uiHelpers: UiHelpers
+
+    @Inject
+    lateinit var imageManager: ImageManager
 
     @Inject
     lateinit var seenUnseenWithCounterFeatureConfig: SeenUnseenWithCounterFeatureConfig
@@ -89,7 +93,8 @@ class SubfilterPageFragment : Fragment() {
 
         recyclerView = view.findViewById(R.id.content_recycler_view)
         recyclerView.layoutManager = LinearLayoutManager(requireActivity())
-        recyclerView.adapter = SubfilterListAdapter(uiHelpers, statsUtils, seenUnseenWithCounterFeatureConfig)
+        recyclerView.adapter =
+            SubfilterListAdapter(uiHelpers, statsUtils, imageManager, seenUnseenWithCounterFeatureConfig)
 
         emptyStateContainer = view.findViewById(R.id.empty_state_container)
         title = emptyStateContainer.findViewById(R.id.title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/adapters/SubfilterListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/adapters/SubfilterListAdapter.kt
@@ -24,10 +24,12 @@ import org.wordpress.android.ui.reader.subfilter.viewholders.TagViewHolder
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
+import org.wordpress.android.util.image.ImageManager
 
 class SubfilterListAdapter(
     val uiHelpers: UiHelpers,
     val statsUtils: StatsUtils,
+    val imageManager: ImageManager,
     val seenUnseenWithCounterFeatureConfig: SeenUnseenWithCounterFeatureConfig
 ) : Adapter<SubfilterListItemViewHolder>() {
     private var items: List<SubfilterListItem> = listOf()
@@ -52,6 +54,7 @@ class SubfilterListAdapter(
             is SiteViewHolder -> holder.bind(
                 item as Site,
                 uiHelpers,
+                imageManager,
                 statsUtils,
                 seenUnseenWithCounterFeatureConfig.isEnabled()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/viewholders/SiteViewHolder.kt
@@ -2,13 +2,18 @@ package org.wordpress.android.ui.reader.subfilter.viewholders
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.isVisible
 import org.wordpress.android.R
+import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site
 import org.wordpress.android.ui.stats.refresh.utils.ONE_THOUSAND
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.UrlUtils
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType
 
 class SiteViewHolder(
     parent: ViewGroup
@@ -16,8 +21,15 @@ class SiteViewHolder(
     private val itemTitle = itemView.findViewById<TextView>(R.id.item_title)
     private val itemUrl = itemView.findViewById<TextView>(R.id.item_url)
     private val itemUnseenCount = itemView.findViewById<TextView>(R.id.unseen_count)
+    private val itemAvatar = itemView.findViewById<ImageView>(R.id.item_avatar)
 
-    fun bind(site: Site, uiHelpers: UiHelpers, statsUtils: StatsUtils, showUnreadpostsCount: Boolean) {
+    fun bind(
+        site: Site,
+        uiHelpers: UiHelpers,
+        imageManager: ImageManager,
+        statsUtils: StatsUtils,
+        showUnreadpostsCount: Boolean
+    ) {
         super.bind(site, uiHelpers)
         this.itemTitle.text = uiHelpers.getTextOfUiString(parent.context, site.label)
         this.itemUrl.visibility = View.VISIBLE
@@ -35,6 +47,22 @@ class SiteViewHolder(
             this.itemUnseenCount.visibility = View.VISIBLE
         } else {
             this.itemUnseenCount.visibility = View.GONE
+        }
+
+        updateSiteAvatar(blog, imageManager)
+    }
+
+    private fun updateSiteAvatar(blog: ReaderBlog, imageManager: ImageManager) {
+        itemAvatar.isVisible = true
+        if (blog.hasImageUrl()) {
+            imageManager.loadIntoCircle(
+                itemAvatar,
+                ImageType.BLAVATAR_CIRCULAR,
+                blog.imageUrl,
+            )
+        } else {
+            imageManager.cancelRequestAndClearImageView(itemAvatar)
+            itemAvatar.setImageResource(R.drawable.bg_oval_placeholder_globe_no_border_24dp)
         }
     }
 }

--- a/WordPress/src/main/res/layout/subfilter_list_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_list_item.xml
@@ -7,6 +7,7 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/item_avatar"
+        style="@style/ReaderImageView.Avatar.OvalSurfaceBackground"
         android:visibility="gone"
         android:layout_width="40dp"
         android:layout_height="40dp"

--- a/WordPress/src/main/res/layout/subfilter_list_item.xml
+++ b/WordPress/src/main/res/layout/subfilter_list_item.xml
@@ -5,15 +5,28 @@
     style="@style/SubfilterSiteTagItem"
     android:layout_width="match_parent">
 
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/item_avatar"
+        android:visibility="gone"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        app:layout_constraintTop_toTopOf="@id/item_title"
+        app:layout_constraintBottom_toBottomOf="@id/item_url"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:src="@drawable/bg_oval_placeholder_globe_no_border_24dp"
+        tools:visibility="visible" />
+
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/item_title"
         style="@style/SiteTagFilteredTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_large"
         app:layout_constraintEnd_toStartOf="@+id/unseen_count"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/item_avatar"
         app:layout_constraintBottom_toTopOf="@+id/item_url"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginStart="0dp"
         app:layout_goneMarginBottom="@dimen/margin_large"
         app:layout_goneMarginEnd="0dp"
         tools:text="Unknown" />
@@ -23,11 +36,13 @@
         style="@style/SiteTagFilteredUrl"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_large"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/unseen_count"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/item_avatar"
         app:layout_constraintTop_toBottomOf="@+id/item_title"
         android:visibility="visible"
+        app:layout_goneMarginStart="0dp"
         app:layout_goneMarginEnd="0dp"
         tools:text="www.unknown.com" />
 


### PR DESCRIPTION
Fixes #19612 

> [!Caution]
> Do not merge before #19860

This adds a site avatar to the Filter sheet for blogs or shows a placeholder (same used in the Manage Subscriptions screen) in case the site does not have an icon.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/12eefd50-221d-4976-ab84-b3cfc10c38f6

-----

## To Test:

1. Install and log into Jetpack
2. Go to the Reader
3. Select a feed that has "Blogs" filter (like "Subscriptions")
4. Tap the "Blogs" filter pill
5. **Verify** the filter list shows the updated blog item UI (with an avatar)

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

7. What automated tests I added (or what prevented me from doing so)

    - N/A, UI only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
