### PR TITLE
[Reader] Change comment subscribe action label to "Follow"

### DIFF
--- a/WordPress/src/main/res/layout/follow_action_layout.xml
+++ b/WordPress/src/main/res/layout/follow_action_layout.xml
@@ -19,7 +19,7 @@
             android:layout_marginEnd="@dimen/margin_large"
             android:layout_marginStart="@dimen/margin_large"
             android:background="?android:attr/actionBarItemBackground"
-            android:text="@string/reader_btn_subscribe"
+            android:text="@string/reader_btn_follow"
             android:textAppearance="?android:attr/actionMenuTextAppearance"
             android:textColor="@color/option_menu_disabled_selector" />
 

--- a/WordPress/src/main/res/menu/threaded_comments_menu.xml
+++ b/WordPress/src/main/res/menu/threaded_comments_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/follow_item"
-        android:title="@string/reader_btn_subscribe"
+        android:title="@string/reader_btn_follow"
         app:actionLayout="@layout/follow_action_layout"
         app:showAsAction="always" />
     <item

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2118,6 +2118,7 @@
 
     <!-- button text -->
     <string name="reader_btn_share">Share</string>
+    <string name="reader_btn_follow">Follow</string>
     <string name="reader_btn_subscribe">Subscribe</string>
     <string name="reader_btn_subscribed">Subscribed</string>
     <string name="reader_secondary_bookmark">Save</string>


### PR DESCRIPTION
Fixes #20118 

![20118-reader-comments-follow](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/f72a3dfe-6689-4503-97a6-dd7548ea5c37)

-----

## To Test:

1. Go to Reader
2. Tap on a Post with comments to open Post Details
3. Tap on "Comments" or scroll down and tap "View all comments"
4. **Verifty** the menu action says "Follow" instead of "Subscribe"

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

6. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## UI Changes Testing Checklist:
N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
