### PR TITLE
Adds notifications list tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
@@ -6,6 +6,7 @@ import android.database.CursorIndexOutOfBoundsException;
 import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.json.JSONException;
@@ -124,7 +125,7 @@ public class NotificationsTable {
         return noteSrc;
     }
 
-    public static void saveNotes(List<Note> notes, boolean clearBeforeSaving) {
+    public static void saveNotes(@NonNull List<Note> notes, boolean clearBeforeSaving) {
         getDb().beginTransaction();
         try {
             if (clearBeforeSaving) {
@@ -142,7 +143,7 @@ public class NotificationsTable {
         }
     }
 
-    public static boolean saveNote(Note note) {
+    public static boolean saveNote(@NonNull Note note) {
         getDb().beginTransaction();
         boolean saved = false;
         try {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/NotificationsTableWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/wrappers/NotificationsTableWrapper.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.datasets.wrappers
+
+import dagger.Reusable
+import org.wordpress.android.datasets.NotificationsTable
+import org.wordpress.android.models.Note
+import javax.inject.Inject
+
+@Reusable
+class NotificationsTableWrapper @Inject constructor() {
+    fun saveNote(note: Note): Boolean = NotificationsTable.saveNote(note)
+
+    fun saveNotes(notes: List<Note>, clearBeforeSaving: Boolean) {
+        NotificationsTable.saveNotes(notes, clearBeforeSaving)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -6,8 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
-import org.greenrobot.eventbus.EventBus
-import org.wordpress.android.datasets.NotificationsTable
+import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.AccountStore
@@ -21,12 +20,13 @@ import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.NOTIFICATIONS
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsChanged
-import org.wordpress.android.ui.notifications.utils.NotificationsActions
+import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.EventBusWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -44,6 +44,9 @@ class NotificationsListViewModel @Inject constructor(
     private val commentStore: CommentsStore,
     private val readerPostTableWrapper: ReaderPostTableWrapper,
     private val readerPostActionsWrapper: ReaderPostActionsWrapper,
+    private val notificationsTableWrapper: NotificationsTableWrapper,
+    private val notificationsActionsWrapper: NotificationsActionsWrapper,
+    private val eventBusWrapper: EventBusWrapper,
     private val accountStore: AccountStore
 ) : ScopedViewModel(bgDispatcher) {
     private val _showJetpackPoweredBottomSheet = MutableLiveData<Event<Boolean>>()
@@ -81,12 +84,12 @@ class NotificationsListViewModel @Inject constructor(
         notes.filter { it.isUnread }
             .map {
                 gcmMessageHandler.removeNotificationWithNoteIdFromSystemBar(context, it.id)
-                NotificationsActions.markNoteAsRead(it)
+                notificationsActionsWrapper.markNoteAsRead(it)
                 it.setRead()
                 it
             }.takeIf { it.isNotEmpty() }?.let {
-                NotificationsTable.saveNotes(it, false)
-                EventBus.getDefault().post(NotificationsChanged())
+                notificationsTableWrapper.saveNotes(it, false)
+                eventBusWrapper.post(NotificationsChanged())
             }
     }
 
@@ -99,7 +102,7 @@ class NotificationsListViewModel @Inject constructor(
         _updatedNote.postValue(note)
         val result = commentStore.likeComment(site, note.commentId, null, liked)
         if (result.isError.not()) {
-            NotificationsTable.saveNote(note)
+            notificationsTableWrapper.saveNote(note)
         }
     }
 
@@ -145,7 +148,7 @@ class NotificationsListViewModel @Inject constructor(
             wpComUserId = accountStore.account.userId
         ) { success ->
             if (success) {
-                NotificationsTable.saveNote(note)
+                notificationsTableWrapper.saveNote(note)
                 if (post == null) {
                     // sync post from server
                     readerPostActionsWrapper.requestBlogPost(note.siteId.toLong(), note.postId.toLong(), null)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.notifications.utils;
 
+import androidx.annotation.Nullable;
+
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
@@ -58,7 +60,7 @@ public class NotificationsActions {
         return notes;
     }
 
-    public static void markNoteAsRead(final Note note) {
+    public static void markNoteAsRead(@Nullable final Note note) {
         if (note == null) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.notifications.utils
 
 import dagger.Reusable
+import org.wordpress.android.models.Note
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -14,4 +15,8 @@ class NotificationsActionsWrapper @Inject constructor() {
                 { continuation.resume(true) },
                 { continuation.resume(true) })
         }
+
+    fun markNoteAsRead(note: Note?) {
+        NotificationsActions.markNoteAsRead(note)
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
 import org.wordpress.android.datasets.wrappers.ReaderPostTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.CommentsStore
@@ -21,10 +22,12 @@ import org.wordpress.android.models.Note
 import org.wordpress.android.models.ReaderPost
 import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
+import org.wordpress.android.ui.notifications.utils.NotificationsActionsWrapper
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
+import org.wordpress.android.util.EventBusWrapper
 
 private const val REQUEST_BLOG_LISTENER_PARAM_POSITION = 2
 
@@ -49,7 +52,17 @@ class NotificationsListViewModelTest : BaseUnitTest() {
     @Mock
     private lateinit var readerPostActionsWrapper: ReaderPostActionsWrapper
 
-    @Mock lateinit var appLogWrapper: AppLogWrapper
+    @Mock
+    private lateinit var notificationsActionsWrapper: NotificationsActionsWrapper
+
+    @Mock
+    private lateinit var notificationsTableWrapper: NotificationsTableWrapper
+
+    @Mock
+    private lateinit var eventBusWrapper: EventBusWrapper
+
+    @Mock
+    private lateinit var appLogWrapper: AppLogWrapper
 
     @Mock
     private lateinit var siteStore: SiteStore
@@ -78,6 +91,9 @@ class NotificationsListViewModelTest : BaseUnitTest() {
             commentStore,
             readerPostTableWrapper,
             readerPostActionsWrapper,
+            notificationsTableWrapper,
+            notificationsActionsWrapper,
+            eventBusWrapper,
             accountStore,
         )
     }


### PR DESCRIPTION
## Description
Adds unit tests for marking notifications as read and liking a comment or post

-----

## To Test:
* *Verify* that all unit tests are 🟢 on the CI
* *Verify* that the mark as read and like/unlike post/comment actions work the same and 495ab1e31d35e477e53692c45fb16a4ff51a1053 did not affect the functionality

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Added notifications list tests

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
