### PR TITLE
Add tapping functionality to domain cards on the Site Domain screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.domains.DomainRegistrationActivity.DomainRegistr
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.ClaimDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetDomain
 import org.wordpress.android.ui.domains.DomainsDashboardNavigationAction.GetPlan
+import org.wordpress.android.ui.domains.management.details.DomainManagementDetailsActivity
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.config.DomainManagementFeatureConfig
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
@@ -100,15 +101,21 @@ class DomainsDashboardFragment : Fragment(R.layout.domains_dashboard_fragment), 
             action.site,
             DOMAIN_PURCHASE
         )
+
         is ClaimDomain -> ActivityLauncher.viewDomainRegistrationActivityForResult(
             this,
             action.site,
             CTA_DOMAIN_CREDIT_REDEMPTION
         )
+
         is GetPlan -> ActivityLauncher.viewDomainRegistrationActivityForResult(
             this,
             action.site,
             FREE_DOMAIN_WITH_ANNUAL_PLAN
+        )
+
+        is DomainsDashboardNavigationAction.OpenDomainManagement -> startActivity(
+            DomainManagementDetailsActivity.createIntent(requireContext(), action.domain, action.detailUrl)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -26,7 +26,7 @@ sealed class DomainsDashboardItem(val type: Type) {
         val isPrimary: Boolean,
         val domainStatus: UiString,
         @ColorRes val domainStatusColor: Int,
-        val expiry: UiString,
+        val expiry: UiString?,
         val onDomainClick: ListItemInteraction? = null
     ) : DomainsDashboardItem(SITE_DOMAINS)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.domains
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Type.ADD_DOMAIN
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Type.PURCHASE_DOMAIN
@@ -22,8 +23,10 @@ sealed class DomainsDashboardItem(val type: Type) {
 
     data class SiteDomains(
         val domain: UiString,
-        val expiry: UiString,
         val isPrimary: Boolean,
+        val domainStatus: UiString,
+        @ColorRes val domainStatusColor: Int,
+        val expiry: UiString,
         val onDomainClick: ListItemInteraction? = null
     ) : DomainsDashboardItem(SITE_DOMAINS)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -24,6 +24,7 @@ sealed class DomainsDashboardItem(val type: Type) {
         val domain: UiString,
         val expiry: UiString,
         val isPrimary: Boolean,
+        val onDomainClick: ListItemInteraction? = null
     ) : DomainsDashboardItem(SITE_DOMAINS)
 
     data class AddDomain(val onClick: ListItemInteraction) : DomainsDashboardItem(ADD_DOMAIN)

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardNavigationAction.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.domains
 import org.wordpress.android.fluxc.model.SiteModel
 
 sealed class DomainsDashboardNavigationAction {
+    data class OpenDomainManagement(val domain: String, val detailUrl: String) : DomainsDashboardNavigationAction()
     data class GetDomain(val site: SiteModel) : DomainsDashboardNavigationAction()
     data class ClaimDomain(val site: SiteModel) : DomainsDashboardNavigationAction()
     data class GetPlan(val site: SiteModel) : DomainsDashboardNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
@@ -46,7 +45,6 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             siteDomainStatus.compoundDrawablesRelative.first().setTint(
                 siteDomainStatus.context.getColor(item.domainStatusColor)
             )
-            chevron.isInvisible = item.onDomainClick == null
             item.onDomainClick?.let { interaction -> root.setOnClickListener { interaction.click() } }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
@@ -41,7 +42,11 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             uiHelpers.setTextOrHide(siteDomain, item.domain)
             uiHelpers.setTextOrHide(siteDomainExpiryDate, item.expiry)
             primarySiteDomainChip.isVisible = item.isPrimary
-            chevron.isVisible = item.onDomainClick != null
+            uiHelpers.setTextOrHide(siteDomainStatus, item.domainStatus)
+            siteDomainStatus.compoundDrawablesRelative.first().setTint(
+                siteDomainStatus.context.getColor(item.domainStatusColor)
+            )
+            chevron.isInvisible = item.onDomainClick == null
             item.onDomainClick?.let { interaction -> root.setOnClickListener { interaction.click() } }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -41,6 +41,7 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             uiHelpers.setTextOrHide(siteDomain, item.domain)
             uiHelpers.setTextOrHide(siteDomainExpiryDate, item.expiry)
             primarySiteDomainChip.isVisible = item.isPrimary
+            item.onDomainClick?.let { interaction -> root.setOnClickListener { interaction.click() } }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -41,6 +41,7 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             uiHelpers.setTextOrHide(siteDomain, item.domain)
             uiHelpers.setTextOrHide(siteDomainExpiryDate, item.expiry)
             primarySiteDomainChip.isVisible = item.isPrimary
+            chevron.isVisible = item.onDomainClick != null
             item.onDomainClick?.let { interaction -> root.setOnClickListener { interaction.click() } }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -140,6 +140,13 @@ class DomainsDashboardViewModel @Inject constructor(
         _uiModel.postValue(listItems)
     }
 
+    private fun getStatusColor(statusType: StatusType?) = when (statusType) {
+        StatusType.SUCCESS -> R.color.jetpack_green_50
+        StatusType.NEUTRAL -> R.color.gray_50
+        StatusType.WARNING -> R.color.orange_50
+        else -> R.color.red_50
+    }
+
     private fun buildCtaItems(
         hasCustomDomains: Boolean,
         hasDomainCredit: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -208,7 +208,9 @@ class DomainsDashboardViewModel @Inject constructor(
                     UiStringText(status)
                 } ?: UiStringRes(R.string.error),
                 getStatusColor(allDomainsDomain?.domainStatus?.statusType),
-                if (it.expirySoon) {
+                if (!it.hasRegistration) {
+                    null
+                } else if (it.expirySoon) {
                     UiStringText(
                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                             R.string.domains_site_domain_expires_soon,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -80,9 +80,11 @@ class DomainsDashboardViewModel @Inject constructor(
 
         val deferredPlansResult = async { fetchPlansUseCase.execute(site) }
         val deferredDomainsResult = async { siteStore.fetchSiteDomains(site) }
+        val deferredAllDomainsResult = async { siteStore.fetchAllDomains() }
 
         val plansResult = deferredPlansResult.await()
         val domainsResult = deferredDomainsResult.await()
+        val allDomainsResult = deferredAllDomainsResult.await()
 
         if (plansResult.isError) {
             AppLog.e(DOMAIN_REGISTRATION, "An error occurred while fetching plans: ${plansResult.error.message}")

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.PlanModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
+import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.domains.DomainsDashboardItem.AddDomain
@@ -121,8 +122,10 @@ class DomainsDashboardViewModel @Inject constructor(
 
         listItems += SiteDomains(
             UiStringText(freeDomainUrl),
-            UiStringRes(R.string.domains_site_domain_never_expires),
-            freeDomainIsPrimary
+            freeDomainIsPrimary,
+            UiStringRes(R.string.active),
+            getStatusColor(StatusType.SUCCESS),
+            UiStringRes(R.string.domains_site_domain_never_expires)
         )
 
         val customDomains = domains.filter { !it.wpcomDomain }
@@ -200,6 +203,11 @@ class DomainsDashboardViewModel @Inject constructor(
 
             SiteDomains(
                 UiStringText(it.domain.orEmpty()),
+                it.primaryDomain,
+                allDomainsDomain?.domainStatus?.status?.let { status ->
+                    UiStringText(status)
+                } ?: UiStringRes(R.string.error),
+                getStatusColor(allDomainsDomain?.domainStatus?.statusType),
                 if (it.expirySoon) {
                     UiStringText(
                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
@@ -213,7 +221,6 @@ class DomainsDashboardViewModel @Inject constructor(
                         listOf(UiStringText(it.expiry.orEmpty()))
                     )
                 },
-                it.primaryDomain,
                 allDomainsDomain?.let { ListItemInteraction.create(allDomainsDomain, this::onDomainClick) }
             )
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -216,6 +216,12 @@ class DomainsDashboardViewModel @Inject constructor(
     private fun getCleanUrl(url: String?) = StringUtils.removeTrailingSlash(UrlUtils.removeScheme(url))
 
     private fun onDomainClick(allDomainsDomain: AllDomainsDomain) {
+        _onNavigation.value = Event(
+            OpenDomainManagement(
+                allDomainsDomain.domain ?: return,
+                allDomainsDomain.getDomainDetailsUrl() ?: return
+            )
+        )
     }
 
     private fun onGetDomainClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.domains.usecases
 
 import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
 class FetchAllDomainsUseCase  @Inject constructor(
@@ -10,7 +11,11 @@ class FetchAllDomainsUseCase  @Inject constructor(
     suspend fun execute(): AllDomains {
         val result = siteStore.fetchAllDomains()
         return when {
-            result.isError -> AllDomains.Error
+            result.isError -> {
+                AppLog.e(AppLog.T.API, "An error occurred while fetching all domains: ${result.error.message}")
+                AllDomains.Error
+            }
+
             result.domains.isNullOrEmpty() -> AllDomains.Empty
             else -> AllDomains.Success(requireNotNull(result.domains))
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/usecases/FetchAllDomainsUseCase.kt
@@ -22,7 +22,7 @@ sealed interface AllDomains {
         val domains: List<AllDomainsDomain>,
     ) : AllDomains
 
-    object Empty : AllDomains
+    data object Empty : AllDomains
 
-    object Error : AllDomains
+    data object Error : AllDomains
 }

--- a/WordPress/src/main/res/drawable/ic_dot_white_8dp.xml
+++ b/WordPress/src/main/res/drawable/ic_dot_white_8dp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/WordPress/src/main/res/layout/domain_site_domains_card.xml
+++ b/WordPress/src/main/res/layout/domain_site_domains_card.xml
@@ -16,16 +16,6 @@
         android:layout_height="wrap_content"
         android:padding="@dimen/margin_extra_large">
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/primary_site_domain_actions"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_ellipsis_vertical_white_24dp"
-            app:tint="?attr/wpColorOnSurfaceMedium" />
-
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/site_domain_expiry_date"
             android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/domain_site_domains_card.xml
+++ b/WordPress/src/main/res/layout/domain_site_domains_card.xml
@@ -22,7 +22,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium_large"
             android:text="@string/domains_site_domain_never_expires"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            app:layout_constraintEnd_toStartOf="@id/chevron"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toEndOf="@id/site_domain_status"
             app:layout_constraintTop_toBottomOf="@id/primary_site_domain_chip" />
 
         <com.google.android.material.chip.Chip
@@ -44,6 +47,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/site_domain"
             app:textStartPadding="@dimen/margin_small" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="?attr/textAppearanceBody2"
+            android:id="@+id/site_domain_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium_large"
+            android:drawablePadding="8dp"
+            android:drawableStart="@drawable/ic_dot_white_8dp"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/primary_site_domain_chip"
+            tools:text="Active" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/site_domain"

--- a/WordPress/src/main/res/layout/domain_site_domains_card.xml
+++ b/WordPress/src/main/res/layout/domain_site_domains_card.xml
@@ -48,11 +48,26 @@
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/site_domain"
             style="?attr/textAppearanceSubtitle1"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_extra_large"
             android:text="@string/domains_site_domain"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintEnd_toStartOf="@id/chevron"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="travelwithkids.wordpress.com" />
 
+        <ImageView
+            android:id="@+id/chevron"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_chevron_right_white_24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/wpColorOnSurfaceMedium" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/main/res/layout/domain_site_domains_card.xml
+++ b/WordPress/src/main/res/layout/domain_site_domains_card.xml
@@ -22,8 +22,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium_large"
             android:text="@string/domains_site_domain_never_expires"
-            android:layout_marginEnd="@dimen/margin_extra_large"
-            app:layout_constraintEnd_toStartOf="@id/chevron"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="1"
             app:layout_constraintStart_toEndOf="@id/site_domain_status"
             app:layout_constraintTop_toBottomOf="@id/primary_site_domain_chip" />
@@ -66,24 +65,11 @@
             style="?attr/textAppearanceSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/margin_extra_large"
             android:text="@string/domains_site_domain"
-            app:layout_constrainedWidth="true"
-            app:layout_constraintEnd_toStartOf="@id/chevron"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="travelwithkids.wordpress.com" />
-
-        <ImageView
-            android:id="@+id/chevron"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:importantForAccessibility="no"
-            android:src="@drawable/ic_chevron_right_white_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?attr/wpColorOnSurfaceMedium" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainsDashboardViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/domains/DomainsDashboardViewModelTest.kt
@@ -10,6 +10,7 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PlanModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.FetchedDomainsPayload
@@ -19,6 +20,8 @@ import org.wordpress.android.ui.domains.DomainsDashboardItem.PurchaseDomain
 import org.wordpress.android.ui.domains.DomainsDashboardItem.PurchasePlan
 import org.wordpress.android.ui.domains.DomainsDashboardItem.SiteDomains
 import org.wordpress.android.ui.domains.DomainsDashboardItem.SiteDomainsHeader
+import org.wordpress.android.ui.domains.usecases.AllDomains
+import org.wordpress.android.ui.domains.usecases.FetchAllDomainsUseCase
 import org.wordpress.android.ui.domains.usecases.FetchPlansUseCase
 import org.wordpress.android.ui.plans.PlansConstants.FREE_PLAN_ID
 import org.wordpress.android.ui.plans.PlansConstants.PREMIUM_PLAN_ID
@@ -32,6 +35,7 @@ class DomainsDashboardViewModelTest : BaseUnitTest() {
     private val analyticsTracker: AnalyticsTrackerWrapper = mock()
     private val htmlMessageUtils: HtmlMessageUtils = mock()
     private val fetchPlansUseCase: FetchPlansUseCase = mock()
+    private val fetchAllDomainsUseCase: FetchAllDomainsUseCase = mock()
 
     private lateinit var viewModel: DomainsDashboardViewModel
 
@@ -44,6 +48,7 @@ class DomainsDashboardViewModelTest : BaseUnitTest() {
             analyticsTracker,
             htmlMessageUtils,
             fetchPlansUseCase,
+            fetchAllDomainsUseCase,
             testDispatcher()
         )
 
@@ -171,6 +176,8 @@ class DomainsDashboardViewModelTest : BaseUnitTest() {
 
         val plan = if (hasDomainCredits) planWithCredits else planWithNoCredits
         whenever(fetchPlansUseCase.execute(site)).thenReturn(OnPlansFetched(site, listOf(plan)))
+        val allDomains = if (hasCustomDomains) listOf(allDomainsDomain) else emptyList()
+        whenever(fetchAllDomainsUseCase.execute()).thenReturn(AllDomains.Success(allDomains))
 
         viewModel.start(site)
     }
@@ -188,6 +195,8 @@ class DomainsDashboardViewModelTest : BaseUnitTest() {
             primaryDomain = false,
             wpcomDomain = false
         )
+
+        private val allDomainsDomain = AllDomainsDomain(domain = "henna.tattoo")
 
         private val siteWithFreePlan = SiteModel().apply {
             siteId = TEST_SITE_ID


### PR DESCRIPTION
This PR makes changes on the Site Domain screen
- When tapping the cards (except the free domain card), it navigates to the domain detail screen.

[domain-detail.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/1d2e1a27-5483-43b2-8311-03fa6f1dcced)

-----

## To Test:

1. Navigate to My Site → More → Domains.
2. Verify the design is as expected.
3. Tap on a custom domain card.
4. Verify the domain detail screen is launched.
5. Test on different orientations and themes.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Nowhere

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

6. What automated tests I added (or what prevented me from doing so)

    - Updated `DomainsDashboardViewModelTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
