### PR TITLE
+ Adds: the Skeleton classes for Site Monitoring Screen 

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1123,6 +1123,11 @@
             android:label="@string/stats"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <activity android:name=".ui.sitemonitor.SiteMonitorParentActivity"
+            android:exported="false"
+            android:label="@string/site_monitoring"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
 
     </application>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.mysite.menu.KEY_QUICK_START_EVENT
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.quickstart.QuickStartEvent
+import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import javax.inject.Inject
@@ -158,9 +159,9 @@ class ActivityNavigator @Inject constructor() {
     }
 
     fun navigateToSiteMonitoring(context: Context, site: SiteModel) {
-        // todo: Implement this method after the SiteMonitorActivity is available and remove the lines below
-        site.name
-        context.packageName
+        val intent = Intent(context, SiteMonitorParentActivity::class.java)
+        intent.putExtra(WordPress.SITE, site)
+        context.startActivity(intent)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -1,0 +1,46 @@
+package org.wordpress.android.ui.sitemonitor
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MainTopAppBar
+import org.wordpress.android.ui.compose.components.NavigationIcons
+import org.wordpress.android.ui.compose.theme.AppTheme
+
+class SiteMonitorParentActivity: AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                SiteMonitorScreen()
+            }
+        }
+    }
+
+    @Composable
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
+    fun SiteMonitorScreen(modifier: Modifier = Modifier) {
+        Scaffold(
+            topBar = {
+                MainTopAppBar(
+                    title = stringResource(id = R.string.site_monitoring),
+                    navigationIcon = NavigationIcons.BackIcon,
+                    onNavigationIconClick = onBackPressedDispatcher::onBackPressed,
+                )
+            },
+            content = {
+                TabScreen(modifier = modifier)
+            }
+        )
+    }
+
+    @Composable
+    fun TabScreen(modifier: Modifier = Modifier) {
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitemonitor
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,19 +19,31 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.util.extensions.getSerializableExtraCompat
 
+@AndroidEntryPoint
 class SiteMonitorParentActivity: AppCompatActivity() {
+    val viewModel:SiteMonitorParentViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
+                viewModel.start(getSite())
                 SiteMonitorScreen()
             }
         }
+    }
+
+    private fun getSite(): SiteModel {
+        return requireNotNull(intent.getSerializableExtraCompat(WordPress.SITE)) as SiteModel
     }
 
     @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -97,5 +97,6 @@ class SiteMonitorParentActivity: AppCompatActivity() {
 
     @Composable
     fun SiteMonitoringWebView(){
+        Text(text = "SiteMonitoringWebView")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -4,8 +4,18 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.TabRow
+import androidx.compose.material.Text
+import androidx.compose.material3.Tab
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import org.wordpress.android.R
@@ -41,6 +51,38 @@ class SiteMonitorParentActivity: AppCompatActivity() {
     }
 
     @Composable
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
     fun TabScreen(modifier: Modifier = Modifier) {
+        var tabIndex by remember { mutableStateOf(0) }
+
+        val tabs = listOf(
+            R.string.site_monitoring_tab_title_metrics,
+            R.string.site_monitoring_tab_title_php_logs,
+            R.string.site_monitoring_tab_title_web_server_logs
+        )
+
+        Column(modifier = modifier.fillMaxWidth()) {
+            TabRow(
+                selectedTabIndex = tabIndex,
+                backgroundColor = MaterialTheme.colors.surface,
+                contentColor = MaterialTheme.colors.onSurface,
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(text = { Text(stringResource(id = title)) },
+                        selected = tabIndex == index,
+                        onClick = { tabIndex = index }
+                    )
+                }
+            }
+            when (tabIndex) {
+                0 -> SiteMonitoringWebView()
+                1 -> SiteMonitoringWebView()
+                2 -> SiteMonitoringWebView()
+            }
+        }
+    }
+
+    @Composable
+    fun SiteMonitoringWebView(){
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.sitemonitor
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class SiteMonitorParentViewModel @Inject constructor(
+    @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+) : ScopedViewModel(bgDispatcher) {
+    private lateinit var site: SiteModel
+
+    fun start(site: SiteModel) {
+        this.site = site
+        trackActivityLaunched()
+    }
+
+    private fun trackActivityLaunched() {
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.sitemonitor
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -22,5 +23,8 @@ class SiteMonitorParentViewModel @Inject constructor(
     }
 
     private fun trackActivityLaunched() {
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModel.kt
@@ -23,8 +23,6 @@ class SiteMonitorParentViewModel @Inject constructor(
     }
 
     private fun trackActivityLaunched() {
-        analyticsTrackerWrapper.track(
-            AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN
-        )
+        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN)
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4856,4 +4856,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
 
     <!-- Site Monitoring -->
     <string name="site_monitoring">Site Monitoring</string>
+    <string name="site_monitoring_tab_title_metrics">Metrics</string>
+    <string name="site_monitoring_tab_title_php_logs">PHP Logs</string>
+    <string name="site_monitoring_tab_title_web_server_logs">Web Server Logs</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentViewModelTest.kt
@@ -1,0 +1,36 @@
+package org.wordpress.android.ui.sitemonitor
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class SiteMonitorParentViewModelTest: BaseUnitTest(){
+    @Mock
+    private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
+    private lateinit var viewModel: SiteMonitorParentViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SiteMonitorParentViewModel(testDispatcher(), analyticsTrackerWrapper)
+    }
+
+    @Test
+    fun `when viewmodel is started, then screen shown tracking is done`() {
+        val site = mock<SiteModel>()
+        viewModel.start(site)
+
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN)
+    }
+}

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1101,7 +1101,8 @@ public final class AnalyticsTracker {
         DYNAMIC_DASHBOARD_CARD_TAPPED,
         DYNAMIC_DASHBOARD_CARD_CTA_TAPPED,
         DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED,
-        DEEP_LINK_FAILED
+        DEEP_LINK_FAILED,
+        SITE_MONITORING_SCREEN_SHOWN
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2697,6 +2697,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "dynamic_dashboard_card_hide_tapped";
             case DEEP_LINK_FAILED:
                 return "deep_link_failed";
+            case SITE_MONITORING_SCREEN_SHOWN:
+                return "site_monitoring_screen_shown";
         }
         return null;
     }


### PR DESCRIPTION
## Part of 
#20035, and #20036, and #20037



## Description 
This PR adds skeleton classes only, implementation for each tab and the screen will come in future PR's

This PR adds 
- **SiteMonitorParentActivity** to contain the tabs for each site monitoring logs 
- Adds tabs for each site monitoring logs 
- Adds a **SiteMonitorParentViewModel** for ui logic
- Adds the logic to the track when the UI is shown 


## Screenshots 
|  Site Monitoring UI Dark Mode |  Light Mode  | 
|---|---|
|  <img width="446" alt="Screenshot 2024-01-25 at 5 43 54 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/906d8942-a532-4f34-895d-df8d8b2a46b1"> |  <img width="446" alt="Screenshot 2024-01-25 at 5 43 30 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/d2e9d02f-f2e4-4ab0-b43f-2fba349bdcbb"> |  


## To Test:

- Install and launch the JP app from this PR
- Login with an account that has an atomic with admin access
- Select ^^ that site
- Navigate to My Site > More > Site Monitoring 
- Tap on the Site Monitoring item
- ✅  A blank screen with tabs for Metrics, PHP Logs and WebServer Logs is shown 
- ✅ Verify that the logs contain 🔵 Tracked: site_monitoring_screen_shown


## Regression Notes

1. Potential unintended areas of impact
Nothing, as this is a new screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
