### PR TITLE
Fix the visibility issue with the menu button on the stats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 24.3
 -----
-
+* [*] [Jetpack-only] Fix the visibility issue with the menu button on the stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20175]
 
 24.2
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -81,15 +81,12 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         }
     }
 
-    @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         statsSection = arguments?.getSerializableCompat(LIST_TYPE)
             ?: activity?.intent?.getSerializableExtraCompat(LIST_TYPE)
                     ?: StatsSection.INSIGHTS
-
-        setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -208,6 +205,12 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             initializeViews(savedInstanceState)
             initializeViewModels(nonNullActivity)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        @Suppress("DEPRECATION")
+        setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
This fixes the visibility issue with the menu button on the stats. Before, the menu button was visible even on granular tabs. Now, it will only be visible on the INSIGHTS tab.

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/55be9de1-7083-4754-b9aa-9e6b27297c21" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/92f0c390-b7a3-41b3-8853-7d979f647317" width=300>|

_A single approval is sufficient._

-----

To reproduce the issue, you should open the stats screen when the initially selected screen is a granular tab.
## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Log in.
2. Open stats.
3. Verify that the menu button is visible when the INSIGHTS tab is selected.
4. Navigate to DAYS tab or any other granular tabs.
5. Verify that the menu button is no longer visible.
6. Navigate back to the home screen.
7. Open stats again.
8. Verify that the menu button is not visible when a granular tab is selected.
9. Navigate to the INSIGHTS tab.
10. Verify that the menu button is visible.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Nothing

12. What automated tests I added (or what prevented me from doing so)

    - None. This is a minor issue. It isn't worth a specific UI test case.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
