### PR TITLE
[Prompts] Build dailyprompt-id tag in code based on the Prompt ID

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Block Editor: Image block media uploads display a custom error message when there is no internet connection [https://github.com/wordpress-mobile/WordPress-Android/pull/19878]
 * [**] Block Editor: Media uploads that failed due to lack of internet connectivity automatically retry once a connection is re-established [https://github.com/wordpress-mobile/WordPress-Android/pull/19803]
 * [*] [Jetpack-only] Added opening domain management from the Site Domain screen by tapping on the domain cards [https://github.com/wordpress-mobile/WordPress-Android/pull/19910]
+* [*] [Jetpack-only] Fix Prompt response posts not having one of the `dailyprompt` tags [https://github.com/wordpress-mobile/WordPress-Android/pull/19971]
 
 24.0
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProvider.kt
@@ -10,15 +10,15 @@ class BloggingPromptsPostTagProvider @Inject constructor(
     private val readerUtilsWrapper: ReaderUtilsWrapper,
 ) {
     fun promptIdTag(
-        tagUrl: String
-    ): String = readerUtilsWrapper.getTagFromTagUrl(tagUrl)
-        .takeIf { it.isNotBlank() }
+        id: Int
+    ): String = "$BLOGGING_PROMPT_ID_TAG_PREFIX$id"
+        .takeIf { id > 0 }
         ?: BLOGGING_PROMPT_TAG
 
-    fun promptIdSearchReaderTag(
+    fun promptSearchReaderTag(
         tagUrl: String
     ): ReaderTag {
-        val promptIdTag = promptIdTag(tagUrl)
+        val promptIdTag = promptTagFromUrl(tagUrl)
         return ReaderTag(
             promptIdTag,
             promptIdTag,
@@ -28,8 +28,15 @@ class BloggingPromptsPostTagProvider @Inject constructor(
         )
     }
 
+    private fun promptTagFromUrl(
+        tagUrl: String
+    ): String = readerUtilsWrapper.getTagFromTagUrl(tagUrl)
+        .takeIf { it.isNotBlank() }
+        ?: BLOGGING_PROMPT_TAG
+
     companion object {
         const val BLOGGING_PROMPT_TAG = "dailyprompt"
+        const val BLOGGING_PROMPT_ID_TAG_PREFIX = "dailyprompt-"
         const val BLOGANUARY_TAG = "bloganuary"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewModelSlice.kt
@@ -95,7 +95,7 @@ class BloggingPromptCardViewModelSlice @Inject constructor(
 
     private fun onBloggingPromptViewAnswersClick(tagUrl: String) {
         bloggingPromptsCardAnalyticsTracker.trackMySiteCardViewAnswersClicked()
-        val tag = bloggingPromptsPostTagProvider.promptIdSearchReaderTag(tagUrl)
+        val tag = bloggingPromptsPostTagProvider.promptSearchReaderTag(tagUrl)
         _onNavigation.value = Event(BloggingPromptCardNavigationAction.ViewAnswers(tag))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorBloggingPromptsViewModel.kt
@@ -55,7 +55,7 @@ class EditorBloggingPromptsViewModel
 
     private fun createPromptTags(prompt: BloggingPromptModel): List<String> = mutableListOf<String>().apply {
         add(BloggingPromptsPostTagProvider.BLOGGING_PROMPT_TAG)
-        add(bloggingPromptsPostTagProvider.promptIdTag(prompt.answeredLink))
+        add(bloggingPromptsPostTagProvider.promptIdTag(prompt.id))
         prompt.bloganuaryId?.let { bloganuaryIdTag ->
             add(BloggingPromptsPostTagProvider.BLOGANUARY_TAG)
             add(bloganuaryIdTag)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
@@ -27,19 +27,15 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should return the expected tag when promptIdTag is called given valid url`() {
-        whenever(readerUtilsWrapper.getTagFromTagUrl(any())).thenReturn(BLOGGING_PROMPT_ID_TAG)
-
-        val actual = tagProvider.promptIdTag("valid-url")
+    fun `Should return the expected tag when promptIdTag is called given valid id`() {
+        val actual = tagProvider.promptIdTag(1234)
 
         assertThat(actual).isEqualTo(BLOGGING_PROMPT_ID_TAG)
     }
 
     @Test
-    fun `Should return the generic tag when promptIdTag is called given invalid url`() {
-        whenever(readerUtilsWrapper.getTagFromTagUrl(any())).thenReturn("")
-
-        val actual = tagProvider.promptIdTag("invalid-url")
+    fun `Should return the generic tag when promptIdTag is called given invalid id`() {
+        val actual = tagProvider.promptIdTag(0)
 
         assertThat(actual).isEqualTo(BloggingPromptsPostTagProvider.BLOGGING_PROMPT_TAG)
     }
@@ -54,7 +50,7 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
             ReaderPostLogic.formatFullEndpointForTag(BLOGGING_PROMPT_ID_TAG),
             ReaderTagType.FOLLOWED,
         )
-        val actual = tagProvider.promptIdSearchReaderTag("valid-url")
+        val actual = tagProvider.promptSearchReaderTag("valid-url")
         assertEquals(expected, actual)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsPostTagProviderTest.kt
@@ -41,7 +41,7 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should return the expected ReaderTag when promptIdSearchReaderTag is called`() {
+    fun `Should return the expected ReaderTag when promptSearchReaderTag is called`() {
         whenever(readerUtilsWrapper.getTagFromTagUrl(any())).thenReturn(BLOGGING_PROMPT_ID_TAG)
         val expected = ReaderTag(
             BLOGGING_PROMPT_ID_TAG,
@@ -54,7 +54,22 @@ class BloggingPromptsPostTagProviderTest : BaseUnitTest() {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun `Should return the base Prompt ReaderTag when promptSearchReaderTag is called`() {
+        whenever(readerUtilsWrapper.getTagFromTagUrl(any())).thenReturn("")
+        val expected = ReaderTag(
+            BLOGGING_PROMPT_TAG,
+            BLOGGING_PROMPT_TAG,
+            BLOGGING_PROMPT_TAG,
+            ReaderPostLogic.formatFullEndpointForTag(BLOGGING_PROMPT_TAG),
+            ReaderTagType.FOLLOWED,
+        )
+        val actual = tagProvider.promptSearchReaderTag("invalid-url")
+        assertEquals(expected, actual)
+    }
+
     companion object {
         private const val BLOGGING_PROMPT_ID_TAG = "dailyprompt-1234"
+        private const val BLOGGING_PROMPT_TAG = "dailyprompt"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewModelSliceTest.kt
@@ -141,7 +141,7 @@ class BloggingPromptCardViewModelSliceTest : BaseUnitTest() {
         val tagUrl = "valid-url"
 
         val expectedTag = mock<ReaderTag>()
-        whenever(bloggingPromptsPostTagProvider.promptIdSearchReaderTag(tagUrl)).thenReturn(expectedTag)
+        whenever(bloggingPromptsPostTagProvider.promptSearchReaderTag(tagUrl)).thenReturn(expectedTag)
 
         val params = viewModelSlice.getBuilderParams(mock())
         params.onViewAnswersClick(tagUrl)


### PR DESCRIPTION
Fixes #19970 

Build the `dailyprompt-id` tag in code, using the Prompt ID, but keep using the answeredLink URL for the "View all responses" search.

-----

## To Test:
Make sure to have a site that supports prompts.

1. Install and log into Jetpack
2. Go to `My Site` dashboard
3. Tap `Answer` in the Prompts card or got to the Prompts card menu -> "View more prompts" -> Tap on any prompt
4. On the Editor, hit publish
5. **Verify** the `dailyprompt-<id>` tag is present in the `Tags` section
6. Go back to `My Site`
7. Tap `View all responses` in the Prompt card
8. **Verify** it still uses the Bloganuary tag (during January)

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
