### PR TITLE
Integrate gutenberg-mobile release v1.110.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,8 @@
 * [*] Block Editor: Add support for unselecting blocks with the hardware back button [https://github.com/wordpress-mobile/WordPress-Android/pull/19828]
 * [**] [internal] Removes unused code using android tool [https://github.com/wordpress-mobile/WordPress-Android/pull/19850]
 * [**] [internal] [Jetpack-only] Adds support for dynamic dashboard cards driven by the backend [https://github.com/wordpress-mobile/WordPress-Android/pull/19801]
+* [***] Block Editor: Avoid keyboard dismiss when interacting with text blocks [https://github.com/WordPress/gutenberg/pull/57070]
+* [**] Block Editor: Auto-scroll upon block insertion [https://github.com/WordPress/gutenberg/pull/57273]
 
 23.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.110.0-alpha3'
+    gutenbergMobileVersion = '6500-c2cc8beca62f11444125153fb60011dc85904d70'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6500-c2cc8beca62f11444125153fb60011dc85904d70'
+    gutenbergMobileVersion = 'v1.110.0'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
     wordPressLoginVersion = '1.10.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.110.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6500

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.