### PR TITLE
[Reader] Remove first tags recommendation card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -139,7 +139,7 @@ class ReaderDiscoverLogic @Inject constructor(
             insertBlogsIntoDb(cards.filterIsInstance<ReaderRecommendedBlogsCard>().map { it.blogs }.flatten())
 
             // Simplify the json. The simplified version is used in the upper layers to load the data from the db.
-            val simplifiedCardsJson = createSimplifiedJson(fullCardsJson)
+            val simplifiedCardsJson = createSimplifiedJson(fullCardsJson, taskType)
             insertCardsJsonIntoDb(simplifiedCardsJson)
 
             val nextPageHandle = parseDiscoverCardsJsonUseCase.parseNextPageHandle(json)
@@ -198,7 +198,7 @@ class ReaderDiscoverLogic @Inject constructor(
      * as it's already stored in the db.
      */
     @Suppress("NestedBlockDepth")
-    private fun createSimplifiedJson(cardsJsonArray: JSONArray): JSONArray {
+    private fun createSimplifiedJson(cardsJsonArray: JSONArray, discoverTasks: DiscoverTasks): JSONArray {
         var index = 0
         val simplifiedJson = JSONArray()
         for (i in 0 until cardsJsonArray.length()) {
@@ -212,6 +212,10 @@ class ReaderDiscoverLogic @Inject constructor(
                     }
                 }
                 JSON_CARD_INTERESTS_YOU_MAY_LIKE -> {
+                    // We should not have an interests/tags card as the first element on Discover feed.
+                    if (i == 0 && discoverTasks == REQUEST_FIRST_PAGE) {
+                        continue
+                    }
                     simplifiedJson.put(index++, cardJson)
                 }
                 JSON_CARD_POST -> {


### PR DESCRIPTION
Fixes #19924 

-----

## To Test:

- Install JP and sign in
- Open "Reader"
- Select "Discover": the first card should not be a tags recommendation card.

-----

## Regression Notes

1. Potential unintended areas of impact

    - "Discover" feed

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    -

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
