### PR TITLE
Update the heading style

### DIFF
--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -13,11 +13,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAlignment="viewStart"
+        android:fontFamily="sans-serif-medium"
         android:padding="@dimen/margin_extra_large"
         android:includeFontPadding="false"
-        android:textAppearance="?attr/textAppearanceSubtitle2"
-        android:textColor="?attr/wpColorOnSurfaceMedium"
+        android:textColor="?attr/wpColorOnSurfaceHigh"
         android:visibility="gone"
+        android:textSize="@dimen/text_sz_large"
         tools:text="Today"
         tools:visibility="visible" />
 


### PR DESCRIPTION
Issue #20020 

This PR contains a change of the heading style in the new design.

| Before | After |
|--|--|
| ![截圖 2024-01-30 下午3 11 48](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/b79ef30c-d7de-4a10-9792-257806a85bc0) | ![截圖 2024-01-30 下午3 12 01](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/f2721b66-d327-4899-b397-e20de4e36987) |

-----

## To Test:

1. Open the Jetpack app and switch to the notifications tab.
2. The UI of the heading (Today) should match the new design. (see: yWt5gg3nWORhu079Qfv3mS-fi-51_1125)
3. Switch to the dark/light theme to see the color works in two themes.
4. Done! Thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications tab

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manuel

6. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
