### PR TITLE
[Reader] Update follow tags logic in "Manage Tags & Blogs" screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -70,7 +70,7 @@ import javax.inject.Inject;
  * followed tags and followed blogs
  */
 public class ReaderSubsActivity extends LocaleAwareActivity
-        implements ReaderTagAdapter.TagDeletedListener {
+        implements ReaderTagAdapter.TagDeletedListener, ReaderTagAdapter.TagAddedListener {
     private EditText mEditAdd;
     private FloatingActionButton mFabButton;
     private ReaderFollowButton mBtnAdd;
@@ -496,6 +496,14 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagSlug())) {
             mLastAddedTagName = null;
         }
+    }
+
+    @Override public void onTagAdded(@NonNull ReaderTag readerTag) {
+        mReaderTracker.trackTag(
+                AnalyticsTracker.Stat.READER_TAG_FOLLOWED,
+                readerTag.getTagSlug(),
+                ReaderTracker.SOURCE_SETTINGS
+        );
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -497,8 +497,6 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagSlug())) {
             mLastAddedTagName = null;
         }
-        String labelRemovedTag = getString(R.string.reader_label_removed_tag);
-        showInfoSnackbar(String.format(labelRemovedTag, tag.getLabel()));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -176,8 +176,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         boolean shouldRefreshSubscriptions = false;
         if (mPageAdapter != null) {
             final ReaderTagFragment readerTagFragment = mPageAdapter.getReaderTagFragment();
-            final ReaderBlogFragment readerBlogFragment = mPageAdapter.getReaderBlogFragment();
-            if (readerTagFragment != null && readerBlogFragment != null) {
+            if (readerTagFragment != null) {
                 shouldRefreshSubscriptions = readerTagFragment.hasChangedSelectedTags();
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -49,10 +49,10 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
         for (final ReaderTag readerTag : mInitialReaderTagList) {
             initialTagsSlugs.add(readerTag.getTagSlug());
         }
-        final List<ReaderTag> currentReaderTagList = getTagAdapter().getItems();
+        final List<ReaderTag> currentlySubscribedReaderTagList = getTagAdapter().getSubscribedItems();
         final Set<String> currentTagsSlugs = new HashSet<>();
-        if (currentReaderTagList != null) {
-            for (final ReaderTag readerTag : currentReaderTagList) {
+        if (currentlySubscribedReaderTagList != null) {
+            for (final ReaderTag readerTag : currentlySubscribedReaderTagList) {
                 currentTagsSlugs.add(readerTag.getTagSlug());
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -25,7 +25,8 @@ import java.util.Set;
 /*
  * fragment hosted by ReaderSubsActivity which shows followed tags
  */
-public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagDeletedListener {
+public class ReaderTagFragment extends Fragment
+        implements ReaderTagAdapter.TagDeletedListener, ReaderTagAdapter.TagAddedListener {
     private ReaderRecyclerView mRecyclerView;
     private ReaderTagAdapter mTagAdapter;
 
@@ -103,6 +104,7 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
             Context context = WPActivityUtils.getThemedContext(getActivity());
             mTagAdapter = new ReaderTagAdapter(context);
             mTagAdapter.setTagDeletedListener(this);
+            mTagAdapter.setTagAddedListener(this);
             mTagAdapter.setDataLoadedListener(isEmpty -> {
                 checkEmptyView();
                 if (mIsFirstDataLoaded) {
@@ -131,6 +133,12 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
         // let the host activity know about the change
         if (getActivity() instanceof ReaderTagAdapter.TagDeletedListener) {
             ((ReaderTagAdapter.TagDeletedListener) getActivity()).onTagDeleted(tag);
+        }
+    }
+
+    @Override public void onTagAdded(@NonNull ReaderTag readerTag) {
+        if (getActivity() instanceof ReaderTagAdapter.TagDeletedListener) {
+            ((ReaderTagAdapter.TagAddedListener) getActivity()).onTagAdded(readerTag);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -106,27 +106,27 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     public void onBindViewHolder(TagViewHolder holder, int position) {
         final ReaderTag tag = mTags.get(position);
         holder.mTxtTagName.setText(tag.getLabel());
-        holder.mRemoveFollowButton.setOnClickListener(view -> {
-            final boolean currentValue = Boolean.TRUE.equals(mBlogIdIsFollowedMap.get(tag.getTagSlug()));
-            final boolean newValue = !currentValue;
-            mBlogIdIsFollowedMap.put(tag.getTagSlug(), newValue);
-            holder.mRemoveFollowButton.setIsFollowed(newValue);
-            performDeleteTag(tag);
-        });
+        holder.mRemoveFollowButton.setOnClickListener(view -> performDeleteTag(tag, holder.mRemoveFollowButton));
     }
 
-    private void performDeleteTag(@NonNull ReaderTag tag) {
+    private void performDeleteTag(@NonNull ReaderTag tag, @NonNull final ReaderFollowButton readerFollowButton) {
         if (!NetworkUtils.checkConnection(getContext())) {
             return;
         }
 
-        ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
-            @Override
-            public void onActionResult(boolean succeeded) {
-                if (!succeeded && hasContext()) {
-                    ToastUtils.showToast(getContext(), R.string.reader_toast_err_removing_tag);
-                    refresh();
-                }
+        final boolean currentFollowValue = Boolean.TRUE.equals(mBlogIdIsFollowedMap.get(tag.getTagSlug()));
+        final boolean newFollowValue = !currentFollowValue;
+        mBlogIdIsFollowedMap.put(tag.getTagSlug(), newFollowValue);
+        readerFollowButton.setIsFollowed(newFollowValue);
+
+        // Disable follow button until API call returns
+        readerFollowButton.setEnabled(false);
+
+        ReaderActions.ActionListener actionListener = succeeded -> {
+            readerFollowButton.setEnabled(true);
+            if (!succeeded && hasContext()) {
+                ToastUtils.showToast(getContext(), R.string.reader_toast_err_removing_tag);
+                refresh();
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -127,13 +127,13 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
 
         final boolean currentFollowValue = Boolean.TRUE.equals(mBlogIdIsFollowedMap.get(tag.getTagSlug()));
         final boolean newFollowValue = !currentFollowValue;
-        mBlogIdIsFollowedMap.put(tag.getTagSlug(), newFollowValue);
         readerFollowButton.setIsFollowed(newFollowValue);
 
         // Disable follow button until API call returns
         readerFollowButton.setEnabled(false);
 
         ReaderActions.ActionListener actionListener = succeeded -> {
+            mBlogIdIsFollowedMap.put(tag.getTagSlug(), newFollowValue);
             readerFollowButton.setEnabled(true);
             if (!succeeded && hasContext()) {
                 ToastUtils.showToast(getContext(), R.string.reader_toast_err_removing_tag);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -102,6 +102,17 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
         return mTags;
     }
 
+    @Nullable
+    public ReaderTagList getSubscribedItems() {
+        final ReaderTagList readerSubscribedTagsList = new ReaderTagList();
+        for (final ReaderTag readerTag : mTags) {
+            if (Boolean.TRUE.equals(mBlogIdIsFollowedMap.get(readerTag.getTagSlug()))) {
+                readerSubscribedTagsList.add(readerTag);
+            }
+        }
+        return readerSubscribedTagsList;
+    }
+
     @Override
     public void onBindViewHolder(TagViewHolder holder, int position) {
         final ReaderTag tag = mTags.get(position);


### PR DESCRIPTION
Fixes #19353 

-----

## To Test:

1. Install JP and sign in;
2. Open Reader;
3. Select "Subscriptions" feed;
4. Tap the tags chip to show the bottom sheet;
5. Tap "Edit" button;
6. Add a new tag;
7. Move back to Reader: the tags chip count should be updated;
8. Repeat steps 4-5;
9. Unsubscribe from a tag: the tag should not be removed from the list, but instead the follow button state should be changed;
10. Move back to Reader: the tags chip count should be updated (which means the unsubscribed tag should not be part of the count);

-----

## Regression Notes

1. Potential unintended areas of impact

    - Tags chip count

12. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

13. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
