### PR TITLE
Add notifications inline action for share an own published post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
@@ -1,15 +1,28 @@
 package org.wordpress.android.models
 
+import org.wordpress.android.models.Notification.PostNotification.Like
+import org.wordpress.android.models.Notification.PostNotification.Reblog
+import org.wordpress.android.models.Notification.PostNotification.NewPost
+
 val Note.type
     get() = NoteType.from(rawType)
 
 sealed class Notification {
-    data class Like(val url: String, val title: String): Notification()
+    sealed class PostNotification: Notification() {
+        abstract val url: String
+        abstract val title: String
+        data class Like(override val url: String, override val title: String): PostNotification()
+        data class Reblog(override val url: String, override val title: String): PostNotification()
+        data class NewPost(override val url: String, override val title: String): PostNotification()
+    }
+    data object Comment: Notification()
     data object Unknown: Notification()
 
     companion object {
         fun from(rawNote: Note) = when(rawNote.type) {
-            NoteType.Like -> Like(url= rawNote.url, title = rawNote.title)
+            NoteType.Like -> Like(url = rawNote.url, title = rawNote.title)
+            NoteType.Reblog -> Reblog(url= rawNote.url, title = rawNote.title)
+            NoteType.NewPost -> NewPost(url= rawNote.url, title = rawNote.title)
             else -> Unknown
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.models.Note
@@ -36,6 +37,8 @@ class NotificationsListViewModel @Inject constructor(
 
     private val _showJetpackOverlay = MutableLiveData<Event<Boolean>>()
     val showJetpackOverlay: LiveData<Event<Boolean>> = _showJetpackOverlay
+
+    val inlineActionEvents = MutableSharedFlow<InlineActionEvent>()
 
     val isNotificationsPermissionsWarningDismissed
         get() = appPrefsWrapper.notificationPermissionsWarningDismissed

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.models.Note
+import org.wordpress.android.models.Notification.PostNotification
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
@@ -75,5 +76,9 @@ class NotificationsListViewModel @Inject constructor(
                 NotificationsTable.saveNotes(it, false)
                 EventBus.getDefault().post(NotificationsChanged())
             }
+    }
+
+    sealed class InlineActionEvent {
+        data class SharePostButtonTapped(val notification: PostNotification): InlineActionEvent()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -278,8 +278,7 @@ class NotesAdapter(
             NoteType.NewPost,
             NoteType.Reblog,
             NoteType.Like -> {
-                // TODO: Use the icon from the Figma design
-                actionIcon.setImageResource(R.drawable.gb_ic_share)
+                actionIcon.setImageResource(R.drawable.block_share)
                 actionIcon.isVisible = true
                 actionIcon.setOnClickListener {
                     // TODO: handle tap on comment's inline action icon (the share icon)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -403,13 +403,7 @@ public class ReaderActivityLauncher {
 
     public static void sharePost(Context context, ReaderPost post) throws ActivityNotFoundException {
         String url = (post.hasShortUrl() ? post.getShortUrl() : post.getUrl());
-
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TEXT, url);
-        intent.putExtra(Intent.EXTRA_SUBJECT, post.getTitle());
-
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share_link)));
+        ActivityLauncher.openShareIntent(context, url, post.getTitle());
     }
 
     public static void openUrl(Context context, String url, OpenUrlType openUrlType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -13,7 +13,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 
-import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;

--- a/WordPress/src/main/res/drawable/block_share.xml
+++ b/WordPress/src/main/res/drawable/block_share.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2.5L12,15.5M12,2.5L9,5.5M12,2.5L15,5.5"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"/>
+  <path
+      android:pathData="M8.5,9H7C5.895,9 5,9.895 5,11V18C5,19.105 5.895,20 7,20H17C18.105,20 19,19.105 19,18V11C19,9.895 18.105,9 17,9H15.5V10.5H17C17.276,10.5 17.5,10.724 17.5,11V18C17.5,18.276 17.276,18.5 17,18.5H7C6.724,18.5 6.5,18.276 6.5,18V11C6.5,10.724 6.724,10.5 7,10.5H8.5V9Z"
+      android:fillColor="#1E1E1E"
+      android:fillType="evenOdd"/>
+</vector>

--- a/WordPress/src/main/res/drawable/block_share.xml
+++ b/WordPress/src/main/res/drawable/block_share.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:pathData="M12,2.5L12,15.5M12,2.5L9,5.5M12,2.5L15,5.5"
+      android:pathData="M12,2.5L12,15.5M9,5.5L12,2.5L15,5.5"
       android:strokeWidth="1.5"
       android:fillColor="#00000000"
       android:strokeColor="#1E1E1E"/>

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -69,6 +69,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/note_avatar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/note_avatar"
+            app:tint="?attr/wpColorOnSurfaceMedium"
             tools:src="@drawable/star_empty" />
 
         <FrameLayout


### PR DESCRIPTION
Fixes #20040

### Description

This PR adds an inline action to share a post.

-----

## To Test:

* Log in to the Jetpack app (with an account containing various notifications)
* Tap the notifications tab
* Scroll to a notification for a post like
* Expect to see a share icon
* Tap the share icon
* Expect the share activity to launch

Test for regression:

* Tap the other part of the notification
* Expect the notification detail view to be presented (as usual)

-----

## Regression Notes

1. Potential unintended areas of impact

Other notification behavior

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

More refactoring is needed to add unit tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
