### PR TITLE
[Fix] Adds export behavior on broadcastreceiver to avoid SDK 34 crash.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.DownloadManager
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
@@ -11,6 +12,7 @@ import android.content.res.Resources
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.Gravity
@@ -1160,10 +1162,18 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         super.onStart()
         dispatcher.register(this)
         EventBus.getDefault().register(this)
-        activity?.registerReceiver(
-            readerFileDownloadManager,
-            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            activity?.registerReceiver(
+                readerFileDownloadManager,
+                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+                ContextWrapper.RECEIVER_NOT_EXPORTED
+            )
+        } else {
+            activity?.registerReceiver(
+                readerFileDownloadManager,
+                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+            )
+        }
     }
 
     override fun onStop() {


### PR DESCRIPTION
Fixes #19917 (Test runtime broadcasts being registered using registerReceiver)

-----

## What

While upgrading to Android 14, runtime registered BroadcastReceivers must define export behavior. Otherwise it crashes. I tested the classes from the project, and only one crashed, `ReaderPostDetailFragment`.

## To Test:

- [ ] Go to reader and click any post to view it. No crash means it worked.

-----

## Regression Notes

1. Potential unintended areas of impact

    n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing. Tested the classes that could be affected.

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
