### PR TITLE
Fix sharing image regression and add support for heic and heif files

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -116,7 +117,11 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
     }
 
     private boolean isAllowedMediaType(@NonNull Uri uri) {
-        String filePath = uri.getPath();
+        String filePath = MediaUtils.getRealPathFromURI(this, uri);
+        // For cases when getRealPathFromURI returns an empty string
+        if (TextUtils.isEmpty(filePath)) {
+            filePath = String.valueOf(uri);
+        }
         return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -112,7 +112,8 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
                 }
             }
         } catch (Exception e) {
-            ToastUtils.showToast(this, R.string.error_media_could_not_share_media_from_device, ToastUtils.Duration.LONG);
+            ToastUtils.showToast(this,
+                    R.string.error_media_could_not_share_media_from_device, ToastUtils.Duration.LONG);
             AppLog.e(T.MEDIA, "ShareIntentReceiver failed to download media ", e);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -112,6 +112,7 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
                 }
             }
         } catch (Exception e) {
+            ToastUtils.showToast(this, R.string.error_media_load, ToastUtils.Duration.LONG);
             AppLog.e(T.MEDIA, "ShareIntentReceiver failed to download media ", e);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -111,7 +111,7 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
                 }
             }
         } catch (Exception e) {
-            AppLog.e(T.MEDIA, "ShareIntentReceiver failed ", e);
+            AppLog.e(T.MEDIA, "ShareIntentReceiver failed to download media ", e);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -112,7 +112,7 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
                 }
             }
         } catch (Exception e) {
-            ToastUtils.showToast(this, R.string.error_media_load, ToastUtils.Duration.LONG);
+            ToastUtils.showToast(this, R.string.error_media_could_not_share_media_from_device, ToastUtils.Duration.LONG);
             AppLog.e(T.MEDIA, "ShareIntentReceiver failed to download media ", e);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -111,6 +112,10 @@ public class ShareIntentReceiverActivity extends LocaleAwareActivity implements 
 
     private boolean isAllowedMediaType(@NonNull Uri uri) {
         String filePath = MediaUtils.getRealPathFromURI(this, uri);
+        // For cases when the uri is already the file path
+        if (TextUtils.isEmpty(filePath)) {
+            filePath = String.valueOf(uri);
+        }
         return MediaUtils.isValidImage(filePath) || MediaUtils.isVideo(filePath);
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2006,7 +2006,8 @@
     <string name="error_media_file_type_not_allowed">This file type is not allowed</string>
     <string name="error_media_unexpected_empty_media_file_path">Unexpected empty file path for Media</string>
     <string name="error_media_could_not_find_media_in_path">Could not find media file in path</string>
-    <string name="error_media_could_not_share_media_from_device">Unable to load the media for sharing. Please check the app\'s permissions or use the app\'s media library.</string>
+    <string name="error_media_could_not_share_media_from_device">Unable to load the media for sharing. Please check the app\'s permissions
+        or use the app\'s media library.</string>
     <string name="error_media_path_is_directory">The specified path is a directory instead of a Media file</string>
     <string name="error_media_upload_failed_for_reason">Media upload failed.\n%1$s</string>
     <string name="error_media_xmlrpc_not_allowed">Your action is not allowed</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2006,6 +2006,7 @@
     <string name="error_media_file_type_not_allowed">This file type is not allowed</string>
     <string name="error_media_unexpected_empty_media_file_path">Unexpected empty file path for Media</string>
     <string name="error_media_could_not_find_media_in_path">Could not find media file in path</string>
+    <string name="error_media_could_not_share_media_from_device">Unable to load the media for sharing. Please check the app\'s permissions or use the app\'s media library.</string>
     <string name="error_media_path_is_directory">The specified path is a directory instead of a Media file</string>
     <string name="error_media_upload_failed_for_reason">Media upload failed.\n%1$s</string>
     <string name="error_media_xmlrpc_not_allowed">Your action is not allowed</string>

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     wordPressFluxCVersion = '2.64.0'
     wordPressLoginVersion = '1.12.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.12.0'
+    wordPressUtilsVersion = '142-c0c7e4a342fb7ffd625fc8962d129293302d9731'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     wordPressFluxCVersion = '2.64.0'
     wordPressLoginVersion = '1.12.0'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '142-c0c7e4a342fb7ffd625fc8962d129293302d9731'
+    wordPressUtilsVersion = '3.13.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/142

Fixes an issue where some shared images into the app aren't being loaded in a post/media library correctly.

To address this problem, it adds a fallback when `getRealPathFromURI` returns an empty string, where it will return the original `uri` to the media type validation functions.

It also includes a change in [WordPress Utils](https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/142) where it adds the `heic` and `heif` formats.

I've also created this https://github.com/wordpress-mobile/WordPress-Android/issues/20140 where it captures an issue where in some cases it's not possible to share an image to the app due to permissions denial. To prevent a crash, a try/catch has been added until that issue is solved.

-----

## To Test:

## Share an image from an image editing app
- Open an image editing app like Lightroom
- Edit an image and share it to the Jetpack app
- Tap on `Add to new post`
- Expect the editor to be opened and the image to be loaded

## Share an image from a browser
- Open a web browser
- Go to any website and long-press on an image
- Share the image to the Jetpack app
- Tap on `Add to new post`
- Expect the editor to be opened and the image to be loaded

## Share an image from the Photos app
- Open the Photos app
- Select an image or images
- Share the image(s) to the Jetpack app
- Tap on `Add to new post`
- Expect the editor to be opened and the image(s) to be loaded

## Share an image from a Files Explorer app
- Open the Files Explorer app
- Select an image or images
- Share the image(s) to the Jetpack app
- Tap on `Add to new post`
- Expect the editor to be opened and the image(s) to be loaded

## Share a HEIC image
- Open the Gallery/Files app
- Select a `heic` image 
- Share the image to the Jetpack app
- Tap on `Add to new post`
- Expect the editor to be opened and the image to be loaded

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A, it should only affect sharing media through intents.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A, relied on manual testing.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
