### PR TITLE
Fix the blocking issue in main thread in the Notifications tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -118,13 +118,13 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        arguments?.let {
-            tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
-        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        arguments?.let {
+            tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
+        }
         notesAdapter = NotesAdapter( requireActivity(), this, null,
             inlineActionEvents = viewModel.inlineActionEvents).apply {
             this.setOnNoteClickListener(mOnNoteClickListener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -117,14 +117,14 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (requireActivity().application as WordPress).component().inject(this)
-        shouldRefreshNotifications = true
+        arguments?.let {
+            tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
+        }
+        shouldRefreshNotifications = tabPosition == 0
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        arguments?.let {
-            tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
-        }
         notesAdapter = NotesAdapter( requireActivity(), this, null,
             inlineActionEvents = viewModel.inlineActionEvents).apply {
             this.setOnNoteClickListener(mOnNoteClickListener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -150,7 +150,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
 
     override fun onDestroyView() {
         super.onDestroyView()
-        notesAdapter.cancelReloadNotesTask()
+        notesAdapter.cancelReloadLocalNotes()
         swipeToRefreshHelper = null
         binding?.notificationsList?.adapter = null
         binding?.notificationsList?.removeCallbacks(showNewUnseenNotificationsRunnable)
@@ -187,7 +187,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         binding?.hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
         if (accountStore.hasAccessToken()) {
-            notesAdapter.reloadNotesFromDBAsync()
+            notesAdapter.reloadLocalNotes()
             if (shouldRefreshNotifications) {
                 fetchNotesFromRemote()
             }
@@ -459,7 +459,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         if (!isAdded) {
             return
         }
-        notesAdapter.reloadNotesFromDBAsync()
+        notesAdapter.reloadLocalNotes()
         if (event.hasUnseenNotes) {
             binding?.showNewUnseenNotificationsUI()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -17,8 +17,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.OnScrollListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
@@ -75,7 +78,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     private lateinit var notesAdapter: NotesAdapter
     private var swipeToRefreshHelper: SwipeToRefreshHelper? = null
     private var isAnimatingOutNewNotificationsBar = false
-    private var shouldRefreshNotifications = false
     private var tabPosition = 0
     private val viewModel: NotificationsListViewModel by viewModels()
 
@@ -103,7 +105,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == RequestCodes.NOTE_DETAIL) {
-            shouldRefreshNotifications = false
             if (resultCode == Activity.RESULT_OK) {
                 val noteId = data?.getStringExtra(NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)
                 val newStatus = data?.getStringExtra(NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA)
@@ -120,7 +121,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         arguments?.let {
             tabPosition = it.getInt(KEY_TAB_POSITION, All.ordinal)
         }
-        shouldRefreshNotifications = tabPosition == 0
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -137,7 +137,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             notificationsList.adapter = notesAdapter
             swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
                 hideNewNotificationsBar()
-                fetchNotesFromRemote()
+                fetchRemoteNotes()
             }
             layoutNewNotificatons.visibility = View.GONE
             layoutNewNotificatons.setOnClickListener { onScrollToTop() }
@@ -145,6 +145,13 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
         viewModel.updatedNote.observe(viewLifecycleOwner) {
             notesAdapter.updateNote(it)
+        }
+
+        if (tabPosition == All.ordinal) {
+            swipeToRefreshHelper?.isRefreshing = true
+            fetchRemoteNotes()
+        } else {
+            notesAdapter.reloadLocalNotes()
         }
     }
 
@@ -173,11 +180,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        shouldRefreshNotifications = true
-    }
-
     override fun getScrollableViewForUniqueIdProvision(): View? {
         return binding?.notificationsList
     }
@@ -186,12 +188,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         super.onResume()
         binding?.hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
-        if (accountStore.hasAccessToken()) {
-            notesAdapter.reloadLocalNotes()
-            if (shouldRefreshNotifications) {
-                fetchNotesFromRemote()
-            }
-        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -248,11 +244,15 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
     private fun NotificationsListFragmentPageBinding.clearPendingNotificationsItemsOnUI() {
         hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
-        NotificationsActions.updateNotesSeenTimestamp()
-        Thread { gcmMessageHandler.removeAllNotifications(activity) }.start()
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                NotificationsActions.updateNotesSeenTimestamp()
+                gcmMessageHandler.removeAllNotifications(activity)
+            }
+        }
     }
 
-    private fun fetchNotesFromRemote() {
+    private fun fetchRemoteNotes() {
         if (!isAdded) {
             return
         }
@@ -405,12 +405,14 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
     }
 
-    private fun updateNote(noteId: String, status: CommentStatus) {
-        val note = NotificationsTable.getNoteById(noteId)
-        if (note != null) {
-            note.localStatus = status.toString()
-            NotificationsTable.saveNote(note)
-            EventBus.getDefault().post(NotificationsChanged())
+    private fun updateNote(noteId: String, status: CommentStatus) = lifecycleScope.launch {
+        withContext(Dispatchers.IO) {
+            val note = NotificationsTable.getNoteById(noteId)
+            if (note != null) {
+                note.localStatus = status.toString()
+                NotificationsTable.saveNote(note)
+                EventBus.getDefault().post(NotificationsChanged())
+            }
         }
     }
 
@@ -439,22 +441,26 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
 
     @Subscribe(sticky = true, threadMode = MAIN)
     fun onEventMainThread(event: NoteLikeOrModerationStatusChanged) {
-        NotificationsActions.downloadNoteAndUpdateDB(
-            event.noteId,
-            {
-                EventBus.getDefault()
-                    .removeStickyEvent(
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                NotificationsActions.downloadNoteAndUpdateDB(
+                    event.noteId,
+                    {
+                        EventBus.getDefault()
+                            .removeStickyEvent(
+                                NoteLikeOrModerationStatusChanged::class.java
+                            )
+                    }
+                ) {
+                    EventBus.getDefault().removeStickyEvent(
                         NoteLikeOrModerationStatusChanged::class.java
                     )
+                }
             }
-        ) {
-            EventBus.getDefault().removeStickyEvent(
-                NoteLikeOrModerationStatusChanged::class.java
-            )
         }
     }
 
-    @Subscribe(threadMode = MAIN)
+    @Subscribe(sticky = true, threadMode = MAIN)
     fun onEventMainThread(event: NotificationsChanged) {
         if (!isAdded) {
             return

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -102,7 +102,7 @@ class NotesAdapter(
     }
 
     /**
-     * Add a note to the adapter and notify the change
+     * Add notes to the adapter and notify the change
      */
     fun addAll(notes: List<Note>) {
         val newNotes = buildFilteredNotesList(notes, currentFilter)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -2,10 +2,8 @@
 
 package org.wordpress.android.ui.notifications.adapters
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
-import android.os.AsyncTask
 import android.text.Spanned
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -24,8 +22,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.datasets.NotificationsTable
@@ -57,6 +57,7 @@ class NotesAdapter(
     private val textIndentSize: Int
     private val dataLoadedListener: DataLoadedListener
     private val onLoadMoreListener: OnLoadMoreListener?
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
     val filteredNotes = ArrayList<Note>()
 
     @Inject
@@ -85,7 +86,7 @@ class NotesAdapter(
 
     var currentFilter = FILTERS.FILTER_ALL
         private set
-    private var reloadNotesFromDBTask: ReloadNotesFromDBTask? = null
+    private var reloadLocalNotesJob: Job? = null
 
     interface DataLoadedListener {
         fun onDataLoaded(itemsCount: Int)
@@ -100,6 +101,9 @@ class NotesAdapter(
         currentFilter = newFilter
     }
 
+    /**
+     * Add a note to the adapter and notify the change
+     */
     fun addAll(notes: List<Note>) {
         val newNotes = buildFilteredNotesList(notes, currentFilter)
         val result = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
@@ -111,7 +115,7 @@ class NotesAdapter(
             override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
                 filteredNotes[oldItemPosition].json.toString() == newNotes[newItemPosition].json.toString()
         })
-
+        
         filteredNotes.clear()
         filteredNotes.addAll(newNotes)
         result.dispatchUpdatesTo(this)
@@ -128,7 +132,6 @@ class NotesAdapter(
     } else null
 
     private fun isValidPosition(position: Int): Boolean = position >= 0 && position < filteredNotes.size
-
 
     override fun getItemCount(): Int = filteredNotes.size
 
@@ -286,17 +289,19 @@ class NotesAdapter(
         onNoteClickListener = mNoteClickListener
     }
 
-    fun cancelReloadNotesTask() {
-        if (reloadNotesFromDBTask != null && reloadNotesFromDBTask!!.status != AsyncTask.Status.FINISHED) {
-            reloadNotesFromDBTask!!.cancel(true)
-            reloadNotesFromDBTask = null
-        }
+    fun cancelReloadLocalNotes() {
+        reloadLocalNotesJob?.cancel()
     }
 
-    fun reloadNotesFromDBAsync() {
-        cancelReloadNotesTask()
-        reloadNotesFromDBTask = ReloadNotesFromDBTask()
-        reloadNotesFromDBTask!!.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
+    /**
+     * Reload the notes from local database and update the adapter
+     */
+    fun reloadLocalNotes() {
+        cancelReloadLocalNotes()
+        reloadLocalNotesJob = coroutineScope.launch {
+            val notes = NotificationsTable.getLatestNotes()
+            withContext(Dispatchers.Main) { addAll(notes) }
+        }
     }
 
     /**
@@ -307,17 +312,6 @@ class NotesAdapter(
         if (notePosition != -1) {
             filteredNotes[notePosition] = note
             notifyItemChanged(notePosition)
-        }
-    }
-
-    @SuppressLint("StaticFieldLeak")
-    private inner class ReloadNotesFromDBTask : AsyncTask<Void?, Void?, ArrayList<Note>>() {
-        override fun doInBackground(vararg voids: Void?): ArrayList<Note> {
-            return NotificationsTable.getLatestNotes()
-        }
-
-        override fun onPostExecute(notes: ArrayList<Note>) {
-            addAll(notes)
         }
     }
 
@@ -337,8 +331,6 @@ class NotesAdapter(
         val threeAvatars3: ImageView
         val unreadNotificationView: View
         val actionIcon: ImageView
-
-        val coroutineScope = CoroutineScope(Dispatchers.Main)
 
         init {
             contentView = checkNotNull(view.findViewById(R.id.note_content_container))

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -302,7 +302,7 @@ class NotesAdapter(
         cancelReloadLocalNotes()
         reloadLocalNotesJob = coroutineScope.launch {
             val notes = NotificationsTable.getLatestNotes()
-            withContext(Dispatchers.Main) { addAll(notes) }
+            addAll(notes)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -104,7 +104,7 @@ class NotesAdapter(
     /**
      * Add notes to the adapter and notify the change
      */
-    fun addAll(notes: List<Note>) {
+    fun addAll(notes: List<Note>) = coroutineScope.launch {
         val newNotes = buildFilteredNotesList(notes, currentFilter)
         val result = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
             override fun getOldListSize(): Int = filteredNotes.size
@@ -115,11 +115,13 @@ class NotesAdapter(
             override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
                 filteredNotes[oldItemPosition].json.toString() == newNotes[newItemPosition].json.toString()
         })
-        
+
         filteredNotes.clear()
         filteredNotes.addAll(newNotes)
-        result.dispatchUpdatesTo(this)
-        dataLoadedListener.onDataLoaded(itemCount)
+        withContext(Dispatchers.Main) {
+            result.dispatchUpdatesTo(this@NotesAdapter)
+            dataLoadedListener.onDataLoaded(itemCount)
+        }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NoteViewHolder =


### PR DESCRIPTION
Fixes #20196 

When I was profiling the threads, I found the main thread spent much time rendering the layouts. It continues re-rendering the UI even though the new data is the same as the old data.

![截圖 2024-02-16 下午4 07 55](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/f6b7d001-70c1-4dac-97ec-e862f1275865)


This PR contains:
1. Stop updating our UI if the data is not changed so it uses `DiffUtil` for resolving the issue.
2. Reduce the API requests for each tab. Only the first tab can fetch remote data when the view of fragment is created.
3. Refactors

-----

## To Test:
1. Open the Jetpack app and switch to the notifications tab.
2. Change the tab to ALL/UNREAD/COMMENT...etc
3. Scroll the notifications list
4. Click the Like inline actions
5. The Like state should be correct
6. Done! Thank you!

P.S. We still have issues in main thread, but it is smoother than the original implementation.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications tab

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

9. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
