### PR TITLE
Add an overflow menu in Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -305,12 +305,13 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     /**
      * For displaying the popup of notifications settings
      */
+    @SuppressLint("InflateParams")
     private fun showNotificationActionsPopup(anchorView: View) {
         val popupWindow = PopupWindow(requireContext(), null, R.style.WordPress)
         popupWindow.isOutsideTouchable = true
         popupWindow.elevation = resources.getDimension(R.dimen.popup_over_toolbar_elevation)
         popupWindow.contentView = LayoutInflater.from(requireContext())
-            .inflate(R.layout.notification_actions, null, false).apply {
+            .inflate(R.layout.notification_actions, null).apply {
                 findViewById<View>(R.id.text_mark_all_as_read).setOnClickListener {
                     markAllAsRead()
                     popupWindow.dismiss()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -31,6 +31,8 @@ import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_FILTER
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATIONS_MARK_ALL_READ_TAPPED
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_MENU_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL
 import org.wordpress.android.databinding.NotificationsListFragmentBinding
 import org.wordpress.android.fluxc.store.AccountStore
@@ -64,6 +66,7 @@ import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE
 import org.wordpress.android.util.WPUrlUtils
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
@@ -78,6 +81,9 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     @Inject
     lateinit var uiHelpers: UiHelpers
+
+    @Inject
+    lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
     private val viewModel: NotificationsListViewModel by viewModels()
 
@@ -284,6 +290,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         val notificationActions = menu.findItem(R.id.notifications_actions)
         notificationActions.isVisible = accountStore.hasAccessToken()
         notificationActions.actionView?.setOnClickListener {
+            analyticsTrackerWrapper.track(NOTIFICATION_MENU_TAPPED)
             showNotificationActionsPopup(it)
         }
         super.onPrepareOptionsMenu(menu)
@@ -320,6 +327,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
      * For marking the status of every notification as read
      */
     private fun markAllAsRead() {
+        analyticsTrackerWrapper.track(NOTIFICATIONS_MARK_ALL_READ_TAPPED)
         // TODO("not yet implemented")
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -8,10 +8,11 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
+import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
+import android.widget.PopupWindow
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
@@ -280,8 +281,11 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     @Suppress("OVERRIDE_DEPRECATION")
     override fun onPrepareOptionsMenu(menu: Menu) {
-        val notificationSettings = menu.findItem(R.id.notifications_settings)
-        notificationSettings.isVisible = accountStore.hasAccessToken()
+        val notificationActions = menu.findItem(R.id.notifications_actions)
+        notificationActions.isVisible = accountStore.hasAccessToken()
+        notificationActions.actionView?.setOnClickListener {
+            showNotificationActionsPopup(it)
+        }
         super.onPrepareOptionsMenu(menu)
     }
 
@@ -291,13 +295,32 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.notifications_settings) {
-            ActivityLauncher.viewNotificationsSettings(activity)
-            return true
-        }
-        return super.onOptionsItemSelected(item)
+    /**
+     * For displaying the popup of notifications settings
+     */
+    private fun showNotificationActionsPopup(anchorView: View) {
+        val popupWindow = PopupWindow(requireContext(), null, R.style.WordPress)
+        popupWindow.isOutsideTouchable = true
+        popupWindow.elevation = resources.getDimension(R.dimen.popup_over_toolbar_elevation)
+        popupWindow.contentView = LayoutInflater.from(requireContext())
+            .inflate(R.layout.notification_actions, null, false).apply {
+                findViewById<View>(R.id.text_mark_all_as_read).setOnClickListener {
+                    markAllAsRead()
+                    popupWindow.dismiss()
+                }
+                findViewById<View>(R.id.text_settings).setOnClickListener {
+                    ActivityLauncher.viewNotificationsSettings(activity)
+                    popupWindow.dismiss()
+                }
+            }
+        popupWindow.showAsDropDown(anchorView)
+    }
+
+    /**
+     * For marking the status of every notification as read
+     */
+    private fun markAllAsRead() {
+        // TODO("not yet implemented")
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -3,6 +3,7 @@
 package org.wordpress.android.ui.notifications
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.os.Build

--- a/WordPress/src/main/res/layout/notification_action_menu.xml
+++ b/WordPress/src/main/res/layout/notification_action_menu.xml
@@ -7,6 +7,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="?attr/selectableItemBackground"
+        android:contentDescription="@string/more"
         android:padding="@dimen/notifications_item_action_padding"
         android:src="@drawable/more_vertical" />
 </FrameLayout>

--- a/WordPress/src/main/res/layout/notification_action_menu.xml
+++ b/WordPress/src/main/res/layout/notification_action_menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:padding="@dimen/notifications_item_action_padding"
+        android:src="@drawable/more_vertical" />
+</FrameLayout>
+

--- a/WordPress/src/main/res/layout/notification_actions.xml
+++ b/WordPress/src/main/res/layout/notification_actions.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardBackgroundColor="?colorSurface"
+    app:cardCornerRadius="@dimen/notifications_popup_radius">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/text_mark_all_as_read"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/notifications_item_action_padding"
+            android:paddingEnd="@dimen/notifications_item_action_padding_end"
+            android:paddingStart="@dimen/notifications_item_action_padding"
+            android:paddingVertical="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_action_mark_all_as_read"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large"
+            app:drawableStartCompat="@drawable/ic_check_24px"
+            app:drawableTint="?wpColorOnSurfaceHigh"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/text_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawablePadding="@dimen/notifications_item_action_padding"
+            android:paddingEnd="@dimen/notifications_item_action_padding_end"
+            android:paddingStart="@dimen/notifications_item_action_padding"
+            android:paddingVertical="@dimen/notifications_item_action_padding"
+            android:text="@string/notification_settings"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large"
+            app:drawableStartCompat="@drawable/ic_cog_white_24dp"
+            app:drawableTint="?wpColorOnSurfaceHigh"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="1px"
+            android:background="@color/grey_300"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_mark_all_as_read" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>
+

--- a/WordPress/src/main/res/menu/notifications_list_menu.xml
+++ b/WordPress/src/main/res/menu/notifications_list_menu.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto">
-
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/notifications_settings"
-        android:icon="@drawable/ic_cog_white_24dp"
-        android:title="@string/notification_settings"
+        android:id="@+id/notifications_actions"
+        android:title="@string/more"
+        app:actionLayout="@layout/notification_action_menu"
         app:showAsAction="always"/>
-
 </menu>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -283,8 +283,10 @@
     <dimen name="notifications_item_vertical_padding">12dp</dimen>
     <dimen name="notifications_item_horizontal_padding">18dp</dimen>
     <dimen name="notifications_item_action_padding">12dp</dimen>
+    <dimen name="notifications_item_action_padding_end">28dp</dimen>
     <dimen name="notifications_header_margin_top_position_0">16dp</dimen>
     <dimen name="notifications_header_margin_top_position_n">4dp</dimen>
+    <dimen name="notifications_popup_radius">4dp</dimen>
 
     <dimen name="progress_bar_height">3dp</dimen>
     <dimen name="activity_progress_bar_height">5dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1578,6 +1578,8 @@
     <string name="notifications_tab_dialog_main_off_title">To see notifications on notifications tab for this site, turn Notifications for this site on.</string>
     <string name="notifications_tab_dialog_main_off_message">Turning Notifications for this site off will disable notifications display on notifications tab for this site. You can fine-tune which kind of notification you see after turning Notifications for this site on.</string>
 
+    <string name="notifications_action_mark_all_as_read">Mark all as read</string>
+
     <string name="main_switch_default_title_on">On</string>
     <string name="main_switch_default_title_off">Off</string>
 

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1104,7 +1104,9 @@ public final class AnalyticsTracker {
         SITE_MONITORING_SCREEN_SHOWN,
         OPENED_SITE_MONITORING,
         SITE_MONITORING_TAB_SHOWN,
-        SITE_MONITORING_TAB_LOADING_ERROR
+        SITE_MONITORING_TAB_LOADING_ERROR,
+        NOTIFICATION_MENU_TAPPED,
+        NOTIFICATIONS_MARK_ALL_READ_TAPPED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2703,6 +2703,10 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "site_monitoring_tab_shown";
             case SITE_MONITORING_TAB_LOADING_ERROR:
                 return "site_monitoring_tab_loading_error";
+            case NOTIFICATION_MENU_TAPPED:
+                return "notification_menu_tapped";
+            case NOTIFICATIONS_MARK_ALL_READ_TAPPED:
+                return "notifications_mark_all_read_tapped";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #20065 

This PR contains:
1. An overflow menu icon in Notifications tab.
2. A popup window for Notification actions.
3. Two events added.

-----

## To Test:

1. Open the Jetpack app and switch to the notifications tab.
4. Click the overflow icon on the top-right corner
5. It should show a popup window with two options.
  - Mark all as read will be implemented in #20066.
  - Notification Settings is the same as the original behavior.
6. The UI of the popup window should match the new design. (See: yWt5gg3nWORhu079Qfv3mS-fi-51_3817)
7. Switch to the dark/light theme to see the color works in two themes. Known issue: the shadow is not prominent enough in dark mode.
8. Validate new events.
9. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications tab

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

6. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
