### PR TITLE
Site Monitoring: Add item to "more" menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.core.app.TaskStackBuilder
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -155,6 +156,11 @@ class ActivityNavigator @Inject constructor() {
         val mainActivityIntent = Intent(context, WPMainActivity::class.java)
         mainActivityIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
         return mainActivityIntent
+    }
+
+    fun navigateToSiteMonitoring(context: Context, site: SiteModel) {
+        Log.i(javaClass.simpleName, "Request to navigateToSiteMonitoring for ${site.name} within ${context.packageName}")
+        // todo: Implement this method after the SiteMonitorActivity is available
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.core.app.TaskStackBuilder
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -159,8 +158,9 @@ class ActivityNavigator @Inject constructor() {
     }
 
     fun navigateToSiteMonitoring(context: Context, site: SiteModel) {
-        Log.i(javaClass.simpleName, "Request to navigateToSiteMonitoring for ${site.name} within ${context.packageName}")
-        // todo: Implement this method after the SiteMonitorActivity is available
+        // todo: Implement this method after the SiteMonitorActivity is available and remove the lines below
+        site.name
+        context.packageName
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -726,6 +726,11 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 .newInstance(action.isPromptsEnabled)
                 .show(requireActivity().supportFragmentManager, BloganuaryNudgeLearnMoreOverlayFragment.TAG)
         }
+
+        is SiteNavigationAction.OpenSiteMonitoring -> activityNavigator.navigateToSiteMonitoring(
+            requireActivity(),
+            action.site
+        )
     }
 
     private fun handleNavigation(action: BloggingPromptCardNavigationAction) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -110,6 +110,7 @@ sealed class SiteNavigationAction {
     object OpenDashboardPersonalization : SiteNavigationAction()
 
     data class OpenBloganuaryNudgeOverlay(val isPromptsEnabled: Boolean): SiteNavigationAction()
+    data class OpenSiteMonitoring(val site: SiteModel) : SiteNavigationAction()
 }
 
 sealed class BloggingPromptCardNavigationAction: SiteNavigationAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
@@ -41,6 +41,7 @@ class ListItemActionHandler @Inject constructor(
             ListItemAction.COMMENTS -> SiteNavigationAction.OpenUnifiedComments(selectedSite)
             ListItemAction.BLAZE -> onBlazeMenuItemClick()
             ListItemAction.MORE -> SiteNavigationAction.OpenMore(selectedSite, quickStartEvent)
+            ListItemAction.SITE_MONITORING -> SiteNavigationAction.OpenSiteMonitoring(selectedSite)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/ListItemAction.kt
@@ -20,4 +20,5 @@ enum class ListItemAction (val trackingLabel: String) {
     BLAZE("blaze"),
     ME("me"),
     MORE("more"),
+    SITE_MONITORING("site_monitoring"),
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -91,6 +91,7 @@ class SiteItemsBuilder @Inject constructor(
     private fun getManageSiteItems(
         params: SiteItemsBuilderParams
     ): List<MySiteCardAndItem> {
+        val siteMonitoring = buildSiteMonitoringOptionsIfNeeded(params)
         val manageSiteItems = buildManageSiteItems(params)
 
         val emptyHeaderItem1 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
@@ -101,6 +102,7 @@ class SiteItemsBuilder @Inject constructor(
         val emptyHeaderItem2 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
         val admin = siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
         return listOf(manageHeader) +
+                siteMonitoring +
                 manageSiteItems +
                 emptyHeaderItem1 +
                 jetpackConfiguration +
@@ -123,6 +125,12 @@ class SiteItemsBuilder @Inject constructor(
             siteListItemBuilder.buildDomainsItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildMeItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildSiteSettingsItemIfAvailable(params.site, params.onClick)
+        )
+    }
+
+    private fun buildSiteMonitoringOptionsIfNeeded(params: SiteItemsBuilderParams): List<MySiteCardAndItem> {
+        return listOfNotNull(
+            siteListItemBuilder.buildSiteMonitoringItemIfAvailable(params.site, params.onClick)
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -245,6 +245,18 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
+    fun buildSiteMonitoringItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): MySiteCardAndItem? {
+        // todo: Add the feature flag wrapper once it is available
+        return if (buildConfigWrapper.isJetpackApp && site.isWPComAtomic && site.isAdmin) {
+            ListItem(
+                R.drawable.gb_ic_tool,
+                UiStringRes(R.string.site_monitoring),
+                onClick = ListItemInteraction.create(ListItemAction.SITE_MONITORING, onClick),
+                listItemAction = ListItemAction.SITE_MONITORING
+            )
+        } else null
+    }
+
     companion object {
         const val HIDE_WP_ADMIN_YEAR = 2015
         const val HIDE_WP_ADMIN_MONTH = 9

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -152,6 +152,7 @@ class MenuActivity : AppCompatActivity() {
                 this,
                 action.campaignListingPageSource
             )
+            is SiteNavigationAction.OpenSiteMonitoring -> activityNavigator.navigateToSiteMonitoring(this, action.site)
             else -> {}
         }
     }

--- a/WordPress/src/main/res/drawable/gb_ic_tool.xml
+++ b/WordPress/src/main/res/drawable/gb_ic_tool.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14.103,7.128l2.26,-2.26a4,4 0,0 0,-5.207 4.804L5.828,15a2,2 0,1 0,2.828 2.828l5.329,-5.328a4,4 0,0 0,4.804 -5.208l-2.261,2.26 -1.912,-0.512 -0.513,-1.912zM6.889,16.768a0.5,0.5 0,1 1,0.707 -0.707,0.5 0.5,0 0,1 -0.707,0.707z" />
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4854,4 +4854,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="gutenberg_native_working_offline" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Working Offline</string>
     <string name="gutenberg_native_waiting_for_connection" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Waiting for connection</string>
 
+    <!-- Site Monitoring -->
+    <string name="site_monitoring">Site Monitoring</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
@@ -190,7 +190,14 @@ class ListItemActionHandlerTest: BaseUnitTest() {
         )
     }
 
-    private fun invokeItemClickAction(action: ListItemAction, ): SiteNavigationAction {
+    @Test
+    fun `when site monitoring item click, then emits OpenSiteMonitoring navigation event`() {
+        val navigationAction = invokeItemClickAction(action = ListItemAction.SITE_MONITORING)
+
+        assertEquals(navigationAction, SiteNavigationAction.OpenSiteMonitoring(site))
+    }
+
+    private fun invokeItemClickAction(action: ListItemAction): SiteNavigationAction {
         return listItemActionHandler.handleAction(action, site)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -115,3 +115,9 @@ val DOMAINS_ITEM = ListItem(
     onClick = ListItemInteraction.create(DOMAINS, SITE_ITEM_ACTION),
     listItemAction = DOMAINS
 )
+val SITE_MONITORING_ITEM = ListItem(
+    R.drawable.gb_ic_tool,
+    UiStringRes(R.string.site_monitoring),
+    onClick = ListItemInteraction.create(ListItemAction.SITE_MONITORING, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.SITE_MONITORING
+)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -76,6 +76,7 @@ class SiteItemsBuilderTest {
     @Test
     fun `adds all the items in the correct order`() {
         setupHeaders(
+            addSiteMonitoringItem = true,
             addActivityLogItem = true,
             addPlanItem = false,
             addPagesItem = true,
@@ -106,6 +107,7 @@ class SiteItemsBuilderTest {
             TRAFFIC_HEADER,
             STATS_ITEM,
             MANAGE_HEADER,
+            SITE_MONITORING_ITEM,
             ACTIVITY_ITEM,
             BACKUP_ITEM,
             SCAN_ITEM,
@@ -229,6 +231,7 @@ class SiteItemsBuilderTest {
 
     @Suppress("ComplexMethod", "LongMethod")
     private fun setupHeaders(
+        addSiteMonitoringItem: Boolean = false,
         addActivityLogItem: Boolean = false,
         addPlanItem: Boolean = false,
         addPagesItem: Boolean = false,
@@ -253,6 +256,11 @@ class SiteItemsBuilderTest {
                 )
             ).thenReturn(
                 PLAN_ITEM.copy(showFocusPoint = showPlansFocusPoint)
+            )
+        }
+        if (addSiteMonitoringItem) {
+            whenever(siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                SITE_MONITORING_ITEM
             )
         }
         if (addActivityLogItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.mysite.items.PLUGINS_ITEM
 import org.wordpress.android.ui.mysite.items.SCAN_ITEM
 import org.wordpress.android.ui.mysite.items.SHARING_ITEM
 import org.wordpress.android.ui.mysite.items.SITE_ITEM_ACTION
+import org.wordpress.android.ui.mysite.items.SITE_MONITORING_ITEM
 import org.wordpress.android.ui.mysite.items.SITE_SETTINGS_ITEM
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
@@ -414,6 +415,58 @@ class SiteListItemBuilderTest {
         assertThat(item).isNull()
     }
 
+    /* SITE MONITORING */
+    @Test
+    fun `give jetpack app, when is atomic and admin, then site monitoring item is built`() {
+        setupSiteMonitoringItems()
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isEqualTo(SITE_MONITORING_ITEM)
+    }
+
+    @Test
+    fun `give jetpack app, when is not atomic, then site monitoring item is not built`() {
+        setupSiteMonitoringItems(
+            isAtomic = false
+        )
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `give jetpack app, when is not admin, then site monitoring item is not built`() {
+        setupSiteMonitoringItems(
+            isAdmin = false
+        )
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `give not jetpack app, when site monitoring item requested, then site monitoring item is not built`() {
+        setupSiteMonitoringItems(
+            isJetpackApp = false
+        )
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    private fun setupSiteMonitoringItems(
+        isJetpackApp: Boolean = true,
+        isAtomic: Boolean = true,
+        isAdmin: Boolean = true
+    ) {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
+        whenever(siteModel.isAdmin).thenReturn(isAdmin)
+        whenever(siteModel.isWPComAtomic).thenReturn(isAtomic)
+    }
     private fun setupSiteSettings(canManageOptions: Boolean = false, isAccessedViaWPComRest: Boolean = true) {
         whenever(siteModel.hasCapabilityManageOptions).thenReturn(canManageOptions)
         whenever(siteUtilsWrapper.isAccessedViaWPComRest(siteModel)).thenReturn(isAccessedViaWPComRest)


### PR DESCRIPTION
Parent #20018 

This PR implements the basics for the Site Monitoring item within the Site Menu
- Shows "Site Monitoring" item if the app is Jetpack, the sites is atomic, and isAdmin 

Note: I left "todos" for the tasks still open. (navigate, feature flag guard, icon finalization). See parent issue for more details.

Dark | Light
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/156e1030-ec3a-4ee9-8e81-ff86c92a49b4"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/8c11bace-89ad-44b6-b776-640418480326">


-----

## To Test:
- Install and launch the JP app from this PR
- Login with an account that has an atomic with admin access
- Select ^^ that site
- Navigate to My Site > More > 
- ✅ Verify that the Site Monitoring Item is shown
- Tap on the Site Monitoring item
- ✅ Verify the logs contain: 🔵 Tracked: more_menu_item_tapped, Properties: {"item":"site_monitoring"}
- Navigate back to My Site tab
- Navigate to Site Selector and change to site that is not atomic
- Navigate to My Site > More > 
- ✅ Verify that the Site Monitoring Item is not shown

-----

## Regression Notes

1. Potential unintended areas of impact
The Site Monitoring item shows when it should not

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and updated unit tests
`ListItemActionHandlerTest`
`SiteItemsBuildterTest`
`SiteListItemBuilderTest`

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
