### PR TITLE
Adds: Site monitoring feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,6 +1,5 @@
 import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
 import se.bjurr.violations.lib.model.SEVERITY
-import io.sentry.android.gradle.extensions.InstrumentationFeature
 
 plugins {
     id "com.android.application"
@@ -164,6 +163,7 @@ android {
         buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
         buildConfigField "boolean", "BLAZE_MANAGE_CAMPAIGNS", "false"
         buildConfigField "boolean", "DASHBOARD_PERSONALIZATION", "false"
+        buildConfigField "boolean", "ENABLE_SITE_MONITORING", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+
+private const val SITE_MONITORING_FEATURE_REMOTE_FIELD = "site_monitoring"
+
+@Feature(SITE_MONITORING_FEATURE_REMOTE_FIELD, false)
+class SiteMonitoringFeatureConfig(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.ENABLE_SITE_MONITORING,
+    SITE_MONITORING_FEATURE_REMOTE_FIELD
+)


### PR DESCRIPTION
## Closes
#20015

## Description
⊕ This PR adds a remote feature flag for Site monitor Project 

## Screenshots
<img width="446" alt="Screenshot 2024-01-24 at 5 19 22 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/6a818dcf-cc85-4746-87fd-a6ad013f6321">

## To Test:
1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Remote Feature` section
3. ✅ Verify that the feature flag `site_monitoring` exists and value is false
-----

## Regression Notes

1. Potential unintended areas of impact
- Nothing, as this is a new feature flag 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing 

3. What automated tests I added (or what prevented me from doing so)

-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
