### PR TITLE
ci: generate and submit `WordPress` dependencies rather than `rootProject`

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           dependency-graph: generate-and-submit
       - name: Generate the dependency graph which will be submitted post-job
-        run: ./gradlew dependencies
+        run: ./gradlew :WordPress:dependencies --no-configure-on-demand


### PR DESCRIPTION
## Description

This is a complementary PR to #19957 . Actually, it'll be better to execute `dependencies` task for the main module of the project rather than for the `rootProject` (some dependencies might be not sent to GH otherwise).

No testing is needed.

