### PR TITLE
[Blogging Prompts] Fix blogging prompts not being translated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha3'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = 'trunk-67afc3a620b4ad56b981d21637db6b3509b07ab6'
+    wordPressFluxCVersion = '2937-8ab039bc759ef0c630af04d1f13eb4e15d66f81d'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha3'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = 'trunk-2e6d205666d5af551527fbf35235e746150312a2'
+    wordPressFluxCVersion = 'trunk-f6280acd06f106062c674b2a6b48be576062b9e9'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.3.0'
     gutenbergMobileVersion = 'v1.110.0-alpha3'
     wordPressAztecVersion = 'v1.9.0'
-    wordPressFluxCVersion = '2937-8ab039bc759ef0c630af04d1f13eb4e15d66f81d'
+    wordPressFluxCVersion = 'trunk-2e6d205666d5af551527fbf35235e746150312a2'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.10.0'


### PR DESCRIPTION
> [!CAUTION]  
> ✅  ~Do not merge until the FluxC version is replaced with the `trunk` commit hash.~

FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2937

Fixes #19887

## To Test:
Taken from FluxC PR:
- Change the device language to a language other than English;
- Run this PR on WordPress-Android and ensure the blogging prompt is in the selected language.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Other endpoints using `BaseWPComRestClient` and `locale` query parameter

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
