### PR TITLE
Prevent processing media if the Uri is null or if mLocalMediaUris is …

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -97,24 +97,21 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
         if (Intent.ACTION_SEND_MULTIPLE.equals(getIntent().getAction())) {
             ArrayList<Uri> externalUris = getIntent().getParcelableArrayListExtra((Intent.EXTRA_STREAM));
             for (Uri uri : externalUris) {
-                if (isAllowedMediaType(uri)) {
+                if (uri != null && isAllowedMediaType(uri)) {
                     mLocalMediaUris.add(MediaUtils.downloadExternalMedia(this, uri));
                 }
             }
         } else if (Intent.ACTION_SEND.equals(getIntent().getAction())) {
             Uri externalUri = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
-            if (isAllowedMediaType(externalUri)) {
+            if (externalUri != null && isAllowedMediaType(externalUri)) {
                 mLocalMediaUris.add(MediaUtils.downloadExternalMedia(this, externalUri));
             }
         }
     }
 
     private boolean isAllowedMediaType(@NonNull Uri uri) {
-        if (uri != null) {
-            String filePath = MediaUtils.getRealPathFromURI(this, uri);
-            return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
-        }
-        return false;
+        String filePath = MediaUtils.getRealPathFromURI(this, uri);
+        return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
     }
 
     private void initShareFragment() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -110,8 +110,11 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
     }
 
     private boolean isAllowedMediaType(@NonNull Uri uri) {
-        String filePath = MediaUtils.getRealPathFromURI(this, uri);
-        return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
+        if (uri != null) {
+            String filePath = MediaUtils.getRealPathFromURI(this, uri);
+            return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
+        }
+        return false;
     }
 
     private void initShareFragment() {
@@ -182,7 +185,7 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
 
         if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
             intent.putExtra(Intent.EXTRA_STREAM, mLocalMediaUris);
-        } else if (Intent.ACTION_SEND.equals(action)) {
+        } else if (Intent.ACTION_SEND.equals(action) && !mLocalMediaUris.isEmpty()) {
             intent.putExtra(Intent.EXTRA_STREAM, mLocalMediaUris.get(0));
         }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/19943
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/19944

This is a regression from https://github.com/wordpress-mobile/WordPress-Android/pull/19754 

It will prevent the app from crashing when `mLocalMediaUris` is empty.

There are a few cases where the media image can't be fetched and this prevents the app from crashing, the image won't be added but at least the app remains open. This is a [known issue](https://github.com/wordpress-mobile/WordPress-Android/issues/19373).

-----

## To Test:

> [!NOTE]  
> I could only reproduce it on a Redmi Note 8T using Android 11 while sharing an image from the File Explorer app. This prevents a crash when the media can't be added, now the app will remain open but the Image won't be added, hopefully will work on fixing [this issue](https://github.com/wordpress-mobile/WordPress-Android/issues/19373) soon. So I propose testing the sharing feature overall:

- **Precondition**: Have different kinds of files on your device: `PDF`, `jpg`,  and `mp4`.
- **NOTE:** The editor takes a bit of time to load when adding media. [GitHub ticket](https://github.com/wordpress-mobile/gutenberg-mobile/issues/6529).
- Install the app from this PR
- Open your Files app
- Multiselect an image and a PDF file 
- Tap on the Share button
- Select the Jetpack app
- **Expect** the editor to be loaded with just the supported media types (images, and videos)

### Extra test case
- Open your Files app
- Select one image
- Select the Jetpack app
- **Expect** the editor to be loaded with the selected image

Test Case 1|Test Case 2
-|-
<video src="https://github.com/WordPress/gutenberg/assets/4885740/dd8dd610-5371-4da0-acf2-a36d1914c97e" />|<video src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/19574a54-0db9-41bf-ab45-e30e8cb80278" />

-----

## Regression Notes

1. Potential unintended areas of impact

    - Sharing Media

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

N/A
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----
