### PR TITLE
Fixes: Issue post list tab switching

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -401,7 +401,16 @@ class PostListMainViewModel @Inject constructor(
     }
 
     fun handleEditPostResult(data: Intent?) {
+        switchToDraftTabIfNeeded(data)
         postActionHandler.handleEditPostResult(data)
+    }
+
+    private fun switchToDraftTabIfNeeded(data: Intent?) {
+        if (data != null && data.getBooleanExtra(EditPostActivity.EXTRA_IS_NEW_POST, false) &&
+            data.getBooleanExtra(EditPostActivity.EXTRA_HAS_CHANGES, false)
+        ) {
+            _selectTab.value = POST_LIST_PAGES.indexOf(DRAFTS)
+        }
     }
 
     private fun editRestoredAutoSavePost(localPostId: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -364,7 +364,7 @@ class PostsListActivity : LocaleAwareActivity(),
         }
     }
 
-    private fun setupActions() {
+    private fun PostListActivityBinding.setupActions() {
         viewModel.dialogAction.observe(this@PostsListActivity) {
             it?.show(this@PostsListActivity, supportFragmentManager, uiHelpers)
         }
@@ -377,11 +377,16 @@ class PostsListActivity : LocaleAwareActivity(),
                     uploadActionUseCase,
                     uploadUtilsWrapper
                 ) { isFirstTimePublishing ->
+                    changeTabsOnPostUpload()
                     bloggingRemindersViewModel.onPublishingPost(site.id, isFirstTimePublishing)
                     reviewViewModel.onPublishingPost(isFirstTimePublishing)
                 }
             }
         }
+    }
+
+    private fun PostListActivityBinding.changeTabsOnPostUpload() {
+        tabLayout.getTabAt(PostListType.PUBLISHED.ordinal)?.select()
     }
 
     private fun PostListActivityBinding.loadViewState(state: PostListMainViewState) {


### PR DESCRIPTION
## Fixes 
This PR introduces a minor change to show the correct tabs when 

-  user creates a new post from post list and press back to the post list 
- user publishes a post from drafts or from drafts → editor → publish 


## To Test:
- Login to the Jetpack app/WP app
- Go to Post list → publish tab or any other tab than Drafts
- Create a post by clicking on Fab 
- Don't publish, Press back 
- Verify that you are re-directed to the Drafts tab 
- Select the post in Drafts tab 
- Publish the post 
- Verify that you are re-directed to publish tab 

## known issues 
- The tab selection change on trashing/deleting/moving a published post to draft is not implemented

## Regression Notes

1. Potential unintended areas of impact
Tabs are not selected properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
