### PR TITLE
EditPostActivity - Update showVideoDurationLimitWarning to use Snackbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3932,7 +3932,12 @@ public class EditPostActivity extends LocaleAwareActivity implements
     }
 
     @Override public void showVideoDurationLimitWarning(@NonNull String fileName) {
-        ToastUtils.showToast(this, R.string.error_media_video_duration_exceeds_limit, ToastUtils.Duration.LONG);
+        String message = getString(R.string.error_media_video_duration_exceeds_limit);
+        WPSnackbar.make(
+                findViewById(R.id.editor_activity),
+                message,
+                Snackbar.LENGTH_LONG
+        ).show();
     }
 
     @Override


### PR DESCRIPTION
Currently, there's an issue where the Video length limitation message is getting cut off when it is shown inside a `Toast`:

<kbd><img src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/1432236d-ea83-44bd-a357-2b5d4ab11b6e" width=200 /></kbd>

The current project's target API is `33` and according to the Toast docs, starting from Android 12 (API 31) it will be limited to two lines. 

> Starting with Android 12 (API level 31), apps targeting Android 12 or newer will have their toasts limited to two lines.
> [Source](https://developer.android.com/reference/android/widget/Toast)

So this PR moves this message to a Snackbar and it will be shown like this:
<kbd><img src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/f955e10d-2244-4e38-8b8a-dc21e9a98316" width=200 /></kbd>

-----

## To Test:

- Install the build from this PR
- Open the Editor
- Add the VideoPress block
- Try to add a video that's over the 5 minute limit
- **Expect** to see the Snackbar with the message showing without getting cut off

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None, it should only affect this functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - It does not apply for this changes.

3. What automated tests I added (or what prevented me from doing so)

    - Just performed manual testing.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
