### PR TITLE
Refactor the usage of the date selector in the Stats screens

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -240,7 +240,7 @@ class StatsViewAllFragment : Fragment(R.layout.stats_view_all_fragment) {
             navigator.navigate(activity, target)
         })
 
-        viewModel.selectedDate.observe(viewLifecycleOwner, { event ->
+        viewModel.selectedDate?.observe(viewLifecycleOwner, { event ->
             if (event != null) {
                 viewModel.onDateChanged()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllFragment.kt
@@ -191,17 +191,17 @@ class StatsViewAllFragment : Fragment(R.layout.stats_view_all_fragment) {
     }
 
     private fun StatsViewAllFragmentBinding.setupObservers(activity: FragmentActivity) {
-        viewModel.isRefreshing.observe(viewLifecycleOwner, {
+        viewModel.isRefreshing.observe(viewLifecycleOwner) {
             it?.let { isRefreshing ->
                 swipeToRefreshHelper.isRefreshing = isRefreshing
             }
-        })
+        }
 
-        viewModel.showSnackbarMessage.observeEvent(viewLifecycleOwner, { holder ->
+        viewModel.showSnackbarMessage.observeEvent(viewLifecycleOwner) { holder ->
             showSnackbar(activity, holder)
-        })
+        }
 
-        viewModel.data.observe(viewLifecycleOwner, {
+        viewModel.data.observe(viewLifecycleOwner) {
             if (it != null) {
                 with(statsListFragment) {
                     recyclerView.visibility = if (it is Success) View.VISIBLE else View.GONE
@@ -214,41 +214,44 @@ class StatsViewAllFragment : Fragment(R.layout.stats_view_all_fragment) {
                         is Success -> {
                             loadData(recyclerView, prepareLayout(it.data, it.type))
                         }
+
                         is Loading -> {
                             loadData(loadingRecyclerView, prepareLayout(it.data, it.type))
                         }
+
                         is Error -> {
                             errorView.statsErrorView.button.setOnClickListener {
                                 viewModel.onRetryClick()
                             }
                         }
+
                         is EmptyBlock -> {
                         }
                     }
                 }
             }
-        })
-        viewModel.navigationTarget.observeEvent(viewLifecycleOwner, { target ->
+        }
+        viewModel.navigationTarget.observeEvent(viewLifecycleOwner) { target ->
             navigator.navigate(activity, target)
-        })
+        }
 
-        viewModel.dateSelectorData.observe(viewLifecycleOwner, { dateSelectorUiModel ->
+        viewModel.dateSelectorData.observe(viewLifecycleOwner) { dateSelectorUiModel ->
             statsListFragment.drawDateSelector(dateSelectorUiModel)
-        })
+        }
 
-        viewModel.navigationTarget.observeEvent(viewLifecycleOwner, { target ->
+        viewModel.navigationTarget.observeEvent(viewLifecycleOwner) { target ->
             navigator.navigate(activity, target)
-        })
+        }
 
-        viewModel.selectedDate?.observe(viewLifecycleOwner, { event ->
+        viewModel.selectedDate?.observe(viewLifecycleOwner) { event ->
             if (event != null) {
                 viewModel.onDateChanged()
             }
-        })
+        }
 
-        viewModel.toolbarHasShadow.observe(viewLifecycleOwner, { hasShadow ->
+        viewModel.toolbarHasShadow.observe(viewLifecycleOwner) { hasShadow ->
             appBarLayout.showShadow(hasShadow == true)
-        })
+        }
     }
 
     private fun showSnackbar(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModel.kt
@@ -20,8 +20,8 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mapNullable
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.throttle
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -31,14 +31,14 @@ class StatsViewAllViewModel(
     val bgDispatcher: CoroutineDispatcher,
     val useCase: BaseStatsUseCase<*, *>,
     private val statsSiteProvider: StatsSiteProvider,
-    private val dateSelector: StatsDateSelector,
+    private val dateSelector: StatsDateSelector?,
     @StringRes val title: Int
 ) : ScopedViewModel(mainDispatcher) {
-    val selectedDate = dateSelector.selectedDate
+    val selectedDate = dateSelector?.selectedDate
 
-    val dateSelectorData: LiveData<DateSelectorUiModel> = dateSelector.dateSelectorData.mapNullable {
+    val dateSelectorData: LiveData<DateSelectorUiModel> = dateSelector?.dateSelectorData?.mapNullable {
         it ?: DateSelectorUiModel(false)
-    }
+    } ?:  MutableLiveData(DateSelectorUiModel(false))
 
     val navigationTarget: LiveData<Event<NavigationTarget>> = useCase.navigationTarget
 
@@ -62,12 +62,12 @@ class StatsViewAllViewModel(
     fun start(startDate: SelectedDate?) {
         launch {
             startDate?.let {
-                dateSelector.start(startDate)
+                dateSelector?.start(startDate)
             }
             loadData(refresh = false, forced = false)
-            dateSelector.updateDateSelector()
+            dateSelector?.updateDateSelector()
         }
-        dateSelector.updateDateSelector()
+        dateSelector?.updateDateSelector()
     }
 
     @SuppressLint("NullSafeMutableLiveData")
@@ -109,13 +109,13 @@ class StatsViewAllViewModel(
 
     fun onNextDateSelected() {
         launch(mainDispatcher) {
-            dateSelector.onNextDateSelected()
+            dateSelector?.onNextDateSelected()
         }
     }
 
     fun onPreviousDateSelected() {
         launch(mainDispatcher) {
-            dateSelector.onPreviousDateSelected()
+            dateSelector?.onPreviousDateSelected()
         }
     }
 
@@ -131,7 +131,7 @@ class StatsViewAllViewModel(
         }
     }
 
-    fun getSelectedDate(): SelectedDate {
-        return dateSelector.getSelectedDate()
+    fun getSelectedDate(): SelectedDate? {
+        return dateSelector?.getSelectedDate()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -243,7 +243,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             navigator.navigate(activity, target)
         }
 
-        viewModel.selectedDate.observe(viewLifecycleOwner) { event ->
+        viewModel.selectedDate?.observe(viewLifecycleOwner) { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedSection)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -49,7 +49,7 @@ abstract class StatsListViewModel(
     defaultDispatcher: CoroutineDispatcher,
     private val statsUseCase: BaseListUseCase,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    protected val dateSelector: StatsDateSelector,
+    protected val dateSelector: StatsDateSelector?,
     popupMenuHandler: ItemPopupMenuHandler? = null,
     private val newsCardHandler: NewsCardHandler? = null,
     actionCardHandler: ActionCardHandler? = null
@@ -72,7 +72,7 @@ abstract class StatsListViewModel(
         ANNUAL_STATS(R.string.stats_insights_annual_site_stats);
     }
 
-    val selectedDate = dateSelector.selectedDate
+    val selectedDate = dateSelector?.selectedDate
 
     private val mutableNavigationTarget = MutableLiveData<Event<NavigationTarget>>()
     val navigationTarget: LiveData<Event<NavigationTarget>> = mergeNotNull(
@@ -85,9 +85,9 @@ abstract class StatsListViewModel(
         statsUseCase.data.throttle(viewModelScope, distinct = true)
     }
 
-    val dateSelectorData: LiveData<DateSelectorUiModel> = dateSelector.dateSelectorData.mapNullable {
+    val dateSelectorData: LiveData<DateSelectorUiModel> = dateSelector?.dateSelectorData?.mapNullable {
         it ?: DateSelectorUiModel(false)
-    }
+    } ?: MutableLiveData(DateSelectorUiModel(false))
 
     val typesChanged = merge(
         popupMenuHandler?.typeMoved,
@@ -115,13 +115,13 @@ abstract class StatsListViewModel(
 
     fun onNextDateSelected() {
         launch(Dispatchers.Default) {
-            dateSelector.onNextDateSelected()
+            dateSelector?.onNextDateSelected()
         }
     }
 
     fun onPreviousDateSelected() {
         launch(Dispatchers.Default) {
-            dateSelector.onPreviousDateSelected()
+            dateSelector?.onPreviousDateSelected()
         }
     }
 
@@ -138,7 +138,7 @@ abstract class StatsListViewModel(
     }
 
     fun onListSelected() {
-        dateSelector.updateDateSelector()
+        dateSelector?.updateDateSelector()
     }
 
     fun onEmptyInsightsButtonClicked() {
@@ -156,10 +156,10 @@ abstract class StatsListViewModel(
             isInitialized = true
             launch {
                 statsUseCase.loadData()
-                dateSelector.updateDateSelector()
+                dateSelector?.updateDateSelector()
             }
         }
-        dateSelector.updateDateSelector()
+        dateSelector?.updateDateSelector()
     }
 
     sealed class UiModel {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/DetailListViewModel.kt
@@ -20,6 +20,6 @@ class DetailListViewModel
 ) : StatsListViewModel(mainDispatcher, detailUseCase, analyticsTracker, dateSelectorFactory.build(DETAIL)) {
     override fun onCleared() {
         super.onCleared()
-        dateSelector.clear()
+        dateSelector?.clear()
     }
 }


### PR DESCRIPTION
This makes `StatsDateSelector` parameter in `StatsListViewModel` and `StatsViewAllViewModel`'s contructor nullable, and if it's null, that means the date selector is not visible.

Before this PR, `StatsListViewModel` and `StatsViewAllViewModelFactory` were using [dateSelectorFactory.build(INSIGHTS)](https://github.com/wordpress-mobile/WordPress-Android/blob/fccf876c789128b413849f728d040e41a54becf6/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewAllViewModelFactory.kt#L122) to hide the date selector. But actually, making `dateSelector` nullable to hide the date selector is a better way, and it will be necessary to manage the granularity spinner on the TRAFFIC tab.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Log in.
2. Navigate to "My Site → Stats"
3. Open all tabs and details of all cards with the "View More" button.
4. Verify that there are no crashes.
5. Verify that the granular screens have date selectors as before. The most reliable method to check this is by comparing all screens with the same screen on iOS or the `trunk` version of Android.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Other stats cards and stats screens

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested other cards and stats screens manually.

7. What automated tests I added (or what prevented me from doing so)

    - None, since this doesn't introduce any change.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
