### PR TITLE
Handles Default User-Agent Failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.113.0-alpha1'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2.67.0'
+    wordPressFluxCVersion = '2961-abf37d171ff06d8881c67fc910a10b82d55d41cd'
     wordPressLoginVersion = '1.14.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.113.0-alpha1'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2961-abf37d171ff06d8881c67fc910a10b82d55d41cd'
+    wordPressFluxCVersion = 'trunk-8b930418a49b0d0846ed56ebf8fd8adad5011901'
     wordPressLoginVersion = '1.14.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'


### PR DESCRIPTION
Fixes Partially https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187

**Depends on PR:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2961

## Description
This PR handles the exception thrown when the default user agent cannot be retrieved preventing a runtime crash.
(internal ref: pcdRpT-5Us-p2)

-----

## To Test:
See https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2961

⚠️  **Please merge after:**
* FluxC PR is merged https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2961 into `trunk`
* The `wordPressFluxCVersion` reference on this PR is updated to point to the latest FluxC `trunk`

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Added tests on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2961

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)