### PR TITLE
Merge 24.0.1 to release/24.1

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,10 @@
 24.1
 -----
 
+24.0.1
+-----
+* [**] Fix crash when RichText values are not defined [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6563]
+
 
 24.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.110.0'
+    gutenbergMobileVersion = '6566-801c7c041d3448cf25539577dfecbeb530cb3e8d'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.61.0'
     wordPressLoginVersion = '1.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6566-801c7c041d3448cf25539577dfecbeb530cb3e8d'
+    gutenbergMobileVersion = 'v1.110.1'
     wordPressAztecVersion = 'v1.9.0'
     wordPressFluxCVersion = '2.61.0'
     wordPressLoginVersion = '1.10.0'

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=24.0
-versionCode=1400
+versionName=24.0.1
+versionCode=1402


### PR DESCRIPTION
The only change in `release/24.0.1` was the gutenberg version update. Per usual, I selected the gutenberg version we have in `release/24.1` for the conflict resolution which will be updated to a new version that contains the hotfix in https://github.com/wordpress-mobile/WordPress-Android/pull/20000.