### PR TITLE
[Reader IA] Fix crash on Subfilter Sheet when rotating the device

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -127,9 +127,11 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
 
             bottomSheet?.let {
                 val behavior = BottomSheetBehavior.from(it)
-                val metrics = resources.displayMetrics
+                val metrics = it.context.resources.displayMetrics
                 behavior.peekHeight = metrics.heightPixels / 2
             }
+
+            dialog?.setOnShowListener(null)
         }
 
         viewModel.isTitleContainerVisible.observe(viewLifecycleOwner) { isVisible ->


### PR DESCRIPTION
Fixes #19991 

Fixes the crash by using the same context as the bottom sheet (instead of trying to use an outdated scope that doesn't exist anymore) and making sure to remove the Dialog's `onShowListener` after executing the initialization code, to avoid it being called again (after rotation everything is recreated anyway so we shouldn't be calling the old bottom sheet).

-----

## To Test:

* Tap on main dropdown menu and select Subscriptions
* Tap on “Tags” pill, let the app open the bottom menu (do not select a tag yet)
* Rotate the device
* **Verify** the app doesn't crash anymore

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.