### PR TITLE
Revert "Removes: unused class WPStartOverPreference.java"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
@@ -1,0 +1,76 @@
+package org.wordpress.android.ui.prefs;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
+
+import org.wordpress.android.R;
+
+/**
+ * Calypso-style Preference that has an icon and a widget in the correct place. If there is a button
+ * with id R.id.button, an onPreferenceClick listener is added.
+ */
+
+public class WPStartOverPreference extends WPPreference {
+    private String mButtonText;
+    private int mButtonTextColor;
+    private boolean mButtonTextAllCaps;
+    private Drawable mPrefIcon;
+
+    public WPStartOverPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        TypedArray array = context.obtainStyledAttributes(attrs, R.styleable.WPStartOverPreference);
+
+        for (int i = 0; i < array.getIndexCount(); ++i) {
+            int index = array.getIndex(i);
+            if (index == R.styleable.WPStartOverPreference_buttonText) {
+                mButtonText = array.getString(index);
+            } else if (index == R.styleable.WPStartOverPreference_buttonTextColor) {
+                mButtonTextColor = array.getColor(index, ContextCompat.getColor(context, 0));
+            } else if (index == R.styleable.WPStartOverPreference_buttonTextAllCaps) {
+                mButtonTextAllCaps = array.getBoolean(index, false);
+            } else if (index == R.styleable.WPStartOverPreference_preficon) {
+                mPrefIcon = VectorDrawableCompat.create(context.getResources(), array.getResourceId(index, 0), null);
+            }
+        }
+
+        array.recycle();
+    }
+
+    @Override
+    protected void onBindView(@NonNull View view) {
+        super.onBindView(view);
+
+        if (view.findViewById(R.id.pref_icon) != null) {
+            ImageView imageView = view.findViewById(R.id.pref_icon);
+            imageView.setImageDrawable(mPrefIcon);
+        }
+
+        if (view.findViewById(R.id.button) != null) {
+            final WPStartOverPreference wpStartOverPreference = this;
+
+            Button button = view.findViewById(R.id.button);
+            button.setText(mButtonText);
+            if (mButtonTextColor > 0) {
+                button.setTextColor(mButtonTextColor);
+            }
+            button.setAllCaps(mButtonTextAllCaps);
+            button.setOnClickListener(v -> getOnPreferenceClickListener().onPreferenceClick(wpStartOverPreference));
+        }
+
+        // TODO: FluxC: We might want to get the selected site here and update the view
+        // if (view.findViewById(R.id.domain) != null) {
+        // TextView textView = (TextView) view.findViewById(R.id.domain);
+        // textView.setText(UrlUtils.getHost(blog.getHomeURL()));
+        // }
+    }
+}


### PR DESCRIPTION
Fixes #19895 

This reverts commit af33b987912a3b7d3ca136ae60929cdb2258983d.

The `WPStartOverPreference` class is shown as unused by Android Studio but it's actually being used in the Site Settings screen.

-----

## To Test:

1. Install and log into Jetpack/WordPress
2. Go to `Site Settings`
3. **Verify** the app doesn't crash anymore

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
