### PR TITLE
Issue/19952 update traffic tab by granularity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -271,7 +271,6 @@ class StatsModule {
      * @param useCasesFactories build the use cases for the DAYS granularity
      */
     @Provides
-    @Singleton
     @Named(TRAFFIC_USE_CASE)
     @Suppress("LongParameterList")
     fun provideTrafficUseCase(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -64,6 +64,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.T
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.ViewsAndVisitorsUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.SelectedTrafficGranularityManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -411,16 +412,20 @@ class StatsModule {
         @Named(DAY_STATS_USE_CASE) dayStatsUseCase: BaseListUseCase,
         @Named(WEEK_STATS_USE_CASE) weekStatsUseCase: BaseListUseCase,
         @Named(MONTH_STATS_USE_CASE) monthStatsUseCase: BaseListUseCase,
-        @Named(YEAR_STATS_USE_CASE) yearStatsUseCase: BaseListUseCase
+        @Named(YEAR_STATS_USE_CASE) yearStatsUseCase: BaseListUseCase,
+        trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
     ): Map<StatsSection, BaseListUseCase> {
-        return mapOf(
-            StatsSection.INSIGHTS to insightsUseCase,
-            StatsSection.TRAFFIC to trafficUseCase,
-            StatsSection.DAYS to dayStatsUseCase,
-            StatsSection.WEEKS to weekStatsUseCase,
-            StatsSection.MONTHS to monthStatsUseCase,
-            StatsSection.YEARS to yearStatsUseCase
-        )
+        return if (trafficTabFeatureConfig.isEnabled()) {
+            mapOf(StatsSection.TRAFFIC to trafficUseCase, StatsSection.INSIGHTS to insightsUseCase)
+        } else {
+            mapOf(
+                StatsSection.INSIGHTS to insightsUseCase,
+                StatsSection.DAYS to dayStatsUseCase,
+                StatsSection.WEEKS to weekStatsUseCase,
+                StatsSection.MONTHS to monthStatsUseCase,
+                StatsSection.YEARS to yearStatsUseCase
+            )
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -62,6 +62,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.T
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalFollowersUseCase.TotalFollowersUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.TotalLikesUseCase.TotalLikesUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.usecases.ViewsAndVisitorsUseCase.ViewsAndVisitorsUseCaseFactory
+import org.wordpress.android.ui.stats.refresh.utils.SelectedTrafficGranularityManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import javax.inject.Named
 import javax.inject.Singleton
@@ -279,13 +280,16 @@ class StatsModule {
         @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
         statsSiteProvider: StatsSiteProvider,
         @Named(GRANULAR_USE_CASE_FACTORIES) useCasesFactories: List<@JvmSuppressWildcards GranularUseCaseFactory>,
+        selectedTrafficGranularityManager: SelectedTrafficGranularityManager,
         uiModelMapper: UiModelMapper
     ): BaseListUseCase {
         return BaseListUseCase(
             bgDispatcher,
             mainDispatcher,
             statsSiteProvider,
-            useCasesFactories.map { it.build(DAYS, BLOCK) },
+            useCasesFactories.map {
+                it.build(selectedTrafficGranularityManager.getSelectedTrafficGranularity(), BLOCK)
+            },
             { statsStore.getTimeStatsTypes(it) },
             uiModelMapper::mapTimeStats
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -22,8 +22,8 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.util.PackageUtils
 import org.wordpress.android.util.combineMap
 import org.wordpress.android.util.distinct
-import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mapAsync
+import org.wordpress.android.util.mapSafe
 import org.wordpress.android.util.mergeAsyncNotNull
 import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.viewmodel.Event
@@ -147,4 +147,13 @@ class BaseListUseCase(
     fun onListSelected() {
         mutableListSelected.call()
     }
+
+    fun clone(newUseCases: List<BaseStatsUseCase<*, *>>) = BaseListUseCase(
+        bgDispatcher,
+        mainDispatcher,
+        statsSiteProvider,
+        newUseCases,
+        getStatsTypes,
+        mapUiModel
+    )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -169,7 +169,10 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
 
             dateSelector.granularitySpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                    selectedTrafficGranularityManager.setSelectedTrafficGranularity(StatsGranularity.entries[position])
+                    with(StatsGranularity.entries[position]) {
+                        selectedTrafficGranularityManager.setSelectedTrafficGranularity(this)
+                        (viewModel as TrafficListViewModel).onGranularitySelected(this)
+                    }
                 }
 
                 @Suppress("EmptyFunctionBlock")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -238,7 +238,14 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     }
 
     private fun StatsListFragmentBinding.setupObservers(activity: FragmentActivity) {
-        viewModel.uiSourceUpdated.observe(viewLifecycleOwner) {
+        viewModel.uiSourceRemoved.observe(viewLifecycleOwner) {
+            viewModel.uiModel.removeObservers(viewLifecycleOwner)
+            viewModel.navigationTarget.removeObservers(viewLifecycleOwner)
+            viewModel.listSelected.removeObservers(viewLifecycleOwner)
+            viewModel.scrollToNewCard.removeObservers(viewLifecycleOwner)
+        }
+
+        viewModel.uiSourceAdded.observe(viewLifecycleOwner) {
             observeUiChanges(activity)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -238,8 +238,8 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     }
 
     private fun StatsListFragmentBinding.setupObservers(activity: FragmentActivity) {
-        viewModel.uiModel.observe(viewLifecycleOwner) {
-            showUiModel(it)
+        viewModel.uiSourceUpdated.observe(viewLifecycleOwner) {
+            observeUiChanges(activity)
         }
 
         viewModel.dateSelectorData.observe(viewLifecycleOwner) { dateSelectorUiModel ->
@@ -251,18 +251,10 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             }
         }
 
-        viewModel.navigationTarget.observeEvent(viewLifecycleOwner) { target ->
-            navigator.navigate(activity, target)
-        }
-
         viewModel.selectedDate?.observe(viewLifecycleOwner) { event ->
             if (event != null) {
                 viewModel.onDateChanged(event.selectedGranularity)
             }
-        }
-
-        viewModel.listSelected.observe(viewLifecycleOwner) {
-            viewModel.onListSelected()
         }
 
         viewModel.typesChanged.observeEvent(viewLifecycleOwner) {
@@ -274,6 +266,16 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 recyclerView.smoothScrollToPosition(adapter.positionOf(statsType))
             }
         }
+    }
+
+    private fun StatsListFragmentBinding.observeUiChanges(activity: FragmentActivity) {
+        viewModel.uiModel.observe(viewLifecycleOwner) {
+            showUiModel(it)
+        }
+
+        viewModel.navigationTarget.observeEvent(viewLifecycleOwner) { target -> navigator.navigate(activity, target) }
+
+        viewModel.listSelected.observe(viewLifecycleOwner) { viewModel.onListSelected() }
 
         viewModel.scrollToNewCard.observeEvent(viewLifecycleOwner) {
             (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
@@ -334,6 +336,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         val layoutManager = recyclerView.layoutManager
         val recyclerViewState = layoutManager?.onSaveInstanceState()
         adapter.update(statsState)
+        recyclerView.scrollToPosition(0)
         layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -11,8 +11,10 @@ import kotlinx.coroutines.delay
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
+import org.wordpress.android.fluxc.store.StatsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.DAY_STATS_USE_CASE
+import org.wordpress.android.ui.stats.refresh.GRANULAR_USE_CASE_FACTORIES
 import org.wordpress.android.ui.stats.refresh.INSIGHTS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.MONTH_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.NavigationTarget
@@ -25,9 +27,12 @@ import org.wordpress.android.ui.stats.refresh.TRAFFIC_USE_CASE
 import org.wordpress.android.ui.stats.refresh.VIEWS_AND_VISITORS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.WEEK_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.YEAR_STATS_USE_CASE
+import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase
+import org.wordpress.android.ui.stats.refresh.lists.sections.granular.GranularUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.ActionCardHandler
 import org.wordpress.android.ui.stats.refresh.utils.ItemPopupMenuHandler
 import org.wordpress.android.ui.stats.refresh.utils.NewsCardHandler
+import org.wordpress.android.ui.stats.refresh.utils.SelectedTrafficGranularityManager
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.mapNullable
@@ -36,6 +41,7 @@ import org.wordpress.android.util.mergeNotNull
 import org.wordpress.android.util.throttle
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
+import org.wordpress.android.viewmodel.SingleLiveEvent
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -71,15 +77,14 @@ abstract class StatsListViewModel(
     val selectedDate = dateSelector?.selectedDate
 
     private val mutableNavigationTarget = MutableLiveData<Event<NavigationTarget>>()
-    val navigationTarget: LiveData<Event<NavigationTarget>> = mergeNotNull(
-        statsUseCase.navigationTarget, mutableNavigationTarget
-    )
+    lateinit var navigationTarget: LiveData<Event<NavigationTarget>>
 
-    val listSelected = statsUseCase.listSelected
+    lateinit var listSelected: LiveData<Unit?>
 
-    val uiModel: LiveData<UiModel?> by lazy {
-        statsUseCase.data.throttle(viewModelScope, distinct = true)
-    }
+    private val mutableUiSourceUpdated = SingleLiveEvent<Unit?>()
+    val uiSourceUpdated: LiveData<Unit?> = mutableUiSourceUpdated
+
+    lateinit var uiModel: LiveData<UiModel?>
 
     val dateSelectorData: LiveData<DateSelectorUiModel> = dateSelector?.dateSelectorData?.mapNullable {
         it ?: DateSelectorUiModel(false)
@@ -93,7 +98,7 @@ abstract class StatsListViewModel(
 
     val scrollTo = newsCardHandler?.scrollTo
 
-    val scrollToNewCard = statsUseCase.scrollTo
+    lateinit var scrollToNewCard: LiveData<Event<StatsStore.StatsType>>
 
     override fun onCleared() {
         statsUseCase.onCleared()
@@ -150,12 +155,21 @@ abstract class StatsListViewModel(
     fun start() {
         if (!isInitialized) {
             isInitialized = true
+            setUiLiveData()
             launch {
                 statsUseCase.loadData()
                 dateSelector?.updateDateSelector()
             }
         }
         dateSelector?.updateDateSelector()
+    }
+
+    protected fun setUiLiveData() {
+        uiModel = statsUseCase.data.throttle(viewModelScope, distinct = true)
+        listSelected = statsUseCase.listSelected
+        navigationTarget = mergeNotNull(statsUseCase.navigationTarget, mutableNavigationTarget)
+        scrollToNewCard = statsUseCase.scrollTo
+        mutableUiSourceUpdated.call()
     }
 
     sealed class UiModel {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/SelectedDateProvider.kt
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.stats.refresh.utils.trackWithGranularity
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.extensions.getParcelableCompat
 import org.wordpress.android.util.extensions.readListCompat
-import org.wordpress.android.util.filter
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,9 +37,7 @@ class SelectedDateProvider
 
     private val selectedDateChanged = MutableLiveData<GranularityChange?>()
 
-    fun granularSelectedDateChanged(statsGranularity: StatsGranularity): LiveData<GranularityChange?> {
-        return selectedDateChanged.filter { it?.selectedGranularity == statsGranularity }
-    }
+    fun granularSelectedDateChanged(): LiveData<GranularityChange?> = selectedDateChanged
 
     fun selectDate(date: Date, statsGranularity: StatsGranularity) {
         val selectedDate = getSelectedDateState(statsGranularity)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -15,7 +15,7 @@ constructor(
     private val selectedDateProvider: SelectedDateProvider,
     private val statsDateFormatter: StatsDateFormatter,
     private val siteProvider: StatsSiteProvider,
-    private val statsGranularity: StatsGranularity,
+    var statsGranularity: StatsGranularity,
     private val isGranularitySpinnerVisible: Boolean,
     private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -22,10 +22,11 @@ constructor(
     private val _dateSelectorUiModel = MutableLiveData<DateSelectorUiModel>()
     val dateSelectorData: LiveData<DateSelectorUiModel> = _dateSelectorUiModel
 
-    val selectedDate = selectedDateProvider.granularSelectedDateChanged(statsGranularity)
-        .perform {
+    var selectedDate = selectedDateProvider.granularSelectedDateChanged().perform {
+        if (statsGranularity == it?.selectedGranularity) {
             updateDateSelector()
         }
+    }
 
     fun start(startDate: SelectedDate) {
         selectedDateProvider.updateSelectedDate(startDate, statsGranularity)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
@@ -44,7 +44,7 @@ class StatsDateSelectorTest : BaseUnitTest() {
     @Before
     fun setUp() {
         dateProviderSelectedDate.value = GranularityChange(statsGranularity)
-        whenever(selectedDateProvider.granularSelectedDateChanged(statsGranularity))
+        whenever(selectedDateProvider.granularSelectedDateChanged())
             .thenReturn(dateProviderSelectedDate)
 
         dateSelector = StatsDateSelector(


### PR DESCRIPTION
Fixes #19952 

This PR handles everything related to the new Traffic tab and the granularity spinner.

-----

## To Test:
Enable `stats_traffic_tab` flag
1. Log in.
2. Navigate to Stats.
3. Check the TRAFFIC and INSIGHTS tabs and all the detail screens on the stats. Compare the data from the web.
4. Change the granularity spinner and selected date to different values. Compare the data from the web.
5. Pull to refresh on all screens. Verify the data is still accurate. (If you want to go deep in testing, change the data by increasing the comment, like, view counts manually before updating)

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - All screens on stats

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually

8. What automated tests I added (or what prevented me from doing so)

    - Updated StatsDateSelector

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
