### PR TITLE
Prevents TransactionTooLargeException error in WebViewActivity

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] [Jetpack-only] Site Monitoring: Add Metrics, PHP Logs, and Web Server Logs under Site Monitoring [https://github.com/wordpress-mobile/WordPress-Android/issues/20067]
 * [**] Prevent images from temporarily disappearing when uploading media [https://github.com/WordPress/gutenberg/pull/57869]
 * [***] [Jetpack-only] Reader: introduced new UI/UX for content navigation and filtering [https://github.com/wordpress-mobile/WordPress-Android/pull/19978]
+* [**] Prevents crashes when the webview state is too big [https://github.com/wordpress-mobile/WordPress-Android/pull/20139]
 
 24.1
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -100,9 +100,13 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
         if (webViewState != null && webViewState.length > WEBVIEW_CHROMIUM_STATE_THRESHOLD) {
             outState.remove(WEBVIEW_CHROMIUM_STATE);
 
+            // Save the URL so it can be restored later
+            String url = mWebView.getUrl();
+            outState.putString(URL, url);
+
             // Track the error to better understand the root of the issue
             Map<String, String> properties = new HashMap<>();
-            properties.put(URL, mWebView.getUrl());
+            properties.put(URL, url);
             AnalyticsTracker.track(AnalyticsTracker.Stat.WEBVIEW_TOO_LARGE_PAYLOAD_ERROR, properties);
         }
         super.onSaveInstanceState(outState);
@@ -114,7 +118,14 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
     @Override
     protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
-        mWebView.restoreState(savedInstanceState);
+        if (savedInstanceState.containsKey(WEBVIEW_CHROMIUM_STATE)) {
+            mWebView.restoreState(savedInstanceState);
+        } else {
+            String url = savedInstanceState.getString(URL);
+            if (url != null) {
+                mWebView.loadUrl(url);
+            }
+        }
     }
 
     @Override

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1106,7 +1106,8 @@ public final class AnalyticsTracker {
         SITE_MONITORING_SCREEN_SHOWN,
         OPENED_SITE_MONITORING,
         SITE_MONITORING_TAB_SHOWN,
-        SITE_MONITORING_TAB_LOADING_ERROR
+        SITE_MONITORING_TAB_LOADING_ERROR,
+        WEBVIEW_TOO_LARGE_PAYLOAD_ERROR,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -2707,6 +2707,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "site_monitoring_tab_shown";
             case SITE_MONITORING_TAB_LOADING_ERROR:
                 return "site_monitoring_tab_loading_error";
+            case WEBVIEW_TOO_LARGE_PAYLOAD_ERROR:
+                return "webview_too_large_payload_error";
         }
         return null;
     }


### PR DESCRIPTION
Fixes #9685

## Description
This PR targets the third common `TransactionTooLargeException` crash occurring when the `WebView` state is too big (the other two were cover by https://github.com/wordpress-mobile/WordPress-Android/pull/19747 and https://github.com/wordpress-mobile/WordPress-Android/pull/20046).
In this case the crash stack trace is like the following indicating a huge `WEBVIEW_CHROMIUM_STATE`:
```
android.os.TransactionTooLargeException: data parcel size 555708 bytes
    at android.os.BinderProxy.transactNative(BinderProxy.java)
    at android.os.BinderProxy.transact(BinderProxy.java:662)
    at android.app.IActivityClientController$Stub$Proxy.activityStopped(IActivityClientController.java:1507)
    at android.app.ActivityClient.activityStopped(ActivityClient.java:100)
    at android.app.servertransaction.PendingTransactionActions$StopInfo.run(PendingTransactionActions.java:135)
    at android.os.Handler.handleCallback(Handler.java:958)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:230)
    at android.os.Looper.loop(Looper.java:319)
    at android.app.ActivityThread.main(ActivityThread.java:8913)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
java.lang.RuntimeException: android.os.TransactionTooLargeException: data parcel size 555708 bytes
Bundle stats:
  android:viewHierarchyState [size=3228]
    android:views [size=3124]
  androidx.lifecycle.BundlableSavedStateRegistry.key [size=1056]
  WEBVIEW_CHROMIUM_STATE [size=550620]
PersistableBundle stats:
  [null]
    at android.app.servertransaction.PendingTransactionActions$StopInfo.run(PendingTransactionActions.java:146)
    at android.os.Handler.handleCallback(Handler.java:958)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:230)
    at android.os.Looper.loop(Looper.java:319)
    at android.app.ActivityThread.main(ActivityThread.java:8913)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
``` 

Two approaches have been tested (see https://github.com/wordpress-mobile/WordPress-Android/issues/9685#issuecomment-1924410092) and the hacky alternative was considered safer since it is applied only when the app is about to crash. Due to the wide usage of this part of the code affecting the `SSLCertsViewActivity`, the `WPWebViewActivity` which is used across the app and also extended by:`DomainRegistrationCheckoutWebViewActivity`, `DomainManagementDetailsActivity`, `ThemeWebActivity`, `SupportWebViewActivity` and `JetpackConnectionWebViewActivity` a more radical change might have unpredicted impact.
A new track event was also added to analyse the cases when the crash occurs, so that we can iterate with a more targeted fix if this is feasible.

The fix involves removing the `WEBVIEW_CHROMIUM_STATE` from the saved Bundle when it exceeds a certain threshold (300KB). When the state is removed the url is reloaded on restore.

Note that the behaviour of the `saveState` method has changed since this part of the code was introduced 9 years ago and [the method no longer stores the display data for the WebView](https://developer.android.com/reference/android/webkit/WebView#saveState(android.os.Bundle)) but just the browsing history. The same approach is also used [in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:android_webview/tools/system_webview_shell/apk/src/org/chromium/webview_shell/WebViewBrowserFragment.java;l=282).

-----

## To Test:
* **Verify** that the behaviour did not change for usual webview loading. You can use the site preview in the My site screen for this.
* Since reproducing the crash is not easy set the threshold to a small value (e.g. with this patch [webview.patch](https://github.com/wordpress-mobile/WordPress-Android/files/14196078/webview.patch)) and:
1. Open a WebView (the site preview in the My site screen)
2. Rotate the device
3. **Verify** that the page reloads
4. **Verify** that an event `webview_too_large_payload_error, Properties: {"url":...}` is tracked

-----


## Regression Notes

1. Potential unintended areas of impact

    - Almost all WebViews

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

6. What automated tests I added (or what prevented me from doing so)

    - None due to the structure of the code

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)