### PR TITLE
build: replace `kapt` with `ksp`

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -4,7 +4,6 @@ import se.bjurr.violations.lib.model.SEVERITY
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.kapt"
     id "org.jetbrains.kotlin.plugin.parcelize"
     id "org.jetbrains.kotlin.plugin.allopen"
     id "io.sentry.android.gradle"
@@ -337,10 +336,6 @@ static def addBuildConfigFieldsFromPrefixedProperties(variant, properties, prefi
         variant.buildConfigField "String", it.key.toUpperCase(), "\"${it.value}\""
     }
 }
-kapt {
-    // Enable to infer error types in stubs (see: https://kotlinlang.org/docs/kapt.html#non-existent-type-correction)
-    correctErrorTypes true
-}
 
 dependencies {
     implementation 'androidx.webkit:webkit:1.10.0'
@@ -453,7 +448,7 @@ dependencies {
         exclude group: 'androidx.appcompat', module: 'appcompat'
     }
     implementation "com.github.bumptech.glide:glide:$glideVersion"
-    kapt "com.github.bumptech.glide:compiler:$glideVersion"
+    ksp "com.github.bumptech.glide:ksp:$glideVersion"
     implementation "com.github.bumptech.glide:volley-integration:$glideVersion"
     implementation "com.github.indexos.media-for-mobile:domain:$indexosMediaForMobileVersion"
     implementation "com.github.indexos.media-for-mobile:android:$indexosMediaForMobileVersion"
@@ -467,9 +462,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
     implementation "com.google.dagger:dagger-android-support:$gradle.ext.daggerVersion"
-    kapt "com.google.dagger:dagger-android-processor:$gradle.ext.daggerVersion"
+    ksp "com.google.dagger:dagger-android-processor:$gradle.ext.daggerVersion"
     implementation "com.google.dagger:hilt-android:$gradle.ext.daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
+    ksp "com.google.dagger:hilt-compiler:$gradle.ext.daggerVersion"
 
     testImplementation "$gradle.ext.storiesAndroidPhotoEditorPath:$automatticStoriesVersion"
 
@@ -526,7 +521,7 @@ dependencies {
     androidTestImplementation (name:'cloudtestingscreenshotter_lib', ext:'aar') // Screenshots on Firebase Cloud Testing
     androidTestImplementation "androidx.work:work-testing:$androidxWorkManagerVersion"
     androidTestImplementation "com.google.dagger:hilt-android-testing:$gradle.ext.daggerVersion"
-    kaptAndroidTest "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
+    kspAndroidTest "com.google.dagger:hilt-android-compiler:$gradle.ext.daggerVersion"
     // Enables Java 8+ API desugaring support
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$androidDesugarVersion"
     lintChecks "org.wordpress:lint:$wordPressLintVersion"

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -19,7 +19,7 @@
     <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/issues/18185 -->
     <issue id="MissingFirebaseInstanceTokenRefresh">
         <!-- GCM -->
-        <ignore path="**/generated/source/kapt/**/org/wordpress/android/push/Hilt_GCMMessageService.java" />
+        <ignore path="**/generated/ksp/**/org/wordpress/android/push/Hilt_GCMMessageService.java" />
     </issue>
     <issue id="GradleDependency" severity="ignore" /> <!-- Dependabot will take care of this -->
     <issue id="MissingNullAnnotationOnField">
@@ -63,7 +63,7 @@
         <ignore path="**/src/wordpress/res" /> <!-- drawable-hdpi, drawable-xxhdpi -->
     </issue>
     <issue id="ObsoleteSdkInt">
-        <ignore path="**/generated/source/kapt/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
+        <ignore path="**/generated/ksp/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
     </issue>
     <!-- INTEROPERABILITY -->
     <issue id="UnknownNullness" severity="informational">

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,6 @@ pluginManagement {
     plugins {
         id "org.jetbrains.kotlin.android" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.jvm" version gradle.ext.kotlinVersion
-        id "org.jetbrains.kotlin.kapt" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.plugin.serialization" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.plugin.parcelize" version gradle.ext.kotlinVersion
         id "org.jetbrains.kotlin.plugin.allopen" version gradle.ext.kotlinVersion


### PR DESCRIPTION
This PR migrates from using kapt to ksp, for running annotation processors of 3rd party libraries.

It targets a feature branch.

-----

## To Test:

Please run and smoke test the app.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - The whole app

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - I smoke tested the app, we rely on automated tests on CI
 
3. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
