### PR TITLE
Format the value on the total followers card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -19,7 +19,9 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.trackWithType
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -36,7 +38,8 @@ class TotalFollowersUseCase @Inject constructor(
     private val totalStatsMapper: TotalStatsMapper,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val actionCardHandler: ActionCardHandler,
-    private val useCaseMode: UseCaseMode
+    private val useCaseMode: UseCaseMode,
+    private val statsUtils: StatsUtils
 ) : StatelessUseCase<Int>(TOTAL_FOLLOWERS, mainDispatcher, bgDispatcher) {
     override fun buildLoadingItem(): List<BlockListItem> = listOf(TitleWithMore(R.string.stats_view_total_followers))
 
@@ -60,7 +63,7 @@ class TotalFollowersUseCase @Inject constructor(
         addActionCard(domainModel)
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
-        items.add(ValueWithChartItem(value = domainModel.toString(), extraBottomMargin = true))
+        items.add(ValueWithChartItem(value = statsUtils.toFormattedString(domainModel, MILLION), extraBottomMargin = true))
         if (totalStatsMapper.shouldShowFollowersGuideCard(domainModel)) {
             items.add(ListItemGuideCard(resourceProvider.getString(R.string.stats_insights_followers_guide_card)))
         }
@@ -96,7 +99,8 @@ class TotalFollowersUseCase @Inject constructor(
         private val resourceProvider: ResourceProvider,
         private val totalStatsMapper: TotalStatsMapper,
         private val analyticsTracker: AnalyticsTrackerWrapper,
-        private val actionCardHandler: ActionCardHandler
+        private val actionCardHandler: ActionCardHandler,
+        private val statsUtils: StatsUtils
     ) : InsightUseCaseFactory {
         override fun build(useCaseMode: UseCaseMode) = TotalFollowersUseCase(
             mainDispatcher,
@@ -107,7 +111,8 @@ class TotalFollowersUseCase @Inject constructor(
             totalStatsMapper,
             analyticsTracker,
             actionCardHandler,
-            useCaseMode
+            useCaseMode,
+            statsUtils
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCase.kt
@@ -63,7 +63,10 @@ class TotalFollowersUseCase @Inject constructor(
         addActionCard(domainModel)
         val items = mutableListOf<BlockListItem>()
         items.add(buildTitle())
-        items.add(ValueWithChartItem(value = statsUtils.toFormattedString(domainModel, MILLION), extraBottomMargin = true))
+        items.add(ValueWithChartItem(
+            value = statsUtils.toFormattedString(domainModel, MILLION),
+            extraBottomMargin = true
+        ))
         if (totalStatsMapper.shouldShowFollowersGuideCard(domainModel)) {
             items.add(ListItemGuideCard(resourceProvider.getString(R.string.stats_insights_followers_guide_card)))
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/insights/usecases/TotalFollowersUseCaseTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R
@@ -24,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ValueWithChartItem
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
 
@@ -51,6 +53,9 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
     lateinit var useCaseMode: UseCaseMode
 
     @Mock
+    lateinit var statsUtils: StatsUtils
+
+    @Mock
     lateinit var actionCardHandler: ActionCardHandler
     private lateinit var useCase: TotalFollowersUseCase
     private val followers = 100
@@ -66,9 +71,11 @@ class TotalFollowersUseCaseTest : BaseUnitTest() {
             totalStatsMapper,
             analyticsTrackerWrapper,
             actionCardHandler,
-            useCaseMode
+            useCaseMode,
+            statsUtils
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
+        whenever(statsUtils.toFormattedString(any<Int>(), any())).then { (it.arguments[0] as Int).toString() }
     }
 
     @Test


### PR DESCRIPTION
Fixes #19893

This adds a feature to format the Total Followers card by
- using comma for values greater than 999,
- using suffixes ("M", "B" etc.) for values equal to or exceeding 1M.

The Total Followers card's behavior is now the same as other total cards.

|before|after|after|
|-|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/eccd47fd-9c9e-44f7-82d6-05845caa9d73" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/5cb96075-125e-4f0a-bb0f-e6085246c5cd" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/97216ad3-fb1e-4907-b1a9-2b038fc28a73" width=300>|

-----

## To Test:
@guarani, I only request reviewing screenshots from you.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Select a site with more than 999 followers.
2. Navigate to My Site → Stats.
3. If the Total Followers card is not visible on the INSIGHTS tab, add it from the ⚙️ icon at the top right.
4. Verify the value on the Total Followers Card is shortened by using suffixes.
5. Select a site with more than 999999 followers.
6. Repeat 2-4.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

3. What automated tests I added (or what prevented me from doing so)

    - None because I haven't added a new feature.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
