### PR TITLE
Site Monitor: Adjust position in menu item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -91,8 +91,8 @@ class SiteItemsBuilder @Inject constructor(
     private fun getManageSiteItems(
         params: SiteItemsBuilderParams
     ): List<MySiteCardAndItem> {
-        val siteMonitoring = buildSiteMonitoringOptionsIfNeeded(params)
         val manageSiteItems = buildManageSiteItems(params)
+        val siteMonitoring = buildSiteMonitoringOptionsIfNeeded(params)
 
         val emptyHeaderItem1 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
         val jetpackConfiguration = buildJetpackDependantConfigurationItemsIfNeeded(params)
@@ -102,8 +102,8 @@ class SiteItemsBuilder @Inject constructor(
         val emptyHeaderItem2 = CategoryEmptyHeaderItem(UiString.UiStringText(""))
         val admin = siteListItemBuilder.buildAdminItemIfAvailable(params.site, params.onClick)
         return listOf(manageHeader) +
-                siteMonitoring +
                 manageSiteItems +
+                siteMonitoring +
                 emptyHeaderItem1 +
                 jetpackConfiguration +
                 lookAndFeel +

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -76,8 +76,8 @@ class SiteItemsBuilderTest {
     @Test
     fun `adds all the items in the correct order`() {
         setupHeaders(
-            addSiteMonitoringItem = true,
             addActivityLogItem = true,
+            addSiteMonitoringItem = true,
             addPlanItem = false,
             addPagesItem = true,
             addAdminItem = true,
@@ -107,10 +107,10 @@ class SiteItemsBuilderTest {
             TRAFFIC_HEADER,
             STATS_ITEM,
             MANAGE_HEADER,
-            SITE_MONITORING_ITEM,
             ACTIVITY_ITEM,
             BACKUP_ITEM,
             SCAN_ITEM,
+            SITE_MONITORING_ITEM,
             EMPTY_HEADER,
             PEOPLE_ITEM,
             PLUGINS_ITEM,
@@ -231,8 +231,8 @@ class SiteItemsBuilderTest {
 
     @Suppress("ComplexMethod", "LongMethod")
     private fun setupHeaders(
-        addSiteMonitoringItem: Boolean = false,
         addActivityLogItem: Boolean = false,
+        addSiteMonitoringItem: Boolean = false,
         addPlanItem: Boolean = false,
         addPagesItem: Boolean = false,
         addAdminItem: Boolean = false,
@@ -258,11 +258,6 @@ class SiteItemsBuilderTest {
                 PLAN_ITEM.copy(showFocusPoint = showPlansFocusPoint)
             )
         }
-        if (addSiteMonitoringItem) {
-            whenever(siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
-                SITE_MONITORING_ITEM
-            )
-        }
         if (addActivityLogItem) {
             whenever(siteListItemBuilder.buildActivityLogItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                 ACTIVITY_ITEM
@@ -276,6 +271,11 @@ class SiteItemsBuilderTest {
         if (addScanItem) {
             whenever(siteListItemBuilder.buildScanItemIfAvailable(SITE_ITEM_ACTION)).thenReturn(
                 SCAN_ITEM
+            )
+        }
+        if (addSiteMonitoringItem) {
+            whenever(siteListItemBuilder.buildSiteMonitoringItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                SITE_MONITORING_ITEM
             )
         }
         if (addPagesItem) {


### PR DESCRIPTION
This PR moves the "Site Monitoring" menu item to below the last manage item (activity log, backup or scan - which is dependent on site capabilities)

See p1706783341392669-slack-C06EFHCP0PN


Before | After
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/98105681-4cb6-48a2-b349-bb54687e1a62"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/62dc1cfa-1283-4e4a-810f-077fdaadf9f1">

Note: Only 1 Reviewer is needed

-----

## To Test:
- Install and launch the app
- Login with an account that has a creator plan
- Navigate to My Site > More
- ✅ Verify the `Site Monitoring` item is shown after the other manage items (activity log, backup, & scan)
-----

## Regression Notes
1. Potential unintended areas of impact: Site monitoring row doesn't show
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Updated unit tests
3. What automated tests I added (or what prevented me from doing so) N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)