### PR TITLE
Use sans serif for notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -251,7 +251,7 @@ public class NoteBlock {
                             });
                         } else {
                             noteBlockHolder.getTextView().setTextSize(28);
-                            TypefaceSpan typefaceSpan = new TypefaceSpan("serif");
+                            TypefaceSpan typefaceSpan = new TypefaceSpan("sans-serif");
                             noteText.setSpan(typefaceSpan, 0, noteText.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                         }
                     }

--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -109,7 +109,7 @@
                 android:id="@+id/text_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:fontFamily="serif"
+                android:fontFamily="sans-serif"
                 android:paddingStart="@dimen/margin_extra_large"
                 android:paddingTop="@dimen/margin_large"
                 android:paddingEnd="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/note_block_comment_user.xml
+++ b/WordPress/src/main/res/layout/note_block_comment_user.xml
@@ -100,7 +100,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="?android:selectableItemBackground"
-        android:fontFamily="serif"
+        android:fontFamily="sans-serif"
         android:paddingBottom="@dimen/margin_medium"
         android:textAppearance="?attr/textAppearanceBody1"
         tools:text="Thanks for stopping by my blog! I hope to see you again. " />


### PR DESCRIPTION
Fixes #20201

### Description

This PR changes the typography of the note block within the comment notification detail view to be sans-serif instead of serif, for consistency with other parts of the app.

Screenshots:

| Before | After |
|-|-|
|![note-block-serif](https://github.com/wordpress-mobile/WordPress-Android/assets/8507675/2c466784-00c4-4377-bd83-614c047dafec)|![note-block-sans](https://github.com/wordpress-mobile/WordPress-Android/assets/8507675/ae1666ed-8240-45f4-874b-9bc8e86b234b)|


-----

## To Test:


* Log into the app with an account that has notifications
* Tap the notifications tab
* Tap a comment notification to open a comment notification detail view
* Observe that the font is sans-serif

-----

## Regression Notes

1. Potential unintended areas of impact

Style changes in other areas of the app

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Code search for usage of the styles

3. What automated tests I added (or what prevented me from doing so)

N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
