### PR TITLE
Add domain status label to cards on Site Domain screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -26,7 +26,7 @@ sealed class DomainsDashboardItem(val type: Type) {
         val isPrimary: Boolean,
         val domainStatus: UiString,
         @ColorRes val domainStatusColor: Int,
-        val expiry: UiString,
+        val expiry: UiString?,
         val onDomainClick: ListItemInteraction? = null
     ) : DomainsDashboardItem(SITE_DOMAINS)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardItem.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.domains
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Type.ADD_DOMAIN
 import org.wordpress.android.ui.domains.DomainsDashboardItem.Type.PURCHASE_DOMAIN
@@ -22,8 +23,10 @@ sealed class DomainsDashboardItem(val type: Type) {
 
     data class SiteDomains(
         val domain: UiString,
-        val expiry: UiString,
         val isPrimary: Boolean,
+        val domainStatus: UiString,
+        @ColorRes val domainStatusColor: Int,
+        val expiry: UiString,
         val onDomainClick: ListItemInteraction? = null
     ) : DomainsDashboardItem(SITE_DOMAINS)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewHolder.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.domains
 
 import android.view.ViewGroup
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
@@ -41,7 +42,11 @@ sealed class DomainsDashboardViewHolder<T : ViewBinding>(
             uiHelpers.setTextOrHide(siteDomain, item.domain)
             uiHelpers.setTextOrHide(siteDomainExpiryDate, item.expiry)
             primarySiteDomainChip.isVisible = item.isPrimary
-            chevron.isVisible = item.onDomainClick != null
+            uiHelpers.setTextOrHide(siteDomainStatus, item.domainStatus)
+            siteDomainStatus.compoundDrawablesRelative.first().setTint(
+                siteDomainStatus.context.getColor(item.domainStatusColor)
+            )
+            chevron.isInvisible = item.onDomainClick == null
             item.onDomainClick?.let { interaction -> root.setOnClickListener { interaction.click() } }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -140,6 +140,13 @@ class DomainsDashboardViewModel @Inject constructor(
         _uiModel.postValue(listItems)
     }
 
+    private fun getStatusColor(statusType: StatusType?) = when (statusType) {
+        StatusType.SUCCESS -> R.color.jetpack_green_50
+        StatusType.NEUTRAL -> R.color.gray_50
+        StatusType.WARNING -> R.color.orange_50
+        else -> R.color.red_50
+    }
+
     private fun buildCtaItems(
         hasCustomDomains: Boolean,
         hasDomainCredit: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -208,7 +208,9 @@ class DomainsDashboardViewModel @Inject constructor(
                     UiStringText(status)
                 } ?: UiStringRes(R.string.error),
                 getStatusColor(allDomainsDomain?.domainStatus?.statusType),
-                if (it.expirySoon) {
+                if (!it.hasRegistration) {
+                    null
+                } else if (it.expirySoon) {
                     UiStringText(
                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
                             R.string.domains_site_domain_expires_soon,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainsDashboardViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.model.PlanModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.Domain
+import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.domains.DomainsDashboardItem.AddDomain
@@ -121,8 +122,10 @@ class DomainsDashboardViewModel @Inject constructor(
 
         listItems += SiteDomains(
             UiStringText(freeDomainUrl),
-            UiStringRes(R.string.domains_site_domain_never_expires),
-            freeDomainIsPrimary
+            freeDomainIsPrimary,
+            UiStringRes(R.string.active),
+            getStatusColor(StatusType.SUCCESS),
+            UiStringRes(R.string.domains_site_domain_never_expires)
         )
 
         val customDomains = domains.filter { !it.wpcomDomain }
@@ -200,6 +203,11 @@ class DomainsDashboardViewModel @Inject constructor(
 
             SiteDomains(
                 UiStringText(it.domain.orEmpty()),
+                it.primaryDomain,
+                allDomainsDomain?.domainStatus?.status?.let { status ->
+                    UiStringText(status)
+                } ?: UiStringRes(R.string.error),
+                getStatusColor(allDomainsDomain?.domainStatus?.statusType),
                 if (it.expirySoon) {
                     UiStringText(
                         htmlMessageUtils.getHtmlMessageFromStringFormatResId(
@@ -213,7 +221,6 @@ class DomainsDashboardViewModel @Inject constructor(
                         listOf(UiStringText(it.expiry.orEmpty()))
                     )
                 },
-                it.primaryDomain,
                 allDomainsDomain?.let { ListItemInteraction.create(allDomainsDomain, this::onDomainClick) }
             )
         }

--- a/WordPress/src/main/res/drawable/ic_dot_white_8dp.xml
+++ b/WordPress/src/main/res/drawable/ic_dot_white_8dp.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <size
+        android:width="8dp"
+        android:height="8dp" />
+    <solid android:color="@color/white" />
+</shape>

--- a/WordPress/src/main/res/layout/domain_site_domains_card.xml
+++ b/WordPress/src/main/res/layout/domain_site_domains_card.xml
@@ -22,7 +22,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_medium_large"
             android:text="@string/domains_site_domain_never_expires"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginEnd="@dimen/margin_extra_large"
+            app:layout_constraintEnd_toStartOf="@id/chevron"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toEndOf="@id/site_domain_status"
             app:layout_constraintTop_toBottomOf="@id/primary_site_domain_chip" />
 
         <com.google.android.material.chip.Chip
@@ -44,6 +47,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/site_domain"
             app:textStartPadding="@dimen/margin_small" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="?attr/textAppearanceBody2"
+            android:id="@+id/site_domain_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium_large"
+            android:drawablePadding="8dp"
+            android:drawableStart="@drawable/ic_dot_white_8dp"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/primary_site_domain_chip"
+            tools:text="Active" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/site_domain"


### PR DESCRIPTION
This adds a status label to the domain card on the Site Domain screen.

It always shows "Active" status for the free domain.

@staskus, you don't need to review the code. I would appreciate it if you could check the logic and test it.

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/fc81e478-0d4b-4624-b441-3d869d6ee0d1" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/3925ef41-46f1-4371-bb32-6ea00cd96b25" width=300>|

#### Edge case

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/bfb94bfa-38cf-40a9-ae5e-9114977666b0" width=600>

-----

## To Test:

1. Select a site, preferably with multiple domains and various domain states.
2. Navigate to My Site → More → Domains.
3. Verify the design is as expected.
4. Tap on a custom domain card.
5. Verify the domain detail screen is launched.
6. Test on different orientations and themes.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - The card's layout

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually for different cases

3. What automated tests I added (or what prevented me from doing so)

    - I believe the added feature is too small for a test.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
