### PR TITLE
[Reader] Fix UninitializedPropertyAccessException in ReaderFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -168,7 +168,9 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        viewModel.onSaveInstanceState(outState)
+        if (::viewModel.isInitialized) {
+            viewModel.onSaveInstanceState(outState)
+        }
     }
 
     private fun updateUiState(uiState: ReaderViewModel.ReaderUiState) {


### PR DESCRIPTION
Fixes #20142 

-----

## To Test:
I couldn't reproduce this crash. The `ViewModel` is initialized when `ReaderFragment#onViewCreated` is called. The crash log tells us that `ReaderFragment#onSaveInstanceState` was called before `ReaderFragment#onViewCreated`, since `ViewModel` was not initialized.

There wasn't a single time where I was able to make `onSaveInstanceState` be called **before** `onViewCreated`:
```
com.jetpack.android.prealpha         E  RL-> ReaderFragment initViewModel
com.jetpack.android.prealpha         E  RL-> WPMainActivity onSaveInstanceState
com.jetpack.android.prealpha         E  RL-> ReaderFragment onSaveInstanceState
```

`onSaveInstanceState` is called after `onStop` in recent versions and might be called before or after (no guarantees on order) `onPause` in older versions. This means for this crash to happen, the `Activity` should've been stopped **before** `onViewCreated` is called.

For now I've added a check to see if the `ViewModel` property was initialized before using it to avoid the crash.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None
    - 
2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --
    - 
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
