### PR TITLE
[Lib] Update Wordpress-Utils from 3.11.0 to 3.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     wordPressFluxCVersion = '2.61.0'
     wordPressLoginVersion = '1.10.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.11.0'
+    wordPressUtilsVersion = '3.12.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug


### PR DESCRIPTION
Related: https://github.com/wordpress-mobile/WordPress-Utils-Android/issues/140

-----

## To Test:

🚬 test the app!

- [ ] Upload media
- [ ] Manage media
- [ ] Make posts
- [ ] Consume posts

-----

## Regression Notes

1. Potential unintended areas of impact

    n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

   Manual testing

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
