### PR TITLE
Remove editor_upload_media_paused analytics event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3683,7 +3683,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         }
 
         if (event.isError() && !NetworkUtils.isNetworkAvailable(this)) {
-            mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media, event.error);
+            mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media);
             return;
         }
 
@@ -3707,7 +3707,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
             // if the remote url on completed is null, we consider this upload wasn't successful
             if (TextUtils.isEmpty(event.media.getUrl()) && !NetworkUtils.isNetworkAvailable(this)) {
                 MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
-                mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media, error);
+                mEditorMedia.onMediaUploadPaused(mEditorMediaUploadListener, event.media);
             } else if (TextUtils.isEmpty(event.media.getUrl())) {
                 MediaError error = new MediaError(MediaErrorType.GENERIC_ERROR);
                 mEditorMedia.onMediaUploadError(mEditorMediaUploadListener, event.media, error);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.EDITOR_UPLOAD_MEDIA_FAILED
-import org.wordpress.android.analytics.AnalyticsTracker.Stat.EDITOR_UPLOAD_MEDIA_PAUSED
 import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.MediaActionBuilder
@@ -313,7 +312,6 @@ class EditorMedia @Inject constructor(
                 }
         }
 
-        analyticsTrackerWrapper.track(EDITOR_UPLOAD_MEDIA_PAUSED, site, properties)
         listener.onMediaUploadPaused(media.id.toString())
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/media/EditorMedia.kt
@@ -303,15 +303,7 @@ class EditorMedia @Inject constructor(
         listener.onMediaUploadFailed(media.id.toString())
     }
 
-    fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel, error: MediaError) = launch {
-        val properties: Map<String, Any?> = withContext(bgDispatcher) {
-            analyticsUtilsWrapper
-                .getMediaProperties(media.isVideo, null, media.filePath)
-                .also {
-                    it["error_type"] = error.type.name
-                }
-        }
-
+    fun onMediaUploadPaused(listener: EditorMediaUploadListener, media: MediaModel) = launch {
         listener.onMediaUploadPaused(media.id.toString())
     }
 

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -211,7 +211,6 @@ public final class AnalyticsTracker {
         EDITOR_EDITED_IMAGE, // Visual editor only
         EDITOR_UPLOAD_MEDIA_FAILED, // Visual editor only
         EDITOR_UPLOAD_MEDIA_RETRIED, // Visual editor only
-        EDITOR_UPLOAD_MEDIA_PAUSED, // Visual editor only
         EDITOR_TAPPED_BLOCKQUOTE,
         EDITOR_TAPPED_BOLD,
         EDITOR_TAPPED_ELLIPSIS_COLLAPSE,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -733,8 +733,6 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "editor_upload_media_failed";
             case EDITOR_UPLOAD_MEDIA_RETRIED:
                 return "editor_upload_media_retried";
-            case EDITOR_UPLOAD_MEDIA_PAUSED:
-                return "editor_upload_media_paused";
             case EDITOR_CLOSED:
                 return "editor_closed";
             case EDITOR_SESSION_START:


### PR DESCRIPTION
Removes instances of the (unreleased) `editor_upload_media_paused` analytics event in favor of tracking these as part of [`media_service_upload_response_error`](https://github.com/wordpress-mobile/WordPress-Android/blob/916c1ccfafb78f3e8ca1773bb9c6d3f49a1a035f/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java#L1618-L1619) in tandem with [`CONNECTION_ERROR`](https://github.com/wordpress-mobile/WordPress-Android/blob/916c1ccfafb78f3e8ca1773bb9c6d3f49a1a035f/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java#L209-L210).

See also:
* https://github.com/wordpress-mobile/WordPress-Android/pull/19890

## To Test:
`editor_upload_media_paused` should no longer appear in analytics events.

-----

## Regression Notes

1. Potential unintended areas of impact
Analytics events

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Testing in Superset/Looker

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

