### PR TITLE
Fix issues related to the Like state in notifications tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -27,6 +27,7 @@ import androidx.core.content.res.ResourcesCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.elevation.ElevationOverlayProvider;
@@ -55,7 +56,6 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
-import org.wordpress.android.fluxc.store.CommentStore.RemoteLikeCommentPayload;
 import org.wordpress.android.fluxc.store.CommentsStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -81,6 +81,7 @@ import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
+import org.wordpress.android.ui.notifications.NotificationsListViewModel;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderAnim;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -115,6 +116,7 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
 import kotlinx.coroutines.DelicateCoroutinesApi;
@@ -130,6 +132,7 @@ import kotlinx.coroutines.GlobalScope;
  */
 @Deprecated
 @SuppressWarnings("DeprecatedIsStillUsed")
+@AndroidEntryPoint
 public class CommentDetailFragment extends ViewPagerFragment implements NotificationFragment, OnConfirmListener,
         OnCollapseListener {
     private static final String KEY_MODE = "KEY_MODE";
@@ -181,6 +184,8 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     @Nullable private CommentDetailFragmentBinding mBinding = null;
     @Nullable private ReaderIncludeCommentBoxBinding mReplyBinding = null;
     @Nullable private CommentActionFooterBinding mActionBinding = null;
+
+    private NotificationsListViewModel mNotificationsViewModel;
 
     /*
      * used when called from comment list
@@ -244,6 +249,7 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         }
 
         setHasOptionsMenu(true);
+        mNotificationsViewModel = new ViewModelProvider(this).get(NotificationsListViewModel.class);
     }
 
     @Override
@@ -1468,9 +1474,8 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
                 setModerateButtonForStatus(actionBinding, CommentStatus.APPROVED);
             }
         }
-        mCommentsStoreAdapter.dispatch(CommentActionBuilder.newLikeCommentAction(
-                new RemoteLikeCommentPayload(site, comment, actionBinding.btnLike.isActivated()))
-        );
+        mNotificationsViewModel.likeComment(mNote, actionBinding.btnLike.isActivated());
+
         actionBinding.btnLike.announceForAccessibility(
                 getText(actionBinding.btnLike.isActivated() ? R.string.comment_liked_talkback
                         : R.string.comment_unliked_talkback)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -115,7 +115,6 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
 import kotlinx.coroutines.DelicateCoroutinesApi;
@@ -131,7 +130,6 @@ import kotlinx.coroutines.GlobalScope;
  */
 @Deprecated
 @SuppressWarnings("DeprecatedIsStillUsed")
-@AndroidEntryPoint
 public class CommentDetailFragment extends ViewPagerFragment implements NotificationFragment, OnConfirmListener,
         OnCollapseListener {
     private static final String KEY_MODE = "KEY_MODE";

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -27,7 +27,6 @@ import androidx.core.content.res.ResourcesCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.elevation.ElevationOverlayProvider;
@@ -56,6 +55,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
+import org.wordpress.android.fluxc.store.CommentStore.RemoteLikeCommentPayload;
 import org.wordpress.android.fluxc.store.CommentsStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -81,7 +81,6 @@ import org.wordpress.android.ui.comments.unified.UnifiedCommentsEditActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
-import org.wordpress.android.ui.notifications.NotificationsListViewModel;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderAnim;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -185,8 +184,6 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
     @Nullable private ReaderIncludeCommentBoxBinding mReplyBinding = null;
     @Nullable private CommentActionFooterBinding mActionBinding = null;
 
-    private NotificationsListViewModel mNotificationsViewModel;
-
     /*
      * used when called from comment list
      */
@@ -249,7 +246,6 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         }
 
         setHasOptionsMenu(true);
-        mNotificationsViewModel = new ViewModelProvider(this).get(NotificationsListViewModel.class);
     }
 
     @Override
@@ -1474,8 +1470,11 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
                 setModerateButtonForStatus(actionBinding, CommentStatus.APPROVED);
             }
         }
-        mNotificationsViewModel.likeComment(mNote, actionBinding.btnLike.isActivated());
-
+        mCommentsStoreAdapter.dispatch(CommentActionBuilder.newLikeCommentAction(
+                new RemoteLikeCommentPayload(site, comment, actionBinding.btnLike.isActivated()))
+        );
+        EventBus.getDefault().postSticky(new NotificationEvents
+                .OnNoteCommentLikeChanged(mNote, actionBinding.btnLike.isActivated()));
         actionBinding.btnLike.announceForAccessibility(
                 getText(actionBinding.btnLike.isActivated() ? R.string.comment_liked_talkback
                         : R.string.comment_unliked_talkback)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1471,8 +1471,11 @@ public class CommentDetailFragment extends ViewPagerFragment implements Notifica
         mCommentsStoreAdapter.dispatch(CommentActionBuilder.newLikeCommentAction(
                 new RemoteLikeCommentPayload(site, comment, actionBinding.btnLike.isActivated()))
         );
-        EventBus.getDefault().postSticky(new NotificationEvents
-                .OnNoteCommentLikeChanged(mNote, actionBinding.btnLike.isActivated()));
+        if (mNote != null) {
+            EventBus.getDefault().postSticky(new NotificationEvents
+                    .OnNoteCommentLikeChanged(mNote, actionBinding.btnLike.isActivated()));
+        }
+
         actionBinding.btnLike.announceForAccessibility(
                 getText(actionBinding.btnLike.isActivated() ? R.string.comment_liked_talkback
                         : R.string.comment_unliked_talkback)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -62,4 +62,14 @@ public class NotificationEvents {
 
         public NotificationsRefreshError() {}
     }
+
+    public static class OnNoteCommentLikeChanged {
+        public final Note note;
+        public final boolean liked;
+
+        public OnNoteCommentLikeChanged(Note note, boolean liked) {
+            this.note = note;
+            this.liked = liked;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.notifications;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.models.Note;
@@ -67,7 +69,17 @@ public class NotificationEvents {
         public final Note note;
         public final boolean liked;
 
-        public OnNoteCommentLikeChanged(Note note, boolean liked) {
+        public OnNoteCommentLikeChanged(@NonNull Note note, boolean liked) {
+            this.note = note;
+            this.liked = liked;
+        }
+    }
+
+    public static class OnNotePostLikeChanged {
+        public final Note note;
+        public final boolean liked;
+
+        public OnNotePostLikeChanged(@NonNull Note note, boolean liked) {
             this.note = note;
             this.liked = liked;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -53,10 +53,12 @@ import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsUn
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.All
 import org.wordpress.android.ui.notifications.NotificationsListFragmentPage.Companion.KEY_TAB_POSITION
 import org.wordpress.android.ui.notifications.adapters.Filter
+import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
+import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE
@@ -166,11 +168,19 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 connectJetpack.visibility = View.GONE
                 tabLayout.visibility = View.VISIBLE
                 viewPager.visibility = View.VISIBLE
+                fetchRemoteNotes()
             }
             setSelectedTab(lastTabPosition)
             setNotificationPermissionWarning()
         }
         viewModel.onResume()
+    }
+
+    private fun fetchRemoteNotes() {
+        if (!isAdded) {
+            return
+        }
+        NotificationsUpdateServiceStarter.startService(activity)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -58,7 +58,6 @@ import org.wordpress.android.ui.notifications.services.NotificationsUpdateServic
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.JetpackBrandingUtils
-import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.WPPermissionUtils
 import org.wordpress.android.util.WPPermissionUtils.NOTIFICATIONS_PERMISSION_REQUEST_CODE

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -49,6 +49,7 @@ import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsCh
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsRefreshCompleted
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsRefreshError
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsUnseenStatus
+import org.wordpress.android.ui.notifications.NotificationEvents.OnNoteCommentLikeChanged
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.All
 import org.wordpress.android.ui.notifications.NotificationsListFragment.Companion.TabPosition.Comment
@@ -149,6 +150,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         }
 
         swipeToRefreshHelper?.isRefreshing = true
+        notesAdapter.reloadLocalNotes()
     }
 
     override fun onDestroyView() {
@@ -184,7 +186,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         super.onResume()
         binding?.hideNewNotificationsBar()
         EventBus.getDefault().post(NotificationsUnseenStatus(false))
-        notesAdapter.reloadLocalNotes()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -509,6 +510,15 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 hideNewNotificationsBar()
             }
         }
+    }
+
+    @Subscribe(sticky = true, threadMode = MAIN)
+    fun onEventMainThread(event: OnNoteCommentLikeChanged) {
+        if (!isAdded) {
+            return
+        }
+        notesAdapter.updateNote(event.note.apply { setLikedComment(event.liked) })
+        EventBus.getDefault().removeStickyEvent(OnNoteCommentLikeChanged::class.java)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -549,10 +549,6 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
                 NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION,
                 isTappedFromPushNotification
             )
-            openNoteForReplyWithParams(detailIntent, activity)
-        }
-
-        private fun openNoteForReplyWithParams(detailIntent: Intent, activity: Activity) {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -518,7 +518,14 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
             return
         }
         notesAdapter.updateNote(event.note.apply { setLikedComment(event.liked) })
-        EventBus.getDefault().removeStickyEvent(OnNoteCommentLikeChanged::class.java)
+    }
+
+    @Subscribe(sticky = true, threadMode = MAIN)
+    fun onEventMainThread(event: NotificationEvents.OnNotePostLikeChanged) {
+        if (!isAdded) {
+            return
+        }
+        notesAdapter.updateNote(event.note.apply { setLikedPost(event.liked) })
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -139,6 +139,8 @@ class NotificationsListViewModel @Inject constructor(
     fun likePost(note: Note, liked: Boolean) = launch {
         note.setLikedPost(liked)
         _updatedNote.postValue(note)
+        // for updating the UI in other tabs
+        EventBus.getDefault().postSticky(NotificationEvents.OnNotePostLikeChanged(note, liked))
         val post = readerPostTableWrapper.getBlogPost(note.siteId.toLong(), note.postId.toLong(), true)
         readerPostActionsWrapper.performLikeActionRemote(
             post = post,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.NOTIFICATIONS
 import org.wordpress.android.ui.notifications.NotificationEvents.NotificationsChanged
+import org.wordpress.android.ui.notifications.NotificationEvents.OnNoteCommentLikeChanged
 import org.wordpress.android.ui.notifications.utils.NotificationsActions
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -97,6 +98,8 @@ class NotificationsListViewModel @Inject constructor(
         }
         note.setLikedComment(liked)
         _updatedNote.postValue(note)
+        // for updating the UI in other tabs
+        EventBus.getDefault().postSticky(OnNoteCommentLikeChanged(note, liked))
         val result = commentStore.likeComment(site, note.commentId, null, liked)
         if (result.isError.not()) {
             NotificationsTable.saveNote(note)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.notifications.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -46,13 +47,20 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      * Add notes to the adapter and notify the change
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
-        val currentSize: Int = filteredNotes.size
         val newNotes = buildFilteredNotesList(notes, currentFilter)
+        val result = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+            override fun getOldListSize(): Int = filteredNotes.size
+            override fun getNewListSize(): Int = newNotes.size
+            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                filteredNotes[oldItemPosition].id == newNotes[newItemPosition].id
+
+            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+                filteredNotes[oldItemPosition].json.toString() == newNotes[newItemPosition].json.toString()
+        })
         filteredNotes.clear()
         filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
-            notifyItemRangeRemoved(0, currentSize)
-            notifyItemRangeInserted(0, newNotes.size)
+            result.dispatchUpdatesTo(this@NotesAdapter)
             onNotesLoaded(newNotes.size)
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
@@ -189,6 +189,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedComment(true)
         verify(commentStore, times(1)).likeComment(site, commentId, null, true)
         verify(notificationsTableWrapper, times(1)).saveNote(note)
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNoteCommentLikeChanged>())
     }
 
     @Test
@@ -214,6 +215,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedComment(false)
         verify(commentStore, times(1)).likeComment(site, commentId, null, false)
         verify(notificationsTableWrapper, times(1)).saveNote(note)
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNoteCommentLikeChanged>())
     }
 
     @Test
@@ -238,6 +240,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedComment(true)
         verify(commentStore, times(1)).likeComment(site, commentId, null, true)
         verify(notificationsTableWrapper, times(0)).saveNote(note)
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNoteCommentLikeChanged>())
     }
 
     @Test
@@ -265,6 +268,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedPost(true)
         verify(readerPostActionsWrapper, times(1))
             .performLikeActionRemote(eq(post), eq(postId), eq(siteId), eq(true), eq(userId), any())
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNotePostLikeChanged>())
         verify(notificationsTableWrapper, times(1)).saveNote(note)
     }
 
@@ -293,6 +297,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedPost(false)
         verify(readerPostActionsWrapper, times(1))
             .performLikeActionRemote(eq(post), eq(postId), eq(siteId), eq(false), eq(userId), any())
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNotePostLikeChanged>())
         verify(notificationsTableWrapper, times(1)).saveNote(note)
     }
 
@@ -321,6 +326,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         verify(note, times(1)).setLikedPost(true)
         verify(readerPostActionsWrapper, times(1))
             .performLikeActionRemote(eq(post), eq(postId), eq(siteId), eq(true), eq(userId), any())
+        verify(eventBusWrapper, times(1)).postSticky(any<NotificationEvents.OnNotePostLikeChanged>())
         verify(notificationsTableWrapper, times(0)).saveNote(note)
     }
 


### PR DESCRIPTION
Fixes #20211, #20210
And https://github.com/wordpress-mobile/WordPress-Android/pull/20223#pullrequestreview-1894675368

-----

The original implementation didn't sync the Like state in every tab. This PR contains:
1. Sync the Like state by using events.
2. Correct the lifecycle of fetching remote data

## To Test:
#20211

1. Sign in the JP app and switch to the notification tab.
2. Click the notification item
3. Click Like in the detail view
4. Back to the notification tab.
5. The Like state should be correct.

#20210
1. Click the system notification.
2. Click the Back button
3. It should display the notification tab correctly

Known issue:
The like state cannot sync correctly when we click Like and switch tab quickly. 
I don't have a solid solution at the moment. It requires a huge refactor for our local database.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications tab

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manuel

8. What automated tests I added (or what prevented me from doing so)

    - Update some unit tests in the NotificationListViewModel

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)