### PR TITLE
[Reader IA] Fix top navigation bar disappearing when system has low-memory

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -210,7 +210,12 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), MenuProvider, 
 
         observeJetpackOverlayEvent(savedInstanceState)
 
-        viewModel.start()
+        viewModel.start(savedInstanceState)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.onSaveInstanceState(outState)
     }
 
     private fun updateUiState(uiState: ReaderViewModel.ReaderUiState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -118,7 +118,7 @@ class ReaderViewModel @Inject constructor(
         EventBus.getDefault().register(this)
     }
 
-    fun start(savedInstanceState: Bundle?) {
+    fun start(savedInstanceState: Bundle? = null) {
         if (tagsRequireUpdate()) _updateTags.value = Event(Unit)
         if (initialized) return
         loadTabs(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader.views.compose.filter
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.os.Parcelable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
@@ -37,6 +38,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.compose.unit.Margin
@@ -210,10 +212,11 @@ enum class ReaderFilterType {
     TAG,
 }
 
+@Parcelize
 data class ReaderFilterSelectedItem(
     val text: UiString,
     val type: ReaderFilterType,
-)
+) : Parcelable
 
 @Preview(name = "Light Mode", showBackground = true)
 @Preview(name = "Dark Mode", showBackground = true, uiMode = UI_MODE_NIGHT_YES)

--- a/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/utils/UiString.kt
@@ -1,20 +1,26 @@
 package org.wordpress.android.ui.utils
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
 
 /**
  * [UiString] is a utility sealed class that represents a string to be used in the UI. It allows a string to be
  * represented as both string resource and text.
  */
-sealed class UiString {
+sealed class UiString : Parcelable {
+    @Parcelize
     data class UiStringText(val text: CharSequence) : UiString()
+    @Parcelize
     data class UiStringRes(@StringRes val stringRes: Int) : UiString()
+    @Parcelize
     data class UiStringResWithParams(@StringRes val stringRes: Int, val params: List<UiString>) : UiString() {
         constructor(@StringRes stringRes: Int, vararg varargParams: UiString) : this(stringRes, varargParams.toList())
     }
 
     // Current localization process does not support <plurals> resource strings,
     // so we need to use multiple string resources. Switch to @PluralsRes when it is supported by localization process.
+    @Parcelize
     data class UiStringPluralRes(
         @StringRes val zeroRes: Int,
         @StringRes val oneRes: Int,


### PR DESCRIPTION
Fixes #20105 

A couple of things were done to fix this issue:
- Try to wait for a non-null top app bar state in functions that REQUIRE an existing top app bar to work
- Properly save and restore top bar state using the Reader Fragment Saved Instance State Bundle

-----

## To Test:

1. Enable the don't keep activities option.
2. Install and log into Jetpack
3. Go to the Reader
4. Go to the Subscriptions feed
5. Open a single post in the reader
6. Tap back
7. **Verify** that the top bar is still there in the correct state

Also, try doing that in other feeds, including selected blog/tag filters, to confirm the top bar does not disappear and saves the correct state.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Wrong top bar state being shown at any given time.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual changes

3. What automated tests I added (or what prevented me from doing so)

    - None **yet**. Unit tests should be added in a future PR to cover the fixed scenarios. 

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
