### PR TITLE
Fixes: the padding of the Loading Indicator

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -221,17 +221,14 @@ class SiteMonitorParentActivity : AppCompatActivity(), SiteMonitorWebViewClient.
         val uiState by remember(key1 = tabType) {
             siteMonitorParentViewModel.getUiState(tabType)
         }
-        LazyColumn  {
-            item {
-                when (uiState) {
-                    is SiteMonitorUiState.Preparing -> LoadingState(modifier)
-                    is SiteMonitorUiState.Prepared, is SiteMonitorUiState.Loaded ->
-                        SiteMonitorWebView(uiState, tabType, modifier)
-                    is SiteMonitorUiState.Error -> SiteMonitorError(uiState as SiteMonitorUiState.Error, modifier)
-                }
-            }
+        when (uiState) {
+            is SiteMonitorUiState.Preparing -> LoadingState(modifier)
+            is SiteMonitorUiState.Prepared, is SiteMonitorUiState.Loaded ->
+                SiteMonitorWebView(uiState, tabType, modifier)
+            is SiteMonitorUiState.Error -> SiteMonitorError(uiState as SiteMonitorUiState.Error, modifier)
         }
     }
+
     @Composable
     fun LoadingState(modifier: Modifier = Modifier) {
         Box(
@@ -299,12 +296,14 @@ class SiteMonitorParentActivity : AppCompatActivity(), SiteMonitorWebViewClient.
             if (uiState is SiteMonitorUiState.Prepared) {
                 LoadingState()
             } else {
-                webView.let { theWebView ->
-                    AndroidView(
-                        factory = { theWebView },
-                        update = { webView = it },
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                LazyColumn(modifier = modifier.fillMaxHeight()) {
+                    item {
+                        AndroidView(
+                            factory = { webView },
+                            update = { webView = it },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -236,7 +236,9 @@ class SiteMonitorParentActivity : AppCompatActivity(), SiteMonitorWebViewClient.
             contentAlignment = Alignment.Center,
             modifier = modifier.fillMaxSize()
         ) {
-            CircularProgressIndicator()
+            CircularProgressIndicator(
+                color = MaterialTheme.colors.onSurface
+            )
         }
     }
 


### PR DESCRIPTION
## Fixes 
#20089

## Description 
This PR fixes the padding of the Loading indicator. The reason for the loading indicator was offset was because the loading state was wrapped inside the Lazy column. Lazy column was added to fix the glitch on loading of the webview, in this PR, the Lazy Column is moved to wrap only the Webview. 

## Screenshots
[Screen_recording_20240201_123756.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/74a7e819-0b34-49a3-a6f0-c88d1d1006e0)

## To Test:
#### Prerequisite
<details><summary>◐ Toggle the <code>site_monitoring</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings` → `Remote Feature Flags`
2. Tap on the item corresponding to the flag - site_monitoring
3. Tap `RESTART THE APP` button

</details>

###  Site monitor loader is shown on the middle of the screen
1. Go to More → Site Monitoring 
2. ✅  Verify that the Loading indicator is shown on the middle of the screen


## Regression Notes

1. Potential unintended areas of impact
Loading indicator is not shown as intended

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
NA


PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
