### PR TITLE
`:libs:processors` annotation processing unit test

### DIFF
--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -17,4 +17,5 @@ dependencies {
     testImplementation "com.github.tschuchortdev:kotlin-compile-testing:1.5.0"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$gradle.ext.kotlinVersion"
 }

--- a/libs/processors/build.gradle
+++ b/libs/processors/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     kapt "com.google.auto.service:auto-service:$googleAutoServiceVersion"
     implementation "com.squareup:kotlinpoet:$squareupKotlinPoetVersion"
 
+    testImplementation "com.github.tschuchortdev:kotlin-compile-testing:1.5.0"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }

--- a/libs/processors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigProcessorTest.kt
+++ b/libs/processors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigProcessorTest.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.processor
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class RemoteConfigProcessorTest {
+
+    @Test
+    fun `given a class with features annotation, when compiling, generate expected configuration check`() {
+        // given
+        val featureA = SourceFile.kotlin(
+            "Feature.kt", """
+        import org.wordpress.android.annotation.Feature
+        import org.wordpress.android.util.config.AppConfig
+
+        @Feature("remoteField", false)
+        class A(appConfig: AppConfig, val remoteField: String ="foo")
+        """
+        )
+
+        // when
+        val result = compile(listOf(featureA))
+
+        // then
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        assertThat(result.classLoader.loadClass("org.wordpress.android.util.config.RemoteFeatureConfigCheck"))
+            .hasDeclaredMethods("checkRemoteFields")
+    }
+
+    private fun compile(src: List<SourceFile>) = KotlinCompilation().apply {
+        sources = src + fakeAppConfig
+        annotationProcessors = listOf(RemoteConfigProcessor())
+        inheritClassPath = true
+        messageOutputStream = System.out
+    }.compile()
+
+    // Fake AppConfig is needed, as it's a class that is expected to be present in the classpath. Originally, this class
+    // is placed in `WordPress` module.
+    private val fakeAppConfig = SourceFile.kotlin(
+        "AppConfig.kt", """
+        package org.wordpress.android.util.config
+
+        class AppConfig
+    """
+    )
+
+}

--- a/libs/processors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigProcessorTest.kt
+++ b/libs/processors/src/test/kotlin/org/wordpress/android/processor/RemoteConfigProcessorTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.junit.Test
 
 class RemoteConfigProcessorTest {
-
     @Test
     fun `given a class with features annotation, when compiling, generate expected configuration check`() {
         // when
@@ -55,7 +54,7 @@ class RemoteConfigProcessorTest {
     }
 
     @Test
-    fun `given class with feature and class with experiment annotation, when compiling, generate expected config defaults class`() {
+    fun `given class with feature and experiment annotation, when compiling, generate config defaults class`() {
         // given
         val experiment = SourceFile.kotlin(
             "Experiment.kt", """
@@ -149,5 +148,4 @@ class RemoteConfigProcessorTest {
         class FeatureA(appConfig: AppConfig, val remoteField: String ="foo")
         """
     )
-
 }


### PR DESCRIPTION
### Description

This PR adds a unit test for `RemoteConfigProcessor`. It'll be useful to validate the correctness of `ksp` migration.

### Context

In #20213 I hesitate with adding unit test for main processing logic, `RemoteConfigProcessor` class, due to the cyclic dependency on `AppConfig` class.

Fortunately, I was able to overcome this by providing a fake `AppConfig` class to sources of test compilation.


### To Test

Not needed, CI check is fine.


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None
    
2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Unit

3. What automated tests I added (or what prevented me from doing so)

    - Unit

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
