### PR TITLE
[Gradle] Added tracks to included_builds.gradle

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -381,7 +381,12 @@ dependencies {
     }
     implementation "$gradle.ext.storiesAndroidMp4ComposePath:$automatticStoriesVersion"
 
-    implementation "com.automattic:Automattic-Tracks-Android:$automatticTracksVersion"
+    implementation("$gradle.ext.tracksBinaryPath") {
+        version {
+            strictly automatticTracksVersion
+        }
+    }
+
     implementation ("com.automattic:rest:$automatticRestVersion") {
         exclude group: 'com.mcxiaoke.volley'
     }

--- a/config/gradle/included_builds.gradle
+++ b/config/gradle/included_builds.gradle
@@ -12,6 +12,7 @@ gradle.ext.aztecAndroidWordPressCommentsPath = "org.wordpress.aztec:wordpress-co
 gradle.ext.aztecAndroidGlideLoaderPath = "org.wordpress.aztec:glide-loader"
 gradle.ext.aztecAndroidPicassoLoaderPath = "org.wordpress.aztec:picasso-loader"
 gradle.ext.aboutAutomatticBinaryPath = "com.automattic:about"
+gradle.ext.tracksBinaryPath = "com.automattic:Automattic-Tracks-Android"
 
 def localBuilds = new File("${rootDir}/local-builds.gradle")
 if (localBuilds.exists()) {
@@ -94,6 +95,15 @@ if (localBuilds.exists()) {
             dependencySubstitution {
                 println "Substituting about-automattic with the local build"
                 substitute module("$gradle.ext.aboutAutomatticBinaryPath") using project(':library')
+            }
+        }
+    }
+
+    if (ext.has("localTracksPath")) {
+        includeBuild(ext.localTracksPath) {
+            dependencySubstitution {
+                println "Substituting tracks with the local build"
+                substitute module("$gradle.ext.tracksBinaryPath") using project(':AutomatticTracks')
             }
         }
     }

--- a/local-builds.gradle-example
+++ b/local-builds.gradle-example
@@ -21,4 +21,5 @@ ext {
     //localLoginFlowPath = "../WordPress-Login-Flow-Android"
     //localStoriesAndroidPath = "../stories-android"
     //localAztecAndroidPath = "../AztecEditor-Android"
+    //localTracksPath = "../Automattic-Tracks-Android"
 }


### PR DESCRIPTION
I needed a way to easily test tracks without pushing to git so the CI makes a release for testing, so I added it to the `local-builds.gradle`.

## To Test:

You'll need to test this manually since you'll need to confirm that it works.

Setup: Make sure the Wordpress-Android project and the [Automattic-Tracks-Android](https://github.com/Automattic/Automattic-Tracks-Android) project are in the same directory.

- [ ] Go to Automattic-Tracks-Android and edit a file with a log so you know it's using the local version vs the gradle lib version. Ex. `Log.d("BLOOP", "Initializing SentryCrashLogging")` in the `SentryCrashLogging#init`.
- [ ] Make sure the tracks lib in `local-builds.gradle` is commented out (`localTracksPath = "../Automattic-Tracks-Android"`). We are testing to make sure that we are loading the gradle built library.
- [ ] 🚬 test the app and ensure no issues. Make sure you see tracks events in the logcat. 
- [ ] Also filter logcat by the test log you put. You should not see it.
- [ ] Now uncomment tracks in `local-build.gradle` (`localTracksPath = "../Automattic-Tracks-Android"`). You'll need to re-sync gradle
- [ ] When running the app, you should see tracks events, but more importantly you should see your test log.

-----

## Regression Notes

1. Potential unintended areas of impact

    There shouldn't be any.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    I 🚬 tested tracks. Made sure I still see tracks events.

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

