### PR TITLE
Github Actions job for sending dependencies to GitHub Dependency Graph

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,0 +1,24 @@
+name: Submit dependencies to GitHub Dependency Graph
+on:
+  push:
+    branches:
+      - trunk
+      - release/*
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - run: cp gradle.properties-example gradle.properties
+      - name: Setup Gradle to generate and submit dependency graphs
+        uses: gradle/gradle-build-action@v2
+        with:
+          dependency-graph: generate-and-submit
+      - name: Generate the dependency graph which will be submitted post-job
+        run: ./gradlew dependencies


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions job to send Gradle/Maven dependencies to Github Dependency Graph for each push to `trunk` or `release/*` branch.

By sending those dependencies, we allow Dependabot to scan whether dependencies we use are affected by known vulnerabilities.

Soon, those metrics will be available to visualize on Apps Metrics ([link](https://metrics.a8c-ci.services/grafana/d/f2131a73-89a3-48b9-8d3b-ecc1456347ac/dependabot-security-alerts?orgId=1)).

More about this project can be found internally at paaHJt-5Tn-p2

### Testing instructions
<!-- Step-by-step testing instructions. When necessary, break out individual scenarios that need testing, and consider including a checklist for the reviewer to go through. -->
This PR can be only verified using the fork: https://github.com/wzieba/WordPress-Android

- Assert that you can see security alerts at https://github.com/wzieba/WordPress-Android/security/dependabot and that some of them are related to `Maven` ecosystem.
