### PR TITLE
Configure `kover`

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -15,12 +15,6 @@ plugins {
     id "org.jetbrains.kotlinx.kover"
 }
 
-koverReport {
-    defaults {
-        mergeWith("wordpressWasabiDebug")
-    }
-}
-
 sentry {
     tracingInstrumentation {
         enabled = true

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -12,6 +12,13 @@ plugins {
     id "se.bjurr.violations.violation-comments-to-github-gradle-plugin"
     id "com.google.gms.google-services"
     id 'dagger.hilt.android.plugin'
+    id "org.jetbrains.kotlinx.kover"
+}
+
+koverReport {
+    defaults {
+        mergeWith("wordpressWasabiDebug")
+    }
 }
 
 sentry {

--- a/build.gradle
+++ b/build.gradle
@@ -247,13 +247,7 @@ tasks.register("configureApply") {
 
 dependencies {
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$gradle.ext.detektVersion"
-
-    kover(
-            project(":WordPress"),
-            project(":libs:editor"),
-            project(":libs:image-editor"),
-            project(":libs:processors"),
-    )
 }
 
+apply from: './config/gradle/code_coverage.gradle'
 apply from: './config/gradle/gradle_build_scan.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id "io.gitlab.arturbosch.detekt"
     id 'com.automattic.android.measure-builds'
+    id "org.jetbrains.kotlinx.kover"
     id "androidx.navigation.safeargs.kotlin" apply false
     id "com.android.library" apply false
     id 'com.google.gms.google-services' apply false
@@ -246,6 +247,13 @@ tasks.register("configureApply") {
 
 dependencies {
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$gradle.ext.detektVersion"
+
+    kover(
+            project(":WordPress"),
+            project(":libs:editor"),
+            project(":libs:image-editor"),
+            project(":libs:processors"),
+    )
 }
 
 apply from: './config/gradle/gradle_build_scan.gradle'

--- a/config/gradle/code_coverage.gradle
+++ b/config/gradle/code_coverage.gradle
@@ -37,7 +37,8 @@ koverReport {
                     '*.debug*',
                     'hilt_aggregated_deps',
                     '*.databinding',
-                    'org.wordpress.android.widgets'
+                    'org.wordpress.android.modules',
+                    'org.wordpress.android.widgets',
             )
 
             classes(
@@ -54,6 +55,8 @@ koverReport {
                     '*Fragment$*',
                     '*FragmentDirections*',
                     '*FragmentKt*',
+                    '*Module',
+                    '*Module_*',
                     '*View',
                     '*View$*',
                     '*ViewHolder',
@@ -61,7 +64,7 @@ koverReport {
                     '*ViewHolderKt*',
                     '*.Hilt_*',
                     '*HiltModules*',
-                    '*_MembersInjector'
+                    '*_MembersInjector',
             )
         }
     }

--- a/config/gradle/code_coverage.gradle
+++ b/config/gradle/code_coverage.gradle
@@ -1,8 +1,8 @@
 static String resolveProjectVariantForCodeCoverage(Project project) {
     if (project.name == "WordPress") {
-        return "wordpressWasabiDebug"
+        return "wordpressVanillaRelease"
     } else {
-        return "debug"
+        return "release"
     }
 }
 

--- a/config/gradle/code_coverage.gradle
+++ b/config/gradle/code_coverage.gradle
@@ -26,3 +26,43 @@ dependencies {
             project(":libs:processors"),
     )
 }
+
+koverReport {
+    filters {
+        excludes {
+            packages(
+                    'com.bumptech.glide',
+                    'dagger.*',
+                    '*.compose*',
+                    '*.debug*',
+                    'hilt_aggregated_deps',
+                    '*.databinding',
+                    'org.wordpress.android.widgets'
+            )
+
+            classes(
+                    '*_Factory*',
+                    '*Activity',
+                    '*Activity$*',
+                    '*Adapter',
+                    '*Adapter$*',
+                    '*BuildConfig',
+                    '*DiffCallback*',
+                    '*Dialog',
+                    '*Dialog$*',
+                    '*Fragment',
+                    '*Fragment$*',
+                    '*FragmentDirections*',
+                    '*FragmentKt*',
+                    '*View',
+                    '*View$*',
+                    '*ViewHolder',
+                    '*ViewHolder$*',
+                    '*ViewHolderKt*',
+                    '*.Hilt_*',
+                    '*HiltModules*',
+                    '*_MembersInjector'
+            )
+        }
+    }
+}

--- a/config/gradle/code_coverage.gradle
+++ b/config/gradle/code_coverage.gradle
@@ -1,0 +1,28 @@
+static String resolveProjectVariantForCodeCoverage(Project project) {
+    if (project.name == "WordPress") {
+        return "wordpressWasabiDebug"
+    } else {
+        return "debug"
+    }
+}
+
+subprojects {
+    pluginManager.withPlugin("org.jetbrains.kotlinx.kover") {
+        if (project.plugins.hasPlugin("com.android.library") || project.plugins.hasPlugin("com.android.application")) {
+            koverReport {
+                defaults {
+                    mergeWith(resolveProjectVariantForCodeCoverage(project))
+                }
+            }
+        }
+    }
+}
+
+dependencies {
+    kover(
+            project(":WordPress"),
+            project(":libs:editor"),
+            project(":libs:image-editor"),
+            project(":libs:processors"),
+    )
+}

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -2,6 +2,13 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.plugin.parcelize"
+    id "org.jetbrains.kotlinx.kover"
+}
+
+koverReport {
+    defaults {
+        mergeWith("debug")
+    }
 }
 
 repositories {

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "org.jetbrains.kotlinx.kover"
 }
 
-koverReport {
-    defaults {
-        mergeWith("debug")
-    }
-}
-
 repositories {
     maven {
         url "https://a8c-libs.s3.amazonaws.com/android"

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -3,6 +3,13 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.plugin.parcelize"
     id "androidx.navigation.safeargs.kotlin"
+    id "org.jetbrains.kotlinx.kover"
+}
+
+koverReport {
+    defaults {
+        mergeWith("debug")
+    }
 }
 
 android {

--- a/libs/image-editor/build.gradle
+++ b/libs/image-editor/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "org.jetbrains.kotlinx.kover"
 }
 
-koverReport {
-    defaults {
-        mergeWith("debug")
-    }
-}
-
 android {
     namespace "org.wordpress.android.imageeditor"
 

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
+    id "org.jetbrains.kotlinx.kover"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ pluginManagement {
     gradle.ext.detektVersion = '1.23.0'
     gradle.ext.violationCommentsVersion = '1.67'
     gradle.ext.measureBuildsVersion = '2.0.3'
+    gradle.ext.koverVersion = '0.7.5'
 
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
@@ -24,6 +25,7 @@ pluginManagement {
         id "io.gitlab.arturbosch.detekt" version gradle.ext.detektVersion
         id "se.bjurr.violations.violation-comments-to-github-gradle-plugin" version gradle.ext.violationCommentsVersion
         id 'com.automattic.android.measure-builds' version gradle.ext.measureBuildsVersion
+        id "org.jetbrains.kotlinx.kover" version gradle.ext.koverVersion
     }
     repositories {
         maven {


### PR DESCRIPTION
## Description

This PR integrates code coverage tooling: [Kover](https://github.com/Kotlin/kotlinx-kover) for modules: `:WordPress`, `:libs:editor`, `:libs:image-editor`, `:libs:processors`. 

### Why exclude remaining modules?

Kover doesn't support Java-only modules - Kotlin Gradle Plugin has to be applied. The Java-only modules are: `:libs:analytics`, `:libs:mocks`, `:libs:networking`. We could apply a Kotlin Gradle Plugin to those modules, and then code coverage should be calculated, but at the same time I don't think it's worth the effort. `:libs:mocks` is not a subject for unit test. The rest of the modules are small and have no tests at all. If in the future there will be a need to add code coverage calculations for those modules as well, it's possible.

There's also `:libs:annotations` module, which has Kotlin Gradle Plugin, but those are only annotations without any tests, so I think there's no need to introduce code coverage to it.

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/8d7de894-4dfe-4df0-b663-cb6125790a9c)

## To Test:

1. Run `./gradlew koverHtmlReport`
2. Open the `.html` file generated by the task `> Task :koverHtmlReport` (see console)
3. Browse the results:
    - Assert there are no unneeded classes, like some Dagger/Hilt, Fragments - anything that can be grouped and should not be a part of code coverage
    - Assert there are classes from subprojects. E.g. check if there are classes from `org.wordpress.android.editor` package, which is part of `:libs:editor` subproject.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->