### PR TITLE
[Reader] Update limit of fetched tag posts from 20 to 7 in Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.reader;
 
 public class ReaderConstants {
     // max # posts to request when updating posts
-    public static final int READER_MAX_POSTS_TO_REQUEST = 20;
+    public static final int READER_MAX_POSTS_TO_REQUEST = 7;
 
     // max # results to request when searching posts & sites
     public static final int READER_MAX_SEARCH_RESULTS_TO_REQUEST = 20;


### PR DESCRIPTION
Fixes #19472

This was previously [implemented](https://github.com/wordpress-mobile/WordPress-Android/pull/19473) and then [reverted](https://github.com/wordpress-mobile/WordPress-Android/pull/19628) because the item animations when paging happened were wrong.

It seems like #19881 fixed the animations issue, which made me implement this again since there's a meaningful performance impact for the user by decreasing the number of fetched posts.

-----

## To Test:

- Install JP and sign in
- Open Reader and select "Subscriptions" menu item;
- Verify if 7 items are fetched each time we fetch a new page.


Another way to test is opening the tag posts list from blogging prompts card:
- Install JP and sign in
- Open "My Site"
- Tap on "View all responses" in blogging prompts card
- Verify if 7 items are fetched each time we fetch a new page.
-----

## Regression Notes

1. Potential unintended areas of impact

    - Inserting new posts wrong animation

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
