### PR TITLE
[Lib] Update Tracks from 3.3 to 3.4 and update sentry gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
-    automatticTracksVersion = '3.3.0'
+    automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.112.0'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = '2.64.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.googleServicesVersion = '4.3.15'
     gradle.ext.navigationVersion = '2.5.3'
-    gradle.ext.sentryVersion = '3.5.0'
+    gradle.ext.sentryVersion = '3.14.0'
     gradle.ext.daggerVersion = "2.46.1"
     gradle.ext.detektVersion = '1.23.0'
     gradle.ext.violationCommentsVersion = '1.67'


### PR DESCRIPTION
Fixes #19980 

-----

This PR updates two related sentry things. First tracks was updated here: https://github.com/Automattic/Automattic-Tracks-Android/pull/195. This is necessary for the upcoming Android targetSdk update. Additionally the sentry gradle sdk also [updated here](https://github.com/getsentry/sentry-android-gradle-plugin/releases/tag/3.14.0). This simply ensures the sentry gradle plugin is aligned with the android sdk version.

## To Test:

You'll need to edit code, so build manually. I used `EditPostActivity` and added the following code in `onCreate`:

```
        try {
            throw new Exception("This is a test.");
        } catch (Exception e) {
            final Map<String, String> tags = new HashMap<>();
            tags.put("tag", T.MAIN.name());
            mCrashLogging.sendReport(e, tags, "THIS IS A TEST ANDROID 14");
        }
```

Feel free to change the exception string so it's more unique to your test.

- [ ] Ideally test with an Android 14 device.
- [ ] Before building change the variant from debug to release. Necessary for Sentry to work.
- [ ] Fire off the crash however you decide.
- [ ] Check Sentry and find the exception. Should reflect fairly quickly.

-----

## Regression Notes

1. Potential unintended areas of impact

    n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
