### PR TITLE
Site Monitor: Refactors and Unit Tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorFragmentContainer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorFragmentContainer.kt
@@ -22,7 +22,7 @@ import androidx.fragment.app.findFragment
 
 @Suppress("SwallowedException")
 @Composable
-fun SiteMonitorFragmentContainer(
+internal fun SiteMonitorFragmentContainer(
     modifier: Modifier = Modifier,
     commit: FragmentTransaction.(containerId: Int) -> Unit
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapper.kt
@@ -7,10 +7,7 @@ class SiteMonitorMapper @Inject constructor(
 ) {
     fun toPrepared(url: String, addressToLoad: String, siteMonitorType: SiteMonitorType) = SiteMonitorUiState.Prepared(
         model = SiteMonitorModel(
-            enableJavascript = true,
-            enableDomStorage = true,
             userAgent = siteMonitorUtils.getUserAgent(),
-            enableChromeClient = true,
             url = url,
             addressToLoad = addressToLoad,
             siteMonitorType = siteMonitorType

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -85,7 +85,7 @@ class SiteMonitorParentActivity: AppCompatActivity() {
 
     @Composable
     @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
-    fun SiteMonitorScreen() {
+    fun SiteMonitorScreen(modifier: Modifier = Modifier) {
         var selectedTab by rememberSaveable { mutableStateOf(SiteMonitorTabItem.Metrics.route) }
         Scaffold(
             topBar = {
@@ -96,7 +96,7 @@ class SiteMonitorParentActivity: AppCompatActivity() {
                 )
             }
         ) { padding ->
-            Column(modifier = Modifier.padding(padding)) {
+            Column(modifier = modifier.padding(padding)) {
                 SiteMonitorTabHeader { clickTab ->
                     selectedTab = clickTab
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabFragment.kt
@@ -174,7 +174,7 @@ class SiteMonitorTabFragment : Fragment(), SiteMonitorWebViewClient.SiteMonitorW
 }
 
 @Composable
-fun LoadingState(modifier: Modifier = Modifier) {
+internal fun LoadingState(modifier: Modifier = Modifier) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier.fillMaxSize()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabHeader.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SiteMonitorTabHeader(navController: (String) -> Unit) {
+internal fun SiteMonitorTabHeader(navController: (String) -> Unit) {
     var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
     val tabs = listOf(
         SiteMonitorTabItem.Metrics,

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabNavigation.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorTabNavigation.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 
 @Composable
-fun <T : Any> SiteMonitorTabNavigation (
+internal fun <T : Any> SiteMonitorTabNavigation (
     currentScreen: T,
     modifier: Modifier = Modifier,
     content: @Composable (T) -> Unit

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUiState.kt
@@ -44,9 +44,6 @@ sealed class SiteMonitorUiState {
 
 data class SiteMonitorModel(
     val siteMonitorType: SiteMonitorType,
-    val enableJavascript: Boolean = true,
-    val enableDomStorage: Boolean = true,
-    val enableChromeClient: Boolean = true,
     val userAgent: String = "",
     val url: String,
     val addressToLoad: String

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapperTest.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.sitemonitor
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class SiteMonitorMapperTest : BaseUnitTest() {
+    @Mock
+    lateinit var siteMonitorUtils: SiteMonitorUtils
+
+    private lateinit var siteMonitorMapper: SiteMonitorMapper
+
+    @Before
+    fun setup() {
+        siteMonitorMapper = SiteMonitorMapper(siteMonitorUtils)
+    }
+
+    @Test
+    fun `given prepared request, when mapper is called, then site monitor model is created`() {
+        whenever(siteMonitorUtils.getUserAgent()).thenReturn(USER_AGENT)
+
+        val state = siteMonitorMapper.toPrepared(URL, ADDRESS_TO_LOAD, SiteMonitorType.METRICS)
+
+        assertThat(state.model.siteMonitorType).isEqualTo(SiteMonitorType.METRICS)
+        assertThat(state.model.url).isEqualTo(URL)
+        assertThat(state.model.addressToLoad).isEqualTo(ADDRESS_TO_LOAD)
+        assertThat(state.model.userAgent).isEqualTo(USER_AGENT)
+    }
+
+    @Test
+    fun `given network error, when mapper is called, then NoNetwork error is created`() {
+        val state = siteMonitorMapper.toNoNetworkError(mock())
+
+        assertThat(state).isInstanceOf(SiteMonitorUiState.NoNetworkError::class.java)
+    }
+
+    @Test
+    fun `given generic error error, when mapper is called, then Generic error is created`() {
+        val state = siteMonitorMapper.toGenericError(mock())
+
+        assertThat(state).isInstanceOf(SiteMonitorUiState.GenericError::class.java)
+    }
+
+    companion object {
+        const val USER_AGENT = "user_agent"
+        const val URL = "url"
+        const val ADDRESS_TO_LOAD = "address_to_load"
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtilsTest.kt
@@ -1,0 +1,92 @@
+package org.wordpress.android.ui.sitemonitor
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+
+@RunWith(MockitoJUnitRunner::class)
+class SiteMonitorUtilsTest {
+    @Mock
+    lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
+    private lateinit var siteMonitorUtils: SiteMonitorUtils
+
+    @Before
+    fun setup() {
+        siteMonitorUtils = SiteMonitorUtils(analyticsTrackerWrapper)
+    }
+
+    @Test
+    fun `when activity is launched, then event is tracked`() {
+        siteMonitorUtils.trackActivityLaunched()
+
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.SITE_MONITORING_SCREEN_SHOWN)
+    }
+
+    @Test
+    fun `given url matches pattern, when sanitize is requested, then url is sanitized`() {
+        val result = siteMonitorUtils.sanitizeSiteUrl("http://example.com")
+
+        assertEquals("example.com", result)
+    }
+
+    @Test
+    fun `given url is null, when sanitize is requested, then url is empty`() {
+        val result = siteMonitorUtils.sanitizeSiteUrl(null)
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `given url does not match pattern, when sanitize is requested, then url is not sanitized`() {
+        val url = "gibberish"
+        val result = siteMonitorUtils.sanitizeSiteUrl(url)
+
+        assertEquals(url, result)
+    }
+
+    @Test
+    fun `when metrics tab is launched, then event is tracked`() {
+        siteMonitorUtils.trackTabLoaded(SiteMonitorType.METRICS)
+
+        // Verify that the correct method was called on the analyticsTrackerWrapper
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
+            mapOf(
+                SiteMonitorUtils.TAB_TRACK_KEY to SiteMonitorType.METRICS.analyticsDescription
+            )
+        )
+    }
+
+    @Test
+    fun `when php logs tab is launched, then event is tracked`() {
+        siteMonitorUtils.trackTabLoaded(SiteMonitorType.PHP_LOGS)
+
+        // Verify that the correct method was called on the analyticsTrackerWrapper
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
+            mapOf(
+                SiteMonitorUtils.TAB_TRACK_KEY to SiteMonitorType.PHP_LOGS.analyticsDescription
+            )
+        )
+    }
+
+    @Test
+    fun `when web server logs tab is launched, then event is tracked`() {
+        siteMonitorUtils.trackTabLoaded(SiteMonitorType.WEB_SERVER_LOGS)
+
+        // Verify that the correct method was called on the analyticsTrackerWrapper
+        verify(analyticsTrackerWrapper).track(
+            AnalyticsTracker.Stat.SITE_MONITORING_TAB_SHOWN,
+            mapOf(
+                SiteMonitorUtils.TAB_TRACK_KEY to SiteMonitorType.WEB_SERVER_LOGS.analyticsDescription
+            )
+        )
+    }
+}


### PR DESCRIPTION
This PR addresses minor refactoring in  #20049 
- Set composables to internal
- Pass along modifier
- Remove unneeded settings from SiteMonitorModel
- Adds unit tests

-----

## To Test:
- Install and launch the JP app from this PR
- Login with an account that has an atomic with admin access
- Select ^^ that site
- Navigate to My Site > More > 
- ✅ Verify that the Site Monitoring Item is shown
- Tap on the Site Monitoring item
- ✅ Verify the view loads and you can see tabs
- ✅ Verify all tabs load as you tap on them

-----

## Regression Notes

1. Potential unintended areas of impact
Site monitor doesn't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
