### PR TITLE
Site Monitor: App links

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -482,12 +482,22 @@
                 <data
                     android:host="wordpress.com"
                     android:pathPattern="/media/.*"
-                    android:scheme="http" />
+                    android:scheme="https" />
 
                 <data
                     android:host="wordpress.com"
                     android:pathPattern="/domains/manage"
                     android:scheme="https" />
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/site-monitoring/.*"
+                    android:scheme="https" />
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/site-monitoring/.*"
+                    android:scheme="http" />
 
             </intent-filter>
         </activity-alias>

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
+import org.wordpress.android.ui.sitemonitor.SiteMonitorType
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import javax.inject.Inject
@@ -162,6 +163,24 @@ class ActivityNavigator @Inject constructor() {
         val intent = Intent(context, SiteMonitorParentActivity::class.java)
         intent.putExtra(WordPress.SITE, site)
         context.startActivity(intent)
+    }
+
+    fun openSiteMonitoringInNewStack(context: Context, site: SiteModel?, siteMonitorType: SiteMonitorType = SiteMonitorType.METRICS) {
+        if (site == null) {
+            ToastUtils.showToast(context, R.string.site_monitoring_cannot_be_started, ToastUtils.Duration.SHORT)
+            return
+        }
+        val props = mutableMapOf("site_monitoring_type" to siteMonitorType.name as Any)
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_SITE_MONITORING, site, props)
+        val taskStackBuilder = TaskStackBuilder.create(context)
+        val mainActivityIntent = getMainActivityInNewStack(context)
+        val intent = Intent(context, SiteMonitorParentActivity::class.java)
+        intent.putExtra(WordPress.SITE, site)
+        intent.putExtra(SiteMonitorParentActivity.ARG_SITE_MONITOR_TYPE_KEY, siteMonitorType)
+        taskStackBuilder
+            .addNextIntent(mainActivityIntent)
+            .addNextIntent(intent)
+            .startActivities()
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -165,7 +165,11 @@ class ActivityNavigator @Inject constructor() {
         context.startActivity(intent)
     }
 
-    fun openSiteMonitoringInNewStack(context: Context, site: SiteModel?, siteMonitorType: SiteMonitorType = SiteMonitorType.METRICS) {
+    fun openSiteMonitoringInNewStack(
+        context: Context,
+        site: SiteModel?,
+        siteMonitorType: SiteMonitorType = SiteMonitorType.METRICS
+    ) {
         if (site == null) {
             ToastUtils.showToast(context, R.string.site_monitoring_cannot_be_started, ToastUtils.Duration.SHORT)
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ShowS
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.StartCreateSiteFlow
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction.ViewPostInReader
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSource.DEEP_LINK
+import org.wordpress.android.ui.sitemonitor.SiteMonitorType
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.util.UriWrapper
 import javax.inject.Inject
@@ -91,6 +92,11 @@ class DeepLinkNavigator
                 navigateAction.site
             )
             NavigateAction.DomainManagement -> ActivityLauncher.openDomainManagement(activity)
+            is NavigateAction.OpenSiteMonitoringForSite -> activityNavigator.openSiteMonitoringInNewStack(
+                activity,
+                navigateAction.site,
+                navigateAction.siteMonitorType
+            )
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -126,5 +132,7 @@ class DeepLinkNavigator
         object OpenMedia : NavigateAction()
         data class OpenMediaPickerForSite(val site: SiteModel) : NavigateAction()
         object DomainManagement : NavigateAction()
+        data class OpenSiteMonitoringForSite(val site: SiteModel?, val siteMonitorType: SiteMonitorType) :
+            NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlers.kt
@@ -20,6 +20,7 @@ class DeepLinkHandlers
     mediaLinkHandler: MediaLinkHandler,
     domainManagementLinkHandler: DomainManagementLinkHandler,
     qrCodeMediaLinkHandler: QRCodeMediaLinkHandler,
+    siteMonitorLinkHandler: SiteMonitorLinkHandler
 ) {
     private val handlers = listOf(
         editorLinkHandler,
@@ -33,6 +34,7 @@ class DeepLinkHandlers
         mediaLinkHandler,
         domainManagementLinkHandler,
         qrCodeMediaLinkHandler,
+        siteMonitorLinkHandler
     )
 
     private val _toast by lazy {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/SiteMonitorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/SiteMonitorLinkHandler.kt
@@ -19,10 +19,15 @@ class SiteMonitorLinkHandler
     }
 
     override fun buildNavigateAction(uri: UriWrapper): DeepLinkNavigator.NavigateAction {
-        val targetHost = uri.pathSegments[1]
+        val targetHost = extractHost(uri)
         val site: SiteModel? = deepLinkUriUtils.hostToSite(targetHost)
         val siteMonitorType = urlToType(uri.toString())
         return DeepLinkNavigator.NavigateAction.OpenSiteMonitoringForSite(site, siteMonitorType)
+    }
+
+    private fun extractHost(uri: UriWrapper): String {
+        if (uri.pathSegments.size <= 1) return ""
+        return uri.pathSegments[1]
     }
 
     override fun stripUrl(uri: UriWrapper): String {

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/SiteMonitorLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/SiteMonitorLinkHandler.kt
@@ -1,0 +1,60 @@
+package org.wordpress.android.ui.deeplinks.handlers
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.deeplinks.DeepLinkNavigator
+import org.wordpress.android.ui.deeplinks.DeepLinkUriUtils
+import org.wordpress.android.ui.deeplinks.DeepLinkingIntentReceiverViewModel
+import org.wordpress.android.ui.sitemonitor.SiteMonitorType
+import org.wordpress.android.util.UriWrapper
+import javax.inject.Inject
+
+class SiteMonitorLinkHandler
+@Inject constructor(private val deepLinkUriUtils: DeepLinkUriUtils) : DeepLinkHandler {
+    /**
+     * Returns true if the URI looks like `wordpress.com/SITE_MONITORING_PATH`
+     */
+    override fun shouldHandleUrl(uri: UriWrapper): Boolean {
+        return (uri.host == DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM &&
+                uri.pathSegments.firstOrNull() == SITE_MONITORING_PATH) || uri.host == SITE_MONITORING_PATH
+    }
+
+    override fun buildNavigateAction(uri: UriWrapper): DeepLinkNavigator.NavigateAction {
+        val targetHost = uri.pathSegments[1]
+        val site: SiteModel? = deepLinkUriUtils.hostToSite(targetHost)
+        val siteMonitorType = urlToType(uri.toString())
+        return DeepLinkNavigator.NavigateAction.OpenSiteMonitoringForSite(site, siteMonitorType)
+    }
+
+    override fun stripUrl(uri: UriWrapper): String {
+        return buildString {
+            val offset = if (uri.host == SITE_MONITORING_PATH) {
+                append(DeepLinkingIntentReceiverViewModel.APPLINK_SCHEME)
+                0
+            } else {
+                append("${DeepLinkingIntentReceiverViewModel.HOST_WORDPRESS_COM}/")
+                1
+            }
+            append(SITE_MONITORING_PATH)
+            val pathSegments = uri.pathSegments
+            val size = pathSegments.size
+            val hasSiteUrl = if (size > offset + 1) pathSegments.getOrNull(offset + 1) != null else false
+            if (hasSiteUrl) {
+                append("/${DeepLinkingIntentReceiverViewModel.SITE_DOMAIN}")
+            }
+        }
+    }
+
+    private fun urlToType(url: String): SiteMonitorType {
+        return when {
+            url.contains(PHP_LOGS_PATTERN) -> SiteMonitorType.PHP_LOGS
+            url.contains(WEB_SERVER_LOGS_PATTERN) -> SiteMonitorType.WEB_SERVER_LOGS
+            else -> SiteMonitorType.METRICS
+        }
+    }
+
+    companion object {
+        private const val SITE_MONITORING_PATH = "site-monitoring"
+        private const val PHP_LOGS_PATTERN = "/php"
+        private const val WEB_SERVER_LOGS_PATTERN = "/web"
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -65,7 +65,13 @@ class SiteMonitorParentActivity: AppCompatActivity() {
         return requireNotNull(intent.getSerializableExtraCompat(WordPress.SITE)) as SiteModel
     }
 
+    private fun getInitialTab(): SiteMonitorType {
+        return intent?.getSerializableExtraCompat(ARG_SITE_MONITOR_TYPE_KEY) as SiteMonitorType?
+            ?: SiteMonitorType.METRICS
+    }
+
     companion object {
+        const val ARG_SITE_MONITOR_TYPE_KEY = "ARG_SITE_MONITOR_TYPE_KEY"
         const val SAVED_STATE_CONTAINER_KEY = "ContainerKey"
         const val SAVED_STATE_CURRENT_TAB_KEY = "CurrentTabKey"
     }
@@ -90,7 +96,7 @@ class SiteMonitorParentActivity: AppCompatActivity() {
                 SiteMonitorTabNavigation(selectedTab) { selectedTab ->
                     val item = enumValues<SiteMonitorTabItem>().find {
                         it.route == selectedTab
-                    } ?: SiteMonitorTabItem.Metrics
+                    } ?: initialItem(getInitialTab())
 
                     SiteMonitorFragmentContainer(
                         modifier = Modifier.fillMaxSize(),
@@ -102,6 +108,12 @@ class SiteMonitorParentActivity: AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun initialItem(type: SiteMonitorType): SiteMonitorTabItem {
+        return enumValues<SiteMonitorTabItem>().find {
+            it.siteMonitorType == type
+        } ?: SiteMonitorTabItem.Metrics
     }
 
     private fun getCommitFunction(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4857,4 +4857,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="site_monitoring_tab_title_metrics">Metrics</string>
     <string name="site_monitoring_tab_title_php_logs">PHP Logs</string>
     <string name="site_monitoring_tab_title_web_server_logs">Web Server Logs</string>
+    <string name="site_monitoring_cannot_be_started">We cannot open site monitoring at the moment. Please try again later</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/DeepLinkHandlersTest.kt
@@ -49,6 +49,9 @@ class DeepLinkHandlersTest : BaseUnitTest() {
     lateinit var qrCodeMediaLinkHandler: QRCodeMediaLinkHandler
 
     @Mock
+    lateinit var siteMonitorLinkHandler: SiteMonitorLinkHandler
+
+    @Mock
     lateinit var uri: UriWrapper
     private lateinit var deepLinkHandlers: DeepLinkHandlers
     private lateinit var handlers: List<DeepLinkHandler>
@@ -67,6 +70,7 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             mediaLinkHandler,
             domainManagementLinkHandler,
             qrCodeMediaLinkHandler,
+            siteMonitorLinkHandler
         )
         initDeepLinkHandlers()
     }
@@ -84,6 +88,7 @@ class DeepLinkHandlersTest : BaseUnitTest() {
             mediaLinkHandler,
             domainManagementLinkHandler,
             qrCodeMediaLinkHandler,
+            siteMonitorLinkHandler
         )
     }
 

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1101,7 +1101,8 @@ public final class AnalyticsTracker {
         DYNAMIC_DASHBOARD_CARD_CTA_TAPPED,
         DYNAMIC_DASHBOARD_CARD_HIDE_TAPPED,
         DEEP_LINK_FAILED,
-        SITE_MONITORING_SCREEN_SHOWN
+        SITE_MONITORING_SCREEN_SHOWN,
+        OPENED_SITE_MONITORING,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2697,6 +2697,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "deep_link_failed";
             case SITE_MONITORING_SCREEN_SHOWN:
                 return "site_monitoring_screen_shown";
+            case OPENED_SITE_MONITORING:
+                return "opened_site_monitoring";
         }
         return null;
     }


### PR DESCRIPTION
#Part of 
#20061

This PR adds support for site-monitoring app links as a part of the Site Monitoring feature
- `wordpress.com/site-monitoring/{blog}`
- `wordpress.com/site-monitoring/{blog}/php`
- `wordpress.com/site-monitoring/{blog}/web`

NOTE: The app links always lands on the Metrics tab. As work evolves with the feature, we will implement direct navigation to php-logs and web-server-logs

## To Test:
**Preparing**
- Remove other versions of the app from your device (WP and JP)
- Download the links zip file, unzip and update the test-site-monitoring-app-links.html file to swap in your domain name.
[test-site-monitoring-app-links.html.zip](https://github.com/wordpress-mobile/WordPress-Android/files/14088977/test-site-monitoring-app-links.html.zip)
- Save the updated html file and download to the device you will be using to test this PR
- Download and install JP app from this PR
- Enable JP to open app links
- Login

**Testing the deep links**
- Open the downloaded `test-site-monitoring-app-links.html` in a browser on your device
- Tap on the `wordpress.com/site-monitoring` link
- ✅ Verify the app is launched and a toast is visible. You are not sent to the site-monitor area
- Tap on the `wordpress.com/site-monitoring/nonsense` link
- ✅ Verify the app is launched and a toast is visible. You are not sent to the site-monitor area
- Tap on the `wordpress.com/site-monitoring/..` for your domain link
- ✅ Verify the app is launched and the site-monitoring view is visible for your domain
- Tap on the `wordpress.com/site-monitoring/../php` for your domain link
- ✅ Verify the app is launched and the site-monitoring view is visible for your domain
- Tap on the `wordpress.com/site-monitoring/../web` for your domain link
- ✅ Verify the app is launched and the site-monitoring view is visible for your domain
- ✅ Verify the logs contain the following entries

🔵 Tracked: deep_linked, Properties: {"intent_action":"android.intent.action.VIEW","intent_host":"wordpress.com","source":"link","url":"wordpress.com\/site-monitoring"}

🔵 Tracked: opened_site_monitoring, Properties: {"site_monitoring_type":"METRICS","blog_id":219175336,"is_jetpack":true,"site_type":"blog"}

🔵 Tracked: opened_site_monitoring, Properties: {"site_monitoring_type":"PHP_LOGS","blog_id":219175336,"is_jetpack":true,"site_type":"blog"}

🔵 Tracked: opened_site_monitoring, Properties: {"site_monitoring_type":"WEB_SERVER_LOGS","blog_id":219175336,"is_jetpack":true,"site_type":"blog"}


-----

## Regression Notes
1. Potential unintended areas of impact
The site monitoring app links do not work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing & updated unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:N/A


------

