### PR TITLE
Prevents the app from crashing when the foreground service fails to start

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -135,7 +135,11 @@ class PostUploadNotifier {
         updateNotificationBuilder(post);
         if (sNotificationData.mNotificationId == 0) {
             sNotificationData.mNotificationId = (new Random()).nextInt();
-            mService.startForeground(sNotificationData.mNotificationId, mNotificationBuilder.build());
+            try {
+                mService.startForeground(sNotificationData.mNotificationId, mNotificationBuilder.build());
+            } catch (RuntimeException exception) {
+                AppLog.e(T.POSTS, "startOrUpdateForegroundNotification failed; See issue #18714", exception);
+            }
         } else {
             // service was already started, let's just modify the notification
             doNotify(sNotificationData.mNotificationId, mNotificationBuilder.build(), null);


### PR DESCRIPTION
Partially/Temporarily #18714

## Description
This PR catches and logs the Runtime exception ([ForegroundServiceStartNotAllowedException](https://developer.android.com/reference/android/app/ForegroundServiceStartNotAllowedException)) thrown at the [PostUploadNotifier](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java#L138) when the service fails to start on Android 12+

Internal ref: pcdRpT-5hm-p2#comment-8537

Note: This is a temporary solution till we upgrade to WorkManager as part of the Android 14 Target SDK Update work (internal ref: pcdRpT-5fy-p2#comment-8380)

-----

## To Test:
* Try to reproduce the crash by starting an upload of a post/media on an Android 13/14 device and putting the app on the background 🤞
* Verify that the error is logged.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)