### PR TITLE
[Reader IA] Add dropdown menu analytics events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -55,6 +55,7 @@ fun JetpackDropdownMenu(
     onSingleItemClick: (MenuElementData.Item.Single) -> Unit,
     menuButtonHeight: Dp = 36.dp,
     contentSizeAnimation: FiniteAnimationSpec<IntSize> = spring(),
+    onDropdownMenuClick: () -> Unit,
 ) {
     Column {
         var isMenuVisible by remember { mutableStateOf(false) }
@@ -63,6 +64,7 @@ fun JetpackDropdownMenu(
             contentSizeAnimation = contentSizeAnimation,
             selectedItem = selectedItem,
             onClick = {
+                onDropdownMenuClick()
                 isMenuVisible = !isMenuVisible
             }
         )
@@ -269,7 +271,8 @@ fun JetpackDropdownMenuPreview() {
             JetpackDropdownMenu(
                 selectedItem = selectedItem,
                 menuItems = menuItems,
-                onSingleItemClick = { selectedItem = it }
+                onSingleItemClick = { selectedItem = it },
+                onDropdownMenuClick = {},
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -380,6 +380,23 @@ class ReaderTracker @Inject constructor(
         analyticsTrackerWrapper.track(AnalyticsTracker.Stat.READER_DROPDOWN_MENU_OPENED)
     }
 
+    fun trackDropdownMenuItemTapped(readerTag: ReaderTag) {
+        when {
+            readerTag.isDiscover -> "discover"
+            readerTag.isFollowedSites -> "following"
+            readerTag.isBookmarked -> "saved"
+            readerTag.isPostsILike -> "liked"
+            readerTag.isA8C -> "a8c"
+            readerTag.isListTopic -> "list"
+            else -> null
+        }?.let { trackingId ->
+            analyticsTrackerWrapper.track(
+                stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+                properties = mapOf("id" to trackingId)
+            )
+        }
+    }
+
     /* HELPER */
 
     @JvmOverloads

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -376,6 +376,10 @@ class ReaderTracker @Inject constructor(
         analyticsUtilsWrapper.trackRailcarRender(railcarJson)
     }
 
+    fun trackDropdownMenuOpened() {
+        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.READER_DROPDOWN_MENU_OPENED)
+    }
+
     /* HELPER */
 
     @JvmOverloads

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -413,6 +413,9 @@ class ReaderViewModel @Inject constructor(
         if (item.id != _topBarUiState.value?.selectedItem?.id) {
             selectedReaderTag?.let { updateSelectedContent(it) }
         }
+        if (selectedReaderTag != null) {
+            readerTracker.trackDropdownMenuItemTapped(selectedReaderTag)
+        }
     }
 
     fun onSubFilterItemSelected(item: SubfilterListItem) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -389,9 +389,14 @@ class ReaderViewModel @Inject constructor(
                     menuItems = menuItems,
                     selectedItem = selectedItem,
                     filterUiState = filterUiState,
+                    onDropdownMenuClick = ::onDropdownMenuClick,
                 )
             )
         }
+    }
+
+    private fun onDropdownMenuClick() {
+        readerTracker.trackDropdownMenuOpened()
     }
 
     private fun getMenuItemFromReaderTag(readerTag: ReaderTag): MenuElementData.Item.Single? =
@@ -515,6 +520,7 @@ class ReaderViewModel @Inject constructor(
         val menuItems: List<MenuElementData>,
         val selectedItem: MenuElementData.Item.Single,
         val filterUiState: FilterUiState? = null,
+        val onDropdownMenuClick: () -> Unit,
     ) {
         data class FilterUiState(
             val blogsFilterCount: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -149,23 +149,6 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
-// TODO verify side effects of removing this logic
-//    private suspend fun initializeTabSelection(tagList: ReaderTagList) {
-//        withContext(bgDispatcher) {
-//            val selectTab = { readerTag: ReaderTag ->
-//                val index = tagList.indexOf(readerTag)
-//                if (index != -1) {
-//                    updateSelectedContent(readerTag)
-//                }
-//            }
-//            appPrefsWrapper.getReaderTag()?.let {
-//                selectTab.invoke(it)
-//            } ?: tagList.find { it.isDiscover }?.let {
-//                selectTab.invoke(it)
-//            }
-//        }
-//    }
-
     fun onTagChanged(selectedTag: ReaderTag?) {
         selectedTag?.let {
             trackReaderTabShownIfNecessary(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -101,6 +101,7 @@ fun ReaderTopAppBar(
                     onSingleItemClick = onMenuItemClick,
                     menuButtonHeight = chipHeight,
                     contentSizeAnimation = tween(ANIM_DURATION),
+                    onDropdownMenuClick = topBarUiState.onDropdownMenuClick,
                 )
 
                 AnimatedVisibility(
@@ -206,6 +207,7 @@ fun ReaderTopAppBarPreview() {
             ReaderViewModel.TopBarUiState(
                 menuItems = menuItems,
                 selectedItem = menuItems.first() as MenuElementData.Item.Single,
+                onDropdownMenuClick = {},
             )
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderTrackerTest.kt
@@ -6,7 +6,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
@@ -202,6 +204,12 @@ class ReaderTrackerTest {
         tracker.stop(ReaderTrackerType.MAIN_READER)
 
         assertThat(tracker.isRunning(ReaderTrackerType.MAIN_READER)).isEqualTo(false)
+    }
+
+    @Test
+    fun `Should track dropdown menu opened correctly`() {
+        tracker.trackDropdownMenuOpened()
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.READER_DROPDOWN_MENU_OPENED)
     }
 
     private fun addToDate(date: Date, seconds: Int): Date {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/ReaderTrackerTest.kt
@@ -9,6 +9,8 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.tracker.ReaderTrackerType
@@ -210,6 +212,108 @@ class ReaderTrackerTest {
     fun `Should track dropdown menu opened correctly`() {
         tracker.trackDropdownMenuOpened()
         verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.READER_DROPDOWN_MENU_OPENED)
+    }
+
+    @Test
+    fun `Should track dropdown menu item Discover tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                ReaderTag.DISCOVER_PATH,
+                ReaderTagType.DEFAULT,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "discover"),
+        )
+    }
+
+    @Test
+    fun `Should track dropdown menu item Subscriptions tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                ReaderTag.FOLLOWING_PATH,
+                ReaderTagType.DEFAULT,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "following"),
+        )
+    }
+
+    @Test
+    fun `Should track dropdown menu item Saved tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                null,
+                ReaderTagType.BOOKMARKED,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "saved"),
+        )
+    }
+
+    @Test
+    fun `Should track dropdown menu item Liked tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                ReaderTag.LIKED_PATH,
+                ReaderTagType.DEFAULT,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "liked"),
+        )
+    }
+
+    @Test
+    fun `Should track dropdown menu item Automattic tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                "/read/a8c",
+                ReaderTagType.DEFAULT,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "a8c"),
+        )
+    }
+
+    @Test
+    fun `Should track dropdown menu custom list item tapped`() {
+        tracker.trackDropdownMenuItemTapped(
+            ReaderTag(
+                "slug",
+                "displayName",
+                "title",
+                "/read/list/",
+                ReaderTagType.DEFAULT,
+            )
+        )
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.READER_DROPDOWN_MENU_ITEM_TAPPED,
+            properties = mapOf("id" to "list"),
+        )
     }
 
     private fun addToDate(date: Date, seconds: Int): Date {

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1100,7 +1100,8 @@ public final class AnalyticsTracker {
         DYNAMIC_DASHBOARD_CARD_CTA_TAPPED,
         DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED,
         DEEP_LINK_FAILED,
-        READER_DROPDOWN_MENU_OPENED
+        READER_DROPDOWN_MENU_OPENED,
+        READER_DROPDOWN_MENU_ITEM_TAPPED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1099,7 +1099,8 @@ public final class AnalyticsTracker {
         DYNAMIC_DASHBOARD_CARD_TAPPED,
         DYNAMIC_DASHBOARD_CARD_CTA_TAPPED,
         DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED,
-        DEEP_LINK_FAILED
+        DEEP_LINK_FAILED,
+        READER_DROPDOWN_MENU_OPENED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2693,6 +2693,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "dynamic_dashboard_card_hide_tapped";
             case DEEP_LINK_FAILED:
                 return "deep_link_failed";
+            case READER_DROPDOWN_MENU_OPENED:
+                return "reader_dropdown_menu_opened";
         }
         return null;
     }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2695,6 +2695,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "deep_link_failed";
             case READER_DROPDOWN_MENU_OPENED:
                 return "reader_dropdown_menu_opened";
+            case READER_DROPDOWN_MENU_ITEM_TAPPED:
+                return "reader_dropdown_menu_item_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #19906 

-----

## To Test:
- Install JP and sign-in;
- Open `"Reader"`;
- Tap on the drop-down menu: you should see the following analytics event in the Logcat:
```
🔵 Tracked: reader_dropdown_menu_opened
```
- Tap each item in the drop-down menu (including a custom list item). You should see the following analytics events being tracked:
```
// When "Discover" is tapped
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"discover"}
// When "Subscriptions" is tapped
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"following"}
// When "Saved" is tapped
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"saved"}
// When "Liked" is tapped
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"liked"}
// When "Automattic" is tapped
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"a8c"}
// When any item in a custom list is tapped (Menu -> Lists -> Tap any item)
🔵 Tracked: reader_dropdown_menu_item_tapped, Properties: {"id":"list"}
```
-----

## Regression Notes

1. Potential unintended areas of impact
None 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and unit tests.

3. What automated tests I added (or what prevented me from doing so)
Updated `ReaderTrackerTest.kt`.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
