### PR TITLE
Injecting GravatarApi and using the instance to upload avatars

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/GravatarModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/GravatarModule.kt
@@ -1,0 +1,17 @@
+package org.wordpress.android.modules
+
+import com.gravatar.GravatarApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+class GravatarModule {
+    @Singleton
+    @Provides
+    fun provideGravatarApi(
+    ): GravatarApi = GravatarApi()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -149,6 +149,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
     @Inject protected UnifiedLoginTracker mUnifiedLoginTracker;
     @Inject protected SignupUtils mSignupUtils;
     @Inject protected MediaPickerLauncher mMediaPickerLauncher;
+    @Inject protected GravatarApi mGravatarApi;
 
     public static SignupEpilogueFragment newInstance(String displayName, String emailAddress,
                                                      String photoUrl, String username,
@@ -728,7 +729,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             final File file = new File(filePath);
             if (file.exists()) {
                 startProgress(false);
-                GravatarApi.uploadGravatar(file, mAccountStore.getAccount().getEmail(),
+                mGravatarApi.uploadGravatar(file, mAccountStore.getAccount().getEmail(),
                         Objects.requireNonNull(mAccountStore.getAccessToken()),
                         new GravatarApi.GravatarUploadListener() {
                             @Override
@@ -830,7 +831,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             try {
                 Uri uri = MediaUtils.downloadExternalMedia(getContext(), Uri.parse(mUrl));
                 File file = new File(new URI(uri.toString()));
-                GravatarApi.uploadGravatar(file, mEmail, mToken,
+                mGravatarApi.uploadGravatar(file, mEmail, mToken,
                         new GravatarApi.GravatarUploadListener() {
                             @Override
                             public void onSuccess() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -145,6 +145,9 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
     @Inject
     lateinit var domainManagementFeatureConfig: DomainManagementFeatureConfig
 
+    @Inject
+    lateinit var gravatarApi: GravatarApi
+
     private val viewModel: MeViewModel by viewModels()
 
     private val shouldShowDomainButton
@@ -662,7 +665,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             return
         }
         binding?.showGravatarProgressBar(true)
-        GravatarApi.uploadGravatar(file, accountStore.account.email, accountStore.accessToken!!,
+        gravatarApi.uploadGravatar(file, accountStore.account.email, accountStore.accessToken!!,
             object : GravatarUploadListener {
                 override fun onSuccess() {
                     AnalyticsTracker.track(ME_GRAVATAR_UPLOADED)


### PR DESCRIPTION
Injecting the GravatarApi with HILT.

This goes with `hamorillo/gravatar-api-to-class`

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Launch the app and verify you can upload a new avatar.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Gravatar upload.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Verify the app compiles, and you can update your avatar should be enough. 

3. What automated tests I added (or what prevented me from doing so)

    - Don't apply.

-----
