### PR TITLE
Add discrete onMediaUploadPaused handler to media uploads when offline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3701,7 +3701,10 @@ public class EditPostActivity extends LocaleAwareActivity implements
             mEditorMedia.onMediaUploadError(mEditorMediaUploadListener, event.media, event.error);
         } else if (event.completed) {
             // if the remote url on completed is null, we consider this upload wasn't successful
-            if (TextUtils.isEmpty(event.media.getUrl())) {
+            if (TextUtils.isEmpty(event.media.getUrl()) && !NetworkUtils.isNetworkAvailable(this)) {
+                MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
+                mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media, error);
+            } else if (TextUtils.isEmpty(event.media.getUrl())) {
                 MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 mEditorMedia.onMediaUploadError(mEditorMediaUploadListener, event.media, error);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3678,7 +3678,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return;
         }
 
-        if (!NetworkUtils.isNetworkAvailable(this)) {
+        if (event.isError() && !NetworkUtils.isNetworkAvailable(this)) {
             mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3678,6 +3678,11 @@ public class EditPostActivity extends LocaleAwareActivity implements
             return;
         }
 
+        if (!NetworkUtils.isNetworkAvailable(this)) {
+            mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media);
+            return;
+        }
+
         // event for unknown media, ignoring
         if (event.media == null) {
             AppLog.w(AppLog.T.MEDIA, "Media event carries null media object, not recognized");

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3679,7 +3679,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         }
 
         if (event.isError() && !NetworkUtils.isNetworkAvailable(this)) {
-            mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media);
+            mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media, event.error);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -298,6 +298,10 @@ class EditorMedia @Inject constructor(
         listener.onMediaUploadFailed(media.id.toString(), error.type.name)
     }
 
+    fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel) = launch {
+        listener.onMediaUploadPaused(media.id.toString())
+    }
+
     sealed class AddMediaToPostUiState(
         val editorOverlayVisibility: Boolean,
         val progressDialogUiState: ProgressDialogUiState

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -295,7 +295,7 @@ class EditorMedia @Inject constructor(
                 }
         }
         analyticsTrackerWrapper.track(EDITOR_UPLOAD_MEDIA_FAILED, properties)
-        listener.onMediaUploadFailed(media.id.toString(), error.type.name)
+        listener.onMediaUploadFailed(media.id.toString())
     }
 
     fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel) = launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -298,7 +298,15 @@ class EditorMedia @Inject constructor(
         listener.onMediaUploadFailed(media.id.toString())
     }
 
-    fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel) = launch {
+    fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel, error: MediaError) = launch {
+        val properties: Map<String, Any?> = withContext(bgDispatcher) {
+            analyticsUtilsWrapper
+                .getMediaProperties(media.isVideo, null, media.filePath)
+                .also {
+                    it["error_type"] = error.type.name
+                }
+        }
+        analyticsTrackerWrapper.track(EDITOR_UPLOAD_MEDIA_FAILED, properties)
         listener.onMediaUploadPaused(media.id.toString())
     }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1431,6 +1431,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mUploadingMediaProgressMax.remove(localMediaId);
     }
 
+    @Override
     public void onMediaUploadPaused(final String localMediaId) {
         mUploadingMediaProgressMax.remove(localMediaId);
     }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1431,6 +1431,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mUploadingMediaProgressMax.remove(localMediaId);
     }
 
+    public void onMediaUploadPaused(final String localMediaId) {
+        mUploadingMediaProgressMax.remove(localMediaId);
+    }
+
     @Override
     public void onVideoInfoRequested(final AztecAttributes attrs) {
         // VideoPress special case here

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1433,7 +1433,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onMediaUploadPaused(final String localMediaId) {
-        mUploadingMediaProgressMax.remove(localMediaId);
+        // Aztec does not leverage the paused media state, only the Gutenberg editor
+        onMediaUploadFailed(localMediaId);
     }
 
     @Override

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1413,7 +1413,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onMediaUploadFailed(final String localMediaId, final String errorType) {
+    public void onMediaUploadFailed(final String localMediaId) {
         if (!isAdded() || mContent == null) {
             return;
         }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -7,7 +7,7 @@ public interface EditorMediaUploadListener {
     void onMediaUploadReattached(String localId, float currentProgress);
     void onMediaUploadSucceeded(String localId, MediaFile mediaFile);
     void onMediaUploadProgress(String localId, float progress);
-    void onMediaUploadFailed(String localId, String errorType);
+    void onMediaUploadFailed(String localId);
     void onGalleryMediaUploadSucceeded(long galleryId, long remoteId, int remaining);
     void onMediaUploadPaused(String localId);
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -9,5 +9,5 @@ public interface EditorMediaUploadListener {
     void onMediaUploadProgress(String localId, float progress);
     void onMediaUploadFailed(String localId, String errorType);
     void onGalleryMediaUploadSucceeded(long galleryId, long remoteId, int remaining);
-    void onMediaUploadPaused(String toString);
+    void onMediaUploadPaused(String localId);
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -9,4 +9,5 @@ public interface EditorMediaUploadListener {
     void onMediaUploadProgress(String localId, float progress);
     void onMediaUploadFailed(String localId, String errorType);
     void onGalleryMediaUploadSucceeded(long galleryId, long remoteId, int remaining);
+    void onMediaUploadPaused(String toString);
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1487,7 +1487,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void onMediaUploadFailed(final String localMediaId, String errorType) {
+    public void onMediaUploadFailed(final String localMediaId) {
         getGutenbergContainerFragment().mediaFileUploadFailed(Integer.valueOf(localMediaId));
         mFailedMediaIds.add(localMediaId);
         mUploadingMediaProgressMax.remove(localMediaId);

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1488,14 +1488,14 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onMediaUploadFailed(final String localMediaId, String errorType) {
-        switch (errorType) {
-            case "CONNECTION_ERROR":
-                getGutenbergContainerFragment().mediaFileUploadPaused(Integer.valueOf(localMediaId));
-                break;
-            default:
-                getGutenbergContainerFragment().mediaFileUploadFailed(Integer.valueOf(localMediaId));
-                break;
-        }
+        getGutenbergContainerFragment().mediaFileUploadFailed(Integer.valueOf(localMediaId));
+        mFailedMediaIds.add(localMediaId);
+        mUploadingMediaProgressMax.remove(localMediaId);
+    }
+
+    @Override
+    public void onMediaUploadPaused(final String localMediaId) {
+        getGutenbergContainerFragment().mediaFileUploadPaused(Integer.valueOf(localMediaId));
         mFailedMediaIds.add(localMediaId);
         mUploadingMediaProgressMax.remove(localMediaId);
     }


### PR DESCRIPTION
Augments the work in https://github.com/wordpress-mobile/WordPress-Android/pull/19878 to pause media upload when internet connection is unavailable.

 This PR introduces a discrete `onMediaUploadPaused` handler to separate concerns and avoid invoking `mediaFileUploadPaused` from within `onMediaUploadFailed`. 


## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)


-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
