### PR TITLE
Integrate Flipper

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -391,10 +391,6 @@ dependencies {
     }
     implementation "org.wordpress:persistentedittext:$wordPressPersistentEditTextVersion"
 
-    // To enable Stetho, a debug bridge that enables the Chrome Developer Tools for debug purposes.
-    debugImplementation "com.facebook.stetho:stetho:$stethoVersion"
-    debugImplementation "com.facebook.stetho:stetho-okhttp3:$stethoVersion"
-
     implementation "androidx.arch.core:core-common:$androidxArchCoreVersion"
     implementation "androidx.arch.core:core-runtime:$androidxArchCoreVersion"
     implementation "com.google.code.gson:gson:$googleGsonVersion"
@@ -562,6 +558,16 @@ dependencies {
     // - Jetpack Compose - UI Tests
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
     implementation "androidx.compose.material3:material3:$androidxComposeMaterial3Version"
+
+    // - Flipper
+    debugImplementation ("com.facebook.flipper:flipper:$flipperVersion") {
+        exclude group:'org.jetbrains.kotlinx', module:'kotlinx-serialization-json-jvm'
+    }
+    debugImplementation "com.facebook.soloader:soloader:$soLoaderVersion"
+    debugImplementation ("com.facebook.flipper:flipper-network-plugin:$flipperVersion"){
+        exclude group:'org.jetbrains.kotlinx', module:'kotlinx-serialization-json-jvm'
+    }
+    releaseImplementation "com.facebook.flipper:flipper-noop:$flipperVersion"
 }
 
 configurations.all {

--- a/WordPress/src/debug/AndroidManifest.xml
+++ b/WordPress/src/debug/AndroidManifest.xml
@@ -38,5 +38,7 @@
             android:name=".ui.debug.preferences.DebugSharedPreferenceFlagsActivity"
             android:label="@string/debug_settings_debug_flags_screen"
             android:theme="@style/WordPress.NoActionBar" />
+        <activity android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+            android:exported="true"/>
     </application>
 </manifest>

--- a/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
+++ b/WordPress/src/debug/java/org/wordpress/android/WordPressDebug.java
@@ -2,7 +2,14 @@ package org.wordpress.android;
 
 import android.os.StrictMode;
 
-import com.facebook.stetho.Stetho;
+import com.facebook.flipper.android.AndroidFlipperClient;
+import com.facebook.flipper.android.utils.FlipperUtils;
+import com.facebook.flipper.core.FlipperClient;
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
+import com.facebook.flipper.plugins.inspector.DescriptorMapping;
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
+import com.facebook.soloader.SoLoader;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -11,14 +18,23 @@ import dagger.hilt.android.HiltAndroidApp;
 
 @HiltAndroidApp
 public class WordPressDebug extends WordPressApp {
+    public static final NetworkFlipperPlugin NETWORK_FLIPPER_PLUGIN = new NetworkFlipperPlugin();
     @Override
     public void onCreate() {
         super.onCreate();
 
         // enableStrictMode()
 
-        // Init Stetho
-        Stetho.initializeWithDefaults(this);
+        // init Flipper
+        SoLoader.init(this, false);
+
+        if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
+            final FlipperClient client = AndroidFlipperClient.getInstance(this);
+            client.addPlugin(new InspectorFlipperPlugin(this, DescriptorMapping.withDefaults()));
+            client.addPlugin(NETWORK_FLIPPER_PLUGIN);
+            client.addPlugin(new DatabasesFlipperPlugin(this));
+            client.start();
+        }
     }
 
     /**

--- a/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
+++ b/WordPress/src/debug/java/org/wordpress/android/modules/InterceptorModule.java
@@ -1,6 +1,8 @@
 package org.wordpress.android.modules;
 
-import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
+
+import org.wordpress.android.WordPressDebug;
 
 import javax.inject.Named;
 
@@ -11,11 +13,12 @@ import dagger.hilt.components.SingletonComponent;
 import dagger.multibindings.IntoSet;
 import okhttp3.Interceptor;
 
+
 @InstallIn(SingletonComponent.class)
 @Module
 public class InterceptorModule {
     @Provides @IntoSet @Named("network-interceptors")
-    public Interceptor provideStethoInterceptor() {
-        return new StethoInterceptor();
+    public Interceptor provideFlipperInterceptor() {
+        return new FlipperOkhttpInterceptor(WordPressDebug.NETWORK_FLIPPER_PLUGIN);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ ext {
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug
-    stethoVersion = '1.6.0'
+    flipperVersion = '0.245.0'
+    soLoaderVersion = '0.10.5'
 
     // main
     androidInstallReferrerVersion = '2.2'


### PR DESCRIPTION
As I mentioned in: pc8HXX-1vJ-p2

This PR replace Stetho with Flipper as the debugging tool. This should only affect local builds.

-----

## To Test:

1. Download the [Flipper](https://href.li/?https://fbflipper.com/) desktop app
2. Check out this branch
3. Build the app locally
4. Flipper should be able to connect with the Jetpack app
5. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

7. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)