### PR TITLE
Remove Gutenberg Video block from excerpt to hide VideoPress URLs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -308,7 +308,7 @@ public class PostUtils {
      * Removes the VideoPress block tag from the given string.
      */
     public static String removeWPVideoPress(String str) {
-        return str.replaceAll("(?s)\\n?<!--\\swp:videopress/video?(.*?)wp:videopress/video\\s-->", "");
+        return str.replaceAll("(?s)\\n?<!--\\swp:video.*?(.*?)wp:video.*?\\s-->", "");
     }
 
     public static String getFormattedDate(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -305,7 +305,7 @@ public class PostUtils {
     }
 
     /**
-     * Removes the VideoPress block tag from the given string.
+     * Removes VideoPress references that occur in the VideoPress or video block from the given string.
      */
     public static String removeWPVideoPress(String str) {
         return str.replaceAll("(?s)\\n?<!--\\swp:video.*?(.*?)wp:video.*?\\s-->", "");

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt
@@ -91,6 +91,51 @@ https://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadCon
     }
 
     @Test
+    fun `removeWPVideoPress removes video block tags and its internals without affecting content in between`() {
+        val content = """
+<!-- wp:paragraph -->
+<p>Before</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:video {"guid":"AbCDe","id":5297} -->
+<figure class="wp-block-video"><div class="wp-block-embed__wrapper">
+https://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
+</div></figure>
+<!-- /wp:video -->
+
+<!-- wp:paragraph -->
+<p>Between</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:video {"guid":"AbCDe","id":5297} -->
+<figure class="wp-block-video"><div class="wp-block-embed__wrapper">
+https://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
+</div></figure>
+<!-- /wp:video -->
+
+<!-- wp:paragraph -->
+<p>After</p>
+<!-- /wp:paragraph -->
+"""
+        val expectedResult = """
+<!-- wp:paragraph -->
+<p>Before</p>
+<!-- /wp:paragraph -->
+
+
+<!-- wp:paragraph -->
+<p>Between</p>
+<!-- /wp:paragraph -->
+
+
+<!-- wp:paragraph -->
+<p>After</p>
+<!-- /wp:paragraph -->
+"""
+        assertThat(PostUtils.removeWPVideoPress(content)).isEqualTo(expectedResult)
+    }
+
+    @Test
     fun `prepareForPublish updates dateLocallyChanged`() {
         val post = invokePreparePostForPublish()
         assertThat(post.dateLocallyChanged).isNotEmpty()


### PR DESCRIPTION
Fixes the Android side of https://github.com/wordpress-mobile/gutenberg-mobile/issues/6669

-----

## Description:

Following the implementation of VideoPress v5, media uploaded to the video block on supported sites will automatically convert to VideoPress. This has led to VideoPress URLs being visible alongside excerpts in the post list section. 

To remove all references to VideoPress from the post excerpt, this PR extends the `removeWPVideoPress` function to include video blocks.

-----

## To Test:

1. In the app, select a WordPress.com site to edit and open the post editor.
2. Add the Video block and go through the steps to add a video.
3. Save your changes and return to the post list.
4. Verify the VideoPress URL does not display in the post list.

-----

## Screenshots:

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2998162/e82f8ce2-ae37-4810-9492-46a73db609c7" width="100%"> | <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2998162/8cde7c8d-1ed6-479a-a197-5b72296a5d7a" width="100%"> |

-----

## Regression Notes:

1. Potential unintended areas of impact

    - As we're making changes to the regex that filters out the VideoPress block from the excerpt, there is a chance this PR could unintentionally change the existing functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - I manually tested the changes and relied on [the existing test](https://github.com/wordpress-mobile/WordPress-Android/blob/b8e313e5085b4259229f4e78628e82e2d9b5d5ae/WordPress/src/test/java/org/wordpress/android/ui/posts/PostUtilsUnitTest.kt#L48-L91) that verifies VideoPress blocks remain correctly hidden. 

3. What automated tests I added (or what prevented me from doing so)

    - I added a new test in https://github.com/wordpress-mobile/WordPress-Android/pull/20299/commits/b8e313e5085b4259229f4e78628e82e2d9b5d5ae that verifies regular video blocks are removed from the post excerpt.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
