### PR TITLE
Removes locale parameter to fix broken tests

### DIFF
--- a/libs/mocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
+++ b/libs/mocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
@@ -1,12 +1,7 @@
 {
     "request": {
       "method": "GET",
-      "urlPattern": "/rest/v1.(1|2)/me/sites(\\?|/|$).*",
-      "queryParameters": {
-        "locale": {
-          "matches": "(.*)"
-        }
-      }
+      "urlPattern": "/rest/v1.(1|2)/me/sites(\\?|/|$).*"
     },
     "response": {
         "status": 200,


### PR DESCRIPTION
## Description

Removes locale parameter to fix broken tests (internal ref: p1704756207963939-slack-C5ALGJYEP) due to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2938

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    N/A

3. What automated tests I added (or what prevented me from doing so)

    This PR fixes broken tests due to the change in the `locale` parameter https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2938

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)