### PR TITLE
[Bloganuary] Keep showing Bloganuary card in January

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.posts.PostCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardType
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository.QuickStartCategory
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
+import org.wordpress.android.ui.utils.UiString
 
 sealed class MySiteCardAndItemBuilderParams {
     data class SiteInfoCardBuilderParams(
@@ -153,6 +154,8 @@ sealed class MySiteCardAndItemBuilderParams {
     ) : MySiteCardAndItemBuilderParams()
 
     data class BloganuaryNudgeCardBuilderParams(
+        val title: UiString,
+        val text: UiString,
         val isEligible: Boolean,
         val onLearnMoreClick: () -> Unit,
         val onMoreMenuClick: () -> Unit,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -102,7 +102,7 @@ fun BloganuaryNudgeCardPreview() {
     AppTheme {
         BloganuaryNudgeCard(
             model = BloganuaryNudgeCardModel(
-                UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+                UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title_december),
                 UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text),
                 onLearnMoreClick = ListItemInteraction.create { },
                 onMoreMenuClick = ListItemInteraction.create { },

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
@@ -11,8 +11,8 @@ class BloganuaryNudgeCardBuilder @Inject constructor() {
     fun build(params: BloganuaryNudgeCardBuilderParams): BloganuaryNudgeCardModel? {
         return if (params.isEligible) {
             BloganuaryNudgeCardModel(
-                title = UiStringRes(R.string.bloganuary_dashboard_nudge_title),
-                text = UiStringRes(R.string.bloganuary_dashboard_nudge_text),
+                title = params.title,
+                text = params.text,
                 onLearnMoreClick = ListItemInteraction.create(params.onLearnMoreClick),
                 onMoreMenuClick = ListItemInteraction.create(params.onMoreMenuClick),
                 onHideMenuItemClick = ListItemInteraction.create(params.onHideMenuItemClick),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilder.kt
@@ -1,10 +1,8 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloganuary
 
-import org.wordpress.android.R
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
 import org.wordpress.android.ui.utils.ListItemInteraction
-import org.wordpress.android.ui.utils.UiString.UiStringRes
 import javax.inject.Inject
 
 class BloganuaryNudgeCardBuilder @Inject constructor() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -40,14 +40,21 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
     }
 
     fun getBuilderParams(): BloganuaryNudgeCardBuilderParams {
-        val now = dateTimeUtilsWrapper.getCalendarInstance()
+        val currentMonth = dateTimeUtilsWrapper.getCalendarInstance().get(Calendar.MONTH)
         val isEligible = bloganuaryNudgeFeatureConfig.isEnabled() &&
-                now.get(Calendar.MONTH) == Calendar.DECEMBER &&
+                currentMonth in listOf(Calendar.DECEMBER, Calendar.JANUARY) &&
                 bloggingPromptsSettingsHelper.isPromptsFeatureAvailable() &&
                 !isCardHiddenByUser()
 
+        // title should be different for different months
+        val titleRes = if (currentMonth == Calendar.JANUARY) {
+            R.string.bloganuary_dashboard_nudge_title_january
+        } else {
+            R.string.bloganuary_dashboard_nudge_title_december
+        }
+
         return BloganuaryNudgeCardBuilderParams(
-            title = UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+            title = UiStringRes(titleRes),
             text = UiStringRes(R.string.bloganuary_dashboard_nudge_text),
             isEligible = isEligible,
             onLearnMoreClick = ::onLearnMoreClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSlice.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.wordpress.android.R
 import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker
 import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker.BloganuaryNudgeCardMenuItem
 import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
@@ -12,6 +13,7 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.Bloganuary
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
 import org.wordpress.android.viewmodel.Event
@@ -45,6 +47,8 @@ class BloganuaryNudgeCardViewModelSlice @Inject constructor(
                 !isCardHiddenByUser()
 
         return BloganuaryNudgeCardBuilderParams(
+            title = UiStringRes(R.string.bloganuary_dashboard_nudge_title),
+            text = UiStringRes(R.string.bloganuary_dashboard_nudge_text),
             isEligible = isEligible,
             onLearnMoreClick = ::onLearnMoreClick,
             onMoreMenuClick = ::onMoreMenuClick,

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -13,7 +13,7 @@ Language: ar
     <string name="bloganuary_dashboard_nudge_overlay_text_two">انشر ردك.</string>
     <string name="bloganuary_dashboard_nudge_overlay_text_one">استقبل موجّهًا جديدًا لإلهامك في كل يوم.</string>
     <string name="bloganuary_dashboard_nudge_text">بالنسبة إلى شهر يناير، ستأتي موجّهات التدوين من Bloganuary - تحدٍّ مجتمعي لدينا لإنشاء عادة التدوين الخاصة بالعام الجديد.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary قادمة!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary قادمة!</string>
     <string name="turn_off">لا، توقف عن الاستخدام</string>
     <string name="leave_on">نعم، واصل الاستخدام</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">لهذا السبب، نوصي بتحرير المكوّن باستخدام متصفح الويب لديك.</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -16,7 +16,7 @@ Language: de
     <string name="bloganuary_dashboard_nudge_overlay_title">Unsere Schreib-Challenge dauert einen Monat – sei dabei</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">Im Januar erhältst du Blog-Schreibanregungen vom Bloganuary, unserer Community-Challenge. Diese soll dir helfen, Bloggen im neuen Jahr zur Gewohnheit zu machen.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary steht vor der Tür!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary steht vor der Tür!</string>
     <string name="turn_off">Nein, deaktivieren</string>
     <string name="leave_on">Ja, aktiviert lassen</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Aus diesem Grund empfehlen wir, den Block in deinem Webbrowser zu bearbeiten.</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -16,7 +16,7 @@ Language: en_GB
     <string name="bloganuary_dashboard_nudge_overlay_title">Join our month-long writing challenge</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary – our community challenge to build a blogging habit for the new year.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary is coming!</string>
     <string name="turn_off">No, turn off</string>
     <string name="leave_on">Yes, leave on</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">For this reason, we recommend editing the block using your web browser.</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -16,7 +16,7 @@ Language: es
     <string name="bloganuary_dashboard_nudge_overlay_title">Únete a nuestro reto de escritura de un mes</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">Durante el mes de enero, recibirás sugerencias de publicación de Bloganuary, nuestro reto de la comunidad para que crees un hábito de publicación sólido para el nuevo año.</string>
-    <string name="bloganuary_dashboard_nudge_title">¡Bloganuary está a la vuelta de la esquina!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">¡Bloganuary está a la vuelta de la esquina!</string>
     <string name="turn_off">No, apágala</string>
     <string name="leave_on">Sí, déjala encendida</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Por esta razón, te recomendamos que edites el bloque utilizando tu navegador web.</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -16,7 +16,7 @@ Language: fr
     <string name="bloganuary_dashboard_nudge_overlay_title">Participer à notre défi d’écriture d’un mois</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">De Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">Pendant le mois de janvier, vous recevrez des invites à bloguer de Bloganuary, notre défi commun pour ancrer l’habitude de bloguer à l’occasion de la nouvelle année.</string>
-    <string name="bloganuary_dashboard_nudge_title">C’est bientôt Bloganuary !</string>
+    <string name="bloganuary_dashboard_nudge_title_december">C’est bientôt Bloganuary !</string>
     <string name="turn_off">Non, désactiver</string>
     <string name="leave_on">Oui, laisser activé</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Pour cette raison, nous vous recommandons de modifier le bloc à l’aide de votre navigateur web.</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -16,7 +16,7 @@ Language: fr
     <string name="bloganuary_dashboard_nudge_overlay_title">Participer à notre défi d’écriture d’un mois</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">De Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">Pendant le mois de janvier, vous recevrez des invites à bloguer de Bloganuary, notre défi commun pour ancrer l’habitude de bloguer à l’occasion de la nouvelle année.</string>
-    <string name="bloganuary_dashboard_nudge_title">C’est bientôt Bloganuary !</string>
+    <string name="bloganuary_dashboard_nudge_title_december">C’est bientôt Bloganuary !</string>
     <string name="turn_off">Non, désactiver</string>
     <string name="leave_on">Oui, laisser activé</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Pour cette raison, nous vous recommandons de modifier le bloc à l’aide de votre navigateur web.</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -15,7 +15,7 @@ Language: he_IL
     <string name="bloganuary_dashboard_nudge_overlay_text_one">כך תגיע אליך מדי יום הצעת כתיבה חדשה שתיתן לך השראה.</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">אנו מזמינים אותך להצטרף לאתגר הכתיבה שלנו שיימשך חודש שלם</string>
     <string name="bloganuary_dashboard_nudge_text">לאורך כל חודש ינואר, יתקבלו מ-Bloganuary הצעות כתיבה יומיות בבלוג. זהו האתגר הקהילתי שלנו לביסוס הרגלי פרסום בבלוג לשנה החדשה.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary מתקרב!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary מתקרב!</string>
     <string name="turn_off">לא, נא לכבות</string>
     <string name="leave_on">כן, להמשיך</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">מסיבה זו מומלץ \'לשטח\' את התוכן על ידי ביטול הקבצת הבלוק או לערוך את הבלוק בעזרת דפדפן האינטרנט.</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -15,7 +15,7 @@ Language: id
     <string name="bloganuary_dashboard_nudge_overlay_text_one">Dapatkan prompt baru untuk menginspirasi Anda setiap hari.</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">Ikuti tantangan menulis sebulan penuh dari kami</string>
     <string name="bloganuary_dashboard_nudge_text">Selama bulan Januari, prompt blogging akan datang dari Bloganuary—tantangan kami untuk komunitas guna membentuk kebiasaan blogging di tahun yang baru.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary segera hadir!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary segera hadir!</string>
     <string name="turn_off">Tidak, matikan</string>
     <string name="leave_on">Ya, biarkan</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Karenanya, kami menyarankan Anda untuk mengedit blok melalui browser web.</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -15,7 +15,7 @@ Language: it
     <string name="bloganuary_dashboard_nudge_overlay_text_one">Ricevi un nuovo suggerimento per ottenere ispirazione ogni giorno.</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">Prendi parte alla nostra sfida di scrittura: dura un mese.</string>
     <string name="bloganuary_dashboard_nudge_text">Per il mese di gennaio, le richieste di blogging arriveranno da Bloganuary: la sfida della nostra community per creare delle abitudini di blogging per il nuovo anno.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary è in arrivo.</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary è in arrivo.</string>
     <string name="turn_off">No, disattiva</string>
     <string name="leave_on">Si, continua</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Per questo motivo consigliamo di modificare il blocco tramite il browser web.</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -15,7 +15,7 @@ Language: ja_JP
     <string name="bloganuary_dashboard_nudge_overlay_text_one">毎日インスピレーションを与える新しいプロンプトを受け取ることができます。</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">1か月間のライティングチャレンジにご参加ください</string>
     <string name="bloganuary_dashboard_nudge_text">1月のブログ作成のプロンプトは Bloganuary より、新年にブログ投稿を習慣付けるためのコミュニティの課題が提示されます。</string>
-    <string name="bloganuary_dashboard_nudge_title">まもなく Bloganuary です !</string>
+    <string name="bloganuary_dashboard_nudge_title_december">まもなく Bloganuary です !</string>
     <string name="turn_off">オフにする</string>
     <string name="leave_on">そのままにする</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">このため、Web ブラウザーでブロックを編集することをお勧めします。</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -15,7 +15,7 @@ Language: ko_KR
     <string name="bloganuary_dashboard_nudge_overlay_text_one">영감을 주는 새로운 프롬프트를 매일 받아보세요.</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">한 달 동안 진행되는 글쓰기 챌린지 참여</string>
     <string name="bloganuary_dashboard_nudge_text">1월 한 달 동안 새해에 블로깅 습관을 들이는 커뮤니티 챌린지인 Bloganuary에서 1월 한 달 동안 블로깅 프롬프트가 제공됩니다.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary가 다가오고 있습니다!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary가 다가오고 있습니다!</string>
     <string name="turn_off">아니요. 끄기</string>
     <string name="leave_on">예. 그대로 두기</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">따라서 웹 브라우저를 사용하여 블록을 편집하는 것이 좋습니다.</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -16,7 +16,7 @@ Language: pt_BR
     <string name="bloganuary_dashboard_nudge_overlay_title">Participe do nosso desafio de escrita do mês</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">Durante o mês de janeiro, as sugestões de publicação virão do Bloganuary, nosso desafio para a comunidade criar um hábito de publicação no ano que se inicia.</string>
-    <string name="bloganuary_dashboard_nudge_title">O Bloganuary está chegando!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">O Bloganuary está chegando!</string>
     <string name="turn_off">Não, desativar</string>
     <string name="leave_on">Sim, manter ativa</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Por isso, recomendamos editar o bloco usando seu navegador.</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -16,7 +16,7 @@ Language: ro
     <string name="bloganuary_dashboard_nudge_overlay_title">Alătură-te provocării noastre de a scrie timp de o lună</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">În luna ianuarie, îndemnurile de a scrie vor veni de la Bloganuary - provocarea comunității noastre de a crea un obicei de a scrie pe bloguri în noul an.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary vine în curând!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary vine în curând!</string>
     <string name="turn_off">Nu, oprește</string>
     <string name="leave_on">Da, lasă în continuare</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Din acest motiv, recomandăm să editezi blocul folosind navigatorul web.</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -16,7 +16,7 @@ Language: ru
     <string name="bloganuary_dashboard_nudge_overlay_title">Присоединяйтесь к нашему писательскому челленджу, который продлится месяц</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">В январе подсказки по ведению блога будут рассылаться через Bloganuary — челлендж сообщества, призванный выработать привычку ежедневно вести блог в новом году.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary уже на пороге!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary уже на пороге!</string>
     <string name="turn_off">Нет, отключить</string>
     <string name="leave_on">Да, оставить</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">По этой причине мы рекомендуем редактировать блок с помощью веб-браузера.</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -14,7 +14,7 @@ Language: sq_AL
     <string name="bloganuary_dashboard_nudge_overlay_text_one">Merrni një cytje të re, për t’ju frymëzuar çdo ditë.</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">Merrni pjesë te sfida jonë, e gjatë një muaj, për shkrim</string>
     <string name="bloganuary_dashboard_nudge_text">Për muajin janar, cytjet për blogim do të vijnë nga Bloganuary - sfida e bashkësisë tonë për të krijuar një zakon blogimi për vitin e ri.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary po vjen!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary po vjen!</string>
     <string name="turn_off">Jo, çaktivizoje</string>
     <string name="leave_on">Po, lëre të aktivizuar</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Për këtë arsye, rekomandojmë përpunimin e bllokut duke përdorur shfletuesin tuaj.</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -16,7 +16,7 @@ Language: sv_SE
     <string name="bloganuary_dashboard_nudge_overlay_title">Gå med i vår månadslånga skrivutmaning</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>
     <string name="bloganuary_dashboard_nudge_text">För månaden januari kommer bloggningsförslagen att komma från Bloganuary – vår communityutmaning avsedd att bygga upp en bloggvana för det nya året.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary är på väg!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary är på väg!</string>
     <string name="turn_off">Nej, stäng av</string>
     <string name="leave_on">Ja, lämna på</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Av den här anledningen rekommenderar vi att du redigerar blocket i din webbläsare.</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -16,7 +16,7 @@ Language: tr
     <string name="bloganuary_dashboard_nudge_overlay_title">Bir ay sürecek yazma etkinliğimize katılın</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Blog yılı</string>
     <string name="bloganuary_dashboard_nudge_text">Yeni yılda blog yazma alışkanlığı oluşturmayı hedefleyen topluluk etkinliğimiz Bloganuary\'den Ocak ayı boyunca blog istemleri alacaksınız.</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary yaklaşıyor!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary yaklaşıyor!</string>
     <string name="turn_off">Hayır, kapat</string>
     <string name="leave_on">Evet, açık kalsın</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">Bu nedenle, bloku web tarayıcınızı kullanarak düzenlemenizi öneririz.</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -15,7 +15,7 @@ Language: zh_CN
     <string name="bloganuary_dashboard_nudge_overlay_text_one">每天接收新的提示，以获取灵感。</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">加入我们为期一个月的写作挑战</string>
     <string name="bloganuary_dashboard_nudge_text">在一月份，Bloganuary 将向您发送博客提示，这是我们发起的一项社区挑战，旨在帮助广大用户在新的一年养成写博客的习惯。</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary 即将上线！</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary 即将上线！</string>
     <string name="turn_off">不，停止优化</string>
     <string name="leave_on">是，继续优化</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">因此，我们建议使用 Web 浏览器编辑该区块。</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -15,7 +15,7 @@ Language: zh_TW
     <string name="bloganuary_dashboard_nudge_overlay_text_one">每天接收新提示，激發靈感。</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">參加為期一個月的寫作挑戰</string>
     <string name="bloganuary_dashboard_nudge_text">Bloganuary 會在 1 月送上網誌提示。這個社群挑戰的目的，是為了協助你在新的一年養成寫網誌的習慣。</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary 挑戰即將來臨！</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary 挑戰即將來臨！</string>
     <string name="turn_off">否，關閉</string>
     <string name="leave_on">是，保持開啟</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">因此，我們建議使用網頁瀏覽器來編輯區塊。</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -15,7 +15,7 @@ Language: zh_TW
     <string name="bloganuary_dashboard_nudge_overlay_text_one">每天接收新提示，激發靈感。</string>
     <string name="bloganuary_dashboard_nudge_overlay_title">參加為期一個月的寫作挑戰</string>
     <string name="bloganuary_dashboard_nudge_text">Bloganuary 會在 1 月送上網誌提示。這個社群挑戰的目的，是為了協助你在新的一年養成寫網誌的習慣。</string>
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary 挑戰即將來臨！</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary 挑戰即將來臨！</string>
     <string name="turn_off">否，關閉</string>
     <string name="leave_on">是，保持開啟</string>
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro">因此，我們建議使用網頁瀏覽器來編輯區塊。</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4821,7 +4821,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_for_this_reason_we_recommend_editing_the_block_using_your_web_bro" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">For this reason, we recommend editing the block using your web browser.</string>
 
     <!-- Bloganuary -->
-    <string name="bloganuary_dashboard_nudge_title">Bloganuary is coming!</string>
+    <string name="bloganuary_dashboard_nudge_title_december">Bloganuary is coming!</string>
+    <string name="bloganuary_dashboard_nudge_title_january">Bloganuary is here!</string>
     <string name="bloganuary_dashboard_nudge_text">For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.</string>
     <string name="bloganuary_dashboard_nudge_learn_more" translatable="false">@string/learn_more</string>
     <string name="bloganuary_dashboard_nudge_overlay_icon_content_description">Bloganuary</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -133,6 +133,8 @@ class CardsBuilderTest {
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloganuaryNudgeCardBuilderParams = BloganuaryNudgeCardBuilderParams(
+                    mock(),
+                    mock(),
                     false,
                     mock(),
                     mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -332,6 +332,8 @@ class CardsBuilderTest : BaseUnitTest() {
                 todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                 postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                 bloganuaryNudgeCardBuilderParams = BloganuaryNudgeCardBuilderParams(
+                    mock(),
+                    mock(),
                     isEligibleForBloganuaryNudge,
                     mock(),
                     mock(),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardBuilderTest.kt
@@ -4,12 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.wordpress.android.ui.mysite.MySiteCardAndItemBuilderParams.BloganuaryNudgeCardBuilderParams
 import org.wordpress.android.ui.utils.UiString
-import org.wordpress.android.R
 
 class BloganuaryNudgeCardBuilderTest {
     @Test
     fun `GIVEN not eligible, WHEN build is called, THEN return null`() {
         val params = BloganuaryNudgeCardBuilderParams(
+            title = UiString.UiStringText("title"),
+            text = UiString.UiStringText("text"),
             isEligible = false,
             onLearnMoreClick = {},
             onMoreMenuClick = {},
@@ -24,6 +25,8 @@ class BloganuaryNudgeCardBuilderTest {
         var currentAction = ""
 
         val params = BloganuaryNudgeCardBuilderParams(
+            title = UiString.UiStringText("title"),
+            text = UiString.UiStringText("text"),
             isEligible = true,
             onLearnMoreClick = { currentAction = "onLearnMoreClick" },
             onMoreMenuClick = { currentAction = "onMoreMenuClick" },
@@ -32,8 +35,8 @@ class BloganuaryNudgeCardBuilderTest {
         val cardModel = BloganuaryNudgeCardBuilder().build(params)
 
         assertThat(cardModel!!).isNotNull
-        assertThat(cardModel.title).isEqualTo(UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title))
-        assertThat(cardModel.text).isEqualTo(UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_text))
+        assertThat(cardModel.title).isEqualTo(UiString.UiStringText("title"))
+        assertThat(cardModel.text).isEqualTo(UiString.UiStringText("text"))
 
         // check if the callbacks are hooked correctly
         assertThat(currentAction).isEmpty()

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewModelSliceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker
 import org.wordpress.android.ui.bloganuary.BloganuaryNudgeAnalyticsTracker.BloganuaryNudgeCardMenuItem
@@ -19,6 +20,7 @@ import org.wordpress.android.ui.bloggingprompts.BloggingPromptsSettingsHelper
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.BloganuaryNudgeFeatureConfig
 
@@ -59,6 +61,7 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `GIVEN FF disabled, WHEN getting builder params, THEN not eligible`() {
+        mockCalendarMonth(Calendar.DECEMBER)
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(false)
 
         val params = viewModel.getBuilderParams()
@@ -76,8 +79,8 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         lenient.`when`(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
         lenient.`when`(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)
 
-        // Test all months except December
-        (Calendar.JANUARY..Calendar.NOVEMBER).forEach { month ->
+        // Test all months except eligible months
+        (Calendar.FEBRUARY..Calendar.NOVEMBER).forEach { month ->
             mockCalendarMonth(month)
 
             val params = viewModel.getBuilderParams()
@@ -130,6 +133,33 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         val params = viewModel.getBuilderParams()
 
         assertThat(params.isEligible).isTrue
+    }
+
+    @Test
+    fun `GIVEN requirements met AND month is DECEMBER, WHEN getting builder params, THEN return correct title`() {
+        mockEligibleRequirements(Calendar.DECEMBER)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.title).isEqualTo(UiStringRes(R.string.bloganuary_dashboard_nudge_title_december))
+    }
+
+    @Test
+    fun `GIVEN requirements met AND month is JANUARY, WHEN getting builder params, THEN return correct title`() {
+        mockEligibleRequirements(Calendar.JANUARY)
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.title).isEqualTo(UiStringRes(R.string.bloganuary_dashboard_nudge_title_january))
+    }
+
+    @Test
+    fun `GIVEN requirements met, WHEN getting builder params, THEN return correct text`() {
+        mockEligibleRequirements()
+
+        val params = viewModel.getBuilderParams()
+
+        assertThat(params.text).isEqualTo(UiStringRes(R.string.bloganuary_dashboard_nudge_text))
     }
 
     @Test
@@ -205,9 +235,9 @@ class BloganuaryNudgeCardViewModelSliceTest : BaseUnitTest() {
         whenever(dateTimeUtilsWrapper.getCalendarInstance()).thenReturn(mockCalendar)
     }
 
-    private fun mockEligibleRequirements() {
+    private fun mockEligibleRequirements(month: Int = Calendar.DECEMBER) {
         whenever(bloganuaryNudgeFeatureConfig.isEnabled()).thenReturn(true)
-        mockCalendarMonth(Calendar.DECEMBER)
+        mockCalendarMonth(month)
         whenever(bloggingPromptsSettingsHelper.isPromptsFeatureAvailable()).thenReturn(true)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(mockSiteModel)
         whenever(appPrefsWrapper.getShouldHideBloganuaryNudgeCard(SITE_ID)).thenReturn(false)


### PR DESCRIPTION
### This PR is a copy of https://github.com/wordpress-mobile/WordPress-Android/pull/19858 targeting `release/23.9` branch.
-----

internal ref: pcdRpT-4FE-p2#comment-8264

Keep showing the Bloganuary card during January with a slight variation on the card title ("Bloganuary is here!" instead of "Bloganuary is coming!") to still bring awareness to the challenge while it's going on.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/7a75b77f-7bb2-4a1c-9dab-1a06eb2ca972

-----

## To Test:

1. Install Jetpack and log in with a site that has support for Prompts (blogs)
2. Go to `My Site` dashboard
3. Change the device date to December
4. **Verify** the Nudge card is shown with "is coming" title
5. Change the device date to January
6. **Verify** the Nudge card is shown with "is here" title
7. Change the device date to any other month
8. **Verify** the Nudge card is no longer shown

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

10. What automated tests I added (or what prevented me from doing so)

    - Unit tests covering the new scenarios.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
