### PR TITLE
Super Fast Media Uploads: Adjustments to scan handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkTrackingUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkTrackingUtils.kt
@@ -6,11 +6,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.OpenI
 import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils.DeepLinkSource.BANNER
 import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils.DeepLinkSource.EMAIL
 import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils.DeepLinkSource.LINK
-import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils.DeepLinkSource.QRCODE_AUTH
-import org.wordpress.android.ui.deeplinks.DeepLinkTrackingUtils.DeepLinkSource.QRCODE_MEDIA
 import org.wordpress.android.ui.deeplinks.handlers.DeepLinkHandlers
-import org.wordpress.android.ui.deeplinks.handlers.QRCodeAuthLinkHandler
-import org.wordpress.android.ui.deeplinks.handlers.QRCodeMediaLinkHandler
 import org.wordpress.android.util.UriWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import javax.inject.Inject
@@ -58,9 +54,10 @@ class DeepLinkTrackingUtils
         val trackingSource = source ?: if (uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM) {
             LINK
         } else {
-            applyBannerOrQrCodeSourceFromUri(uri)
+            BANNER
         }
-        return TrackingData(trackingSource, url ?: "", sourceInfo)
+        val trackingSourceInfo = sourceInfo ?: applyBannerSourceInfoIfNeeded(uri)
+        return TrackingData(trackingSource, url ?: "", trackingSourceInfo)
     }
 
     private fun extractTargetUri(uri: UriWrapper): UriWrapper {
@@ -73,12 +70,10 @@ class DeepLinkTrackingUtils
         } ?: uri
     }
 
-    private fun applyBannerOrQrCodeSourceFromUri(uri: UriWrapper): DeepLinkSource {
-        return when (uri.getQueryParameter("campaign")) {
-            null -> BANNER
-            QRCodeMediaLinkHandler.CAMPAIGN_TYPE -> QRCODE_MEDIA
-            QRCodeAuthLinkHandler.CAMPAIGN_TYPE -> QRCODE_AUTH
-            else -> LINK
+    private fun applyBannerSourceInfoIfNeeded(uri: UriWrapper): String? {
+        return when (val campaign = uri.getQueryParameter("campaign")) {
+            null -> null
+            else -> campaign
         }
     }
 
@@ -88,7 +83,5 @@ class DeepLinkTrackingUtils
         EMAIL("email"),
         BANNER("banner"),
         LINK("link"),
-        QRCODE_AUTH("qr-code-auth"),
-        QRCODE_MEDIA("qr-code-media")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
@@ -1,12 +1,15 @@
 package org.wordpress.android.ui.deeplinks.handlers
 
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
 import org.wordpress.android.util.UriWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 class QRCodeMediaLinkHandler @Inject constructor(
-    private val deepLinkUriUtils: DeepLinkUriUtils
+    private val deepLinkUriUtils: DeepLinkUriUtils,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) : DeepLinkHandler {
     /**
      * Returns true if the URI looks like `apps.wordpress.com/get`
@@ -22,6 +25,9 @@ class QRCodeMediaLinkHandler @Inject constructor(
         val extractedSiteId = extractSiteIdFromUrl(uri)
         return when (val siteModel = extractedSiteId?.let { siteId -> deepLinkUriUtils.blogIdToSite(siteId) }) {
             null -> {
+                analyticsTrackerWrapper.track(AnalyticsTracker.Stat.DEEP_LINK_FAILED,
+                    mapOf(ERROR to INVALID_SITE_ID,
+                        CAMPAIGN to uri.getQueryParameter(CAMPAIGN)?.replace("-", "_")))
                 NavigateAction.OpenMySite
             }
             else -> {
@@ -51,6 +57,8 @@ class QRCodeMediaLinkHandler @Inject constructor(
         private const val GET_PATH = "get"
         private const val HOST_APPS_WORDPRESS_COM = "apps.wordpress.com"
         private const val CAMPAIGN = "campaign"
+        private const val ERROR = "error"
+        private const val INVALID_SITE_ID = "invalid_site_id"
         const val CAMPAIGN_TYPE = "qr-code-media"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
@@ -12,7 +12,7 @@ class QRCodeMediaLinkHandler @Inject constructor(
      * Returns true if the URI looks like `apps.wordpress.com/get`
      */
     override fun shouldHandleUrl(uri: UriWrapper): Boolean {
-        // https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:227148183
+        // https://apps.wordpress.com/get/?campaign=qr-code-media#/media/{blog_id}
         return uri.host == HOST_APPS_WORDPRESS_COM &&
                 uri.pathSegments.firstOrNull() == GET_PATH &&
                 uri.getQueryParameter(CAMPAIGN) == CAMPAIGN_TYPE
@@ -37,9 +37,12 @@ class QRCodeMediaLinkHandler @Inject constructor(
     }
 
     private fun extractSiteIdFromUrl(uri: UriWrapper): String? {
-        uri.getQueryParameter("data")?.let { data ->
-            val siteIdPair = data.split(",").find { it.startsWith("site_id:") }
-            return siteIdPair?.substringAfter(":")
+        uri.fragment?.let { fragment ->
+            val pathSegments = fragment.split("/")
+
+            if (pathSegments.isNotEmpty()) {
+                return pathSegments.last()
+            }
         }
         return null
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkTrackingUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/DeepLinkTrackingUtilsTest.kt
@@ -106,7 +106,7 @@ class DeepLinkTrackingUtilsTest {
 
         deepLinkTrackingUtils.track(action, OpenMediaPickerForSite(mock()), mediaUri)
 
-        assertTrackingData("apps.wordpress.com", DeepLinkSource.QRCODE_MEDIA, expectedUrl)
+        assertTrackingData("apps.wordpress.com", DeepLinkSource.BANNER, expectedUrl, "qr-code-media")
     }
 
     @Test
@@ -124,7 +124,7 @@ class DeepLinkTrackingUtilsTest {
             authUri
         )
 
-        assertTrackingData("apps.wordpress.com", DeepLinkSource.QRCODE_AUTH, expectedUrl)
+        assertTrackingData("apps.wordpress.com", DeepLinkSource.BANNER, expectedUrl, "login-qr-code")
     }
 
     private fun assertTrackingData(

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
@@ -26,12 +26,12 @@ class QRCodeMediaLinkHandlerTest {
         qrCodeMediaLinkHandler = QRCodeMediaLinkHandler(deepLinkUriUtils)
     }
 
-    // https://apps.wordpress.com/get/?campaign=qr-code-media&data=post_id:6,site_id:227148183
+    // https://apps.wordpress.com/get/?campaign=qr-code-media#/media/225903215
     @Test
     fun `given proper media url, when deep linked, then handles URI`() {
         val mediaUri = buildUri(
             host = "apps.wordpress.com",
-            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
+            queryParams = mapOf("campaign" to "qr-code-media"),
             path = arrayOf("get")
         )
 
@@ -52,7 +52,7 @@ class QRCodeMediaLinkHandlerTest {
     @Test
     fun `given improper media query params, when deep linked, then handles URI`() {
         val mediaUri = buildUri(host = "apps.wordpress.com",
-            queryParams = mapOf("campaign" to "qr-code-no-good", "data" to "post_id:6,site_id:227148183"),
+            queryParams = mapOf("campaign" to "qr-code-no-good"),
             path = arrayOf("get"), )
 
         val isMediaQrCodeUri = qrCodeMediaLinkHandler.shouldHandleUrl(mediaUri)
@@ -72,10 +72,10 @@ class QRCodeMediaLinkHandlerTest {
     @Test
     fun `given unrecognized siteId, when deep linked, then opens my site view`() {
         val mediaUri = buildUri(host = "apps.wordpress.com",
-            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
+            queryParams = mapOf("campaign" to "qr-code-media"),
             path = arrayOf("get"), )
 
-        whenever(mediaUri.getQueryParameter("data")).thenReturn(null)
+        whenever(mediaUri.fragment).thenReturn(null)
 
         val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
 
@@ -85,12 +85,9 @@ class QRCodeMediaLinkHandlerTest {
     @Test
     fun `given recognized siteId, when deep linked, then opens media launcher view`() {
         val siteId = "227148183"
-        val data = "post_id:6,site_id:227148183"
-        val mediaUri = buildUri(host = "apps.wordpress.com",
-            queryParams = mapOf("campaign" to "qr-code-media", "data" to "post_id:6,site_id:227148183"),
-            path = arrayOf("get"), )
+        val mediaUri = buildUri()
+        whenever(mediaUri.fragment).thenReturn("/media/$siteId")
 
-        whenever(mediaUri.getQueryParameter("data")).thenReturn(data)
         whenever(deepLinkUriUtils.blogIdToSite(siteId)).thenReturn(site)
 
         val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
@@ -6,11 +6,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
 import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
 import org.wordpress.android.ui.deeplinks.buildUri
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class QRCodeMediaLinkHandlerTest {
@@ -18,12 +21,15 @@ class QRCodeMediaLinkHandlerTest {
     lateinit var deepLinkUriUtils: DeepLinkUriUtils
 
     @Mock
+    lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
+    @Mock
     lateinit var site: SiteModel
     private lateinit var qrCodeMediaLinkHandler: QRCodeMediaLinkHandler
 
     @Before
     fun setUp() {
-        qrCodeMediaLinkHandler = QRCodeMediaLinkHandler(deepLinkUriUtils)
+        qrCodeMediaLinkHandler = QRCodeMediaLinkHandler(deepLinkUriUtils, analyticsTrackerWrapper)
     }
 
     // https://apps.wordpress.com/get/?campaign=qr-code-media#/media/225903215
@@ -93,5 +99,21 @@ class QRCodeMediaLinkHandlerTest {
         val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
 
         assertThat(navigateAction).isEqualTo(NavigateAction.OpenMediaPickerForSite(site))
+    }
+
+    @Test
+    fun `given unrecognized siteId, when deep linked, then event is tracked`() {
+        val mediaUri = buildUri(host = "apps.wordpress.com",
+            queryParams = mapOf("campaign" to "qr-code-media"),
+            path = arrayOf("get"), )
+
+        whenever(mediaUri.fragment).thenReturn(null)
+
+        qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
+
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.DEEP_LINK_FAILED,
+            mapOf("error" to "invalid_site_id",
+                "campaign" to "qr_code_media"))
     }
 }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1098,7 +1098,8 @@ public final class AnalyticsTracker {
         DYNAMIC_DASHBOARD_CARD_SHOWN,
         DYNAMIC_DASHBOARD_CARD_TAPPED,
         DYNAMIC_DASHBOARD_CARD_CTA_TAPPED,
-        DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED
+        DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED,
+        DEEP_LINK_FAILED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2691,6 +2691,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "dynamic_dashboard_card_cta_tapped";
             case DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED:
                 return "dynamic_dashboard_card_hide_tapped";
+            case DEEP_LINK_FAILED:
+                return "deep_link_failed";
         }
         return null;
     }


### PR DESCRIPTION
This PR builds upon #19822 to support changes to the URL format and event tracking. The end result remains the same.

- Change URL parsing to handle the inclusion of a fragment and the removal of siteId and postId
- Update the function that handles extracting the siteId from the URl
- Update `deep_linked` event. Property `source` rolls back to its original value of `banner`. Property `source_info` includes the value from the campaign query parameter on the URL.  (This changes for qr code auth too)
- Add new deep_linked_failed event with properties: `error=invalid_site_id` & `campaign={campaign value}`
- Update unit tests

-----

## To Test:
#### Prerequisites: 
- Find a siteId for a site associated with a WP.com account that you will run these tests with. Jot this number down.
- Generate two test QR Codes [ I used `https://qr.io/` ]
-- Replace the "{your site id}" in the following URL with the valid site id from above. `https://apps.wordpress.com/get/?campaign=qr-code-media#/media/{your site id}`
-- Replace the "{invalid site id}" in the following URL with an invalid site id. `https://apps.wordpress.com/get/?campaign=qr-code-media#/media/{invalid site id}`
- Download and install JP from this PR
- Login with the account that includes the valid siteId you captured above

#### Test Media Link 
- Close or background the JP app
- Open the device camera
- Scan the QR Code with the valid site
- ✅ Verify the app launches and the media photo picker is opened (you will be prompted with permission view if you have not already allowed the proper permissions for selecting photos)
-  ✅ Verify logs contain: 🔵 Tracked: deep_linked, Properties: {"intent_action":"android.intent.action.VIEW","intent_host":"apps.wordpress.com","source":"banner","source_info":"qr-code-media","url":"apps.wordpress.com\/get"}
- Close or background the JP app
- Scan the QR Code with the invalid site
- ✅ Verify the app launches and the my site view is opened
- ✅ Verify logs contain: 🔵 Tracked: deep_link_failed, Properties: {"error":"invalid_site_id","campaign":"qr_code_media"}

#### Test QR Code Login still works when scanned from ME
- Open a browser on the web in incognito mode (if you are already logged in to WP.com)
- Navigate to `https://wordpress.com/log-in/` > Login via the mobile app
- STOP
- Go back to the app
- Navigate to Me > Scan Login Code
- Scan the login code shown on the web browser
- ✅ Verify the qr code login flow is launched

#### Test QR Code Login still works when scanned from camera
- Close or background the JP app
- Open a browser on the web in incognito mode (if you are already logged in to WP.com)
- Navigate to `https://wordpress.com/log-in/` > Login via the mobile app
- STOP
- Open the camera on your device
- Scan the login code shown on the web browser
- ✅ Verify the app is opened and the qr code login flow is launched
- ✅ Verify logs contain: 🔵 Tracked: deep_linked, Properties: 🔵 Tracked: deep_linked, Properties: {"intent_action":"android.intent.action.VIEW","intent_host":"apps.wordpress.com","source":"banner","source_info":"login-qr-code","url":"apps.wordpress.com\/get"}
-----

## Regression Notes

1. Potential unintended areas of impact
Media picker doesn't launch on scan 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
Updated `DeepLinkTrackingUtilsTest` and `QRCodeMediaLinkHandlerTest`

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist: N/A
