### PR TITLE
fix: Prevent Gutenberg connection logic from crashing Aztec

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,10 @@
 24.1
 -----
 
+24.0.2
+-----
+* [**] Fix Aztec editor crash when losing or gaining network connectivity [https://github.com/wordpress-mobile/WordPress-Android/pull/20053]
+
 24.0.1
 -----
 * [**] Fix crash when RichText values are not defined [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6563]

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -71,6 +71,7 @@ import org.wordpress.android.editor.EditorMediaUploadListener;
 import org.wordpress.android.editor.EditorMediaUtils;
 import org.wordpress.android.editor.EditorThemeUpdateListener;
 import org.wordpress.android.editor.ExceptionLogger;
+import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener;
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase;
 import org.wordpress.android.editor.gutenberg.DialogVisibility;
 import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment;
@@ -3844,6 +3845,8 @@ public class EditPostActivity extends LocaleAwareActivity implements
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ConnectionChangeReceiver.ConnectionChangeEvent event) {
+        if (!(mEditorFragment instanceof GutenbergNetworkConnectionListener)) return;
+
         ((GutenbergEditorFragment) mEditorFragment).onConnectionStatusChange(event.isConnected());
     }
 


### PR DESCRIPTION
## Description

A network connectivity subscriber was added to the post activity in: https://github.com/wordpress-mobile/WordPress-Android/pull/19692

However, it was not scoped to only run in the Gutenberg editor. Because
no guard was in place, the subscriber attempted to invoke a non-existent
method on the Aztec editor, resulting in a crash.

Fixes #20052

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Enable the Classic editor plugin for a site.
1. Create a post with the classic editor on the web.
1. Open the post in the Android app.
1. Disable your device's network connection (e.g., enable airplane mode).
1. Verify the editor does not crash.
1. Enable your device's network connection (e.g., disable airplane mode).
1. Verify the editor does not crash.

## Regression Notes

1. Potential unintended areas of impact
    Regressions could be introduced to the Gutenberg or Aztec editor.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manual tested both editors for basic usage; e.g., text entry, toggling network
connectivity.
4. What automated tests I added (or what prevented me from doing so)
    None. Lack of existing Aztec tests boilerplate and unfamiliarity with the
testing infrastructure.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
