### PR TITLE
[Reader] Remove duplicates from the server blogs list only if local and remote  lists don't match

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.reader.services.update;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
@@ -322,13 +324,12 @@ public class ReaderUpdateLogic {
             public void run() {
                 ReaderBlogList serverBlogs = ReaderBlogList.fromJson(jsonObject);
                 ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
-                // Remove duplicates from the server blogs list only if local and remote  lists don't match.
-                if (serverBlogs.size() != localBlogs.size()) {
-                    // This is required because under rare circumstances the server can return duplicates.
-                    // We could have modified the function isSameList to eliminate the length check,
-                    // but it's better to keep it separate since we aim to remove this check as soon as possible.
-                    removeDuplicateFromServerResponse(serverBlogs);
-                }
+
+                // This is required because under rare circumstances the server can return duplicates.
+                // We could have modified the function isSameList to eliminate the length check,
+                // but it's better to keep it separate since we aim to remove this check as soon as possible.
+                removeDuplicateBlogs(serverBlogs);
+
                 if (!localBlogs.isSameList(serverBlogs)) {
                     // always update the list of followed blogs if there are *any* changes between
                     // server and local (including subscription count, description, etc.)
@@ -345,20 +346,26 @@ public class ReaderUpdateLogic {
 
                 taskCompleted(UpdateTask.FOLLOWED_BLOGS);
             }
-            /* This method remove duplicate ReaderBlog from list. */
-            private void removeDuplicateFromServerResponse(ReaderBlogList serverBlogs) {
-                for (int i = 0; i < serverBlogs.size(); i++) {
-                    ReaderBlog outer = serverBlogs.get(i);
-                    for (int j = serverBlogs.size() - 1; j > i; j--) {
-                        ReaderBlog inner = serverBlogs.get(j);
-                        if (outer.blogId == inner.blogId) {
-                            // If the 'id' property is the same,
-                            // remove the later object to avoid duplicates
-                            serverBlogs.remove(j);
-                        }
-                    }
+        }.start();
+    }
+
+    /**
+     * Remove duplicates from the input list.
+     * Note that this method modifies the input list.
+     *
+     * @param blogList The list of blogs to remove duplicates from.
+     */
+    private void removeDuplicateBlogs(@NonNull ReaderBlogList blogList) {
+        for (int i = 0; i < blogList.size(); i++) {
+            ReaderBlog outer = blogList.get(i);
+            for (int j = blogList.size() - 1; j > i; j--) {
+                ReaderBlog inner = blogList.get(j);
+                if (outer.blogId == inner.blogId) {
+                    // If the 'id' property is the same,
+                    // remove the later object to avoid duplicates
+                    blogList.remove(j);
                 }
             }
-        }.start();
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a rare issue where the blogs list returned from the server could contain duplicate entries. 
We will address the problem on the server when resources are available. In the meantime, we are fixing the issue on the client side, because the duplicate followed sites are causing unnecessary UI updates.

To test:
* This could be tricky to test since you need to manually duplicate the entries on the list. We haven't found a reliable way to duplicate followed blogs.
* Could be easier to manually duplicate the entry in AS - `serverBlogs.add(serverBlogs.get(0));`
* Then, set a breakpoint in [the code that updates the blogs locally](https://github.com/wordpress-mobile/WordPress-Android/blob/62591c6a3387a8242726f57a3917a81e14f6f5b7/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java#L333). You should not reach that code.
-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
