### PR TITLE
🤖 Adds accessibility descriptions on inline actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -97,6 +97,7 @@ class NoteViewHolder(
                 )
             }
         }
+        binding.action.contentDescription = binding.root.context.getString(R.string.share_action)
     }
 
     private fun bindLikePostAction(note: Note) {
@@ -136,6 +137,8 @@ class NoteViewHolder(
         val color = if (liked) binding.root.context.getColor(R.color.inline_action_filled)
         else binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
         ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))
+        binding.action.contentDescription =
+            binding.root.context.getString(if (liked) R.string.mnu_comment_liked else R.string.reader_label_like)
     }
 
     @StringRes


### PR DESCRIPTION
Fixes #20212

-----

## To Test:

1. Open the notifications tab
2. Turn talkback on
3. Browse through the list
4. Focus on a liked post or comment
5. **Verify** that it is announce as "Liked"
6. Focus on a not like post or comments
7. **Verify** that the "Like" action is announced
8. Focus on a sharable post
9. **Verify** that the "Share" action is announced
10. **Verify** that no action is announced on list items without an action

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

12. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
