### PR TITLE
Site Monitor: Add analytics for tabs and fix tab colors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -28,15 +28,22 @@ import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SiteMonitorParentActivity: AppCompatActivity() {
+    @Inject
+    lateinit var siteMonitorUtils: SiteMonitorUtils
+
     private var savedStateSparseArray = SparseArray<Fragment.SavedState>()
     private var currentSelectItemId = 0
 
     @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        siteMonitorUtils.trackActivityLaunched()
+
         if (savedInstanceState != null) {
             savedStateSparseArray = savedInstanceState.getSparseParcelableArray(
                 SAVED_STATE_CONTAINER_KEY
@@ -97,6 +104,8 @@ class SiteMonitorParentActivity: AppCompatActivity() {
                     val item = enumValues<SiteMonitorTabItem>().find {
                         it.route == selectedTab
                     } ?: initialItem(getInitialTab())
+
+                    siteMonitorUtils.trackTabLoaded(item.siteMonitorType)
 
                     SiteMonitorFragmentContainer(
                         modifier = Modifier.fillMaxSize(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.sitemonitor
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -11,8 +13,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
@@ -25,8 +29,16 @@ fun SiteMonitorTabHeader(navController: (String) -> Unit) {
     )
     TabRow(
         selectedTabIndex = selectedTabIndex,
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        containerColor = MaterialTheme.colors.surface,
+        contentColor = MaterialTheme.colors.onSurface,
+        indicator = { tabPositions ->
+            // Customizing the indicator color and style
+            TabRowDefaults.Indicator(
+                Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
+                color = MaterialTheme.colors.onSurface,
+                height = 2.0.dp
+            )
+        }
     ) {
         tabs.forEachIndexed { index, item ->
             Tab(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 @Composable
 fun SiteMonitorTabHeader(navController: (String) -> Unit) {
@@ -46,7 +45,6 @@ fun SiteMonitorTabHeader(navController: (String) -> Unit) {
                     Column (horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
                             text = stringResource(item.title),
-                            fontSize = 12.sp,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabViewModel.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.sitemonitor
 
 import android.text.TextUtils
-import android.util.Log
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +31,6 @@ class SiteMonitorTabViewModel @Inject constructor(
     val uiState: StateFlow<SiteMonitorUiState> = _uiState
 
     fun start(type: SiteMonitorType, urlTemplate: String, site: SiteModel) {
-        Log.i("Track", "TheViewModel start with $urlTemplate and $type")
         this.siteMonitorType = type
         this.urlTemplate = urlTemplate
         this.site = site

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabViewModel.kt
@@ -106,7 +106,6 @@ class SiteMonitorTabViewModel @Inject constructor(
     }
 
     fun onUrlLoaded() {
-        siteMonitorUtils.trackTabLoaded(siteMonitorType)
         postUiState(SiteMonitorUiState.Loaded)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUiState.kt
@@ -51,8 +51,8 @@ data class SiteMonitorModel(
     val url: String,
     val addressToLoad: String
 )
-enum class SiteMonitorType {
-    METRICS,
-    PHP_LOGS,
-    WEB_SERVER_LOGS
+enum class SiteMonitorType(val analyticsDescription: String) {
+    METRICS("metrics"),
+    PHP_LOGS("php_logs"),
+    WEB_SERVER_LOGS("server_logs")
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.sitemonitor
 
-import android.util.Log
 import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.WPWebViewActivity
@@ -21,7 +20,6 @@ class SiteMonitorUtils @Inject constructor(
 
 
     fun trackActivityLaunched() {
-        Log.i(javaClass.simpleName, "track Site Monitor screen shown")
         analyticsTrackerWrapper.track(AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN)
     }
 
@@ -36,7 +34,6 @@ class SiteMonitorUtils @Inject constructor(
     }
 
     fun trackTabLoaded(siteMonitorType: SiteMonitorType) {
-        Log.i(javaClass.simpleName, "track TabLoaded with $siteMonitorType")
         analyticsTrackerWrapper.track(
             AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
@@ -25,14 +25,6 @@ class SiteMonitorUtils @Inject constructor(
 
     fun sanitizeSiteUrl(url: String?) = url?.replace(Regex(HTTP_PATTERN), "") ?: ""
 
-    fun urlToType(url: String): SiteMonitorType {
-        return when {
-            url.contains(PHP_LOGS_PATTERN) -> SiteMonitorType.PHP_LOGS
-            url.contains(WEB_SERVER_LOGS_PATTERN) -> SiteMonitorType.WEB_SERVER_LOGS
-            else -> SiteMonitorType.METRICS
-        }
-    }
-
     fun trackTabLoaded(siteMonitorType: SiteMonitorType) {
         analyticsTrackerWrapper.track(
             AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
@@ -37,7 +37,7 @@ class SiteMonitorUtils @Inject constructor(
         analyticsTrackerWrapper.track(
             AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
             mapOf(
-                TAB_TRACK_KEY to siteMonitorType
+                TAB_TRACK_KEY to siteMonitorType.analyticsDescription
             ))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
@@ -21,6 +21,7 @@ class SiteMonitorUtils @Inject constructor(
 
 
     fun trackActivityLaunched() {
+        Log.i(javaClass.simpleName, "track Site Monitor screen shown")
         analyticsTrackerWrapper.track(AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN)
     }
 
@@ -35,13 +36,18 @@ class SiteMonitorUtils @Inject constructor(
     }
 
     fun trackTabLoaded(siteMonitorType: SiteMonitorType) {
-        // todo: need to set this up properly with track events
         Log.i(javaClass.simpleName, "track TabLoaded with $siteMonitorType")
+        analyticsTrackerWrapper.track(
+            AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
+            mapOf(
+                TAB_TRACK_KEY to siteMonitorType
+            ))
     }
 
     companion object {
         const val HTTP_PATTERN = "(https?://)"
         const val PHP_LOGS_PATTERN = "/php"
         const val WEB_SERVER_LOGS_PATTERN = "/web"
+        const val TAB_TRACK_KEY = "tab"
     }
 }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1103,6 +1103,7 @@ public final class AnalyticsTracker {
         DEEP_LINK_FAILED,
         SITE_MONITORING_SCREEN_SHOWN,
         OPENED_SITE_MONITORING,
+        SITE_MONITORING_TAB_SHOWN,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2699,6 +2699,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "site_monitoring_screen_shown";
             case OPENED_SITE_MONITORING:
                 return "opened_site_monitoring";
+            case SITE_MONITORING_TAB_SHOWN:
+                return "site_monitoring_tab_shown";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #
#20062 #20063 
-----

## Description
This PR contains 2 commits. With the first one we modify the color of the site monitor tab's indicator. The other one adds analytics for the site monitor tabs. 

## Screenshots 
|  Site Monitoring UI Dark Mode |  Light Mode  | 
|---|---|
|  <img width="446" alt="Screenshot 2024-01-25 at 5 43 54 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5176760/d53f387d-9c72-42b1-8344-2bdb8f2199db"> |  <img width="446" alt="Screenshot 2024-01-25 at 5 43 30 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/5176760/6920fdfd-2819-47e7-a10d-32e4608ac230"> |  

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Install and launch the JP app from this PR
- Login with an account that has an atomic with admin access
- Select ^^ that site
- Navigate to My Site > More > Site Monitoring
- [x] Check that the color of the tabs indicator is the proper for light and dark modes
- [x] Try to switch between tabs and check that the proper analytic event is recorded and is not sent multiple times. (`site_monitoring_tab_shown` with the event prop `tab: metrics | php_logs | server_logs`)

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and checking the logs. 

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
