### PR TITLE
Remove uncessary accesstoken checks - let the app crash on null access tokens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -726,11 +726,6 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     protected void startGravatarUpload(final String filePath) {
         if (!TextUtils.isEmpty(filePath)) {
             final File file = new File(filePath);
-            if (!mAccount.hasAccessToken()) {
-                // FIXME: show a toast
-                return;
-            }
-
             if (file.exists()) {
                 startProgress(false);
                 GravatarApi.uploadGravatar(file, mAccountStore.getAccount().getEmail(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -658,18 +658,10 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
         val file = File(filePath)
         if (!file.exists()) {
-            ToastUtils.showToast(
-                activity,
-                R.string.error_locating_image,
-                SHORT
-            )
+            ToastUtils.showToast(activity, R.string.error_locating_image, SHORT)
             return
         }
         binding?.showGravatarProgressBar(true)
-        if (!accountStore.hasAccessToken()) {
-            // FIXME: Change the toast message
-            ToastUtils.showToast(activity, R.string.error_locating_image, SHORT);
-        }
         GravatarApi.uploadGravatar(file, accountStore.account.email, accountStore.accessToken!!,
             object : GravatarUploadListener {
                 override fun onSuccess() {


### PR DESCRIPTION
I guarded against a null accessToken in e5da2b6ece15269386b6f07c15c1fe8d84a4f128 - that was a mistake IMO, accesstoken shouldn't be null there, and this is the case we should crash early