### PR TITLE
fix: Properly space Day One name

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
@@ -13,7 +13,7 @@ enum class BloggingPromptAttribution(
     NO_ATTRIBUTION("", -1, -1),
     DAY_ONE(
         "dayone",
-        R.string.my_site_blogging_prompt_card_attribution_dayone,
+        R.string.my_site_blogging_prompt_card_attribution_day_one,
         R.drawable.ic_dayone_24dp,
     ),
     BLOGANUARY(

--- a/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
+++ b/WordPress/src/main/res/layout/blogging_prompt_card_compact.xml
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_small"
                 android:textAppearance="?attr/textAppearanceCaption"
-                tools:text="@string/my_site_blogging_prompt_card_attribution_dayone" />
+                tools:text="@string/my_site_blogging_prompt_card_attribution_day_one" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -75,7 +75,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_small"
                 android:textAppearance="?attr/textAppearanceCaption"
-                tools:text="@string/my_site_blogging_prompt_card_attribution_dayone" />
+                tools:text="@string/my_site_blogging_prompt_card_attribution_day_one" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2400,7 +2400,7 @@
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="my_site_blogging_prompt_card_menu_skip">Skip for today</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Turn off prompts</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From &lt;b&gt;DayOne&lt;/b&gt;</string>
+    <string name="my_site_blogging_prompt_card_attribution_dayone">From &lt;b&gt;Day One&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_attribution_bloganuary">From &lt;b&gt;Bloganuary&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2400,7 +2400,7 @@
     <string name="my_site_blogging_prompt_card_menu_view_more">View more prompts</string>
     <string name="my_site_blogging_prompt_card_menu_skip">Skip for today</string>
     <string name="my_site_blogging_prompt_card_menu_remove">Turn off prompts</string>
-    <string name="my_site_blogging_prompt_card_attribution_dayone">From &lt;b&gt;Day One&lt;/b&gt;</string>
+    <string name="my_site_blogging_prompt_card_attribution_day_one">From &lt;b&gt;Day One&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_attribution_bloganuary">From &lt;b&gt;Bloganuary&lt;/b&gt;</string>
     <string name="my_site_blogging_prompt_card_menu_learn_more">Learn more</string>
     <string name="my_site_blogging_prompt_card_skipped_snackbar">Skipped today\'s blogging prompt</string>


### PR DESCRIPTION
The Day One brand name includes a space between the two words.

<details><summary>Screenshots</summary>

| Before | After |
| - | - |
| <img width="598" alt="day-one-before" src="https://github.com/wordpress-mobile/WordPress-Android/assets/438664/19416559-91b5-4b1c-875a-4e4c2546c072"> | <img width="598" alt="day-one-after" src="https://github.com/wordpress-mobile/WordPress-Android/assets/438664/c81d72f2-4750-4289-84f7-e5bfe9ffae8b"> |

</details>

## To Test:

1. Check out the branch and apply the following testing diff:
    <details><summary>Testing Diff</summary>

    ```diff
    diff --git a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
    index 178c7da39b..d5947570ba 100644
    --- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
    +++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
    @@ -36,11 +36,11 @@ enum class BloggingPromptAttribution(
              * for the BLOGANUARY campaign at this point, but might be in the future.
              */
             fun fromPrompt(
    -            prompt: BloggingPromptModel
    -        ): BloggingPromptAttribution = if (!prompt.bloganuaryId.isNullOrBlank()) {
    +            @Suppress("UNUSED_PARAMETER") prompt: BloggingPromptModel
    +        ): BloggingPromptAttribution = if (false) {
                 BLOGANUARY
             } else {
    -            fromString(prompt.attribution)
    +            fromString("dayone")
             }
         }
     }
    
    ```
    </details>
1. Build and launch the app.
1. Load the My Site tab and verify the "Day One" name in the Blogging Prompt attribution includes a space.

## Regression Notes

1. Potential unintended areas of impact
    Blogging Prompts, translations.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Interacted with Blogging Prompts, test different device languages.
4. What automated tests I added (or what prevented me from doing so)
    Automated tests felt unnecessary for a typo.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
