### PR TITLE
[Reader IA][Search] Hook Search top bar action to existing functionality

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -145,7 +145,8 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
                         onMenuItemClick = viewModel::onTopBarMenuItemClick,
                         onFilterClick = ::tryOpenFilterList,
                         onClearFilterClick = ::clearFilter,
-                        onSearchClick = {}
+                        isSearchVisible = state.isSearchActionVisible,
+                        onSearchClick = viewModel::onSearchActionClicked,
                     )
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -389,6 +389,7 @@ class ReaderViewModel @Inject constructor(
                     menuItems = menuItems,
                     selectedItem = selectedItem,
                     filterUiState = filterUiState,
+                    isSearchActionVisible = isSearchSupported(),
                 )
             )
         }
@@ -515,6 +516,7 @@ class ReaderViewModel @Inject constructor(
         val menuItems: List<MenuElementData>,
         val selectedItem: MenuElementData.Item.Single,
         val filterUiState: FilterUiState? = null,
+        val isSearchActionVisible: Boolean = false,
     ) {
         data class FilterUiState(
             val blogsFilterCount: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -54,7 +54,8 @@ fun ReaderTopAppBar(
     onMenuItemClick: (MenuElementData.Item.Single) -> Unit,
     onFilterClick: (ReaderFilterType) -> Unit,
     onClearFilterClick: () -> Unit,
-    onSearchClick: () -> Unit,
+    isSearchVisible: Boolean,
+    onSearchClick: () -> Unit = {},
 ) {
     var selectedItem by remember { mutableStateOf(topBarUiState.selectedItem) }
     var isFilterShown by remember { mutableStateOf(topBarUiState.filterUiState != null) }
@@ -124,17 +125,19 @@ fun ReaderTopAppBar(
             }
         }
         Spacer(Modifier.width(Margin.ExtraSmall.value))
-        IconButton(
-            modifier = Modifier.align(Alignment.CenterVertically),
-            onClick = { onSearchClick() }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_magnifying_glass_16dp),
-                contentDescription = stringResource(
-                    R.string.reader_search_content_description
-                ),
-                tint = MaterialTheme.colors.onSurface,
-            )
+        if (isSearchVisible) {
+            IconButton(
+                modifier = Modifier.align(Alignment.CenterVertically),
+                onClick = { onSearchClick() }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_magnifying_glass_16dp),
+                    contentDescription = stringResource(
+                        R.string.reader_search_content_description
+                    ),
+                    tint = MaterialTheme.colors.onSurface,
+                )
+            }
         }
     }
 }
@@ -225,6 +228,7 @@ fun ReaderTopAppBarPreview() {
                 },
                 onFilterClick = {},
                 onClearFilterClick = {},
+                isSearchVisible = true,
                 onSearchClick = {},
             )
         }


### PR DESCRIPTION
Fixes #19923 

The search action in the new Reader top bar was not working so far, so this PR hooks it to the existing logic to show/hide it when the search feature is supported (logged into WPcom account or not) and to open the existing Search screen when tapped.

-----

## To Test:

### Search action visibility
The search action should only show up for users logged into Jetpack with a WPcom account, so it's hidden for users logged with self-hosted sites.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/d0763135-82b7-4b50-bfac-03afa4a56bbc

#### Hidden
1. Log into Jetpack with a self-hosted site
2. Go to Reader
3. **Verify** the search action icon is not shown in the top bar for any feeds

#### Showing
1. Log into Jetpack with a WPcom account
2. Go to Reader
3. **Verify** the search action icon is shown in the top bar for all feeds

###  Search action opening Search screen
Tapping the search action should redirect the user to the existing Reader Search feature.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/62f21efa-0775-4cf8-b636-4a03f6f93730

1. Log into Jetpack with a WPcom account
2. Go to Reader
3. Tap the search action icon in the top bar
4. **Verify** it opens the existing Search screen

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

6. What automated tests I added (or what prevented me from doing so)

    - None yet (unit tests for the top bar will be done in a different PR)

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
