### PR TITLE
🤖 Remove deprecated reblog notification type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.kt
@@ -198,8 +198,6 @@ class Note {
         get() = isTypeRaw(NOTE_LIKE_TYPE)
     val isCommentLikeType: Boolean
         get() = isTypeRaw(NOTE_COMMENT_LIKE_TYPE)
-    val isReblogType: Boolean
-        get() = isTypeRaw(NOTE_REBLOG_TYPE)
     val isViewMilestoneType: Boolean
         get() = isTypeRaw(NOTE_VIEW_MILESTONE)
     val isCommentReplyType: Boolean
@@ -208,7 +206,7 @@ class Note {
         // Returns true if the user has replied to this comment note
         get() = isCommentType && !TextUtils.isEmpty(commentSubjectNoticon)
     val isUserList: Boolean
-        get() = isLikeType || isFollowType || isReblogType
+        get() = isLikeType || isFollowType
     val isUnread: Boolean // Parsing every time since it may change
         get() = queryJSON("read", 0) != 1
     val timestamp: Long
@@ -364,7 +362,6 @@ class Note {
         const val NOTE_COMMENT_TYPE = "comment"
         const val NOTE_MATCHER_TYPE = "automattcher"
         const val NOTE_COMMENT_LIKE_TYPE = "comment_like"
-        const val NOTE_REBLOG_TYPE = "reblog"
         const val NOTE_NEW_POST_TYPE = "new_post"
         const val NOTE_VIEW_MILESTONE = "view_milestone"
         const val NOTE_UNKNOWN_TYPE = "unknown"

--- a/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
@@ -1,25 +1,19 @@
 package org.wordpress.android.models
 
-import org.wordpress.android.models.Notification.PostNotification.Like
-import org.wordpress.android.models.Notification.PostNotification.NewPost
 
 val Note.type
     get() = NoteType.from(rawType)
 
 sealed class Notification {
-    sealed class PostNotification: Notification() {
-        abstract val url: String
-        abstract val title: String
-        data class Like(override val url: String, override val title: String): PostNotification()
-        data class NewPost(override val url: String, override val title: String): PostNotification()
-    }
+    data class Like(val url: String, val title: String): Notification()
+    data object NewPost: Notification()
     data object Comment: Notification()
     data object Unknown: Notification()
 
     companion object {
         fun from(rawNote: Note) = when(rawNote.type) {
             NoteType.Like -> Like(url = rawNote.url, title = rawNote.title)
-            NoteType.NewPost -> NewPost(url= rawNote.url, title = rawNote.title)
+            NoteType.NewPost -> NewPost
             NoteType.Comment -> Comment
             else -> Unknown
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.models
 
 import org.wordpress.android.models.Notification.PostNotification.Like
-import org.wordpress.android.models.Notification.PostNotification.Reblog
 import org.wordpress.android.models.Notification.PostNotification.NewPost
 
 val Note.type
@@ -12,7 +11,6 @@ sealed class Notification {
         abstract val url: String
         abstract val title: String
         data class Like(override val url: String, override val title: String): PostNotification()
-        data class Reblog(override val url: String, override val title: String): PostNotification()
         data class NewPost(override val url: String, override val title: String): PostNotification()
     }
     data object Comment: Notification()
@@ -21,7 +19,6 @@ sealed class Notification {
     companion object {
         fun from(rawNote: Note) = when(rawNote.type) {
             NoteType.Like -> Like(url = rawNote.url, title = rawNote.title)
-            NoteType.Reblog -> Reblog(url= rawNote.url, title = rawNote.title)
             NoteType.NewPost -> NewPost(url= rawNote.url, title = rawNote.title)
             NoteType.Comment -> Comment
             else -> Unknown
@@ -34,7 +31,6 @@ enum class NoteType(val rawType: String) {
     Comment(Note.NOTE_COMMENT_TYPE),
     Matcher(Note.NOTE_MATCHER_TYPE),
     CommentLike(Note.NOTE_COMMENT_LIKE_TYPE),
-    Reblog(Note.NOTE_REBLOG_TYPE),
     NewPost(Note.NOTE_NEW_POST_TYPE),
     ViewMilestone(Note.NOTE_VIEW_MILESTONE),
     Unknown(Note.NOTE_UNKNOWN_TYPE);

--- a/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/NoteExtensions.kt
@@ -5,14 +5,14 @@ val Note.type
     get() = NoteType.from(rawType)
 
 sealed class Notification {
-    data class Like(val url: String, val title: String): Notification()
+    data class PostLike(val url: String, val title: String): Notification()
     data object NewPost: Notification()
     data object Comment: Notification()
     data object Unknown: Notification()
 
     companion object {
         fun from(rawNote: Note) = when(rawNote.type) {
-            NoteType.Like -> Like(url = rawNote.url, title = rawNote.title)
+            NoteType.PostLike -> PostLike(url = rawNote.url, title = rawNote.title)
             NoteType.NewPost -> NewPost
             NoteType.Comment -> Comment
             else -> Unknown
@@ -21,7 +21,7 @@ sealed class Notification {
 }
 enum class NoteType(val rawType: String) {
     Follow(Note.NOTE_FOLLOW_TYPE),
-    Like(Note.NOTE_LIKE_TYPE),
+    PostLike(Note.NOTE_LIKE_TYPE),
     Comment(Note.NOTE_COMMENT_TYPE),
     Matcher(Note.NOTE_MATCHER_TYPE),
     CommentLike(Note.NOTE_COMMENT_LIKE_TYPE),

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -83,7 +83,6 @@ public class GCMMessageHandler {
     private static final String PUSH_TYPE_COMMENT_LIKE = "comment_like";
     private static final String PUSH_TYPE_AUTOMATTCHER = "automattcher";
     private static final String PUSH_TYPE_FOLLOW = "follow";
-    private static final String PUSH_TYPE_REBLOG = "reblog";
     private static final String PUSH_TYPE_PUSH_AUTH = "push_auth";
     private static final String PUSH_TYPE_BADGE_RESET = "badge-reset";
     private static final String PUSH_TYPE_NOTE_DELETE = "note-delete";
@@ -749,8 +748,6 @@ public class GCMMessageHandler {
                     return NotificationType.AUTOMATTCHER;
                 case PUSH_TYPE_FOLLOW:
                     return NotificationType.FOLLOW;
-                case PUSH_TYPE_REBLOG:
-                    return NotificationType.REBLOG;
                 case PUSH_TYPE_PUSH_AUTH:
                     return NotificationType.AUTHENTICATION;
                 case PUSH_TYPE_BADGE_RESET:
@@ -1104,7 +1101,6 @@ public class GCMMessageHandler {
                 case PUSH_TYPE_COMMENT_LIKE:
                 case PUSH_TYPE_AUTOMATTCHER:
                 case PUSH_TYPE_FOLLOW:
-                case PUSH_TYPE_REBLOG:
                     return true;
                 default:
                     return false;

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationType.kt
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationType.kt
@@ -6,7 +6,6 @@ enum class NotificationType {
     COMMENT_LIKE,
     AUTOMATTCHER,
     FOLLOW,
-    REBLOG,
     BADGE_RESET,
     NOTE_DELETE,
     TEST_NOTE,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -550,7 +550,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
                 // Check if this is a comment notification that has been replied to
                 // The block will not have a type, and its id will match the comment reply id in the Note.
                 (blockObject.type == null && note.commentReplyId == commentReplyId)
-            } else if (note.isFollowType || note.isLikeType || note.isReblogType) {
+            } else if (note.isFollowType || note.isLikeType) {
                 // User list notifications have a footer if they have 10 or more users in the body
                 // The last block will not have a type, so we can use that to determine if it is the footer
                 blockObject.type == null

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.store.CommentsStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.Note
-import org.wordpress.android.models.Notification.PostNotification
+import org.wordpress.android.models.Notification
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
@@ -163,7 +163,7 @@ class NotificationsListViewModel @Inject constructor(
     }
 
     sealed class InlineActionEvent {
-        data class SharePostButtonTapped(val notification: PostNotification) : InlineActionEvent()
+        data class SharePostButtonTapped(val notification: Notification.Like) : InlineActionEvent()
         class LikeCommentButtonTapped(val note: Note, val liked: Boolean) : InlineActionEvent()
         class LikePostButtonTapped(val note: Note, val liked: Boolean) : InlineActionEvent()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListViewModel.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.fluxc.store.CommentsStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.models.Note
-import org.wordpress.android.models.Notification
+import org.wordpress.android.models.Notification.PostLike
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.push.GCMMessageHandler
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
@@ -163,7 +163,7 @@ class NotificationsListViewModel @Inject constructor(
     }
 
     sealed class InlineActionEvent {
-        data class SharePostButtonTapped(val notification: Notification.Like) : InlineActionEvent()
+        data class SharePostButtonTapped(val notification: PostLike) : InlineActionEvent()
         class LikeCommentButtonTapped(val note: Note, val liked: Boolean) : InlineActionEvent()
         class LikePostButtonTapped(val note: Note, val liked: Boolean) : InlineActionEvent()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/SystemNotificationsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/SystemNotificationsTracker.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.push.NotificationType.POST_PUBLISHED
 import org.wordpress.android.push.NotificationType.POST_UPLOAD_ERROR
 import org.wordpress.android.push.NotificationType.POST_UPLOAD_SUCCESS
 import org.wordpress.android.push.NotificationType.QUICK_START_REMINDER
-import org.wordpress.android.push.NotificationType.REBLOG
 import org.wordpress.android.push.NotificationType.STORY_FRAME_SAVE_ERROR
 import org.wordpress.android.push.NotificationType.STORY_FRAME_SAVE_SUCCESS
 import org.wordpress.android.push.NotificationType.STORY_SAVE_ERROR
@@ -91,7 +90,6 @@ class SystemNotificationsTracker
             COMMENT_LIKE -> COMMENT_LIKE_VALUE
             AUTOMATTCHER -> AUTOMATTCHER_VALUE
             FOLLOW -> FOLLOW_VALUE
-            REBLOG -> REBLOG_VALUE
             BADGE_RESET -> BADGE_RESET_VALUE
             NOTE_DELETE -> NOTE_DELETE_VALUE
             TEST_NOTE -> TEST_NOTE_VALUE
@@ -127,7 +125,6 @@ class SystemNotificationsTracker
         private const val COMMENT_LIKE_VALUE = "comment_like"
         private const val AUTOMATTCHER_VALUE = "automattcher"
         private const val FOLLOW_VALUE = "follow"
-        private const val REBLOG_VALUE = "reblog"
         private const val BADGE_RESET_VALUE = "badge_reset"
         private const val NOTE_DELETE_VALUE = "note_delete"
         private const val TEST_NOTE_VALUE = "test_note"

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -78,14 +78,14 @@ class NoteViewHolder(
         when (notification) {
             Notification.Comment -> bindLikeCommentAction(note)
             is Notification.NewPost -> bindLikePostAction(note)
-            is Notification.Like -> bindShareAction(notification)
+            is Notification.PostLike -> bindShareAction(notification)
             is Notification.Unknown -> {
                 binding.action.isVisible = false
             }
         }
     }
 
-    private fun bindShareAction(notification: Notification.Like) {
+    private fun bindShareAction(notification: Notification.PostLike) {
         binding.action.setImageResource(R.drawable.block_share)
         val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
         ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -77,15 +77,15 @@ class NoteViewHolder(
     fun bindInlineActions(note: Note) = Notification.from(note).let { notification ->
         when (notification) {
             Notification.Comment -> bindLikeCommentAction(note)
-            is Notification.PostNotification.NewPost -> bindLikePostAction(note)
-            is Notification.PostNotification -> bindShareAction(notification)
+            is Notification.NewPost -> bindLikePostAction(note)
+            is Notification.Like -> bindShareAction(notification)
             is Notification.Unknown -> {
                 binding.action.isVisible = false
             }
         }
     }
 
-    private fun bindShareAction(notification: Notification.PostNotification) {
+    private fun bindShareAction(notification: Notification.Like) {
         binding.action.setImageResource(R.drawable.block_share)
         val color = binding.root.context.getColorFromAttribute(R.attr.wpColorOnSurfaceMedium)
         ImageViewCompat.setImageTintList(binding.action, ColorStateList.valueOf(color))

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/SystemNotificationsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/SystemNotificationsTrackerTest.kt
@@ -35,7 +35,6 @@ import org.wordpress.android.push.NotificationType.POST_PUBLISHED
 import org.wordpress.android.push.NotificationType.POST_UPLOAD_ERROR
 import org.wordpress.android.push.NotificationType.POST_UPLOAD_SUCCESS
 import org.wordpress.android.push.NotificationType.QUICK_START_REMINDER
-import org.wordpress.android.push.NotificationType.REBLOG
 import org.wordpress.android.push.NotificationType.STORY_FRAME_SAVE_ERROR
 import org.wordpress.android.push.NotificationType.STORY_FRAME_SAVE_SUCCESS
 import org.wordpress.android.push.NotificationType.STORY_SAVE_ERROR
@@ -64,7 +63,6 @@ class SystemNotificationsTrackerTest {
         COMMENT_LIKE to "comment_like",
         AUTOMATTCHER to "automattcher",
         FOLLOW to "follow",
-        REBLOG to "reblog",
         BADGE_RESET to "badge_reset",
         NOTE_DELETE to "note_delete",
         TEST_NOTE to "test_note",


### PR DESCRIPTION
Fixes #20250

-----

## To Test:
Verify no breakages in the functionality

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - None since this PR involves code removal

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
