### PR TITLE
Replace INSERT with INSERT OR REPLACE when updating publicize connections table

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java
@@ -233,7 +233,7 @@ public class PublicizeTable {
             db.delete(CONNECTIONS_TABLE, "site_id=?", new String[]{Long.toString(siteId)});
 
             stmt = db.compileStatement(
-                    "INSERT INTO " + CONNECTIONS_TABLE
+                    "INSERT OR REPLACE INTO " + CONNECTIONS_TABLE
                     + " (id," // 1
                     + " site_id," // 2
                     + " user_id," // 3


### PR DESCRIPTION
[Since 2018 SQLite supports](https://www.sqlite.org/lang_upsert.html) the `UPSERT` clause, but our app supports Android versions that might not have the minimum SQLite version to use it (which is `3.24.0`). See this [unofficial table](https://stackoverflow.com/a/4377116) that compares Android OS version associated with the minimum SQLite version.

For this reason I'm using `INSERT OR REPLACE` which we already use in other parts of the project.

Fixes #19050 

-----

## To Test:

I'm not sure how to test this out. In theory we're [deleting all the social connections associated with the selected site](https://github.com/wordpress-mobile/WordPress-Android/blob/1c807ba3d662141da6fd121d783dd8dda59bb80e/WordPress/src/main/java/org/wordpress/android/datasets/PublicizeTable.java#L233) before inserting what we got from the endpoint, so right now the only hypothesis I have is that somehow we're getting a collection of social connections from the back-end where we have two elements with the same connection ID. 

To confirm this, I manually added two elements with the same connection ID in the connections array we get from the back-end and the crash happened (without the changes in this PR)

<img width="1216" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/fb3d2b73-4662-4442-a3bf-a70a44644c61">

Next I ran the same build with the duplicate connection ID elements but this time with the changes in this PR, and the crash didn't happen

<img width="436" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/57436c0e-a75c-4858-bc04-18483ae5bbfe">


I've also tried: 
- Installing an older version (`22.9` since the crash starts in `23.0`) and updating to `24.3` and couldn't reproduce the crash;
- Connecting the same social network account to multiple sites, but the connection IDs were always different;
- Verifying if the insertion of connections is being triggered even if the [remote and local lists are the same](https://github.com/wordpress-mobile/WordPress-Android/blob/0dcd74381922f5c9a42e7f99bbc1717fb68d462c/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateServicesV2.kt#L41), but this also seems to be working.

-----

## Regression Notes

1. Potential unintended areas of impact

    -  "My Site" -> "Social" screens

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
