### PR TITLE
fix: apply code coverage exclusion rules to all projects

### DIFF
--- a/config/gradle/code_coverage.gradle
+++ b/config/gradle/code_coverage.gradle
@@ -6,7 +6,7 @@ static String resolveProjectVariantForCodeCoverage(Project project) {
     }
 }
 
-subprojects {
+allprojects {
     pluginManager.withPlugin("org.jetbrains.kotlinx.kover") {
         if (project.plugins.hasPlugin("com.android.library") || project.plugins.hasPlugin("com.android.application")) {
             koverReport {


### PR DESCRIPTION
### Description

This minor PR corrects a mistake introduced in #19936 . As the merged Kover report is configured in the `rootProject`, we can't configure exclusions using `subprojects` as it specifically filters out the `rootProject`.

Instead of `allprojects` should be used.

### Test

Before: report from running `koverHtmlReport` Gradle task contains `hilt_aggregated_deps` package

After: report from running `koverHtmlReport` Gradle task does not contain `hilt_aggregated_deps` package