### PR TITLE
Fix in app reviews crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -137,7 +137,6 @@ import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
-import org.wordpress.android.ui.utils.InAppReviewsUtilsKt;
 import org.wordpress.android.ui.utils.JetpackAppMigrationFlowUtils;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
 import org.wordpress.android.util.AniUtils;
@@ -183,6 +182,7 @@ import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVari
 import static org.wordpress.android.login.LoginAnalyticsListener.CreatedAccountSource.EMAIL;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
+import static org.wordpress.android.util.extensions.InAppReviewExtensionsKt.logException;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -853,7 +853,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 Task<Void> flow = manager.launchReviewFlow(this, reviewInfo);
                 flow.addOnFailureListener(e -> AppLog.e(T.MAIN, "Error launching google review API flow.", e));
             } else {
-                InAppReviewsUtilsKt.logException(task);
+                logException(task);
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -29,11 +29,9 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.play.core.review.ReviewException;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
-import com.google.android.play.core.review.model.ReviewErrorCode;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -139,6 +137,7 @@ import org.wordpress.android.ui.stories.intro.StoriesIntroDialogFragment;
 import org.wordpress.android.ui.uploads.UploadActionUseCase;
 import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper;
+import org.wordpress.android.ui.utils.InAppReviewsUtilsKt;
 import org.wordpress.android.ui.utils.JetpackAppMigrationFlowUtils;
 import org.wordpress.android.ui.whatsnew.FeatureAnnouncementDialogFragment;
 import org.wordpress.android.util.AniUtils;
@@ -854,12 +853,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                 Task<Void> flow = manager.launchReviewFlow(this, reviewInfo);
                 flow.addOnFailureListener(e -> AppLog.e(T.MAIN, "Error launching google review API flow.", e));
             } else {
-                @ReviewErrorCode int reviewErrorCode = ((ReviewException) task.getException()).getErrorCode();
-                AppLog.e(
-                        T.MAIN,
-                        "Error fetching ReviewInfo object from Review API to start in-app review process",
-                        reviewErrorCode
-                );
+                InAppReviewsUtilsKt.logException(task);
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -21,9 +21,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.play.core.review.ReviewException
 import com.google.android.play.core.review.ReviewManagerFactory
-import com.google.android.play.core.review.model.ReviewErrorCode
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PostListActivityBinding
@@ -61,6 +59,7 @@ import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.logException
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
@@ -360,12 +359,7 @@ class PostsListActivity : LocaleAwareActivity(),
                     AppLog.e(AppLog.T.POSTS, "Error launching google review API flow.", e)
                 }
             } else {
-                @ReviewErrorCode val reviewErrorCode = (task.exception as ReviewException).errorCode
-                AppLog.e(
-                    AppLog.T.POSTS,
-                    "Error fetching ReviewInfo object from Review API to start in-app review process",
-                    reviewErrorCode
-                )
+                task.logException()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -59,12 +59,12 @@ import org.wordpress.android.ui.stories.StoriesMediaPickerResultHandler
 import org.wordpress.android.ui.uploads.UploadActionUseCase
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.ui.utils.logException
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.SnackbarItem
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
+import org.wordpress.android.util.extensions.logException
 import org.wordpress.android.util.extensions.redirectContextClickToLongPressListener
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.viewmodel.observeEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/InAppReviewsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/InAppReviewsUtils.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.ui.utils
+
+import com.google.android.gms.tasks.Task
+import com.google.android.play.core.review.ReviewException
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.model.ReviewErrorCode
+import org.wordpress.android.util.AppLog
+
+fun Task<ReviewInfo>.logException() {
+    val errorMessage = "Error fetching ReviewInfo object from Review API to start in-app review process"
+    (exception as? ReviewException)?.let {
+        @ReviewErrorCode val reviewErrorCode = it.errorCode
+        AppLog.e(AppLog.T.UTILS, errorMessage, reviewErrorCode)
+    } ?: AppLog.e(AppLog.T.UTILS, "$errorMessage: ${exception?.message}")
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/InAppReviewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/InAppReviewExtensions.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.utils
+package org.wordpress.android.util.extensions
 
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.review.ReviewException


### PR DESCRIPTION
There are a few crash reports that occurred when logging the crash exception. 
- I created an extension function to log the exception from a single place.
- If the exception can't be cast to `ReviewException`, it will log the `Exception`'s message.




-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

This change cannot be tested using the .apk generated in this PR. The .apk should be uploaded to [internal app sharing](https://developer.android.com/guide/playcore/in-app-review/test#internal-app-sharing). Even if we do so, reproducing the exception is not easy.

I am confident that the change is safe. Please review it and let me know if you believe it requires specific testing.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

3. What automated tests I added (or what prevented me from doing so)

    - Nothing. I don't believe it's worthwhile to mock `ReviewException` and add a unit test. The `Task<ReviewInfo>.logException()` logic is quite basic.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
