### PR TITLE
Stats Traffic invoke traffic tab from widgets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -158,6 +158,7 @@ import org.wordpress.android.ui.reader.views.ReaderTagHeaderView;
 import org.wordpress.android.ui.reader.views.ReaderWebView;
 import org.wordpress.android.ui.sitecreation.theme.DesignPreviewFragment;
 import org.wordpress.android.ui.stats.StatsConnectJetpackActivity;
+import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetBlockListProviderFactory;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.AllTimeWidgetListProvider;
 import org.wordpress.android.ui.stats.refresh.lists.widget.alltime.StatsAllTimeWidget;
@@ -552,6 +553,8 @@ public interface AppComponent {
     void inject(StatsWeekWidget object);
 
     void inject(WeekViewsWidgetListProvider object);
+
+    void inject(WidgetBlockListProvider object);
 
     void inject(WeekWidgetBlockListProviderFactory object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTimeframe.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTimeframe.kt
@@ -8,5 +8,6 @@ enum class StatsTimeframe {
     DAY,
     WEEK,
     MONTH,
-    YEAR
+    YEAR,
+    TRAFFIC,
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -141,6 +141,7 @@ class StatsViewModel
 
     private fun getInitialTimeFrame(intent: Intent): StatsSection? {
         return when (intent.getSerializableExtraCompat<Serializable>(StatsActivity.ARG_DESIRED_TIMEFRAME)) {
+            StatsTimeframe.TRAFFIC -> StatsSection.TRAFFIC
             StatsTimeframe.INSIGHTS -> StatsSection.INSIGHTS
             DAY -> StatsSection.DAYS
             WEEK -> StatsSection.WEEKS

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetBlockListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/WidgetBlockListProvider.kt
@@ -14,12 +14,24 @@ import org.wordpress.android.ui.stats.refresh.StatsActivity
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
+import javax.inject.Inject
 
-class WidgetBlockListProvider(val context: Context, val viewModel: WidgetBlockListViewModel, intent: Intent) :
-    RemoteViewsFactory {
+class WidgetBlockListProvider(
+    val context: Context,
+    val viewModel: WidgetBlockListViewModel,
+    intent: Intent
+) : RemoteViewsFactory {
+    @Inject
+    lateinit var trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
     private val colorMode: Color = intent.getColorMode()
     private val siteId: Int = intent.getIntExtra(SITE_ID_KEY, -1)
     private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
+
+    init {
+        (context.applicationContext as WordPress).component().inject(this)
+    }
 
     override fun onCreate() {
         viewModel.start(siteId, colorMode, appWidgetId)
@@ -53,10 +65,11 @@ class WidgetBlockListProvider(val context: Context, val viewModel: WidgetBlockLi
         rv.setTextViewText(R.id.start_block_value, uiModel.startValue)
         rv.setTextViewText(R.id.end_block_title, uiModel.endKey)
         rv.setTextViewText(R.id.end_block_value, uiModel.endValue)
+        val timeframe = if (trafficTabFeatureConfig.isEnabled()) StatsTimeframe.TRAFFIC else uiModel.targetTimeframe
         val intent = Intent()
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.putExtra(WordPress.LOCAL_SITE_ID, uiModel.localSiteId)
-        intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, uiModel.targetTimeframe)
+        intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, timeframe)
         intent.putExtra(StatsActivity.ARG_LAUNCHED_FROM, StatsLaunchedFrom.WIDGET)
         rv.setOnClickFillInIntent(R.id.container, intent)
         return rv

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
+import org.wordpress.android.ui.stats.StatsTimeframe.TRAFFIC
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.DARK
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color.LIGHT
@@ -32,6 +33,7 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.stats.refresh.utils.trackMinifiedWidget
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 import javax.inject.Named
@@ -47,7 +49,8 @@ class MinifiedWidgetUpdater
     private val statsUtils: StatsUtils,
     private val todayInsightsStore: TodayInsightsStore,
     private val widgetUtils: WidgetUtils,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
 ) : WidgetUpdater {
     private val coroutineScope = CoroutineScope(defaultDispatcher)
     override fun updateAppWidget(
@@ -74,9 +77,12 @@ class MinifiedWidgetUpdater
             views.setViewVisibility(R.id.widget_content, View.VISIBLE)
             views.setViewVisibility(R.id.widget_site_icon, View.VISIBLE)
             views.setViewVisibility(R.id.widget_retry_button, View.GONE)
+
+            val timeframe = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
+
             views.setOnClickPendingIntent(
                 R.id.widget_container,
-                widgetUtils.getPendingSelfIntent(context, siteModel.id, INSIGHTS)
+                widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
             )
             showValue(widgetManager, appWidgetId, views, siteModel, dataType, isWideView)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModel.kt
@@ -7,11 +7,13 @@ import org.wordpress.android.fluxc.model.stats.VisitsModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.WidgetBlockListViewModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -22,7 +24,8 @@ class TodayWidgetBlockListViewModel
     private val resourceProvider: ResourceProvider,
     private val todayWidgetUpdater: TodayWidgetUpdater,
     private val appPrefsWrapper: AppPrefsWrapper,
-    private val statsUtils: StatsUtils
+    private val statsUtils: StatsUtils,
+    private val trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
 ) : WidgetBlockListViewModel {
     private var siteId: Int? = null
     private var colorMode: Color = Color.LIGHT
@@ -79,7 +82,10 @@ class TodayWidgetBlockListViewModel
                 resourceProvider.getString(R.string.stats_views),
                 statsUtils.toFormattedString(domainModel.views, MILLION),
                 resourceProvider.getString(R.string.stats_visitors),
-                statsUtils.toFormattedString(domainModel.visitors, MILLION)
+                statsUtils.toFormattedString(domainModel.visitors, MILLION),
+                targetTimeframe = if (trafficTabFeatureConfig.isEnabled()) {
+                    StatsTimeframe.TRAFFIC
+                } else StatsTimeframe.INSIGHTS
             ),
             BlockItemUiModel(
                 layout,
@@ -87,7 +93,10 @@ class TodayWidgetBlockListViewModel
                 resourceProvider.getString(R.string.likes),
                 statsUtils.toFormattedString(domainModel.likes, MILLION),
                 resourceProvider.getString(R.string.stats_comments),
-                statsUtils.toFormattedString(domainModel.comments, MILLION)
+                statsUtils.toFormattedString(domainModel.comments, MILLION),
+                targetTimeframe = if (trafficTabFeatureConfig.isEnabled()) {
+                    StatsTimeframe.TRAFFIC
+                } else StatsTimeframe.INSIGHTS
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetListProvider.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import javax.inject.Inject
 
 class TodayWidgetListProvider(val context: Context, intent: Intent) : RemoteViewsFactory {
@@ -21,6 +22,10 @@ class TodayWidgetListProvider(val context: Context, intent: Intent) : RemoteView
 
     @Inject
     lateinit var widgetUpdater: TodayWidgetUpdater
+
+    @Inject
+    lateinit var trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
     private val colorMode: Color = intent.getColorMode()
     private val siteId: Int = intent.getIntExtra(SITE_ID_KEY, 0)
     private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
@@ -67,7 +72,11 @@ class TodayWidgetListProvider(val context: Context, intent: Intent) : RemoteView
         val intent = Intent()
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.putExtra(WordPress.LOCAL_SITE_ID, uiModel.localSiteId)
-        intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.INSIGHTS)
+        if (trafficTabFeatureConfig.isEnabled()) {
+            intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.TRAFFIC)
+        } else {
+            intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.INSIGHTS)
+        }
         intent.putExtra(StatsActivity.ARG_LAUNCHED_FROM, StatsLaunchedFrom.WIDGET)
         rv.setOnClickFillInIntent(R.id.container, intent)
         return rv

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.ui.stats.refresh.utils.trackWithWidgetType
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -29,7 +30,8 @@ class TodayWidgetUpdater
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val resourceProvider: ResourceProvider,
     private val widgetUtils: WidgetUtils,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
 ) : WidgetUpdater {
     override fun updateAppWidget(
         context: Context,
@@ -52,10 +54,15 @@ class TodayWidgetUpdater
         val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
         if (networkAvailable && hasAccessToken && siteModel != null) {
             widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
+            val timeframe = if (statsTrafficTabFeatureConfig.isEnabled()) {
+                StatsTimeframe.TRAFFIC
+            } else {
+                StatsTimeframe.INSIGHTS
+            }
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, StatsTimeframe.INSIGHTS)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
                 )
             }
             widgetUtils.showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetListProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetListProvider.kt
@@ -7,12 +7,14 @@ import android.widget.RemoteViews
 import android.widget.RemoteViewsService.RemoteViewsFactory
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
-import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
+import org.wordpress.android.ui.stats.StatsTimeframe.TRAFFIC
 import org.wordpress.android.ui.stats.refresh.StatsActivity
 import org.wordpress.android.ui.stats.refresh.lists.widget.SITE_ID_KEY
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.utils.getColorMode
 import org.wordpress.android.ui.stats.refresh.utils.StatsLaunchedFrom
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import javax.inject.Inject
 
 class WeekViewsWidgetListProvider(val context: Context, intent: Intent) : RemoteViewsFactory {
@@ -21,6 +23,10 @@ class WeekViewsWidgetListProvider(val context: Context, intent: Intent) : Remote
 
     @Inject
     lateinit var widgetUpdater: WeekViewsWidgetUpdater
+
+    @Inject
+    lateinit var trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
     private val colorMode: Color = intent.getColorMode()
     private val siteId: Int = intent.getIntExtra(SITE_ID_KEY, 0)
     private val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
@@ -66,9 +72,10 @@ class WeekViewsWidgetListProvider(val context: Context, intent: Intent) : Remote
         rv.setTextViewText(R.id.period, uiModel.key)
         rv.setTextViewText(R.id.value, uiModel.value)
         val intent = Intent()
+        val timeframe = if (trafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.putExtra(WordPress.LOCAL_SITE_ID, uiModel.localSiteId)
-        intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, StatsTimeframe.INSIGHTS)
+        intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, timeframe)
         intent.putExtra(StatsActivity.ARG_LAUNCHED_FROM, StatsLaunchedFrom.WIDGET)
         rv.setOnClickFillInIntent(R.id.container, intent)
         return rv

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetUpdater.kt
@@ -10,7 +10,8 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.stats.StatsTimeframe
+import org.wordpress.android.ui.stats.StatsTimeframe.INSIGHTS
+import org.wordpress.android.ui.stats.StatsTimeframe.TRAFFIC
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsWidgetConfigureFragment.WidgetType.WEEK_TOTAL
@@ -18,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.utils.WidgetUtils
 import org.wordpress.android.ui.stats.refresh.utils.trackWithWidgetType
 import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
 
@@ -28,7 +30,8 @@ class WeekViewsWidgetUpdater @Inject constructor(
     private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val resourceProvider: ResourceProvider,
     private val widgetUtils: WidgetUtils,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
 ) : WidgetUpdater {
     override fun updateAppWidget(
         context: Context,
@@ -49,12 +52,13 @@ class WeekViewsWidgetUpdater @Inject constructor(
         views.setTextViewText(R.id.widget_title, resourceProvider.getString(R.string.stats_widget_weekly_views_name))
         val hasAccessToken = accountStore.hasAccessToken()
         val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
+        val timeframe = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
         if (networkAvailable && hasAccessToken && siteModel != null) {
             widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, StatsTimeframe.INSIGHTS)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
                 )
             }
             widgetUtils.showList(

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetBlockListViewModelTest.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetBlockListProvider.BlockItemUiModel
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsColorSelectionViewModel.Color
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 
 @RunWith(MockitoJUnitRunner::class)
@@ -48,6 +49,9 @@ class TodayWidgetBlockListViewModelTest {
 
     @Mock
     private lateinit var todayWidgetUpdater: TodayWidgetUpdater
+
+    @Mock
+    private lateinit var trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
     private lateinit var viewModel: TodayWidgetBlockListViewModel
     private val siteId: Int = 15
     private val appWidgetId: Int = 1
@@ -61,7 +65,8 @@ class TodayWidgetBlockListViewModelTest {
             resourceProvider,
             todayWidgetUpdater,
             appPrefsWrapper,
-            statsUtils
+            statsUtils,
+            trafficTabFeatureConfig
         )
         viewModel.start(siteId, color, appWidgetId)
         whenever(statsUtils.toFormattedString(any<Int>(), any())).then { (it.arguments[0] as Int).toString() }


### PR DESCRIPTION
Fixes # https://github.com/wordpress-mobile/jetpack-issue-repo/issues/17

Updates the home screen widgets to invoke Traffic tab where required.

-----

| Widgets | Widgets |
|--------|--------|
| ![Screenshot_20240227_155137](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/f0ee467c-a58c-477f-a02f-c26e18c59dcf) | ![Screenshot_20240227_155152](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/f5b48493-5a08-42d0-8499-a79b02e61a86)| 

## To Test:
- Enable `stats_traffic_tab` feature flag (Me -> Debug settings - Remote Features)
- **Restart** the app
- Go to Stats
- `Verify` only Traffic tab, and Insights tabs are shown 
- `Long press` on the app icon in the launcher on device home screen
- `Select` Widgets
- `Long press` on each of the widgets below
- `Add` it to home screen
- `Follow` the prompt to configure the widget with a Site, Colour, and a View as required


#### 1. At a glance widget
- `Ensure` it open in Traffic tab when feature flag is enabled

#### 2. All-time widget
- There's no change here as All-time card is only available on Insights
- `Ensure` it open in Insights tab as before even when feature flag is enabled 

#### 3. Today widget
- `Ensure` it open in Traffic tab when feature flag is enabled

#### 4. Views this week widget
- `Ensure` it open in Traffic tab when feature flag is enabled

#### 5. Views widget
- `Ensure` it open in Traffic tab when feature flag is enabled
- `Tap` on each rows like Today or a date
- `Verify` that it open the respective date views

##### Finally
- Disable the feature flag
- Test each of the widgets opens in Insights or tabs respectively as before

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested with, and without feature flag, and existing unit tests

12. What automated tests I added (or what prevented me from doing so)

    - Updated existing tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
