### PR TITLE
Stats traffic tab feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -145,6 +145,7 @@ android {
         buildConfigField "boolean", "BLOGANUARY_DASHBOARD_NUDGE", "false"
         buildConfigField "boolean", "IN_APP_REVIEWS", "false"
         buildConfigField "boolean", "DYNAMIC_DASHBOARD_CARDS", "false"
+        buildConfigField "boolean", "STATS_TRAFFIC_TAB", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/StatsTrafficTabFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/StatsTrafficTabFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val STATS_TRAFFIC_TAB_REMOTE_FIELD = "stats_traffic_tab"
+
+@Feature(STATS_TRAFFIC_TAB_REMOTE_FIELD, false)
+class StatsTrafficTabFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.STATS_TRAFFIC_TAB,
+    STATS_TRAFFIC_TAB_REMOTE_FIELD
+)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/jetpack-issue-repo/issues/9

-----

<img width=320 src="https://github.com/wordpress-mobile/WordPress-Android/assets/990349/ff96260a-ea9e-4a89-8eec-5e9bc9f3c8e8" />


## To Test:

- Launch JP app
- `Go` to Debug settings (Me -> Debug settings)
- `Verify` `stats_traffic_tab` is present as shown above

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Existing unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
