### PR TITLE
🤖 Fixes comment like blinking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -517,7 +517,7 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         if (!isAdded) {
             return
         }
-        notesAdapter.updateNote(event.note.apply { setLikedComment(event.liked) })
+        notesAdapter.updateNote(event.note)
     }
 
     @Subscribe(sticky = true, threadMode = MAIN)


### PR DESCRIPTION
Fixes #20248 

## Description
This PR removes the call to `Note.setLikedComment` from the `OnNoteCommentLikeChanged` event handler since the status is already set at that point.

-----

## To Test:

1. Open the notifications screen
2. Tap on a comment like notification
3. Change the like status in the detail screen
4. Browse back to the list
5. **Verify** that the like status does not blink

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

7. What automated tests I added (or what prevented me from doing so)

    - Relied on the existing `NotificationsListViewModelTest`

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
