### PR TITLE
Disable the Stories feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 24.1
 -----
+* [**] Disabled the ability of creating new Story posts. [#20014]
 
 24.0.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -86,6 +86,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
+    @Suppress("FunctionOnlyReturningConstant")
     fun shouldShowStoryPost(): Boolean = false
 
     fun shouldShowJetpackPoweredEditorFeatures(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -86,13 +86,7 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         }
     }
 
-    fun shouldShowStoryPost(): Boolean {
-        val currentPhase = getCurrentPhase() ?: return true
-        return when (currentPhase) {
-            is PhaseStaticPosters, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
-            else -> true
-        }
-    }
+    fun shouldShowStoryPost(): Boolean = false
 
     fun shouldShowJetpackPoweredEditorFeatures(): Boolean {
         val currentPhase = getCurrentPhase() ?: return true


### PR DESCRIPTION
See: p1706056464986299/1705928714.429819-slack-C0436E5L5V1

We want to disable the Stories feature, this PR simply turns off the flag. There will be a follow-up PR for removing the feature from our codebase.

-----

## To Test:

1. Sign in the JP app.
2. Click on the FAB.
3. It should not display the `Story post` option.
4. Click on `Blog post` in the FAB options.
5. Click on the ＋ icon at the left-bottom corner to open the `Search blocks` full-screen bottom sheet.
6. Search `story`
7. The `Story block` should not be found in the search result.
8. Done!

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

10. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)