### PR TITLE
[Reader] reader_accessed event not triggerered when app is resumed 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1141,7 +1141,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
             if (!mIsChangingConfiguration) {
                 // Don't track if onResume was called after a screen orientation change
                 trackLastVisiblePage(currentPageType);
-                return;
             }
 
             if (currentPageType == PageType.NOTIFS) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -233,10 +233,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_CURRENT_FOCUS = "CURRENT_FOCUS";
     public static final String ARG_BYPASS_MIGRATION = "bypass_migration";
     public static final String ARG_MEDIA = "show_media";
-
-    // Track the first `onResume` event for the current session so we can use it for Analytics tracking
-    private static boolean mFirstResume = true;
-
     private WPMainNavigationView mBottomNav;
 
     private TextView mConnectionBar;
@@ -1135,7 +1131,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         if (mBottomNav != null) {
             PageType currentPageType = mBottomNav.getCurrentSelectedPage();
-            trackLastVisiblePage(currentPageType, mFirstResume);
+            trackLastVisiblePage(currentPageType);
 
             if (currentPageType == PageType.NOTIFS) {
                 // if we are presenting the notifications list, it's safe to clear any outstanding
@@ -1167,8 +1163,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 mSelectedSiteRepository.hasSelectedSite() && mBottomNav != null
                 && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE
         );
-
-        mFirstResume = false;
     }
 
     private void checkQuickStartNotificationStatus() {
@@ -1214,7 +1208,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public void onPageChanged(int position) {
         mReaderTracker.onBottomNavigationTabChanged();
         PageType pageType = WPMainNavigationView.getPageType(position);
-        trackLastVisiblePage(pageType, true);
+        trackLastVisiblePage(pageType);
         mCurrentActiveFocusPoint = null;
         if (pageType == PageType.READER) {
             // MySite fragment might not be attached to activity, so we need to remove focus point from here
@@ -1288,31 +1282,23 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
     }
 
-    private void trackLastVisiblePage(PageType pageType, boolean trackAnalytics) {
+    private void trackLastVisiblePage(@NonNull final PageType pageType) {
         switch (pageType) {
             case MY_SITE:
                 ActivityId.trackLastActivity(ActivityId.MY_SITE);
-                if (trackAnalytics) {
-                     mAnalyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, getSelectedSite());
-                }
+                mAnalyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, getSelectedSite());
                 break;
             case READER:
                 ActivityId.trackLastActivity(ActivityId.READER);
-                if (trackAnalytics) {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.READER_ACCESSED);
-                }
+                AnalyticsTracker.track(AnalyticsTracker.Stat.READER_ACCESSED);
                 break;
             case NOTIFS:
                 ActivityId.trackLastActivity(ActivityId.NOTIFICATIONS);
-                if (trackAnalytics) {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED);
-                }
+                AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED);
                 break;
             case ME:
                 ActivityId.trackLastActivity(ActivityId.ME);
-                if (trackAnalytics) {
-                    AnalyticsTracker.track(Stat.ME_ACCESSED);
-                }
+                AnalyticsTracker.track(Stat.ME_ACCESSED);
                 break;
             default:
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -231,8 +231,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
     public static final String ARG_STAT_TO_TRACK = "stat_to_track";
     public static final String ARG_EDITOR_ORIGIN = "editor_origin";
     public static final String ARG_CURRENT_FOCUS = "CURRENT_FOCUS";
+    public static final String ARG_IS_CHANGING_CONFIGURATION = "IS_CHANGING_CONFIGURATION";
     public static final String ARG_BYPASS_MIGRATION = "bypass_migration";
     public static final String ARG_MEDIA = "show_media";
+    private boolean mIsChangingConfiguration = false;
     private WPMainNavigationView mBottomNav;
 
     private TextView mConnectionBar;
@@ -500,6 +502,10 @@ public class WPMainActivity extends LocaleAwareActivity implements
         }
 
         displayJetpackFeatureCollectionOverlayIfNeeded();
+
+        if (savedInstanceState != null) {
+            mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
+        }
     }
 
     private void initBackPressHandler() {
@@ -654,6 +660,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putSerializable(ARG_CURRENT_FOCUS, mCurrentActiveFocusPoint);
+        outState.putSerializable(ARG_IS_CHANGING_CONFIGURATION, isChangingConfigurations());
         super.onSaveInstanceState(outState);
     }
 
@@ -1131,7 +1138,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
 
         if (mBottomNav != null) {
             PageType currentPageType = mBottomNav.getCurrentSelectedPage();
-            trackLastVisiblePage(currentPageType);
+            if (!mIsChangingConfiguration) {
+                // Don't track if onResume was called after a screen orientation change
+                trackLastVisiblePage(currentPageType);
+                return;
+            }
 
             if (currentPageType == PageType.NOTIFS) {
                 // if we are presenting the notifications list, it's safe to clear any outstanding
@@ -1163,6 +1174,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 mSelectedSiteRepository.hasSelectedSite() && mBottomNav != null
                 && mBottomNav.getCurrentSelectedPage() == PageType.MY_SITE
         );
+        mIsChangingConfiguration = false;
     }
 
     private void checkQuickStartNotificationStatus() {


### PR DESCRIPTION
Fixes #19278

-----

## To Test:
1 - Install JP and sign in;
2 - Verify the selected tab correct analytics event is tracked:
```
- Reader: 🔵 Tracked: reader_accessed
- My Site: 🔵 Tracked: my_site_tab_accessed, Properties: {"blog_id":<id>,"site_type":"blog","is_jetpack":false}
- Notifications: 🔵 Tracked: notifications_accessed
- Me: 🔵 Tracked: me_tab_accessed
```
3 - Send the app to background (e.g. tap home button) and open it again: the event from step 2 should be tracked again (previously this wasn't happening);
4 - Repeat steps 2-3 with the four tabs.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - This logic is currently implemented in `Activity`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
