### PR TITLE
[Reader IA] Show onboarding for users with no tags or dailyprompt tag only

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderRecommende
 import org.wordpress.android.models.discover.ReaderDiscoverCards
 import org.wordpress.android.modules.IO_THREAD
 import org.wordpress.android.modules.UI_THREAD
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsPostTagProvider.Companion.BLOGGING_PROMPT_TAG
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType.TAG_FOLLOWED
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostNewUiState
@@ -149,7 +150,10 @@ class ReaderDiscoverViewModel @Inject constructor(
         _uiState.addSource(readerDiscoverDataProvider.discoverFeed) { posts ->
             launch {
                 val userTags = getFollowedTagsUseCase.get()
-                if (userTags.isEmpty()) {
+
+                // since new users have the dailyprompt tag followed by default, we need to ignore them when
+                // checking if the user has any tags followed, so we show the onboarding state (ShowNoFollowedTags)
+                if (userTags.filterNot { it.tagSlug == BLOGGING_PROMPT_TAG }.isEmpty()) {
                     _uiState.value = DiscoverUiState.EmptyUiState.ShowNoFollowedTagsUiState {
                         parentViewModel.onShowReaderInterests()
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsPostTagProvider.Companion.BLOGGING_PROMPT_TAG
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsFragment.EntryPoint
 import org.wordpress.android.ui.reader.discover.interests.ReaderInterestsViewModel.DoneButtonUiState.DoneButtonDisabledUiState
@@ -92,7 +93,9 @@ class ReaderInterestsViewModel @Inject constructor(
     }
 
     private fun checkAndLoadInterests(userTags: ReaderTagList) {
-        if (userTags.isEmpty()) {
+        // since new users have the dailyprompt tag followed by default, we need to ignore them when
+        // checking if the user has any tags followed, so we show the onboarding state (ShowNoFollowedTags)
+        if (userTags.filterNot { it.tagSlug == BLOGGING_PROMPT_TAG }.isEmpty()) {
             loadInterests(userTags)
         } else {
             parentViewModel?.onCloseReaderInterests()

--- a/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_interests_fragment_layout.xml
@@ -66,7 +66,7 @@
             <com.google.android.material.textview.MaterialTextView
                 style="@style/ReaderTextView.Interests.Title"
                 android:id="@+id/title"
-                android:text="@string/reader_label_choose_your_interests"
+                android:text="@string/reader_label_choose_interests"
                 android:visibility="gone"
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="@id/guideline_beginning"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2162,7 +2162,7 @@
     <string name="reader_label_local_related_posts">More from %s</string>
     <string name="reader_label_global_related_posts">More on WordPress.com</string>
     <string name="reader_label_visit">Visit site</string>
-    <string name="reader_label_choose_your_interests">Choose your topics</string>
+    <string name="reader_label_choose_interests">Choose your interests</string>
     <string name="reader_view_comments">View comments</string>
     <string name="reader_welcome_banner">Welcome to Reader. Discover millions of blogs at your fingertips.</string>
     <string name="reader_label_toolbar_back">Back</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModelTest.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
+import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.models.discover.ReaderDiscoverCard.InterestsYouMayLikeCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderPostCard
 import org.wordpress.android.models.discover.ReaderDiscoverCard.ReaderRecommendedBlogsCard
@@ -284,6 +285,29 @@ class ReaderDiscoverViewModelTest : BaseUnitTest() {
     fun `ShowFollowInterestsEmptyUiState is shown when the user does NOT follow any tags`() = test {
         // Arrange
         whenever(getFollowedTagsUseCase.get()).thenReturn(ReaderTagList())
+        val uiStates = init().uiStates
+        // Act
+        viewModel.start(parentViewModel)
+        // Assert
+        assertThat(uiStates.size).isEqualTo(2)
+        assertThat(uiStates[1]).isInstanceOf(ShowNoFollowedTagsUiState::class.java)
+    }
+
+    @Test
+    fun `ShowFollowInterestsEmptyUiState is shown when the user follows only the daily prompt tag`() = test {
+        // Arrange
+        val tagsWithDailyPrompt = ReaderTagList().apply {
+            add(
+                ReaderTag(
+                    "dailyprompt",
+                    "dailyprompt",
+                    "dailyprompt",
+                    "https://public-api.wordpress.com/rest/v1.2/read/tags/dailyprompt/posts",
+                    ReaderTagType.DEFAULT
+                )
+            )
+        }
+        whenever(getFollowedTagsUseCase.get()).thenReturn(tagsWithDailyPrompt)
         val uiStates = init().uiStates
         // Act
         viewModel.start(parentViewModel)

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/interests/ReaderInterestsViewModelTest.kt
@@ -88,6 +88,20 @@ class ReaderInterestsViewModelTest : BaseUnitTest() {
         }
 
     @Test
+    fun `getInterests invoked if only daily prompt user tag received from repo`() =
+        testWithDailyPromptUserTag {
+            // Given
+            val interests = getInterests()
+            whenever(readerTagRepository.getInterests()).thenReturn(SuccessWithData(interests))
+
+            // When
+            initViewModel()
+
+            // Then
+            verify(readerTagRepository, times(1)).getInterests()
+        }
+
+    @Test
     fun `discover close reader screen triggered if non empty user tags are received from repo`() =
         testWithNonEmptyUserTags {
             // When
@@ -598,6 +612,25 @@ class ReaderInterestsViewModelTest : BaseUnitTest() {
     private fun <T> testWithEmptyUserTags(block: suspend CoroutineScope.() -> T) {
         test {
             whenever(readerTagRepository.getUserTags()).thenReturn(SuccessWithData(ReaderTagList()))
+            block()
+        }
+    }
+
+    private fun <T> testWithDailyPromptUserTag(block: suspend CoroutineScope.() -> T) {
+        test {
+            val tagsWithDailyPrompt = ReaderTagList().apply {
+                add(
+                    ReaderTag(
+                        "dailyprompt",
+                        "dailyprompt",
+                        "dailyprompt",
+                        "https://public-api.wordpress.com/rest/v1.2/read/tags/dailyprompt/posts",
+                        ReaderTagType.DEFAULT
+                    )
+                )
+            }
+
+            whenever(readerTagRepository.getUserTags()).thenReturn(SuccessWithData(tagsWithDailyPrompt))
             block()
         }
     }


### PR DESCRIPTION
Fixes #20091 

Ignores the `dailyprompt` tag when checking for the subscribed tags to show the Discover Onboarding / Choose your interests (onboarding) screens.

-----

## To Test:

### Requirements
Create a new account to run the test (`dailyprompt` tag auto-injected by default) or prepare an existing account by unsubscribing from all tags and subscribing only to `dailyprompt` tag.

### Steps
1. Install Jetpack and log in/sign up
2. Go to Reader
3. Go to Discover
4. **Verify** the "Welcome" message with a "Get Started" button is shown
5. Tap "Get Started"
6. **Verify** the "Choose your interests" screen with the tag cloud shows up

Also, test that having no tags at all shows the Welcome screen and that having other tags doesn't show it.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Added unit tests for the new scenario.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
