### PR TITLE
Refactors for notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -61,6 +61,7 @@ import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
+import org.wordpress.android.ui.notifications.adapters.NoteViewHolder;
 import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver;
 import org.wordpress.android.ui.pages.PageListFragment;
 import org.wordpress.android.ui.pages.PageParentFragment;
@@ -342,6 +343,8 @@ public interface AppComponent {
     void inject(WPWebViewClient object);
 
     void inject(NotesAdapter object);
+
+    void inject(NoteViewHolder object);
 
     void inject(ThemeBrowserFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -110,7 +110,7 @@ import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.NotificationsListViewModel;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
+import org.wordpress.android.ui.notifications.adapters.Filter;
 import org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
@@ -1087,7 +1087,7 @@ public class WPMainActivity extends LocaleAwareActivity implements
                                             NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA,
                                             false);
                                     NotificationsListFragment.openNoteForReply(WPMainActivity.this, noteId,
-                                            shouldShowKeyboard, null, NotesAdapter.FILTERS.FILTER_ALL, true);
+                                            shouldShowKeyboard, null, Filter.ALL, true);
                                     return null;
                                 }
                             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.engagement.EngagedPeopleListFragment;
 import org.wordpress.android.ui.engagement.ListScenarioUtils;
+import org.wordpress.android.ui.notifications.adapters.Filter;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
@@ -203,9 +204,9 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
             }
         }
 
-        NotesAdapter.FILTERS filter = NotesAdapter.FILTERS.FILTER_ALL;
+        Filter filter = Filter.ALL;
         if (getIntent().hasExtra(NotificationsListFragment.NOTE_CURRENT_LIST_FILTER_EXTRA)) {
-            filter = (NotesAdapter.FILTERS) getIntent()
+            filter = (Filter) getIntent()
                     .getSerializableExtra(NotificationsListFragment.NOTE_CURRENT_LIST_FILTER_EXTRA);
         }
 
@@ -371,7 +372,7 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
     }
 
     private NotificationDetailFragmentAdapter buildNoteListAdapterAndSetPosition(Note note,
-                                                                                 NotesAdapter.FILTERS filter) {
+                                                                                 Filter filter) {
         NotificationDetailFragmentAdapter adapter;
         ArrayList<Note> notes = NotificationsTable.getLatestNotes();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -58,12 +58,10 @@ import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILT
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_FOLLOW
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_LIKE
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_UNREAD
-import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
-import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE
@@ -89,7 +87,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     private val viewModel: NotificationsListViewModel by viewModels()
 
-    private var shouldRefreshNotifications = false
     private var lastTabPosition = 0
     private var binding: NotificationsListFragmentBinding? = null
 
@@ -99,11 +96,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         if (savedInstanceState != null) {
             binding?.setSelectedTab(savedInstanceState.getInt(KEY_LAST_TAB_POSITION, All.ordinal))
         }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        shouldRefreshNotifications = true
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -161,11 +153,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        shouldRefreshNotifications = true
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
@@ -184,9 +171,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 connectJetpack.visibility = View.GONE
                 tabLayout.visibility = View.VISIBLE
                 viewPager.visibility = View.VISIBLE
-                if (shouldRefreshNotifications) {
-                    fetchNotesFromRemote()
-                }
             }
             setSelectedTab(lastTabPosition)
             setNotificationPermissionWarning()
@@ -204,13 +188,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             val params = toolbarMain.layoutParams as LayoutParams
             params.scrollFlags = 0
         }
-    }
-
-    private fun fetchNotesFromRemote() {
-        if (!isAdded || !NetworkUtils.isNetworkAvailable(activity)) {
-            return
-        }
-        NotificationsUpdateServiceStarter.startService(activity)
     }
 
     private fun NotificationsListFragmentBinding.setSelectedTab(position: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -52,12 +52,7 @@ import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFra
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsUnseenStatus
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.All
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage.Companion.KEY_TAB_POSITION
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_ALL
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_COMMENT
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_FOLLOW
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_LIKE
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS.FILTER_UNREAD
+import org.wordpress.android.ui.notifications.adapters.Filter
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity
 import org.wordpress.android.ui.utils.UiHelpers
@@ -322,12 +317,12 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         const val NOTE_MODERATE_STATUS_EXTRA = "moderateNoteStatus"
         const val NOTE_CURRENT_LIST_FILTER_EXTRA = "currentFilter"
 
-        enum class TabPosition(@StringRes val titleRes: Int, val filter: FILTERS) {
-            All(R.string.notifications_tab_title_all, FILTER_ALL),
-            Unread(R.string.notifications_tab_title_unread_notifications, FILTER_UNREAD),
-            Comment(R.string.notifications_tab_title_comments, FILTER_COMMENT),
-            Follow(R.string.notifications_tab_title_follows, FILTER_FOLLOW),
-            Like(R.string.notifications_tab_title_likes, FILTER_LIKE);
+        enum class TabPosition(@StringRes val titleRes: Int, val filter: Filter) {
+            All(R.string.notifications_tab_title_all, Filter.ALL),
+            Unread(R.string.notifications_tab_title_unread_notifications, Filter.UNREAD),
+            Comment(R.string.notifications_tab_title_comments, Filter.COMMENT),
+            Follow(R.string.notifications_tab_title_follows, Filter.FOLLOW),
+            Like(R.string.notifications_tab_title_likes, Filter.LIKE);
         }
 
         private const val KEY_LAST_TAB_POSITION = "lastTabPosition"
@@ -348,7 +343,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             noteId: String?,
             shouldShowKeyboard: Boolean,
             replyText: String?,
-            filter: FILTERS?,
+            filter: Filter?,
             isTappedFromPushNotification: Boolean
         ) {
             if (noteId == null || activity == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -55,8 +55,8 @@ import org.wordpress.android.ui.notifications.NotificationsListFragment.Companio
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Unread
 import org.wordpress.android.ui.notifications.NotificationsListViewModel.InlineActionEvent
 import org.wordpress.android.ui.notifications.NotificationsListViewModel.InlineActionEvent.SharePostButtonTapped
+import org.wordpress.android.ui.notifications.adapters.Filter
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter
-import org.wordpress.android.ui.notifications.adapters.NotesAdapter.FILTERS
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
 import org.wordpress.android.ui.notifications.utils.NotificationsActions
 import org.wordpress.android.ui.reader.ReaderActivityLauncher
@@ -137,7 +137,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             }
             layoutNewNotificatons.visibility = View.GONE
             layoutNewNotificatons.setOnClickListener { onScrollToTop() }
-            (TabPosition.values().getOrNull(tabPosition) ?: All).let { notesAdapter.setFilter(it.filter) }
+            (TabPosition.entries.getOrNull(tabPosition) ?: All).let { notesAdapter.setFilter(it.filter) }
         }
         viewModel.updatedNote.observe(viewLifecycleOwner) {
             notesAdapter.updateNote(it)
@@ -531,7 +531,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             noteId: String?,
             shouldShowKeyboard: Boolean = false,
             replyText: String? = null,
-            filter: FILTERS? = null,
+            filter: Filter? = null,
             isTappedFromPushNotification: Boolean = false,
         ) {
             if (noteId == null || activity == null || activity.isFinishing) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -131,7 +131,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 .launchIn(viewLifecycleOwner.lifecycleScope)
         }
         binding = NotificationsListFragmentPageBinding.bind(view).apply {
-            notificationsList.layoutManager = LinearLayoutManagerWrapper(activity)
+            notificationsList.layoutManager = LinearLayoutManagerWrapper(view.context)
             notificationsList.adapter = notesAdapter
             swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
                 hideNewNotificationsBar()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -74,7 +74,6 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.AppRatingDialog.incrementInteractions
 import javax.inject.Inject
 
-
 @AndroidEntryPoint
 class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_list_fragment_page),
     OnScrollToTopListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.notifications
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
+import android.util.AttributeSet
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.Animation.AnimationListener
@@ -129,7 +131,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 .launchIn(viewLifecycleOwner.lifecycleScope)
         }
         binding = NotificationsListFragmentPageBinding.bind(view).apply {
-            notificationsList.layoutManager = LinearLayoutManager(view.context)
+            notificationsList.layoutManager = LinearLayoutManagerWrapper(view.context)
             notificationsList.adapter = notesAdapter
             swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
                 hideNewNotificationsBar()
@@ -553,5 +555,23 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         private fun openNoteForReplyWithParams(detailIntent: Intent, activity: Activity) {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL)
         }
+    }
+
+    internal class LinearLayoutManagerWrapper : LinearLayoutManager {
+        constructor(context: Context) : super(context)
+        constructor(context: Context, orientation: Int, reverseLayout: Boolean) : super(
+            context,
+            orientation,
+            reverseLayout
+        )
+
+        constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
+            context,
+            attrs,
+            defStyleAttr,
+            defStyleRes
+        )
+
+        override fun supportsPredictiveItemAnimations(): Boolean = false
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.notifications
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
+import android.util.AttributeSet
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.Animation.AnimationListener
@@ -72,6 +74,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.widgets.AppRatingDialog.incrementInteractions
 import javax.inject.Inject
 
+
 @AndroidEntryPoint
 class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_list_fragment_page),
     OnScrollToTopListener {
@@ -129,7 +132,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 .launchIn(viewLifecycleOwner.lifecycleScope)
         }
         binding = NotificationsListFragmentPageBinding.bind(view).apply {
-            notificationsList.layoutManager = LinearLayoutManager(activity)
+            notificationsList.layoutManager = LinearLayoutManagerWrapper(activity)
             notificationsList.adapter = notesAdapter
             swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
                 hideNewNotificationsBar()
@@ -553,5 +556,27 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         private fun openNoteForReplyWithParams(detailIntent: Intent, activity: Activity) {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL)
         }
+    }
+
+    /**
+     * LinearLayoutManagerWrapper is a workaround for a bug in RecyclerView that causes IndexOutOfBoundsException
+     * @see [link](https://stackoverflow.com/questions/31759171/recyclerview-and-java-lang-indexoutofboundsexception-inconsistency-detected-in)
+     */
+    internal class LinearLayoutManagerWrapper : LinearLayoutManager {
+        constructor(context: Context) : super(context)
+        constructor(context: Context, orientation: Int, reverseLayout: Boolean) : super(
+            context,
+            orientation,
+            reverseLayout
+        )
+
+        constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
+            context,
+            attrs,
+            defStyleAttr,
+            defStyleRes
+        )
+
+        override fun supportsPredictiveItemAnimations(): Boolean = false
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -557,6 +557,10 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
     }
 
+    /**
+     * LinearLayoutManagerWrapper is a workaround for a bug in RecyclerView that blocks the UI thread
+     * when we perform the first click on the inline actions in the notifications list.
+     */
     internal class LinearLayoutManagerWrapper : LinearLayoutManager {
         constructor(context: Context) : super(context)
         constructor(context: Context, orientation: Int, reverseLayout: Boolean) : super(

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -1,11 +1,9 @@
 package org.wordpress.android.ui.notifications
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.AttributeSet
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.Animation.AnimationListener
@@ -131,7 +129,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 .launchIn(viewLifecycleOwner.lifecycleScope)
         }
         binding = NotificationsListFragmentPageBinding.bind(view).apply {
-            notificationsList.layoutManager = LinearLayoutManagerWrapper(view.context)
+            notificationsList.layoutManager = LinearLayoutManager(view.context)
             notificationsList.adapter = notesAdapter
             swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(notificationsRefresh) {
                 hideNewNotificationsBar()
@@ -555,27 +553,5 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         private fun openNoteForReplyWithParams(detailIntent: Intent, activity: Activity) {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL)
         }
-    }
-
-    /**
-     * LinearLayoutManagerWrapper is a workaround for a bug in RecyclerView that causes IndexOutOfBoundsException
-     * @see [link](https://stackoverflow.com/questions/31759171/recyclerview-and-java-lang-indexoutofboundsexception-inconsistency-detected-in)
-     */
-    internal class LinearLayoutManagerWrapper : LinearLayoutManager {
-        constructor(context: Context) : super(context)
-        constructor(context: Context, orientation: Int, reverseLayout: Boolean) : super(
-            context,
-            orientation,
-            reverseLayout
-        )
-
-        constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
-            context,
-            attrs,
-            defStyleAttr,
-            defStyleRes
-        )
-
-        override fun supportsPredictiveItemAnimations(): Boolean = false
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
+import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.NotificationsListItemBinding
 import org.wordpress.android.models.Note
 import org.wordpress.android.models.Notification
@@ -34,7 +35,7 @@ import javax.inject.Inject
 import kotlin.math.roundToInt
 
 class NoteViewHolder(
-    val binding: NotificationsListItemBinding,
+    private val binding: NotificationsListItemBinding,
     private val inlineActionEvents: MutableSharedFlow<NotificationsListViewModel.InlineActionEvent>,
     private val coroutineScope: CoroutineScope
 ) : RecyclerView.ViewHolder(binding.root) {
@@ -42,6 +43,11 @@ class NoteViewHolder(
     lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
     @Inject
     lateinit var imageManager: ImageManager
+
+    init {
+        (itemView.context.applicationContext as WordPress).component().inject(this)
+    }
+
     fun bindTimeGroupHeader(note: Note, previousNote: Note?, position: Int) {
         // Display time group header
         timeGroupHeaderText(note, previousNote)?.let { timeGroupText ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -1,0 +1,263 @@
+package org.wordpress.android.ui.notifications.adapters
+
+import android.content.res.ColorStateList
+import android.text.Spanned
+import android.text.TextUtils
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.text.BidiFormatter
+import androidx.core.view.ViewCompat
+import androidx.core.view.isVisible
+import androidx.core.widget.ImageViewCompat
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import org.wordpress.android.R
+import org.wordpress.android.databinding.NotificationsListItemBinding
+import org.wordpress.android.models.Note
+import org.wordpress.android.models.Notification
+import org.wordpress.android.ui.comments.CommentUtils
+import org.wordpress.android.ui.notifications.NotificationsListViewModel
+import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
+import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
+import org.wordpress.android.util.GravatarUtils
+import org.wordpress.android.util.RtlUtils
+import org.wordpress.android.util.extensions.getColorFromAttribute
+import org.wordpress.android.util.image.ImageManager
+import org.wordpress.android.util.image.ImageType
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+class NoteViewHolder(
+    val binding: NotificationsListItemBinding,
+    private val inlineActionEvents: MutableSharedFlow<NotificationsListViewModel.InlineActionEvent>,
+    private val coroutineScope: CoroutineScope
+) : RecyclerView.ViewHolder(binding.root) {
+    @Inject
+    lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
+    @Inject
+    lateinit var imageManager: ImageManager
+    fun bindTimeGroupHeader(note: Note, previousNote: Note?, position: Int) {
+        // Display time group header
+        timeGroupHeaderText(note, previousNote)?.let { timeGroupText ->
+            with(binding.headerText) {
+                visibility = View.VISIBLE
+                setText(timeGroupText)
+            }
+        } ?: run {
+            binding.headerText.visibility = View.GONE
+        }
+
+        // handle the margin top for the header
+        val headerMarginTop: Int
+        val context = itemView.context
+        headerMarginTop = if (position == 0) {
+            context.resources
+                .getDimensionPixelSize(R.dimen.notifications_header_margin_top_position_0)
+        } else {
+            context.resources
+                .getDimensionPixelSize(R.dimen.notifications_header_margin_top_position_n)
+        }
+        val layoutParams = binding.headerText.layoutParams as ViewGroup.MarginLayoutParams
+        layoutParams.topMargin = headerMarginTop
+        binding.headerText.layoutParams = layoutParams
+    }
+
+    fun bindInlineActions(note: Note) = Notification.from(note).let { notification ->
+        when (notification) {
+            Notification.Comment -> bindLikeCommentAction(note)
+            is Notification.PostNotification.NewPost -> bindLikePostAction(note)
+            is Notification.PostNotification -> bindShareAction(notification)
+            is Notification.Unknown -> {
+                binding.action.isVisible = false
+            }
+        }
+    }
+
+    private fun bindShareAction(notification: Notification.PostNotification) {
+        binding.action.setImageResource(R.drawable.block_share)
+        val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
+        ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))
+        binding.action.isVisible = true
+        binding.action.setOnClickListener {
+            coroutineScope.launch {
+                inlineActionEvents.emit(
+                    NotificationsListViewModel.InlineActionEvent.SharePostButtonTapped(notification)
+                )
+            }
+        }
+    }
+
+    private fun bindLikePostAction(note: Note) {
+        if (note.canLikePost().not()) return
+        setupLikeIcon(note.hasLikedPost())
+        binding.action.setOnClickListener {
+            val liked = note.hasLikedPost().not()
+            setupLikeIcon(liked)
+            coroutineScope.launch {
+                inlineActionEvents.emit(
+                    NotificationsListViewModel.InlineActionEvent.LikePostButtonTapped(note, liked)
+                )
+            }
+        }
+    }
+
+    private fun bindLikeCommentAction(note: Note) {
+        if (note.canLikeComment().not()) return
+        setupLikeIcon(note.hasLikedComment())
+        binding.action.setOnClickListener {
+            val liked = note.hasLikedComment().not()
+            setupLikeIcon(liked)
+            coroutineScope.launch {
+                inlineActionEvents.emit(
+                    NotificationsListViewModel.InlineActionEvent.LikeCommentButtonTapped(
+                        note,
+                        liked
+                    )
+                )
+            }
+        }
+    }
+
+    private fun setupLikeIcon(liked: Boolean) {
+        binding.action.isVisible = true
+        binding.action.setImageResource(if (liked) R.drawable.star_filled else R.drawable.star_empty)
+        val color = if (liked) binding.root.context.getColor(R.color.inline_action_filled)
+        else binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
+        ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))
+    }
+
+    @StringRes
+    private fun timeGroupHeaderText(note: Note, previousNote: Note?) =
+        previousNote?.timeGroup.let { previousTimeGroup ->
+            val timeGroup = note.timeGroup
+            if (previousTimeGroup?.let { it == timeGroup } == true) {
+                // If the previous time group exists and is the same, we don't need a new one
+                null
+            } else {
+                // Otherwise, we create a new one
+                when (timeGroup) {
+                    Note.NoteTimeGroup.GROUP_TODAY -> R.string.stats_timeframe_today
+                    Note.NoteTimeGroup.GROUP_YESTERDAY -> R.string.stats_timeframe_yesterday
+                    Note.NoteTimeGroup.GROUP_OLDER_TWO_DAYS -> R.string.older_two_days
+                    Note.NoteTimeGroup.GROUP_OLDER_WEEK -> R.string.older_last_week
+                    Note.NoteTimeGroup.GROUP_OLDER_MONTH -> R.string.older_month
+                }
+            }
+        }
+
+    fun bindSubject(note: Note) {
+        // Subject is stored in db as html to preserve text formatting
+        var noteSubjectSpanned: Spanned = note.getFormattedSubject(notificationsUtilsWrapper)
+        // Trim the '\n\n' added by HtmlCompat.fromHtml(...)
+        noteSubjectSpanned = noteSubjectSpanned.subSequence(
+            0,
+            TextUtils.getTrimmedLength(noteSubjectSpanned)
+        ) as Spanned
+        val spans = noteSubjectSpanned.getSpans(
+            0,
+            noteSubjectSpanned.length,
+            NoteBlockClickableSpan::class.java
+        )
+        for (span in spans) {
+            span.enableColors(itemView.context)
+        }
+        binding.noteSubject.text = noteSubjectSpanned
+    }
+
+    fun bindSubjectNoticon(note: Note) {
+        val noteSubjectNoticon = note.commentSubjectNoticon
+        if (!TextUtils.isEmpty(noteSubjectNoticon)) {
+            val parent = binding.noteSubject.parent
+            // Fix position of the subject noticon in the RtL mode
+            if (parent is ViewGroup) {
+                val textDirection = if (BidiFormatter.getInstance()
+                        .isRtl(binding.noteSubject.text)
+                ) ViewCompat.LAYOUT_DIRECTION_RTL else ViewCompat.LAYOUT_DIRECTION_LTR
+                ViewCompat.setLayoutDirection(parent, textDirection)
+            }
+            // mirror noticon in the rtl mode
+            if (RtlUtils.isRtl(itemView.context)) {
+                binding.noteSubjectNoticon.scaleX = -1f
+            }
+            val textIndentSize = itemView.context.resources
+                .getDimensionPixelSize(R.dimen.notifications_text_indent_sz)
+            CommentUtils.indentTextViewFirstLine(binding.noteSubject, textIndentSize)
+            binding.noteSubjectNoticon.text = noteSubjectNoticon
+            binding.noteSubjectNoticon.visibility = View.VISIBLE
+        } else {
+            binding.noteSubjectNoticon.visibility = View.GONE
+        }
+    }
+
+    fun bindContent(note: Note) {
+        val noteSnippet = note.commentSubject
+        if (!TextUtils.isEmpty(noteSnippet)) {
+            handleMaxLines(binding.noteSubject, binding.noteDetail)
+            binding.noteDetail.text = noteSnippet
+            binding.noteDetail.visibility = View.VISIBLE
+        } else {
+            binding.noteDetail.visibility = View.GONE
+        }
+    }
+
+    private fun handleMaxLines(subject: TextView, detail: TextView) {
+        subject.viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
+            override fun onPreDraw(): Boolean {
+                subject.viewTreeObserver.removeOnPreDrawListener(this)
+                if (subject.lineCount == 2) {
+                    detail.maxLines = 1
+                } else {
+                    detail.maxLines = 2
+                }
+                return false
+            }
+        })
+    }
+
+    fun bindAvatars(note: Note) {
+        if (note.shouldShowMultipleAvatars() && note.iconURLs != null && note.iconURLs!!.size > 1) {
+            val avatars = note.iconURLs!!.toList()
+            if (avatars.size == 2) {
+                binding.noteAvatar.visibility = View.INVISIBLE
+                binding.twoAvatarsView.root.visibility = View.VISIBLE
+                binding.threeAvatarsView.root.visibility = View.INVISIBLE
+                loadAvatar(binding.twoAvatarsView.twoAvatars1, avatars[1])
+                loadAvatar(binding.twoAvatarsView.twoAvatars2, avatars[0])
+            } else { // size > 3
+                binding.noteAvatar.visibility = View.INVISIBLE
+                binding.twoAvatarsView.root.visibility = View.INVISIBLE
+                binding.threeAvatarsView.root.visibility = View.VISIBLE
+                loadAvatar(binding.threeAvatarsView.threeAvatars1, avatars[2])
+                loadAvatar(binding.threeAvatarsView.threeAvatars2, avatars[1])
+                loadAvatar(binding.threeAvatarsView.threeAvatars3, avatars[0])
+            }
+        } else { // single avatar
+            binding.noteAvatar.visibility = View.VISIBLE
+            binding.twoAvatarsView.root.visibility = View.INVISIBLE
+            binding.threeAvatarsView.root.visibility = View.INVISIBLE
+            loadAvatar(binding.noteAvatar, note.iconURL)
+        }
+    }
+
+    private fun loadAvatar(imageView: ImageView, avatarUrl: String) {
+        val avatarSize = imageView.context.resources.getDimension(R.dimen.notifications_avatar_sz).roundToInt()
+        val url = GravatarUtils.fixGravatarUrl(avatarUrl, avatarSize)
+        imageManager.loadIntoCircle(imageView, ImageType.AVATAR_WITH_BACKGROUND, url)
+    }
+
+    private fun Note.shouldShowMultipleAvatars() = isFollowType || isLikeType || isCommentLikeType
+
+    fun bindOthers(note: Note, onNoteClicked: (String) -> Unit) {
+        binding.noteContentContainer.setOnClickListener { onNoteClicked(note.id) }
+        binding.notificationUnread.isVisible = note.isUnread
+    }
+
+    private val Note.timeGroup
+        get() = Note.getTimeGroupForTimestamp(timestamp)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -74,11 +74,9 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
 
     override fun getItemCount(): Int = filteredNotes.size
 
-
     override fun onBindViewHolder(noteViewHolder: NoteViewHolder, position: Int) {
         val note = filteredNotes.getOrNull(position) ?: return
         val previousNote = filteredNotes.getOrNull(position - 1)
-
 
         noteViewHolder.bindTimeGroupHeader(note, previousNote, position)
         noteViewHolder.bindSubject(note)
@@ -87,7 +85,6 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
         noteViewHolder.bindAvatars(note)
         noteViewHolder.bindInlineActions(note)
         noteViewHolder.bindOthers(note, onNoteClicked)
-
 
         // request to load more comments when we near the end
         if (position >= itemCount - 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -49,6 +49,7 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
         withContext(Dispatchers.Main) {
+            // make sure that the differ should be in the main thread, otherwise it will throw an IndexOutOfBoundsException
             val newNotes = buildFilteredNotesList(notes, currentFilter)
             val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
                 override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -49,8 +49,6 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
         withContext(Dispatchers.Main) {
-            // make sure that the differ should be in the main thread,
-            // otherwise it will throw an IndexOutOfBoundsException
             val newNotes = buildFilteredNotesList(notes, currentFilter)
             val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
                 override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -49,7 +49,8 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
         withContext(Dispatchers.Main) {
-            // make sure that the differ should be in the main thread, otherwise it will throw an IndexOutOfBoundsException
+            // make sure that the differ should be in the main thread,
+            // otherwise it will throw an IndexOutOfBoundsException
             val newNotes = buildFilteredNotesList(notes, currentFilter)
             val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
                 override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -48,18 +48,19 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      * Add notes to the adapter and notify the change
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
-        val newNotes = buildFilteredNotesList(notes, currentFilter)
-        val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
-            override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =
-                oldItem.id == newItem.id
-
-            override fun areContentsTheSame(oldItem: Note, newItem: Note): Boolean =
-                oldItem.json.toString() == newItem.json.toString()
-        })
-
-        filteredNotes.clear()
-        filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
+            val newNotes = buildFilteredNotesList(notes, currentFilter)
+            val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
+                override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =
+                    oldItem.id == newItem.id
+
+                override fun areContentsTheSame(oldItem: Note, newItem: Note): Boolean =
+                    oldItem.json.toString() == newItem.json.toString()
+            })
+
+            filteredNotes.clear()
+            filteredNotes.addAll(newNotes)
+
             differ.submitList(newNotes)
             onNotesLoaded(itemCount)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -3,8 +3,6 @@ package org.wordpress.android.ui.notifications.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.AsyncListDiffer
-import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,21 +46,14 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      * Add notes to the adapter and notify the change
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
+        val currentSize: Int = filteredNotes.size
+        val newNotes = buildFilteredNotesList(notes, currentFilter)
+        filteredNotes.clear()
+        filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
-            val newNotes = buildFilteredNotesList(notes, currentFilter)
-            val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
-                override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =
-                    oldItem.id == newItem.id
-
-                override fun areContentsTheSame(oldItem: Note, newItem: Note): Boolean =
-                    oldItem.json.toString() == newItem.json.toString()
-            })
-
-            filteredNotes.clear()
-            filteredNotes.addAll(newNotes)
-
-            differ.submitList(newNotes)
-            onNotesLoaded(itemCount)
+            notifyItemRangeRemoved(0, currentSize)
+            notifyItemRangeInserted(0, newNotes.size)
+            onNotesLoaded(newNotes.size)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -1,21 +1,8 @@
 package org.wordpress.android.ui.notifications.adapters
 
 import android.content.Context
-import android.content.res.ColorStateList
-import android.text.Spanned
-import android.text.TextUtils
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.MarginLayoutParams
-import android.view.ViewTreeObserver
-import android.widget.ImageView
-import android.widget.TextView
-import androidx.annotation.StringRes
-import androidx.core.text.BidiFormatter
-import androidx.core.view.ViewCompat
-import androidx.core.view.isVisible
-import androidx.core.widget.ImageViewCompat
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import androidx.recyclerview.widget.RecyclerView
@@ -25,28 +12,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.NotificationsListItemBinding
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.models.Note
-import org.wordpress.android.models.Note.NoteTimeGroup
-import org.wordpress.android.models.Notification
-import org.wordpress.android.models.Notification.Comment
-import org.wordpress.android.models.Notification.PostNotification
-import org.wordpress.android.models.Notification.Unknown
-import org.wordpress.android.ui.comments.CommentUtils
 import org.wordpress.android.ui.notifications.NotificationsListViewModel.InlineActionEvent
-import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
-import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
-import org.wordpress.android.util.GravatarUtils
-import org.wordpress.android.util.RtlUtils
-import org.wordpress.android.util.extensions.getColorFromAttribute
 import org.wordpress.android.util.extensions.indexOrNull
-import org.wordpress.android.util.image.ImageManager
-import org.wordpress.android.util.image.ImageType
-import javax.inject.Inject
-import kotlin.math.roundToInt
 
 class NotesAdapter(context: Context, private val inlineActionEvents: MutableSharedFlow<InlineActionEvent>) :
     RecyclerView.Adapter<NoteViewHolder>() {
@@ -58,12 +29,6 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
     var onScrolledToBottom = { _: Long -> }
     var currentFilter = Filter.ALL
         private set
-
-    @Inject
-    lateinit var imageManager: ImageManager
-
-    @Inject
-    lateinit var notificationsUtilsWrapper: NotificationsUtilsWrapper
 
     init {
         (context.applicationContext as WordPress).component().inject(this)
@@ -84,7 +49,7 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
         val newNotes = buildFilteredNotesList(notes, currentFilter)
-        val differ = AsyncListDiffer(this@NotesAdapter, object: ItemCallback<Note>(){
+        val differ = AsyncListDiffer(this@NotesAdapter, object : ItemCallback<Note>() {
             override fun areItemsTheSame(oldItem: Note, newItem: Note): Boolean =
                 oldItem.id == newItem.id
 
@@ -109,157 +74,25 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
 
     override fun getItemCount(): Int = filteredNotes.size
 
-    private val Note.timeGroup
-        get() = Note.getTimeGroupForTimestamp(timestamp)
 
-    @StringRes
-    private fun timeGroupHeaderText(note: Note, previousNote: Note?) =
-        previousNote?.timeGroup.let { previousTimeGroup ->
-            val timeGroup = note.timeGroup
-            if (previousTimeGroup?.let { it == timeGroup } == true) {
-                // If the previous time group exists and is the same, we don't need a new one
-                null
-            } else {
-                // Otherwise, we create a new one
-                when (timeGroup) {
-                    NoteTimeGroup.GROUP_TODAY -> R.string.stats_timeframe_today
-                    NoteTimeGroup.GROUP_YESTERDAY -> R.string.stats_timeframe_yesterday
-                    NoteTimeGroup.GROUP_OLDER_TWO_DAYS -> R.string.older_two_days
-                    NoteTimeGroup.GROUP_OLDER_WEEK -> R.string.older_last_week
-                    NoteTimeGroup.GROUP_OLDER_MONTH -> R.string.older_month
-                }
-            }
-        }
-
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun onBindViewHolder(noteViewHolder: NoteViewHolder, position: Int) {
         val note = filteredNotes.getOrNull(position) ?: return
         val previousNote = filteredNotes.getOrNull(position - 1)
-        noteViewHolder.binding.noteContentContainer.setOnClickListener { onNoteClicked(note.id) }
 
-        // Display time group header
-        timeGroupHeaderText(note, previousNote)?.let { timeGroupText ->
-            with(noteViewHolder.binding.headerText) {
-                visibility = View.VISIBLE
-                setText(timeGroupText)
-            }
-        } ?: run {
-            noteViewHolder.binding.headerText.visibility = View.GONE
-        }
 
-        // Subject is stored in db as html to preserve text formatting
-        var noteSubjectSpanned: Spanned = note.getFormattedSubject(notificationsUtilsWrapper)
-        // Trim the '\n\n' added by HtmlCompat.fromHtml(...)
-        noteSubjectSpanned = noteSubjectSpanned.subSequence(
-            0,
-            TextUtils.getTrimmedLength(noteSubjectSpanned)
-        ) as Spanned
-        val spans = noteSubjectSpanned.getSpans(
-            0,
-            noteSubjectSpanned.length,
-            NoteBlockClickableSpan::class.java
-        )
-        for (span in spans) {
-            span.enableColors(noteViewHolder.itemView.context)
-        }
-        noteViewHolder.binding.noteSubject.text = noteSubjectSpanned
-        val noteSubjectNoticon = note.commentSubjectNoticon
-        if (!TextUtils.isEmpty(noteSubjectNoticon)) {
-            val parent = noteViewHolder.binding.noteSubject.parent
-            // Fix position of the subject noticon in the RtL mode
-            if (parent is ViewGroup) {
-                val textDirection = if (BidiFormatter.getInstance()
-                        .isRtl(noteViewHolder.binding.noteSubject.text)
-                ) ViewCompat.LAYOUT_DIRECTION_RTL else ViewCompat.LAYOUT_DIRECTION_LTR
-                ViewCompat.setLayoutDirection(parent, textDirection)
-            }
-            // mirror noticon in the rtl mode
-            if (RtlUtils.isRtl(noteViewHolder.itemView.context)) {
-                noteViewHolder.binding.noteSubjectNoticon.scaleX = -1f
-            }
-            val textIndentSize = noteViewHolder.itemView.context.resources
-                .getDimensionPixelSize(R.dimen.notifications_text_indent_sz)
-            CommentUtils.indentTextViewFirstLine(noteViewHolder.binding.noteSubject, textIndentSize)
-            noteViewHolder.binding.noteSubjectNoticon.text = noteSubjectNoticon
-            noteViewHolder.binding.noteSubjectNoticon.visibility = View.VISIBLE
-        } else {
-            noteViewHolder.binding.noteSubjectNoticon.visibility = View.GONE
-        }
-        val noteSnippet = note.commentSubject
-        if (!TextUtils.isEmpty(noteSnippet)) {
-            handleMaxLines(noteViewHolder.binding.noteSubject, noteViewHolder.binding.noteDetail)
-            noteViewHolder.binding.noteDetail.text = noteSnippet
-            noteViewHolder.binding.noteDetail.visibility = View.VISIBLE
-        } else {
-            noteViewHolder.binding.noteDetail.visibility = View.GONE
-        }
-        noteViewHolder.loadAvatars(note)
-        noteViewHolder.bindInlineActionIconsForNote(note)
-        noteViewHolder.binding.notificationUnread.isVisible = note.isUnread
+        noteViewHolder.bindTimeGroupHeader(note, previousNote, position)
+        noteViewHolder.bindSubject(note)
+        noteViewHolder.bindSubjectNoticon(note)
+        noteViewHolder.bindContent(note)
+        noteViewHolder.bindAvatars(note)
+        noteViewHolder.bindInlineActions(note)
+        noteViewHolder.bindOthers(note, onNoteClicked)
+
 
         // request to load more comments when we near the end
         if (position >= itemCount - 1) {
             onScrolledToBottom(note.timestamp)
         }
-        val headerMarginTop: Int
-        val context = noteViewHolder.itemView.context
-        headerMarginTop = if (position == 0) {
-            context.resources
-                .getDimensionPixelSize(R.dimen.notifications_header_margin_top_position_0)
-        } else {
-            context.resources
-                .getDimensionPixelSize(R.dimen.notifications_header_margin_top_position_n)
-        }
-        val layoutParams = noteViewHolder.binding.headerText.layoutParams as MarginLayoutParams
-        layoutParams.topMargin = headerMarginTop
-        noteViewHolder.binding.headerText.layoutParams = layoutParams
-    }
-
-    private fun NoteViewHolder.loadAvatars(note: Note) {
-        if (note.shouldShowMultipleAvatars() && note.iconURLs != null && note.iconURLs!!.size > 1) {
-            val avatars = note.iconURLs!!.toList()
-            if (avatars.size == 2) {
-                binding.noteAvatar.visibility = View.INVISIBLE
-                binding.twoAvatarsView.root.visibility = View.VISIBLE
-                binding.threeAvatarsView.root.visibility = View.INVISIBLE
-                loadAvatar(binding.twoAvatarsView.twoAvatars1, avatars[1])
-                loadAvatar(binding.twoAvatarsView.twoAvatars2, avatars[0])
-            } else { // size > 3
-                binding.noteAvatar.visibility = View.INVISIBLE
-                binding.twoAvatarsView.root.visibility = View.INVISIBLE
-                binding.threeAvatarsView.root.visibility = View.VISIBLE
-                loadAvatar(binding.threeAvatarsView.threeAvatars1, avatars[2])
-                loadAvatar(binding.threeAvatarsView.threeAvatars2, avatars[1])
-                loadAvatar(binding.threeAvatarsView.threeAvatars3, avatars[0])
-            }
-        } else { // single avatar
-            binding.noteAvatar.visibility = View.VISIBLE
-            binding.twoAvatarsView.root.visibility = View.INVISIBLE
-            binding.threeAvatarsView.root.visibility = View.INVISIBLE
-            loadAvatar(binding.noteAvatar, note.iconURL)
-        }
-    }
-
-    private fun loadAvatar(imageView: ImageView, avatarUrl: String) {
-        val avatarSize = imageView.context.resources.getDimension(R.dimen.notifications_avatar_sz).roundToInt()
-        val url = GravatarUtils.fixGravatarUrl(avatarUrl, avatarSize)
-        imageManager.loadIntoCircle(imageView, ImageType.AVATAR_WITH_BACKGROUND, url)
-    }
-
-    private fun Note.shouldShowMultipleAvatars() = isFollowType || isLikeType || isCommentLikeType
-
-    private fun handleMaxLines(subject: TextView, detail: TextView) {
-        subject.viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
-            override fun onPreDraw(): Boolean {
-                subject.viewTreeObserver.removeOnPreDrawListener(this)
-                if (subject.lineCount == 2) {
-                    detail.maxLines = 1
-                } else {
-                    detail.maxLines = 2
-                }
-                return false
-            }
-        })
     }
 
     fun cancelReloadLocalNotes() {
@@ -302,73 +135,6 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
                 Filter.LIKE -> note.isLikeType
             }
         }.sortedByDescending { it.timestamp }.let { result -> ArrayList(result) }
-    }
-}
-
-class NoteViewHolder(
-    val binding: NotificationsListItemBinding,
-    private val inlineActionEvents: MutableSharedFlow<InlineActionEvent>,
-    private val coroutineScope: CoroutineScope
-) : RecyclerView.ViewHolder(binding.root) {
-    fun bindInlineActionIconsForNote(note: Note) = Notification.from(note).let { notification ->
-        when (notification) {
-            Comment -> bindLikeCommentAction(note)
-            is PostNotification.NewPost -> bindLikePostAction(note)
-            is PostNotification -> bindShareAction(notification)
-            is Unknown -> {
-                binding.action.isVisible = false
-            }
-        }
-    }
-
-    private fun bindShareAction(notification: PostNotification) {
-        binding.action.setImageResource(R.drawable.block_share)
-        val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
-        ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))
-        binding.action.isVisible = true
-        binding.action.setOnClickListener {
-            coroutineScope.launch {
-                inlineActionEvents.emit(
-                    InlineActionEvent.SharePostButtonTapped(notification)
-                )
-            }
-        }
-    }
-
-    private fun bindLikePostAction(note: Note) {
-        if (note.canLikePost().not()) return
-        setupLikeIcon(note.hasLikedPost())
-        binding.action.setOnClickListener {
-            val liked = note.hasLikedPost().not()
-            setupLikeIcon(liked)
-            coroutineScope.launch {
-                inlineActionEvents.emit(
-                    InlineActionEvent.LikePostButtonTapped(note, liked)
-                )
-            }
-        }
-    }
-
-    private fun bindLikeCommentAction(note: Note) {
-        if (note.canLikeComment().not()) return
-        setupLikeIcon(note.hasLikedComment())
-        binding.action.setOnClickListener {
-            val liked = note.hasLikedComment().not()
-            setupLikeIcon(liked)
-            coroutineScope.launch {
-                inlineActionEvents.emit(
-                    InlineActionEvent.LikeCommentButtonTapped(note, liked)
-                )
-            }
-        }
-    }
-
-    private fun setupLikeIcon(liked: Boolean) {
-        binding.action.isVisible = true
-        binding.action.setImageResource(if (liked) R.drawable.star_filled else R.drawable.star_empty)
-        val color = if (liked) binding.root.context.getColor(R.color.inline_action_filled)
-        else binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
-        ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))
     }
 }
 


### PR DESCRIPTION
Part of pc8HXX-1ua-p2

This PR contains:
1. Extract NoteViewHolder from NoteAdapter
2. Use ViewBinding in NoteViewHolder
3. Remove a duplicated API request from NotificationsListFragment
4. Fix IndexOutOfBoundsException in NoteAdapter
5. Refactors

-----

## To Test:
1. Sign in the JP app and switch to Notifications tab
2. Click some notification items
3. The behavior should be the same as before.
4. Switch to ALL/UNREAD/COMMENTS...etc
5. Repeat 2 & 3
6. The behavior should be the same as before, thank you.

P.S. The original implementation caused an IndexOutOfBoundsException after switching to ALL/UNREAD/COMMENTS tabs multiple times and then clicking on the notification item.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications tab

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

9. What automated tests I added (or what prevented me from doing so)

    - none

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)