### PR TITLE
[Reader IA] Prevent unwanted Reader feed state reset when reopening Reader tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -232,6 +232,11 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
         if (uiState.selectedReaderTag == null) {
             return
         }
+
+        // only initialize the fragment if it's not already initialized
+        val currentFragmentTag = childFragmentManager.findFragmentById(R.id.container)?.tag
+        if (currentFragmentTag == uiState.selectedReaderTag.tagSlug) return
+
         childFragmentManager.beginTransaction().apply {
             val fragment = if (uiState.selectedReaderTag.isDiscover()) {
                 ReaderDiscoverFragment()
@@ -243,7 +248,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
                     uiState.selectedReaderTag.isFilterable
                 )
             }
-            replace(R.id.container, fragment)
+            replace(R.id.container, fragment, uiState.selectedReaderTag.tagSlug)
             commit()
         }
         viewModel.uiState.value?.let {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -229,16 +229,14 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
     }
 
     private fun initContentContainer(uiState: ContentUiState) {
-        if (uiState.selectedReaderTag == null) {
+        // only initialize the fragment if there's one selected and it's not already initialized
+        val currentFragmentTag = childFragmentManager.findFragmentById(R.id.container)?.tag
+        if (uiState.selectedReaderTag == null || uiState.selectedReaderTag.tagSlug == currentFragmentTag) {
             return
         }
 
-        // only initialize the fragment if it's not already initialized
-        val currentFragmentTag = childFragmentManager.findFragmentById(R.id.container)?.tag
-        if (currentFragmentTag == uiState.selectedReaderTag.tagSlug) return
-
         childFragmentManager.beginTransaction().apply {
-            val fragment = if (uiState.selectedReaderTag.isDiscover()) {
+            val fragment = if (uiState.selectedReaderTag.isDiscover) {
                 ReaderDiscoverFragment()
             } else {
                 ReaderPostListFragment.newInstanceForTag(


### PR DESCRIPTION
Fixes #19852 
Fixes #19992 
Fixes #20086

This PR fixes multiple issues related to the Reader content feed and top bar selection refreshing when exiting and opening Reader again (like going to a different bottom tab and rotating the device) since the root cause was the same: the current Reader feed Fragment was being reinitialized every time, even when it was already showing the correct content.

The fix was simply adding a tag to the instantiated fragment and checking if that tag matches the new tag we are trying to initialize, and then we just initialize a new fragment when it's indeed different.

-----

## To Test:

Go to the 3 issues mentioned before and go through the steps to reproduce for each, verifying the issue no longer happens.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Not loading after feed change

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual Testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A, changes in the view layer.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
No UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
