### PR TITLE
fix: disable crash logging (Sentry) debug logs also on debug

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
@@ -43,7 +43,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     }
 
     override val buildType: String = BuildConfig.BUILD_TYPE
-    override val enableCrashLoggingLogs: Boolean = BuildConfig.DEBUG
+    override val enableCrashLoggingLogs: Boolean = false
     override val locale: Locale
         get() = localeManager.getLocale()
     override val releaseName: String = BuildConfig.VERSION_NAME


### PR DESCRIPTION
Sentry started to log too much after the bump to 6.32.0

See internal conversation: p1707817029678899-slack-C04TBSWP09M

-----

## To Test:

Run the app and see if the logs are not flooded with logs from `Sentry` tag

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)