### PR TITLE
Add stats granularity spinner to Traffic tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -61,6 +61,7 @@ import org.wordpress.android.ui.stats.refresh.lists.MonthsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.TotalCommentsDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.TotalFollowersDetailListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.TotalLikesDetailListViewModel;
+import org.wordpress.android.ui.stats.refresh.lists.TrafficListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.WeeksListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.YearsListViewModel;
 import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel;
@@ -157,6 +158,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(InsightsListViewModel.class)
     abstract ViewModel insightsTabViewModel(InsightsListViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(TrafficListViewModel.class)
+    abstract ViewModel trafficTabViewModel(TrafficListViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -331,6 +331,7 @@ class StatsViewModel
 
     data class DateSelectorUiModel(
         val isVisible: Boolean = false,
+        val isGranularitySpinnerVisible: Boolean = false,
         val date: String? = null,
         val timeZone: String? = null,
         val enableSelectPrevious: Boolean = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -210,8 +210,8 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             StatsSection.TOTAL_LIKES_DETAIL -> TotalLikesDetailListViewModel::class.java
             StatsSection.TOTAL_COMMENTS_DETAIL -> TotalCommentsDetailListViewModel::class.java
             StatsSection.TOTAL_FOLLOWERS_DETAIL -> TotalFollowersDetailListViewModel::class.java
-            StatsSection.ANNUAL_STATS,
             StatsSection.TRAFFIC -> TrafficListViewModel::class.java
+            StatsSection.ANNUAL_STATS,
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java
             StatsSection.WEEKS -> WeeksListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
-import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -152,9 +151,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             }
         })
 
-        dateSelector.granularitySpinner.isVisible = statsTrafficTabFeatureConfig.isEnabled()
-        dateSelector.granularitySpace.isVisible = statsTrafficTabFeatureConfig.isEnabled()
-        dateSelector.dateSpace.isVisible = !statsTrafficTabFeatureConfig.isEnabled()
         if (statsTrafficTabFeatureConfig.isEnabled()) {
             dateSelector.granularitySpinner.adapter = ArrayAdapter(
                 requireContext(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -211,7 +211,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             StatsSection.TOTAL_COMMENTS_DETAIL -> TotalCommentsDetailListViewModel::class.java
             StatsSection.TOTAL_FOLLOWERS_DETAIL -> TotalFollowersDetailListViewModel::class.java
             StatsSection.ANNUAL_STATS,
-            StatsSection.TRAFFIC -> DaysListViewModel::class.java // Replace with TrafficListViewModel
+            StatsSection.TRAFFIC -> TrafficListViewModel::class.java
             StatsSection.INSIGHTS -> InsightsListViewModel::class.java
             StatsSection.DAYS -> DaysListViewModel::class.java
             StatsSection.WEEKS -> WeeksListViewModel::class.java

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -6,6 +6,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -16,6 +19,7 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
 import org.wordpress.android.databinding.StatsListFragmentBinding
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
@@ -27,6 +31,8 @@ import org.wordpress.android.ui.stats.refresh.lists.detail.DetailListViewModel
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsNavigator
 import org.wordpress.android.ui.stats.refresh.utils.drawDateSelector
+import org.wordpress.android.ui.stats.refresh.utils.toNameResource
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
@@ -48,6 +54,10 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
 
     @Inject
     lateinit var navigator: StatsNavigator
+
+    @Inject
+    lateinit var statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
     private lateinit var viewModel: StatsListViewModel
     private lateinit var statsSection: StatsSection
 
@@ -141,6 +151,27 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 }
             }
         })
+
+        dateSelector.granularitySpinner.isVisible = statsTrafficTabFeatureConfig.isEnabled()
+        dateSelector.granularitySpace.isVisible = statsTrafficTabFeatureConfig.isEnabled()
+        dateSelector.dateSpace.isVisible = !statsTrafficTabFeatureConfig.isEnabled()
+        if (statsTrafficTabFeatureConfig.isEnabled()) {
+            dateSelector.granularitySpinner.adapter = ArrayAdapter(
+                requireContext(),
+                R.layout.filter_spinner_item,
+                StatsGranularity.entries.map { getString(it.toNameResource()) }
+            ).apply { setDropDownViewResource(R.layout.toolbar_spinner_dropdown_item) }
+
+            dateSelector.granularitySpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    // TODO update TRAFFIC tab
+                }
+
+                @Suppress("EmptyFunctionBlock")
+                override fun onNothingSelected(parent: AdapterView<*>?) {
+                }
+            }
+        }
 
         dateSelector.nextDateButton.setOnClickListener {
             viewModel.onNextDateSelected()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.stats.refresh.YEAR_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.DAYS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TRAFFIC
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.WEEKS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.YEARS
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
@@ -225,6 +226,13 @@ class DaysListViewModel @Inject constructor(
     analyticsTracker: AnalyticsTrackerWrapper,
     dateSelectorFactory: StatsDateSelector.Factory
 ) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(DAYS))
+
+class TrafficListViewModel @Inject constructor(
+    @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
+    @Named(DAY_STATS_USE_CASE) statsUseCase: BaseListUseCase,
+    analyticsTracker: AnalyticsTrackerWrapper,
+    dateSelectorFactory: StatsDateSelector.Factory
+) : StatsListViewModel(mainDispatcher, statsUseCase, analyticsTracker, dateSelectorFactory.build(TRAFFIC))
 
 // Using Weeks granularity on new insight details screens
 class InsightsDetailListViewModel @Inject constructor(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import android.view.View
+import androidx.core.view.isVisible
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 
@@ -26,5 +27,8 @@ fun StatsListFragmentBinding.drawDateSelector(dateSelectorUiModel: DateSelectorU
         if (nextDateButton.isEnabled != enableNextButton) {
             nextDateButton.isEnabled = enableNextButton
         }
+        granularitySpinner.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible == true
+        granularitySpace.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible == true
+        dateSpace.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible != true
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.utils
 import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
@@ -63,4 +64,11 @@ fun StatsGranularity.toStatsSection(): StatsSection {
         MONTHS -> StatsSection.MONTHS
         YEARS -> StatsSection.YEARS
     }
+}
+
+fun StatsGranularity.toNameResource() = when {
+    this == DAYS -> R.string.stats_timeframe_by_day
+    this == WEEKS -> R.string.stats_timeframe_by_week
+    this == MONTHS -> R.string.stats_timeframe_by_month
+    else -> R.string.stats_timeframe_by_year
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -39,6 +39,7 @@ constructor(
 
     fun updateDateSelector() {
         val shouldShowDateSelection = this.statsSection != INSIGHTS
+        val shouldShowGranularitySpinner = this.statsSection == TRAFFIC
 
         val updatedDate = getDateLabelForSection()
         val currentState = dateSelectorData.value
@@ -52,6 +53,7 @@ constructor(
             }
             val updatedState = DateSelectorUiModel(
                 shouldShowDateSelection,
+                shouldShowGranularitySpinner,
                 updatedDate,
                 enableSelectPrevious = selectedDateProvider.hasPreviousDate(statsSection),
                 enableSelectNext = selectedDateProvider.hasNextDate(statsSection),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -39,7 +39,7 @@ constructor(
 
     fun updateDateSelector() {
         val shouldShowDateSelection = this.statsSection != INSIGHTS
-        val shouldShowGranularitySpinner = this.statsSection == TRAFFIC
+        val shouldShowGranularitySpinner = statsTrafficTabFeatureConfig.isEnabled() && this.statsSection == TRAFFIC
 
         val updatedDate = getDateLabelForSection()
         val currentState = dateSelectorData.value

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSect
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TRAFFIC
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.util.perform
 import javax.inject.Inject
 
@@ -21,6 +22,7 @@ constructor(
     private val selectedDateProvider: SelectedDateProvider,
     private val statsDateFormatter: StatsDateFormatter,
     private val siteProvider: StatsSiteProvider,
+    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig,
     private val statsSection: StatsSection
 ) {
     private val _dateSelectorUiModel = MutableLiveData<DateSelectorUiModel>()
@@ -43,7 +45,11 @@ constructor(
         if (!shouldShowDateSelection && currentState?.isVisible != false) {
             emitValue(currentState, DateSelectorUiModel(false))
         } else {
-            val timeZone = statsDateFormatter.printTimeZone(siteProvider.siteModel)
+            val timeZone = if (statsTrafficTabFeatureConfig.isEnabled()) {
+                null
+            } else {
+                statsDateFormatter.printTimeZone(siteProvider.siteModel)
+            }
             val updatedState = DateSelectorUiModel(
                 shouldShowDateSelection,
                 updatedDate,
@@ -107,13 +113,15 @@ constructor(
     @Inject constructor(
         private val selectedDateProvider: SelectedDateProvider,
         private val siteProvider: StatsSiteProvider,
-        private val statsDateFormatter: StatsDateFormatter
+        private val statsDateFormatter: StatsDateFormatter,
+        private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
     ) {
         fun build(statsSection: StatsSection): StatsDateSelector {
             return StatsDateSelector(
                 selectedDateProvider,
                 statsDateFormatter,
                 siteProvider,
+                statsTrafficTabFeatureConfig,
                 statsSection
             )
         }

--- a/WordPress/src/main/res/layout/stats_date_selector.xml
+++ b/WordPress/src/main/res/layout/stats_date_selector.xml
@@ -1,72 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/date_selector_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:minHeight="@dimen/one_line_list_item_height">
+    android:gravity="center_vertical"
+    android:minHeight="52dp"
+    android:orientation="horizontal"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingVertical="@dimen/margin_extra_small"
+    tools:ignore="RtlSymmetry">
 
-    <org.wordpress.android.widgets.MaterialTextViewWithNumerals
-        android:id="@+id/selectedDateTextView"
-        style="@style/StatsDateSelectorTitle"
-        android:layout_width="0dp"
+    <Spinner
+        android:id="@+id/granularity_spinner"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="1dp"
-        android:text="@string/unknown"
-        app:layout_constraintBottom_toTopOf="@+id/currentSiteTimeZone"
-        app:layout_constraintEnd_toStartOf="@+id/previousDateButton"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_goneMarginBottom="10dp" />
+        android:minHeight="@dimen/min_touch_target_sz"
+        android:overlapAnchor="false"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/currentSiteTimeZone"
-        style="@style/StatsDateTimeZone"
+    <Space
+        android:id="@+id/granularity_space"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="10dp"
-        android:text="@string/unknown"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/previousDateButton"
-        app:layout_constraintStart_toStartOf="@+id/selectedDateTextView"
-        app:layout_constraintTop_toBottomOf="@+id/selectedDateTextView" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="vertical">
+
+        <org.wordpress.android.widgets.MaterialTextViewWithNumerals
+            android:id="@+id/selectedDateTextView"
+            style="@style/StatsDateSelectorTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/unknown" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/currentSiteTimeZone"
+            style="@style/StatsDateTimeZone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/unknown"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <Space
+        android:id="@+id/date_space"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="gone" />
 
     <ImageButton
         android:id="@+id/previousDateButton"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="16dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/margin_medium"
         android:background="?selectableItemBackgroundBorderless"
         android:contentDescription="@string/stats_select_previous_period_description"
-        android:padding="4dp"
         android:src="@drawable/ic_chevron_left_white_24dp"
-        app:tint="@color/on_surface_disabled_selector"
         android:tintMode="src_in"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/nextDateButton"
-        app:layout_constraintStart_toEndOf="@+id/selectedDateTextView"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:tint="@color/on_surface_disabled_selector" />
 
     <ImageButton
         android:id="@+id/nextDateButton"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="12dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/margin_medium"
         android:background="?selectableItemBackgroundBorderless"
         android:contentDescription="@string/stats_select_next_period_description"
-        android:padding="4dp"
         android:src="@drawable/ic_chevron_right_white_24dp"
-        app:tint="@color/on_surface_disabled_selector"
         android:tintMode="src_in"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+        app:tint="@color/on_surface_disabled_selector" />
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1275,6 +1275,10 @@
     <string name="stats_timeframe_weeks">Weeks</string>
     <string name="stats_timeframe_months">Months</string>
     <string name="stats_timeframe_years">Years</string>
+    <string name="stats_timeframe_by_day">By day</string>
+    <string name="stats_timeframe_by_week">By week</string>
+    <string name="stats_timeframe_by_month">By month</string>
+    <string name="stats_timeframe_by_year">By year</string>
     <string name="stats_timeframe_last_seven_days">Last 7-days</string>
     <string name="stats_timeframe_previous_seven_days">Previous 7-days</string>
     <string name="stats_views">Views</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
@@ -17,6 +16,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -29,14 +29,15 @@ class StatsDateSelectorTest : BaseUnitTest() {
 
     @Mock
     lateinit var siteProvider: StatsSiteProvider
+
+    @Mock
+    lateinit var statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
     private val selectedDate = Date(0)
     private val selectedDateLabel = "Jan 1"
     private val statsSection = StatsSection.DAYS
     private val statsGranularity = StatsGranularity.DAYS
     private val updatedDate = Date(10)
     private val updatedLabel = "Jan 2"
-    private val siteTimeZone = "GMT"
-    private val site = SiteModel()
 
     private val dateProviderSelectedDate = MutableLiveData<SectionChange>()
 
@@ -51,13 +52,13 @@ class StatsDateSelectorTest : BaseUnitTest() {
             selectedDateProvider,
             statsDateFormatter,
             siteProvider,
+            statsTrafficTabFeatureConfig,
             statsSection
         )
         whenever(selectedDateProvider.getSelectedDate(statsSection)).thenReturn(selectedDate)
         whenever(statsDateFormatter.printGranularDate(selectedDate, statsGranularity)).thenReturn(selectedDateLabel)
         whenever(statsDateFormatter.printGranularDate(updatedDate, statsGranularity)).thenReturn(updatedLabel)
-        whenever(siteProvider.siteModel).thenReturn(site)
-        whenever(statsDateFormatter.printTimeZone(site)).thenReturn(siteTimeZone)
+        whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
     }
 
     @Test
@@ -90,7 +91,6 @@ class StatsDateSelectorTest : BaseUnitTest() {
         Assertions.assertThat(model?.enableSelectPrevious).isTrue()
         Assertions.assertThat(model?.enableSelectNext).isTrue()
         Assertions.assertThat(model?.date).isEqualTo(selectedDateLabel)
-        Assertions.assertThat(model?.timeZone).isEqualTo(siteTimeZone)
     }
 
     @Test
@@ -120,6 +120,7 @@ class StatsDateSelectorTest : BaseUnitTest() {
             selectedDateProvider,
             statsDateFormatter,
             siteProvider,
+            statsTrafficTabFeatureConfig,
             StatsSection.INSIGHTS
         )
         var model: DateSelectorUiModel? = null


### PR DESCRIPTION
This adds a stats granularity spinner to the Traffic tab and removes the timezone from the date selector bar.
This only adds the view, itemSelectedListener will be implemented in another PR.

**Note for the reviewer:**
The dates on the date selector bar are aligned to the left when the `stats_traffic_tab` flag is disabled. To align dates to the left when the flag is disabled and to the right when the flag is enabled, `stats_date_selector.xml` has been updated, and `Space` views have been added to the layout.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ccaf900a-6e15-44bc-8680-972e195f07f7" width=300>

The same spinner view from the People screen has been used on the stats screen.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/d09c150e-f519-4492-8f36-d7ca5b5557fc" width=300>

-----

## To Test:
1. Log in.
2. Navigate to "My Site → Stats → DAYS"
5. Verify the date selector bar does not include granularity spinner.
6. Navigate to "Me → Debug settings"
7. Check `stats_traffic_tab` on REMOTE FEATURES tab.
8. Navigate to "My Site → Stats → DAYS"
9. Verify the date selector bar has a granularity spinner and the layout looks as expected.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Date selector bar when the `stats_traffic_tab` flag is disabled.

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested when the `stats_traffic_tab` flag is disabled.

8. What automated tests I added (or what prevented me from doing so)

    - The addition of a new spinner is not worth including a new UI test.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
