### PR TITLE
Update notification rows

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -277,18 +277,7 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         String noteSnippet = note.getCommentSubject();
 
         if (!TextUtils.isEmpty(noteSnippet)) {
-            // handle the max lines for the view of detail
-            noteViewHolder.mTxtSubject.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
-                @Override public boolean onPreDraw() {
-                    noteViewHolder.mTxtSubject.getViewTreeObserver().removeOnPreDrawListener(this);
-                    if (noteViewHolder.mTxtSubject.getLineCount() == 2) {
-                        noteViewHolder.mTxtDetail.setMaxLines(1);
-                    } else {
-                        noteViewHolder.mTxtDetail.setMaxLines(2);
-                    }
-                    return false;
-                }
-            });
+            handleMaxLines(noteViewHolder.mTxtSubject, noteViewHolder.mTxtDetail);
             noteViewHolder.mTxtDetail.setText(noteSnippet);
             noteViewHolder.mTxtDetail.setVisibility(View.VISIBLE);
         } else {
@@ -308,6 +297,20 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         if (mOnLoadMoreListener != null && position >= getItemCount() - 1) {
             mOnLoadMoreListener.onLoadMore(note.getTimestamp());
         }
+    }
+
+    private void handleMaxLines(final TextView subject, final TextView detail) {
+        subject.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override public boolean onPreDraw() {
+                subject.getViewTreeObserver().removeOnPreDrawListener(this);
+                if (subject.getLineCount() == 2) {
+                    detail.setMaxLines(1);
+                } else {
+                    detail.setMaxLines(2);
+                }
+                return false;
+            }
+        });
     }
 
     private int getPositionForNoteUnfiltered(String noteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -276,12 +277,23 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         }
 
         String noteSnippet = note.getCommentSubject();
+
         if (!TextUtils.isEmpty(noteSnippet)) {
-            noteViewHolder.mTxtSubject.setMaxLines(2);
+            // handle the max lines for the view of detail
+            noteViewHolder.mTxtSubject.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+                @Override public boolean onPreDraw() {
+                    noteViewHolder.mTxtSubject.getViewTreeObserver().removeOnPreDrawListener(this);
+                    if (noteViewHolder.mTxtSubject.getLineCount() == 2) {
+                        noteViewHolder.mTxtDetail.setMaxLines(1);
+                    } else {
+                        noteViewHolder.mTxtDetail.setMaxLines(2);
+                    }
+                    return false;
+                }
+            });
             noteViewHolder.mTxtDetail.setText(noteSnippet);
             noteViewHolder.mTxtDetail.setVisibility(View.VISIBLE);
         } else {
-            noteViewHolder.mTxtSubject.setMaxLines(3);
             noteViewHolder.mTxtDetail.setVisibility(View.GONE);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -215,10 +215,8 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         if (previousTimeGroup != null && previousTimeGroup == timeGroup) {
             noteViewHolder.mHeaderText.setVisibility(View.GONE);
-            noteViewHolder.mHeaderDivider.setVisibility(View.GONE);
         } else {
             noteViewHolder.mHeaderText.setVisibility(View.VISIBLE);
-            noteViewHolder.mHeaderDivider.setVisibility(View.VISIBLE);
 
             if (timeGroup == Note.NoteTimeGroup.GROUP_TODAY) {
                 noteViewHolder.mHeaderText.setText(R.string.stats_timeframe_today);
@@ -365,7 +363,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     class NoteViewHolder extends RecyclerView.ViewHolder {
         private final View mContentView;
         private final TextView mHeaderText;
-        private final View mHeaderDivider;
         private final TextView mTxtSubject;
         private final TextView mTxtSubjectNoticon;
         private final TextView mTxtDetail;
@@ -375,7 +372,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             super(view);
             mContentView = view.findViewById(R.id.note_content_container);
             mHeaderText = view.findViewById(R.id.header_text);
-            mHeaderDivider = view.findViewById(R.id.header_divider);
             mTxtSubject = view.findViewById(R.id.note_subject);
             mTxtSubjectNoticon = view.findViewById(R.id.note_subject_noticon);
             mTxtDetail = view.findViewById(R.id.note_detail);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
@@ -15,7 +14,6 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.AlignmentSpan;
 import android.text.style.ImageSpan;
-import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.TextView;
 
@@ -278,13 +276,6 @@ public class NotificationsUtils {
                     && indices.get(1) <= spannableStringBuilder.length()) {
                     spannableStringBuilder
                             .setSpan(clickableSpan, indices.get(0), indices.get(1), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-
-                    // Add additional styling if the range wants it
-                    if (clickableSpan.getSpanStyle() != Typeface.NORMAL) {
-                        StyleSpan styleSpan = new StyleSpan(clickableSpan.getSpanStyle());
-                        spannableStringBuilder
-                                .setSpan(styleSpan, indices.get(0), indices.get(1), Spanned.SPAN_INCLUSIVE_INCLUSIVE);
-                    }
 
                     if (onNoteBlockTextClickListener != null && textView != null) {
                         textView.setLinksClickable(true);

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -76,8 +76,8 @@
                     android:ellipsize="end"
                     android:gravity="start"
                     android:maxLines="2"
+                    android:textAppearance="@style/WordPress.TextAppearance.NotificationItemTitle"
                     android:textAlignment="viewStart"
-                    android:textAppearance="?attr/textAppearanceSubtitle1"
                     tools:text="Bob Ross commented on your post Happy Trees" />
 
             </FrameLayout>
@@ -91,7 +91,7 @@
                 android:ellipsize="end"
                 android:importantForAccessibility="no"
                 android:maxLines="2"
-                android:textAppearance="?attr/textAppearanceBody2"
+                android:textAppearance="@style/WordPress.TextAppearance.NotificationItemContent"
                 android:visibility="gone"
                 tools:text="What an amazing post!"
                 tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -20,12 +19,6 @@
         android:visibility="gone"
         tools:text="Today"
         tools:visibility="visible" />
-
-    <View
-        android:id="@+id/header_divider"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/list_divider_height"
-        android:background="?android:attr/listDivider" />
 
     <FrameLayout
         android:id="@+id/note_content_container"
@@ -98,10 +91,4 @@
 
         </RelativeLayout>
     </FrameLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/list_divider_height"
-        android:background="?android:attr/listDivider" />
-
 </LinearLayout>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -29,6 +29,8 @@
         <item name="wpColorActionModeIcon">?attr/colorOnSurface</item>
         <item name="wpColorSurfaceSecondary">@color/background_dark_elevated</item>
         <item name="wpColorLoginPrologueBg">?attr/colorSurface</item>
+        <item name="wpColorTextPrimary">?attr/wpColorOnSurfaceHigh</item>
+        <item name="wpColorTextSecondary">@color/text_secondary</item>
 
         <item name="toolbarIconNormalColor">@color/material_on_surface_emphasis_medium</item>
         <item name="toolbarIconHighlightColor">?attr/colorPrimary</item>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -10,6 +10,8 @@
     <attr name="wpColorAppBar" format="reference|color" />
     <attr name="wpColorOnSurfaceMedium" format="reference|color" />
     <attr name="wpColorOnSurfaceHigh" format="reference|color" />
+    <attr name="wpColorTextPrimary" format="reference|color" />
+    <attr name="wpColorTextSecondary" format="reference|color" />
 
     <attr name="wpColorWarningDark" format="reference|color" />
     <attr name="wpColorWarningLight" format="reference|color" />

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -142,4 +142,5 @@
     <!-- Partial Media Access -->
     <color name="partial_media_access_prompt_background">#DEDEDE</color>
 
+    <color name="text_secondary">#8A8A8E</color>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -174,6 +174,7 @@
     <dimen name="text_sz_extra_small">10sp</dimen>
     <dimen name="text_sz_small">12sp</dimen>
     <dimen name="text_sz_medium">14sp</dimen>
+    <dimen name="text_sz_medium_large">15sp</dimen>
     <dimen name="text_sz_large">16sp</dimen>
     <dimen name="text_sz_larger">18sp</dimen>
     <dimen name="text_sz_extra_large">20sp</dimen>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -48,6 +48,8 @@
         <item name="wpColorActionModeIcon">?attr/colorOnSurface</item>
         <item name="wpColorSurfaceSecondary">@color/neutral_5</item>
         <item name="wpColorLoginPrologueBg">@color/blue_0</item>
+        <item name="wpColorTextPrimary">?attr/wpColorOnSurfaceHigh</item>
+        <item name="wpColorTextSecondary">@color/text_secondary</item>
 
         <item name="colorGutenbergDivider">@color/wp_grey_lighten_30</item>
         <item name="colorGutenbergBackground">@android:color/white</item>
@@ -625,6 +627,15 @@
     <style name="DialogAnimations">
         <item name="android:windowEnterAnimation">@anim/activity_slide_in_from_right</item>
         <item name="android:windowExitAnimation">@anim/activity_slide_out_to_right</item>
+    </style>
+
+    <style name="WordPress.TextAppearance.NotificationItemTitle" parent="TextAppearance.MaterialComponents.Body2">
+        <item name="android:textSize">@dimen/text_sz_medium_large</item>
+        <item name="android:textColor">?attr/wpColorTextPrimary</item>
+    </style>
+
+    <style name="WordPress.TextAppearance.NotificationItemContent" parent="WordPress.TextAppearance.NotificationItemTitle">
+        <item name="android:textColor">?attr/wpColorTextSecondary</item>
     </style>
 
     <style name="MyProfileRow">


### PR DESCRIPTION
Issue #20021 

This PR contains a change related to the notification redesign. Please check #20021 for the further information.

-----

## To Test:
1. Open the Jetpack app and switch to the notifications tab.
2. The UI of the rows should match the new design. (See: yWt5gg3nWORhu079Qfv3mS-fi-51_1131)
3. Switch to the dark/light theme to see the color works in two themes.
4. Done, thank you!

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications tab

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manuel

5. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
