### PR TITLE
[Reader][Crash] Make sure query is not null in Reader Search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
@@ -17,7 +17,7 @@ public class ReaderSearchJobService extends JobService implements ServiceComplet
     private ReaderSearchLogic mReaderSearchLogic;
 
     @Override public boolean onStartJob(JobParameters params) {
-        if (params.getExtras() != null && params.getExtras().containsKey(ARG_QUERY)) {
+        if (params.getExtras() != null && params.getExtras().getString(ARG_QUERY) != null) {
             String query = params.getExtras().getString(ARG_QUERY);
             int offset = params.getExtras().getInt(ARG_OFFSET, 0);
             mReaderSearchLogic.startSearch(query, offset, params);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.reader.services.search;
 
+import androidx.annotation.NonNull;
+
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
@@ -24,7 +26,7 @@ public class ReaderSearchLogic {
         mCompletionListener = listener;
     }
 
-    public void startSearch(final String query, final int offset, Object companion) {
+    public void startSearch(@NonNull final String query, final int offset, Object companion) {
         mListenerCompanion = companion;
         String path = "read/search?q="
                       + UrlUtils.urlEncode(query)


### PR DESCRIPTION
Fixes #20249 

I was not able to reproduce the issue, but looking at the stack trace and the reports in Sentry it looks like somehow the `query` parameter was `null` when starting the `ReaderSearchJobService` service. 

I also noticed that all cases seem to have happened when the device got a Network Connection and decided to start the service when the app was already destroyed, which leads me to believe this is being caused by the Network constraint we set on that Job, which might delay its execution in some situation when the user loses connectivity and connects later.

https://github.com/wordpress-mobile/WordPress-Android/blob/ac56c495d4f5cecf2a50f349576f23515679d8b1/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java#L42

The fix presented here simply completes the Job immediately if the query was null, which is an invalid situation, but in the future we need to get rid of using `JobService` for this kind of user-initiated data fetch that should only happen while the app is opened and replace it with Coroutines as suggested by this [Background work overview](https://developer.android.com/develop/background-work/background-tasks) guide.

-----

## To Test:
N/A, I wasn't able to reproduce the issue, even with "Don't keep activities" enabled.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
