### PR TITLE
Super Fast Media: Show error message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityNavigator.kt
@@ -186,5 +186,19 @@ class ActivityNavigator @Inject constructor() {
             .addNextIntent(intent)
             .startActivities()
     }
-}
 
+    fun openMySiteWithMessageInNewStack(
+        context: Context,
+        message: Int
+    ) {
+        val taskStackBuilder = TaskStackBuilder.create(context)
+        val mainActivityIntent = getMainActivityInNewStack(context)
+        val intent = Intent(context, WPMainActivity::class.java)
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE, WPMainActivity.ARG_MY_SITE)
+        intent.putExtra(WPMainActivity.ARG_OPEN_PAGE_MESSAGE, message)
+        taskStackBuilder
+            .addNextIntent(mainActivityIntent)
+            .addNextIntent(intent)
+            .startActivities()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkNavigator.kt
@@ -97,6 +97,10 @@ class DeepLinkNavigator
                 navigateAction.site,
                 navigateAction.siteMonitorType
             )
+            is NavigateAction.OpenMySiteWithMessage -> activityNavigator.openMySiteWithMessageInNewStack(
+                activity,
+                navigateAction.message
+            )
         }
         if (navigateAction != LoginForResult) {
             activity.finish()
@@ -134,5 +138,6 @@ class DeepLinkNavigator
         object DomainManagement : NavigateAction()
         data class OpenSiteMonitoringForSite(val site: SiteModel?, val siteMonitorType: SiteMonitorType) :
             NavigateAction()
+        data class OpenMySiteWithMessage(val message: Int) : NavigateAction()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandler.kt
@@ -28,7 +28,7 @@ class QRCodeMediaLinkHandler @Inject constructor(
                 analyticsTrackerWrapper.track(AnalyticsTracker.Stat.DEEP_LINK_FAILED,
                     mapOf(ERROR to INVALID_SITE_ID,
                         CAMPAIGN to uri.getQueryParameter(CAMPAIGN)?.replace("-", "_")))
-                NavigateAction.OpenMySite
+                NavigateAction.OpenMySiteWithMessage(org.wordpress.android.R.string.qrcode_media_deeplink_error)
             }
             else -> {
                 NavigateAction.OpenMediaPickerForSite(siteModel)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4878,4 +4878,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="site_monitoring_tab_title_php_logs">PHP Logs</string>
     <string name="site_monitoring_tab_title_web_server_logs">Web Server Logs</string>
     <string name="site_monitoring_cannot_be_started">We cannot open site monitoring at the moment. Please try again later</string>
+
+    <!-- Super Fast Media Upload QRCodeMediaLink -->
+    <string name="qrcode_media_deeplink_error">Site not found. Check that you are logged into the correct account.</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/deeplinks/handlers/QRCodeMediaLinkHandlerTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.deeplinks.DeepLinkNavigator.NavigateAction
@@ -76,7 +77,7 @@ class QRCodeMediaLinkHandlerTest {
     }
 
     @Test
-    fun `given unrecognized siteId, when deep linked, then opens my site view`() {
+    fun `given unrecognized siteId, when deep linked, then opens my site view with message`() {
         val mediaUri = buildUri(host = "apps.wordpress.com",
             queryParams = mapOf("campaign" to "qr-code-media"),
             path = arrayOf("get"), )
@@ -85,7 +86,7 @@ class QRCodeMediaLinkHandlerTest {
 
         val navigateAction = qrCodeMediaLinkHandler.buildNavigateAction(mediaUri)
 
-        assertThat(navigateAction).isEqualTo(NavigateAction.OpenMySite)
+        assertThat(navigateAction).isEqualTo(NavigateAction.OpenMySiteWithMessage(R.string.qrcode_media_deeplink_error))
     }
 
     @Test


### PR DESCRIPTION
This PR incorporates a snackbar message to inform users of errors encountered when attempting to launch the site via the quick start media uploader QR code. This request came from feedback on the cFt. See p58i-gxT-p2#comment-61623

<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/cb7dcc61-a4cc-4de8-be4a-862961bd1c51">


-----

## To Test:
Note: The flow is only available to proxied Automatticians on simple sites or users that have beta jetpack blocks enabled.

**Test Error Message is shown**
- Uninstall any JP apps on your device
- Install this JP app from this PR and make sure it can open app links
- Log in with a non-a8c account
- Open a browser on your laptop and navigate to WP and login using your a8c account
- Create or edit a post
- Add any image or gallery block where you want to add an image from your phone.
- Select the Jetpack Mobile App option. From the Select Image dropdown.
- Scan the QR code with your device. Using the camera and click the url.
- ✅ Verify you land on the My Site tab and you see the error message as shown in the screenshot above
- Do not close the qr code dialog that is open on your laptop

**Test Normal Flow**
- On the device, logout of the non-a8c account and login with the a8c account (same one you are logged into on your laptop)
- Using your device camera, rescan the qr code
- ✅ Verify you land on the media upload area for the selected site and no error message is shown
- Select the image on your phone and upload the image(s).
- See the image(s) show up in the block.

-----

## Regression Notes
1. Potential unintended areas of impact
The error message is not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Update `QRCodeMediaLinkHandlerTest`

3. What automated tests I added (or what prevented me from doing so)
N/A
-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:
- [X] WordPress.com sites and self-hosted Jetpack sites.
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)