### PR TITLE
Deprecate org.wordpress-mobile dependency group in favor of org.wordpress

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,10 @@ updates:
       # dependapot.
       - dependency-name: "org.wordpress:fluxc"
       - dependency-name: "org.wordpress:utils"
+      # org.wordpress-mobile.gutenberg-mobile is deprecated and org.wordpress.gutenberg-mobile is used instead.
+      # Temporarily leaving this declaration during transition, but this should be removed soon.
       - dependency-name: "org.wordpress-mobile.gutenberg-mobile:react-native-gutenberg-bridge"
+      - dependency-name: "org.wordpress.gutenberg-mobile:react-native-gutenberg-bridge"
       - dependency-name: "org.wordpress:login"
       - dependency-name: "com.automattic:stories"
       - dependency-name: "com.automattic.stories:mp4compose"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -36,12 +36,16 @@ repositories {
             includeGroup "org.wordpress.aztec"
             includeGroup "org.wordpress.fluxc"
             includeGroup "org.wordpress.wellsql"
-            includeGroup "org.wordpress-mobile"
-            includeGroup "org.wordpress-mobile.gutenberg-mobile"
-            includeGroupByRegex "org.wordpress-mobile.react-native-libraries.*"
+            includeGroup "org.wordpress.gutenberg-mobile"
+            includeGroupByRegex "org.wordpress.react-native-libraries.*"
             includeGroup "com.automattic"
             includeGroup "com.automattic.stories"
             includeGroup "com.automattic.tracks"
+            // 'org.wordpress-mobile' group is deprecated. It's kept for now for smoother transition
+            // but it should be removed soon (within couple weeks)
+            includeGroup "org.wordpress-mobile"
+            includeGroup "org.wordpress-mobile.gutenberg-mobile"
+            includeGroupByRegex "org.wordpress-mobile.react-native-libraries.*"
         }
     }
     maven {

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -11,6 +11,9 @@ repositories {
         content {
             includeGroup "org.wordpress"
             includeGroup "org.wordpress.aztec"
+            includeGroupByRegex "org.wordpress.react-native-libraries.*"
+            // 'org.wordpress-mobile' group is deprecated. It's kept for now for smoother transition
+            // but it should be removed soon (within couple weeks)
             includeGroup "org.wordpress-mobile"
             includeGroup "org.wordpress-mobile.gutenberg-mobile"
             includeGroupByRegex "org.wordpress-mobile.react-native-libraries.*"


### PR DESCRIPTION
Out of abundance of caution, we are updating the group id used to publish `gutenberg-mobile` artifacts from `org.wordpress-mobile` to `org.wordpress` since we don't own the `wordpress-mobile` domain. Instead of removing the old group id, I opted to deprecate it for now for smoother transition for developers. I intend to remove these deprecated domains  some time next week.

I didn't test this because the artifacts are not ready yet, but it's a straightforward change and one that can't break anything. So, my suggestion is to merge it and address any issues once the artifacts are updated.