### PR TITLE
Integrate gutenberg-mobile release v1.112.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [**] Fix editor crash occurring on large posts [https://github.com/wordpress-mobile/WordPress-Android/pull/20046]
 * [*] [Jetpack-only] Site Monitoring: Add Metrics, PHP Logs, and Web Server Logs under Site Monitoring [https://github.com/wordpress-mobile/WordPress-Android/issues/20067]
+* [**] Prevent images from temporarily disappearing when uploading media [https://github.com/WordPress/gutenberg/pull/57869]
 
 24.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = '6597-5d9a47fd0849cc6f47a035704101ed9d2097f26e'
+    gutenbergMobileVersion = 'v1.112.0'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = '2.64.0'
     wordPressLoginVersion = '1.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.3.0'
-    gutenbergMobileVersion = 'v1.112.0-alpha5'
+    gutenbergMobileVersion = '6597-5d9a47fd0849cc6f47a035704101ed9d2097f26e'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = '2.64.0'
     wordPressLoginVersion = '1.11.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.112.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6597

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.