### PR TITLE
Adds: Site monitoring FF to SiteListItemBuilder

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -247,8 +247,13 @@ class SiteListItemBuilder @Inject constructor(
         } else null
     }
 
+    @Suppress("ComplexCondition")
     fun buildSiteMonitoringItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): MySiteCardAndItem? {
-        return if (siteMonitoringFeatureConfig.isEnabled() && site.isWPComAtomic && site.isAdmin) {
+        return if (buildConfigWrapper.isJetpackApp
+            && site.isWPComAtomic
+            && site.isAdmin
+            && siteMonitoringFeatureConfig.isEnabled()
+        ) {
             ListItem(
                 R.drawable.gb_ic_tool,
                 UiStringRes(R.string.site_monitoring),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.SiteMonitoringFeatureConfig
 import java.util.GregorianCalendar
 import java.util.TimeZone
 import javax.inject.Inject
@@ -39,7 +40,8 @@ class SiteListItemBuilder @Inject constructor(
     private val siteUtilsWrapper: SiteUtilsWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val themeBrowserUtils: ThemeBrowserUtils,
-    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+    private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
+    private val siteMonitoringFeatureConfig: SiteMonitoringFeatureConfig
 ) {
     fun buildActivityLogItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(
@@ -246,8 +248,7 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildSiteMonitoringItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): MySiteCardAndItem? {
-        // todo: Add the feature flag wrapper once it is available
-        return if (buildConfigWrapper.isJetpackApp && site.isWPComAtomic && site.isAdmin) {
+        return if (siteMonitoringFeatureConfig.isEnabled() && site.isWPComAtomic && site.isAdmin) {
             ListItem(
                 R.drawable.gb_ic_tool,
                 UiStringRes(R.string.site_monitoring),

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
@@ -2,14 +2,19 @@ package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
 
 private const val SITE_MONITORING_FEATURE_REMOTE_FIELD = "site_monitoring"
 
 @Feature(SITE_MONITORING_FEATURE_REMOTE_FIELD, false)
-class SiteMonitoringFeatureConfig(
+class SiteMonitoringFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(
     appConfig,
     BuildConfig.ENABLE_SITE_MONITORING,
     SITE_MONITORING_FEATURE_REMOTE_FIELD
-)
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SiteMonitoringFeatureConfig.kt
@@ -13,8 +13,5 @@ class SiteMonitoringFeatureConfig @Inject constructor(
     appConfig,
     BuildConfig.ENABLE_SITE_MONITORING,
     SITE_MONITORING_FEATURE_REMOTE_FIELD
-) {
-    override fun isEnabled(): Boolean {
-        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
-    }
-}
+)
+

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -422,9 +422,11 @@ class SiteListItemBuilderTest {
 
     /* SITE MONITORING */
     @Test
-    fun `give jetpack app, when is atomic and admin and FF is enabled, then site monitoring item is built`() {
+    fun `give site monitoring FF is true, when is atomic and admin, then site monitoring item is built`() {
         setupSiteMonitoringItems(
-            isSiteMonitoringFeatureFlagEnabled = true
+            isSiteMonitoringFeatureFlagEnabled = true,
+            isAtomic = true,
+            isAdmin = true
         )
 
         val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
@@ -433,28 +435,10 @@ class SiteListItemBuilderTest {
     }
 
     @Test
-    fun `give jetpack app, when is atomic and admin and FF is disabled, then site monitoring item is not built`() {
-        setupSiteMonitoringItems()
-
-        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
-
-        assertThat(item).isNull()
-    }
-
-    @Test
-    fun `give jetpack app, when is not atomic, then site monitoring item is not built`() {
+    fun `give site monitoring FF is true, when is atomic and NOT admin, then site monitoring item is not built`() {
         setupSiteMonitoringItems(
-            isAtomic = false
-        )
-
-        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
-
-        assertThat(item).isNull()
-    }
-
-    @Test
-    fun `give jetpack app, when is not admin, then site monitoring item is not built`() {
-        setupSiteMonitoringItems(
+            isSiteMonitoringFeatureFlagEnabled = true,
+            isAtomic = true,
             isAdmin = false
         )
 
@@ -464,9 +448,22 @@ class SiteListItemBuilderTest {
     }
 
     @Test
-    fun `give not jetpack app, when site monitoring item requested, then site monitoring item is not built`() {
+    fun `give site monitoring FF is true, when is admin and NOT atomic, then site monitoring item is not built`() {
         setupSiteMonitoringItems(
-            isJetpackApp = false
+            isSiteMonitoringFeatureFlagEnabled = true,
+            isAdmin = true
+        )
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `give site monitoring FF is false, when is admin and atomic, then site monitoring item is not built`() {
+        setupSiteMonitoringItems(
+            isAtomic = true,
+            isAdmin = true
         )
 
         val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
@@ -475,12 +472,10 @@ class SiteListItemBuilderTest {
     }
 
     private fun setupSiteMonitoringItems(
-        isJetpackApp: Boolean = true,
         isSiteMonitoringFeatureFlagEnabled: Boolean = false,
-        isAtomic: Boolean = true,
-        isAdmin: Boolean = true
+        isAtomic: Boolean = false,
+        isAdmin: Boolean = false
     ) {
-        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
         whenever(siteMonitoringFeatureConfig.isEnabled()).thenReturn(isSiteMonitoringFeatureFlagEnabled)
         whenever(siteModel.isAdmin).thenReturn(isAdmin)
         whenever(siteModel.isWPComAtomic).thenReturn(isAtomic)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -29,6 +29,7 @@ import org.wordpress.android.ui.plugins.PluginUtilsWrapper
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
+import org.wordpress.android.util.config.SiteMonitoringFeatureConfig
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteListItemBuilderTest {
@@ -53,6 +54,9 @@ class SiteListItemBuilderTest {
     @Mock
     lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
+    @Mock
+    lateinit var siteMonitoringFeatureConfig: SiteMonitoringFeatureConfig
+
     private lateinit var siteListItemBuilder: SiteListItemBuilder
 
     @Before
@@ -63,7 +67,8 @@ class SiteListItemBuilderTest {
             siteUtilsWrapper,
             buildConfigWrapper,
             themeBrowserUtils,
-            jetpackFeatureRemovalPhaseHelper
+            jetpackFeatureRemovalPhaseHelper,
+            siteMonitoringFeatureConfig
         )
     }
 
@@ -417,12 +422,23 @@ class SiteListItemBuilderTest {
 
     /* SITE MONITORING */
     @Test
-    fun `give jetpack app, when is atomic and admin, then site monitoring item is built`() {
-        setupSiteMonitoringItems()
+    fun `give jetpack app, when is atomic and admin and FF is enabled, then site monitoring item is built`() {
+        setupSiteMonitoringItems(
+            isSiteMonitoringFeatureFlagEnabled = true
+        )
 
         val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
 
         assertThat(item).isEqualTo(SITE_MONITORING_ITEM)
+    }
+
+    @Test
+    fun `give jetpack app, when is atomic and admin and FF is disabled, then site monitoring item is not built`() {
+        setupSiteMonitoringItems()
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
     }
 
     @Test
@@ -460,10 +476,12 @@ class SiteListItemBuilderTest {
 
     private fun setupSiteMonitoringItems(
         isJetpackApp: Boolean = true,
+        isSiteMonitoringFeatureFlagEnabled: Boolean = false,
         isAtomic: Boolean = true,
         isAdmin: Boolean = true
     ) {
         whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
+        whenever(siteMonitoringFeatureConfig.isEnabled()).thenReturn(isSiteMonitoringFeatureFlagEnabled)
         whenever(siteModel.isAdmin).thenReturn(isAdmin)
         whenever(siteModel.isWPComAtomic).thenReturn(isAtomic)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -422,8 +422,9 @@ class SiteListItemBuilderTest {
 
     /* SITE MONITORING */
     @Test
-    fun `give site monitoring FF is true, when is atomic and admin, then site monitoring item is built`() {
+    fun `give jetpack app, when FF is true and site is atomic and admin, then site monitoring item is built`() {
         setupSiteMonitoringItems(
+            isJetpackApp = true,
             isSiteMonitoringFeatureFlagEnabled = true,
             isAtomic = true,
             isAdmin = true
@@ -435,8 +436,9 @@ class SiteListItemBuilderTest {
     }
 
     @Test
-    fun `give site monitoring FF is true, when is atomic and NOT admin, then site monitoring item is not built`() {
+    fun `give jetpack app, when FF is true and site is atomic and NOT admin, then site monitoring item is not built`() {
         setupSiteMonitoringItems(
+            isJetpackApp = true,
             isSiteMonitoringFeatureFlagEnabled = true,
             isAtomic = true,
             isAdmin = false
@@ -448,8 +450,9 @@ class SiteListItemBuilderTest {
     }
 
     @Test
-    fun `give site monitoring FF is true, when is admin and NOT atomic, then site monitoring item is not built`() {
+    fun `give jetpack app, when FF is true and site is admin and NOT atomic, then site monitoring item is not built`() {
         setupSiteMonitoringItems(
+            isJetpackApp = true,
             isSiteMonitoringFeatureFlagEnabled = true,
             isAdmin = true
         )
@@ -460,8 +463,23 @@ class SiteListItemBuilderTest {
     }
 
     @Test
-    fun `give site monitoring FF is false, when is admin and atomic, then site monitoring item is not built`() {
+    fun `give jetpack app, when FF is false and site is admin and atomic, then site monitoring item is not built`() {
         setupSiteMonitoringItems(
+            isJetpackApp = true,
+            isAtomic = true,
+            isAdmin = true
+        )
+
+        val item = siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)
+
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `give not jetpack app, when FF is true and site is atomic and admin, then site monitoring item is not built`() {
+        setupSiteMonitoringItems(
+            isJetpackApp = false,
+            isSiteMonitoringFeatureFlagEnabled = true,
             isAtomic = true,
             isAdmin = true
         )
@@ -472,10 +490,12 @@ class SiteListItemBuilderTest {
     }
 
     private fun setupSiteMonitoringItems(
+        isJetpackApp: Boolean = false,
         isSiteMonitoringFeatureFlagEnabled: Boolean = false,
         isAtomic: Boolean = false,
         isAdmin: Boolean = false
     ) {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(isJetpackApp)
         whenever(siteMonitoringFeatureConfig.isEnabled()).thenReturn(isSiteMonitoringFeatureFlagEnabled)
         whenever(siteModel.isAdmin).thenReturn(isAdmin)
         whenever(siteModel.isWPComAtomic).thenReturn(isAtomic)


### PR DESCRIPTION
Fixes #
#20043 
-----

## Description
This PR connects the Site monitoring FF with the site monitoring option in the More menu. 

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Install and launch the JP app from this PR
- Login with an account that has an atomic with admin access
- Select ^^ that site
- Navigate to My Site > More >
- [ ] Verify that the Site Monitoring Item is NOT shown
- Navigate to Me > Debug Settings > Remote Features and enable the site_monitoring option
- Go back and navigate to My Site > More >
- [ ] Verify that the Site Monitoring Item is shown

-----

## Regression Notes

1. Potential unintended areas of impact

    - The Site Monitoring item shows when it should not

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and updated unit test `SiteItemsBuilderTest`

3. What automated tests I added (or what prevented me from doing so)

    N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
