### PR TITLE
tools: make dependency diff report foldable

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -640,9 +640,7 @@ tasks.register("dependencyTreeDiffCommentToGitHub", ViolationCommentsToGitHubTas
     commentOnlyChangedFiles = false
     minSeverity = SEVERITY.INFO
     commentTemplate = """
-### The PR caused the following dependency changes:
-
-<details><summary>expand</summary>
+<details><summary>The PR caused some dependency changes (expand to see details)</summary>
 <p>
 
 ```diff

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -642,9 +642,15 @@ tasks.register("dependencyTreeDiffCommentToGitHub", ViolationCommentsToGitHubTas
     commentTemplate = """
 ### The PR caused the following dependency changes:
 
+<details><summary>expand</summary>
+<p>
+
 ```diff
 {{{violation.message}}}
 ```
+
+</p>
+</details>
 
 *Please review and act accordingly*
 """


### PR DESCRIPTION
This small tooling-only PR makes dependency diff reports foldable, like in WooCommerce Android: https://github.com/woocommerce/woocommerce-android/pull/10855#issuecomment-1949109579

It saves scrolling when working with a PR.

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/75b2c453-c13a-490f-a6e0-2c334246a4cf)
