### PR TITLE
Fastfile: Use `next_release_version` instead of `next_minor_version`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -115,9 +115,9 @@ def code_freeze_beta_version
   # Read the current release version from the .xcconfig file and parse it into an AppVersion object
   current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_version_name)
   # Calculate the next major version number
-  next_minor_version = VERSION_CALCULATOR.next_minor_version(version: current_version)
+  next_version = VERSION_CALCULATOR.next_release_version(version: current_version)
   # Calculate the next build number
-  code_freeze_beta_version = VERSION_CALCULATOR.next_build_number(version: next_minor_version)
+  code_freeze_beta_version = VERSION_CALCULATOR.next_build_number(version: next_version)
   # Return the formatted release version
   VERSION_FORMATTER.beta_version(code_freeze_beta_version)
 end


### PR DESCRIPTION
This PR fixes a bug where the `code_freeze_beta_version` method returned the incorrect version number. This was due to calling the `VERSION_CALCULATOR.next_minor_version` method instead of `VERSION_CALCULATOR.next_release_version` method. The `next_minor_version` method doesn't account for the "marketing" versioning scheme logic of bumping the major version number after the minor number is 9.

## Testing

I tested this by creating running a new test lane: 

```
lane :test_version do
  UI.message("code_freeze_beta_version: #{code_freeze_beta_version}")
end
```

Running that lane confirmed that the new beta version is now `24.0-rc-1` instead of the `23.10-rc-1` that @oguzkocer reported: p1704762661520239-slack-C02KLTL3MKM