### PR TITLE
[Reader][Crash] Fix Subfilter sheet crash when restoring instance

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -640,7 +640,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                         BottomSheetVisible visibleState = (BottomSheetVisible) uiState;
                         bottomSheet = SubfilterBottomSheetFragment.newInstance(
                                 SubFilterViewModel.getViewModelKeyForTag(mTagFragmentStartedWith),
-                                visibleState.getCategories(),
+                                visibleState.getCategory(),
                                 mUiHelpers.getTextOfUiString(requireContext(), visibleState.getTitle())
                         );
                         bottomSheet.show(getChildFragmentManager(), SUBFILTER_BOTTOM_SHEET_TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -66,9 +66,14 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
-        val bottomSheetTitle = requireArguments().getCharSequence(SUBFILTER_TITLE_KEY)!!
-        val category = requireArguments().getSerializableCompat<SubfilterCategory>(SUBFILTER_CATEGORY_KEY)!!
+        val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)
+        val bottomSheetTitle = requireArguments().getCharSequence(SUBFILTER_TITLE_KEY)
+        val category = requireArguments().getSerializableCompat<SubfilterCategory>(SUBFILTER_CATEGORY_KEY)
+
+        if (subfilterVmKey == null || category == null || bottomSheetTitle == null) {
+            dismiss()
+            return
+        }
 
         viewModel = ViewModelProvider(
             parentFragment as ViewModelStoreOwner,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.SITES
 import org.wordpress.android.ui.reader.subfilter.SubfilterCategory.TAGS
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Tag
 import org.wordpress.android.ui.reader.subfilter.SubfilterPagerAdapter
-import org.wordpress.android.util.extensions.getParcelableArrayListCompat
+import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
 import com.google.android.material.R as MaterialR
 
@@ -36,19 +36,19 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
     companion object {
         const val SUBFILTER_VIEW_MODEL_KEY = "subfilter_view_model_key"
         const val SUBFILTER_TITLE_KEY = "subfilter_title_key"
-        const val SUBFILTER_CATEGORIES_KEY = "subfilter_categories_key"
+        const val SUBFILTER_CATEGORY_KEY = "subfilter_category_key"
 
         @JvmStatic
         fun newInstance(
             subfilterViewModelKey: String,
-            categories: List<SubfilterCategory>,
+            category: SubfilterCategory,
             title: CharSequence
         ): SubfilterBottomSheetFragment {
             val fragment = SubfilterBottomSheetFragment()
             val bundle = Bundle()
             bundle.putString(SUBFILTER_VIEW_MODEL_KEY, subfilterViewModelKey)
             bundle.putCharSequence(SUBFILTER_TITLE_KEY, title)
-            bundle.putParcelableArrayList(SUBFILTER_CATEGORIES_KEY, ArrayList(categories))
+            bundle.putSerializable(SUBFILTER_CATEGORY_KEY, category)
 
             fragment.arguments = bundle
             return fragment
@@ -68,9 +68,7 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
 
         val subfilterVmKey = requireArguments().getString(SUBFILTER_VIEW_MODEL_KEY)!!
         val bottomSheetTitle = requireArguments().getCharSequence(SUBFILTER_TITLE_KEY)!!
-        val categories = requireNotNull(
-            requireArguments().getParcelableArrayListCompat<SubfilterCategory>(SUBFILTER_CATEGORIES_KEY)
-        )
+        val category = requireArguments().getSerializableCompat<SubfilterCategory>(SUBFILTER_CATEGORY_KEY)!!
 
         viewModel = ViewModelProvider(
             parentFragment as ViewModelStoreOwner,
@@ -87,7 +85,7 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
             requireActivity(),
             childFragmentManager,
             subfilterVmKey,
-            categories.toList()
+            listOf(category)
         )
         pager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
             override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
@@ -110,7 +108,6 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
         }
 
         editSubscriptions.setOnClickListener {
-            val category = categories.firstOrNull() ?: return@setOnClickListener
             val subsPageIndex = when (category) {
                 SITES -> ReaderSubsActivity.TAB_IDX_FOLLOWED_BLOGS
                 TAGS -> ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/BottomSheetUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/BottomSheetUiState.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.ui.utils.UiString
 sealed class BottomSheetUiState(val isVisible: Boolean) {
     data class BottomSheetVisible(
         val title: UiString,
-        val categories: List<SubfilterCategory>
+        val category: SubfilterCategory
     ) : BottomSheetUiState(true)
 
     object BottomSheetHidden : BottomSheetUiState(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -234,7 +234,7 @@ class SubFilterViewModel @Inject constructor(
         _bottomSheetUiState.value = Event(
             BottomSheetVisible(
                 UiStringRes(category.titleRes),
-                listOf(category) // TODO thomashortadev this should accept only a single category
+                category
             )
         )
         val source = when(category) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -104,7 +104,7 @@ class SubfilterPageFragment : Fragment() {
         subFilterViewModel = ViewModelProvider(
             requireParentFragment().parentFragment as ViewModelStoreOwner,
             viewModelFactory
-        ).get(subfilterVmKey, SubFilterViewModel::class.java)
+        )[subfilterVmKey, SubFilterViewModel::class.java]
 
         subFilterViewModel.subFilters.observe(viewLifecycleOwner) {
             (recyclerView.adapter as? SubfilterListAdapter)?.let { adapter ->
@@ -184,7 +184,7 @@ class SubfilterPageFragment : Fragment() {
 class SubfilterPagerAdapter(
     val context: Context,
     val fm: FragmentManager,
-    val subfilterViewModelKey: String,
+    private val subfilterViewModelKey: String,
     categories: List<SubfilterCategory>
 ) : FragmentPagerAdapter(fm) {
     private val filterCategory = categories
@@ -198,7 +198,7 @@ class SubfilterPagerAdapter(
         return fragment
     }
 
-    override fun getPageTitle(position: Int): CharSequence? {
+    override fun getPageTitle(position: Int): CharSequence {
         return context.getString(filterCategory[position].titleRes)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubfilterPageFragment.kt
@@ -4,9 +4,6 @@ package org.wordpress.android.ui.reader.subfilter
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcel
-import android.os.Parcelable
-import android.os.Parcelable.Creator
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -215,25 +212,7 @@ class SubfilterPagerAdapter(
     }
 }
 
-enum class SubfilterCategory(@StringRes val titleRes: Int, val type: ItemType) : Parcelable {
+enum class SubfilterCategory(@StringRes val titleRes: Int, val type: ItemType) {
     SITES(R.string.reader_filter_by_blog_title, SITE),
     TAGS(R.string.reader_filter_by_tag_title, TAG);
-
-    override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeInt(type.ordinal)
-    }
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    companion object CREATOR : Creator<SubfilterCategory> {
-        override fun createFromParcel(parcel: Parcel): SubfilterCategory {
-            return values()[parcel.readInt()]
-        }
-
-        override fun newArray(size: Int): Array<SubfilterCategory?> {
-            return arrayOfNulls(size)
-        }
-    }
 }


### PR DESCRIPTION
Fixes #20148 

### Original Crash (from #20148)
_Note:_ I was not able to reproduce the exact same crash reported in the parent issue, but from the logs it looks like the crash happened when the system was trying to recreate the app when it was in a state of showing the Subfilter bottom sheet.

The original crash doesn't make much sense though as the variable it complains of being `null` is always set correctly in the `arguments` bundle from our code and when getting the arguments bundle for process recreation, the system is the one responsible for storing and retrieving the `arguments` bundle, so it feels like the system somehow deleted those arguments, leading to the crash.

Just to make sure we avoid this unlike crash anyway I added some safeguards to simply dismiss the dialog when recreating the app if any of the required arguments is `null`, which will make the app open normally but simply with the filter sheet closed.

I was only able to test this by forcing the removal of one or more arguments via code, after reading them inside `SubfilterBottomSheetFragment#onViewCreated`, so I could test the crash and solution.

### Another crash in the same "system restore" scenario

I was, however, able to reproduce a crash on the same scenario, but caused a bit further down the code path, when the ` SubfilterBottomSheetFragment` tries retrieving the `SubfilterCategory` list but crashes because our Parccelable implementation of that `enum` was not working as expected.

Stack trace:
```
AndroidRuntime: java.lang.ArrayIndexOutOfBoundsException: length=2; index=2
AndroidRuntime: 	at org.wordpress.android.ui.reader.subfilter.SubfilterCategory$CREATOR.createFromParcel(SubfilterPageFragment.kt:232)
AndroidRuntime: 	at org.wordpress.android.ui.reader.subfilter.SubfilterCategory$CREATOR.createFromParcel(SubfilterPageFragment.kt:230)
AndroidRuntime: 	at android.os.Parcel.readParcelableInternal(Parcel.java:4870)
AndroidRuntime: 	at android.os.Parcel.readValue(Parcel.java:4621)
AndroidRuntime: 	at android.os.Parcel.readValue(Parcel.java:4390)
AndroidRuntime: 	at android.os.Parcel.readListInternal(Parcel.java:5399)
AndroidRuntime: 	at android.os.Parcel.readArrayListInternal(Parcel.java:5418)
AndroidRuntime: 	at android.os.Parcel.readValue(Parcel.java:4651)
AndroidRuntime: 	at android.os.Parcel.readValue(Parcel.java:4390)
AndroidRuntime: 	at android.os.Parcel.-$$Nest$mreadValue(Unknown Source:0)
AndroidRuntime: 	at android.os.Parcel$LazyValue.apply(Parcel.java:4488)
AndroidRuntime: 	at android.os.Parcel$LazyValue.apply(Parcel.java:4447)
AndroidRuntime: 	at android.os.BaseBundle.unwrapLazyValueFromMapLocked(BaseBundle.java:415)
AndroidRuntime: 	at android.os.BaseBundle.getValueAt(BaseBundle.java:401)
AndroidRuntime: 	at android.os.BaseBundle.getValue(BaseBundle.java:381)
AndroidRuntime: 	at android.os.BaseBundle.getValue(BaseBundle.java:364)
AndroidRuntime: 	at android.os.BaseBundle.getValue(BaseBundle.java:357)
AndroidRuntime: 	at android.os.Bundle.getParcelableArrayList(Bundle.java:1046)
AndroidRuntime: 	at androidx.core.os.BundleCompat.getParcelableArrayList(BundleCompat.java:152)
AndroidRuntime: 	at org.wordpress.android.ui.reader.SubfilterBottomSheetFragment.onViewCreated(SubfilterBottomSheetFragment.kt:155)
AndroidRuntime: 	at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3147)
AndroidRuntime: 	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:588)
AndroidRuntime: 	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:272)
AndroidRuntime: 	...
```

I am also fixing this crash in this PR, targeting to `release/24.2`, where we now only need 1 filter category anyway, so we can remove the `Parcelable` implementation of that enum and just Serialize the single enum instance for the `arguments` bundle, which gets rid of the crash.

-----

## To Test:

1. Enable "Don't keep activities" developer option in the system
2. Open and log into Jetpack
3. Open the Reader
4. Go to "Subscriptions"
5. Select either the blog or the tag subfilter (pill on the top bar)
6. With the Subfilter sheet open, send the app to the background
7. Open the app again from Recents
8. **Verify** the app does not crash

Running the steps above on a previous build should cause the app to crash because of the `SubfilterCategory` Parcelable issue mentioned above.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

10. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements to my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
