### PR TITLE
Added release notes for domain card management feature on Site Domains

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Block Editor: Image block media uploads display a custom error message when there is no internet connection [https://github.com/wordpress-mobile/WordPress-Android/pull/19878]
 * [**] Block Editor: Media uploads that failed due to lack of internet connectivity automatically retry once a connection is re-established [https://github.com/wordpress-mobile/WordPress-Android/pull/19803]
+* [*] [Jetpack-only] Added opening domain management from the Site Domain screen by tapping on the domain cards [https://github.com/wordpress-mobile/WordPress-Android/pull/19910]
 
 24.0
 -----


### PR DESCRIPTION
This adds release notes for the UI update and new domain management feature on the Site domain screen, which has been added with https://github.com/wordpress-mobile/WordPress-Android/pull/19910.
