### PR TITLE
[Reader IA] Fix ReaderPostTable sorting date as string

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -1097,7 +1097,7 @@ public class ReaderPostTable {
      */
     public static ReaderBlogIdPostIdList getBlogIdPostIdsInBlog(long blogId, int maxPosts) {
         String sql = "SELECT post_id FROM tbl_posts WHERE blog_id=? AND tag_name='' AND tag_type=0"
-                     + " ORDER BY date_published DESC";
+                     + " ORDER BY datetime(date_published) DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -658,7 +658,7 @@ public class ReaderPostTable {
     public static String getOldestPubDateInBlog(long blogId) {
         String sql = "SELECT date_published FROM tbl_posts"
                      + " WHERE blog_id=? AND tag_name='' AND tag_type=0"
-                     + " ORDER BY date_published LIMIT 1";
+                     + " ORDER BY datetime(date_published) LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(blogId)});
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -665,7 +665,7 @@ public class ReaderPostTable {
     public static String getOldestPubDateInFeed(long feedId) {
         String sql = "SELECT date_published FROM tbl_posts"
                      + " WHERE feed_id=? AND tag_name='' AND tag_type=0"
-                     + " ORDER BY date_published LIMIT 1";
+                     + " ORDER BY datetime(date_published) LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(feedId)});
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -1020,7 +1020,7 @@ public class ReaderPostTable {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql =
                 "SELECT " + columns + " FROM tbl_posts WHERE feed_id=? AND tag_name='' AND tag_type=0"
-                + " ORDER BY date_published DESC";
+                + " ORDER BY datetime(date_published) DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -982,7 +982,7 @@ public class ReaderPostTable {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql =
                 "SELECT " + columns + " FROM tbl_posts WHERE blog_id=? AND tag_name='' AND tag_type=0"
-                + " ORDER BY date_published DESC";
+                + " ORDER BY datetime(date_published) DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + maxPosts;

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -749,7 +749,7 @@ public class ReaderPostTable {
         } else if (tag.tagType == ReaderTagType.SEARCH) {
             return "score";
         } else if (tag.isTagTopic() || tag.isBookmarked()) {
-            return "date_tagged";
+            return "datetime(date_tagged)";
         } else {
             return "datetime(date_published)";
         }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -745,7 +745,7 @@ public class ReaderPostTable {
         if (tag.isPostsILike()) {
             return "datetime(date_liked)";
         } else if (tag.isFollowedSites()) {
-            return "date_published";
+            return "datetime(date_published)";
         } else if (tag.tagType == ReaderTagType.SEARCH) {
             return "score";
         } else if (tag.isTagTopic() || tag.isBookmarked()) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -743,7 +743,7 @@ public class ReaderPostTable {
      */
     private static String getSortColumnForTag(ReaderTag tag) {
         if (tag.isPostsILike()) {
-            return "date_liked";
+            return "datetime(date_liked)";
         } else if (tag.isFollowedSites()) {
             return "date_published";
         } else if (tag.tagType == ReaderTagType.SEARCH) {


### PR DESCRIPTION
Fixes #19897 

I've changed the methods that were previously sorting dates as strings to use `datetime` in `ReaderPostTable` ([see issue](https://github.com/wordpress-mobile/WordPress-Android/issues/19897) for context). In all scenarios the sorting was already working as expected, but this is only true because the posts have the same timezone. It's a weak solution IMHO because if the timezone changes it will break the sorting everywhere. The goal of this PR is to avoid having these problems in the future (like we had with https://github.com/wordpress-mobile/WordPress-Android/pull/19881).

-----

## To Test:
Basically Reader feeds have to continue working as expected.
- Instal JP and sign in;
- Open "Reader";
- Verify "Discover", "Subscriptions", "Saved", "Liked", "Automattic" and custom lists are working as expected (specially the sorting). Please note that not all feeds have the same sorting based on `date_publishing` (see [here](https://github.com/wordpress-mobile/WordPress-Android/pull/19949/files#diff-6698962ec7d529d03ed4128791bac7a7a2279f17bbe052d31bd8542a6a59875aR744));
- Open any blog details;
- Verify the posts list is working as expected (specially the sorting);
- Open any tag;
- Verify the posts list is working as expected (specially the sorting).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader feeds

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
