### PR TITLE
[Reader] Implement analytics events considering new filter UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -384,6 +384,6 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
 
     private fun clearFilter() {
         val viewModel = getSubFilterViewModel() ?: return
-        viewModel.setDefaultSubfilter()
+        viewModel.setDefaultSubfilter(isClearingFilter = true)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -638,7 +638,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
                                 visibleState.getCategories(),
                                 mUiHelpers.getTextOfUiString(requireContext(), visibleState.getTitle())
                         );
-                        mReaderTracker.track(Stat.READER_FILTER_SHEET_DISPLAYED);
                         bottomSheet.show(getChildFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);
                     } else if (!uiState.isVisible() && bottomSheet != null) {
                         bottomSheet.dismiss();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -791,7 +791,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             mSubFilterViewModel.setSubfilterFromTag(newTag);
         } else if (isFollowingScreen() && !ReaderTagTable.tagExists(getCurrentTag())) {
             // user just removed a tag which was selected in the subfilter
-            mSubFilterViewModel.setDefaultSubfilter();
+            mSubFilterViewModel.setDefaultSubfilter(false);
         } else {
             // otherwise, refresh posts to make sure any changes are reflected and auto-update
             // posts in the current tag if it's time
@@ -827,7 +827,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
             refreshPosts();
         } else {
             if (mIsFilterableScreen) {
-                mSubFilterViewModel.setDefaultSubfilter();
+                mSubFilterViewModel.setDefaultSubfilter(false);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -193,13 +193,14 @@ class SubFilterViewModel @Inject constructor(
         )
     }
 
-    fun setDefaultSubfilter() {
+    fun setDefaultSubfilter(isClearingFilter: Boolean) {
         readerTracker.track(Stat.READER_FILTER_SHEET_CLEARED)
         updateSubfilter(
-            SiteAll(
+            filter = SiteAll(
                 onClickAction = ::onSubfilterClicked,
-                isSelected = true
-            )
+                isSelected = true,
+                isClearingFilter = isClearingFilter,
+            ),
         )
     }
 
@@ -291,7 +292,10 @@ class SubFilterViewModel @Inject constructor(
     }
 
     fun onSubfilterSelected(subfilterListItem: SubfilterListItem) {
-        readerTracker.track(Stat.READER_FILTER_SHEET_ITEM_SELECTED)
+        // We should not track subfilter selected if we're clearing a filter that is currently applied.
+        if (!subfilterListItem.isClearingFilter) {
+            readerTracker.track(Stat.READER_FILTER_SHEET_ITEM_SELECTED)
+        }
         changeSubfilter(subfilterListItem, true, mTagFragmentStartedWith)
     }
 
@@ -345,7 +349,7 @@ class SubFilterViewModel @Inject constructor(
                 )
             )
 
-            setDefaultSubfilter()
+            setDefaultSubfilter(false)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -213,6 +213,11 @@ class SubFilterViewModel @Inject constructor(
                 listOf(category) // TODO thomashortadev this should accept only a single category
             )
         )
+        val source = when(category) {
+            SubfilterCategory.SITES -> "blogs"
+            SubfilterCategory.TAGS -> "tags"
+        }
+        readerTracker.track(Stat.READER_FILTER_SHEET_DISPLAYED, source)
     }
 
     fun updateTagsAndSites() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterListItem.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 
 sealed class SubfilterListItem(val type: ItemType, val isTrackedItem: Boolean = false) {
     open var isSelected: Boolean = false
+    open var isClearingFilter: Boolean = false
     open val onClickAction: ((filter: SubfilterListItem) -> Unit)? = null
     open val label: UiString? = null
 
@@ -52,6 +53,7 @@ sealed class SubfilterListItem(val type: ItemType, val isTrackedItem: Boolean = 
     @Suppress("DataClassShouldBeImmutable")
     data class SiteAll(
         override var isSelected: Boolean = false,
+        override var isClearingFilter: Boolean = false,
         override val onClickAction: (filter: SubfilterListItem) -> Unit
     ) : SubfilterListItem(SITE_ALL) {
         override val label: UiString = UiStringRes(R.string.reader_filter_cta)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderTag
@@ -136,7 +137,7 @@ class SubFilterViewModelTest : BaseUnitTest() {
 
     @Test
     fun `view model doesn't start tracking subfiltered list if filter is a not tracked item`() {
-        viewModel.setDefaultSubfilter()
+        viewModel.setDefaultSubfilter(false)
 
         // this is done to focus this unit test only on effects of initSubfiltersTracking
         // usually it's not considered great to use this function but here it seemed
@@ -171,7 +172,7 @@ class SubFilterViewModelTest : BaseUnitTest() {
     @Test
     fun `view model is able to set default subfilter`() {
         var item: SubfilterListItem? = null
-        viewModel.setDefaultSubfilter()
+        viewModel.setDefaultSubfilter(false)
 
         viewModel.currentSubFilter.observeForever { item = it }
 
@@ -423,5 +424,25 @@ class SubFilterViewModelTest : BaseUnitTest() {
             assertThat(it.listType).isEqualTo(ReaderPostListType.TAG_FOLLOWED)
             assertThat(it.isFiltered).isEqualTo(true)
         }
+    }
+
+    @Test
+    fun `Should NOT track READER_FILTER_SHEET_ITEM_SELECTED if clearing filter when onSubfilterSelected is called`() {
+        val filter = SiteAll(
+            isClearingFilter = true,
+            onClickAction = {},
+        )
+        viewModel.onSubfilterSelected(filter)
+        verify(readerTracker, times(0)).track(AnalyticsTracker.Stat.READER_FILTER_SHEET_ITEM_SELECTED)
+    }
+
+    @Test
+    fun `Should track READER_FILTER_SHEET_ITEM_SELECTED if NOT clearing filter when onSubfilterSelected is called`() {
+        val filter = SiteAll(
+            isClearingFilter = false,
+            onClickAction = {},
+        )
+        viewModel.onSubfilterSelected(filter)
+        verify(readerTracker).track(AnalyticsTracker.Stat.READER_FILTER_SHEET_ITEM_SELECTED)
     }
 }


### PR DESCRIPTION
Fixes #19925 

-----

## To Test:

1 - Install JP and sign in
2 - Open `Reader`
3 - Select `Subscriptions` in the drop-down menu
4 - Tap the blogs chip: the following event should be tracked with the new parameter `"source"`:
```
🔵 Tracked: reader_filter_sheet_displayed, Properties: {"source":"blogs"}
```
5 - Dismiss the blogs chip and tap the tags chip: the following event should be tracked with the new parameter `"source"`:
```
🔵 Tracked: reader_filter_sheet_displayed, Properties: {"source":"tags"}
```

6 - Tap any tag in the bottom sheet: the following event should be tracked:
```
🔵 Tracked: reader_filter_sheet_item_selected
```

7- Tap "x" to clear the filter: the following even should be tracked:
```
🔵 Tracked: reader_filter_sheet_cleared
```

8- You should NOT see `reader_filter_sheet_item_selected` being tracked when the filter is cleared;
9 - Repeat steps 6-8 using a blog instead of tag.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Existing analytics events not being triggered

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and updated unit tests.

3. What automated tests I added (or what prevented me from doing so)

    - Updated `SubFilterViewModelTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
