### PR TITLE
[Reader IA] Refresh blogs count after subscribing/unsubscribing from search screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -184,8 +184,11 @@ public class ReaderActivityLauncher {
     }
 
     public static void showReaderSearch(Context context) {
-        Intent intent = new Intent(context, ReaderSearchActivity.class);
-        context.startActivity(intent);
+        context.startActivity(createReaderSearchIntent(context));
+    }
+
+    public static Intent createReaderSearchIntent(@NonNull final Context context) {
+        return new Intent(context, ReaderSearchActivity.class);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -1,7 +1,13 @@
 package org.wordpress.android.ui.reader
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -67,6 +73,8 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
 
     private var binding: ReaderFragmentLayoutBinding? = null
 
+    private var readerSearchResultLauncher: ActivityResultLauncher<Intent>? = null
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding = ReaderFragmentLayoutBinding.bind(view).apply {
             initTopAppBar()
@@ -87,6 +95,28 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     override fun onPause() {
         super.onPause()
         activity?.let { viewModel.onScreenInBackground(it.isChangingConfigurations) }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        initReaderSearchActivityResultLauncher()
+    }
+
+    private fun initReaderSearchActivityResultLauncher() {
+        readerSearchResultLauncher = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val data = result.data
+                if (data != null) {
+                    val shouldRefreshSubscriptions =
+                        data.getBooleanExtra(ReaderSearchActivity.RESULT_SHOULD_REFRESH_SUBSCRIPTIONS, false)
+                    if (shouldRefreshSubscriptions) {
+                        getSubFilterViewModel()?.loadSubFilters()
+                    }
+                }
+            }
+        }
     }
 
     private fun ReaderFragmentLayoutBinding.initTopAppBar() {
@@ -125,7 +155,10 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         }
 
         viewModel.showSearch.observeEvent(viewLifecycleOwner) {
-            ReaderActivityLauncher.showReaderSearch(context)
+            context?.let {
+                val intent = ReaderActivityLauncher.createReaderSearchIntent(it)
+                readerSearchResultLauncher?.launch(intent)
+            }
         }
 
         viewModel.showReaderInterests.observeEvent(viewLifecycleOwner) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -28,7 +28,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
-import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -28,6 +28,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
@@ -1261,7 +1262,10 @@ public class ReaderPostListFragment extends ViewPagerFragment
             }
 
             @Override
-            public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
+            public boolean onMenuItemActionCollapse(@NonNull final MenuItem item) {
+                if (getActivity() instanceof ReaderSearchActivity) {
+                    ((ReaderSearchActivity) requireActivity()).finishWithRefreshSubscriptionsResult();
+                }
                 requireActivity().finish();
                 return false;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSearchActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader
 
+import android.content.Intent
 import android.os.Bundle
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
@@ -45,5 +46,16 @@ class ReaderSearchActivity : LocaleAwareActivity() {
     override fun onPause() {
         super.onPause()
         readerTracker.stop(MAIN_READER)
+    }
+
+    fun finishWithRefreshSubscriptionsResult() {
+        val data = Intent()
+        data.putExtra(ReaderSubsActivity.RESULT_SHOULD_REFRESH_SUBSCRIPTIONS, true)
+        setResult(RESULT_OK, data)
+        finish()
+    }
+
+    companion object {
+        const val RESULT_SHOULD_REFRESH_SUBSCRIPTIONS = "should_refresh_subscriptions"
     }
 }


### PR DESCRIPTION
Fixes #20011 

-----

## To Test:

1. Install Jetpack and sign-in;
2. Open Reader;
3. Open Search;
4. Search for a blog;
5. Subscribe to it;
6. Return to the Reader feed: the blogs count should be correct;
7. Repeat steps 3-6 but this time unsubscribe from a blog.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
