### PR TITLE
chore: Enable offline media upload features

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,8 @@
 
 24.1
 -----
-* [**] Image block media uploads display a custom error message when there is no internet connection [https://github.com/wordpress-mobile/WordPress-Android/pull/19878]
+* [**] Block Editor: Image block media uploads display a custom error message when there is no internet connection [https://github.com/wordpress-mobile/WordPress-Android/pull/19878]
+* [**] Block Editor: Media uploads that failed due to lack of internet connectivity automatically retry once a connection is re-established [https://github.com/wordpress-mobile/WordPress-Android/pull/19803]
 
 24.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6530-6bf7eb09130bc7879ce5a0f270484b04ba60a36e'
+    gutenbergMobileVersion = 'v1.111.0-alpha2'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.61.0'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.111.0-alpha1'
+    gutenbergMobileVersion = '6530-6bf7eb09130bc7879ce5a0f270484b04ba60a36e'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.61.0'
     wordPressLoginVersion = '1.10.0'

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1601,7 +1601,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @Override
     public void onConnectionStatusChange(boolean isConnected) {
         getGutenbergContainerFragment().onConnectionStatusChange(isConnected);
-        if (BuildConfig.DEBUG && isConnected && hasFailedMediaUploads()) {
+        if (isConnected && hasFailedMediaUploads()) {
             mEditorFragmentListener.onMediaRetryAll(mFailedMediaIds);
         }
     }


### PR DESCRIPTION
## Related
- https://github.com/WordPress/gutenberg/pull/57731
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6530

## Description

Remove `DEV` flags disabling offline media upload features.

## Testing Instructions

N/A, features were tested in individual PRs.

## Regression Notes

1. Potential unintended areas of impact
    Very little. This change removes a `DEV` flag.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A, no changes.
3. What automated tests I added (or what prevented me from doing so)
    N/A, flags are not tested.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
