### PR TITLE
[Gutenberg] Add onMediaUploadPaused handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.110.0-alpha2'
+    gutenbergMobileVersion = '6499-739f8cc2e2587e1499af7250e8b904c7e8bc5f5f'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -7,6 +7,7 @@ public interface EditorMediaUploadListener {
     void onMediaUploadReattached(String localId, float currentProgress);
     void onMediaUploadSucceeded(String localId, MediaFile mediaFile);
     void onMediaUploadProgress(String localId, float progress);
-    void onMediaUploadFailed(String localId);
+    void onMediaUploadFailed(String localId, float progress);
+    void onMediaUploadPaused(String localId, float progress);
     void onGalleryMediaUploadSucceeded(long galleryId, long remoteId, int remaining);
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -308,6 +308,10 @@ public class GutenbergContainerFragment extends Fragment {
         mWPAndroidGlueCode.mediaFileSaveFailed(mediaId);
     }
 
+    public void mediaFileSavePaused(final String mediaId) {
+        mWPAndroidGlueCode.mediaFileSavePaused(mediaId);
+    }
+
     public void mediaFileSaveSucceeded(final String mediaId, final String mediaUrl) {
         mWPAndroidGlueCode.mediaFileSaveSucceeded(mediaId, mediaUrl);
     }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1513,9 +1513,15 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().mediaFileSaveProgress(localId, progress);
     }
 
-    @Override public void onMediaSaveFailed(String localId) {
+    @Override public void onMediaSaveFailed(String localId, float progress) {
         getGutenbergContainerFragment().mediaFileSaveFailed(localId);
         mFailedMediaIds.add(localId);
+        mUploadingMediaProgressMax.remove(localId);
+    }
+
+    @Override public void onMediaUploadPaused(String localId, float progress) {
+        getGutenbergContainerFragment().mediaFileSaveFailed(localId);
+
         mUploadingMediaProgressMax.remove(localId);
     }
 


### PR DESCRIPTION
**WIP** 

Adds onMediaUploadPaused for mobile editor media uploads. References:

* https://github.com/WordPress/gutenberg/pull/57476
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6499

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
