### PR TITLE
[Offline Mode] Post sync before editing

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -158,6 +158,7 @@ android {
         buildConfigField "boolean", "BLAZE_MANAGE_CAMPAIGNS", "false"
         buildConfigField "boolean", "DASHBOARD_PERSONALIZATION", "false"
         buildConfigField "boolean", "ENABLE_SITE_MONITORING", "false"
+        buildConfigField "boolean", "SYNC_PUBLISHING", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/modules/PostModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/PostModule.kt
@@ -6,10 +6,12 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.wordpress.android.ui.posts.IPostFreshnessChecker
 import org.wordpress.android.ui.posts.PostFreshnessCheckerImpl
+import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 class PostModule {
+    @Singleton
     @Provides
     fun providePostFreshnessChecker(): IPostFreshnessChecker = PostFreshnessCheckerImpl()
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/PostModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/modules/PostModule.kt
@@ -1,0 +1,15 @@
+package org.wordpress.android.modules
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.wordpress.android.ui.posts.IPostFreshnessChecker
+import org.wordpress.android.ui.posts.PostFreshnessCheckerImpl
+
+@InstallIn(SingletonComponent::class)
+@Module
+class PostModule {
+    @Provides
+    fun providePostFreshnessChecker(): IPostFreshnessChecker = PostFreshnessCheckerImpl()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -222,6 +222,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource;
 import org.wordpress.android.util.config.ContactSupportFeatureConfig;
 import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig;
+import org.wordpress.android.util.config.SyncPublishingFeatureConfig;
 import org.wordpress.android.util.extensions.AppBarLayoutExtensionsKt;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -426,6 +427,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
     @Inject BloggingPromptsStore mBloggingPromptsStore;
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
     @Inject ContactSupportFeatureConfig mContactSupportFeatureConfig;
+    @Inject SyncPublishingFeatureConfig mSyncPublishingFeatureConfig;
 
     private StorePostViewModel mViewModel;
     private StorageUtilsViewModel mStorageUtilsViewModel;
@@ -806,7 +808,9 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mUpdatingPostArea = findViewById(R.id.updating);
 
         // check if post content needs updating
-        mViewModel.checkIfUpdatedPostVersionExists(mEditPostRepository, mSite);
+       if (mSyncPublishingFeatureConfig.isEnabled()) {
+           mViewModel.checkIfUpdatedPostVersionExists(mEditPostRepository, mSite);
+       }
     }
 
     private void showUpdatingPostArea() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/IPostFreshnessChecker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/IPostFreshnessChecker.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.model.PostImmutableModel
+
+/**
+ * This interface is implemented by a component that determines if a post
+ * is "fresh" or we need to refetch it from the backend.
+ */
+interface IPostFreshnessChecker {
+    fun shouldRefreshPost(post: PostImmutableModel): Boolean
+}
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostFreshnessCheckerImpl.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostFreshnessCheckerImpl.kt
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.posts
+
+import org.wordpress.android.fluxc.model.PostImmutableModel
+
+class PostFreshnessCheckerImpl(
+    private val timeProvider: TimeProvider = SystemTimeProvider()
+) : IPostFreshnessChecker {
+    override fun shouldRefreshPost(post: PostImmutableModel): Boolean {
+        return postNeedsRefresh(post)
+    }
+
+    private fun postNeedsRefresh(post: PostImmutableModel) : Boolean {
+        return timeProvider.currentTimeMillis() - post.dbTimestamp > CACHE_VALIDITY_MILLIS
+    }
+
+    companion object {
+        // Todo turn this into a remote config value
+        const val CACHE_VALIDITY_MILLIS = 20000
+    }
+}
+
+class SystemTimeProvider : TimeProvider {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -16,7 +16,11 @@ import javax.inject.Inject
  *
  */
 @Reusable
-class PostUtilsWrapper @Inject constructor(private val dateProvider: DateProvider) {
+class PostUtilsWrapper
+@Inject constructor(
+    private val dateProvider: DateProvider,
+    private val postFreshnessChecker: IPostFreshnessChecker
+) {
     fun isPublishable(post: PostImmutableModel) = PostUtils.isPublishable(post)
 
     fun isPostInConflictWithRemote(post: PostImmutableModel) =
@@ -51,4 +55,7 @@ class PostUtilsWrapper @Inject constructor(private val dateProvider: DateProvide
 
     fun shouldPublishImmediatelyOptionBeAvailable(status: PostStatus?) =
         PostUtils.shouldPublishImmediatelyOptionBeAvailable(status)
+
+    fun shouldRefreshPost(post: PostImmutableModel) : Boolean =
+        postFreshnessChecker.shouldRefreshPost(post)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtilsWrapper.kt
@@ -18,8 +18,7 @@ import javax.inject.Inject
 @Reusable
 class PostUtilsWrapper
 @Inject constructor(
-    private val dateProvider: DateProvider,
-    private val postFreshnessChecker: IPostFreshnessChecker
+    private val dateProvider: DateProvider
 ) {
     fun isPublishable(post: PostImmutableModel) = PostUtils.isPublishable(post)
 
@@ -55,7 +54,4 @@ class PostUtilsWrapper
 
     fun shouldPublishImmediatelyOptionBeAvailable(status: PostStatus?) =
         PostUtils.shouldPublishImmediatelyOptionBeAvailable(status)
-
-    fun shouldRefreshPost(post: PostImmutableModel) : Boolean =
-        postFreshnessChecker.shouldRefreshPost(post)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -12,11 +12,14 @@ import org.wordpress.android.editor.gutenberg.DialogVisibility.Hidden
 import org.wordpress.android.editor.gutenberg.DialogVisibility.Showing
 import org.wordpress.android.editor.gutenberg.DialogVisibilityProvider
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.PostActionBuilder
+import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded
+import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.posts.EditPostRepository
@@ -63,6 +66,12 @@ class StorePostViewModel
         postValue(Hidden)
     }
     override val savingInProgressDialogVisibility: LiveData<DialogVisibility> = _savingProgressDialogVisibility
+
+    private val _onPostUpdateUiVisible = MutableLiveData<Boolean>()
+    val onPostUpdateUiVisible: LiveData<Boolean> = _onPostUpdateUiVisible
+
+    private val _onPostUpdateResult = MutableLiveData<Boolean>()
+    val onPostUpdateResult: LiveData<Boolean> = _onPostUpdateResult
 
     init {
         dispatcher.register(this)
@@ -190,6 +199,21 @@ class StorePostViewModel
         _onFinish.postValue(Event(state))
     }
 
+    fun checkIfUpdatedPostVersionExists(
+        editPostRepository: EditPostRepository,
+        site: SiteModel
+    ) {
+        editPostRepository.getPost()?.let { postModel ->
+            if (!postModel.isLocalDraft
+                    && !postModel.isLocallyChanged
+                    && postUtils.shouldRefreshPost(postModel)) {
+                _onPostUpdateUiVisible.postValue(true)
+                val payload = RemotePostPayload(editPostRepository.getEditablePost(), site)
+                dispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload))
+            }
+        }
+    }
+
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe
     fun onPostUploaded(event: OnPostUploaded) {
@@ -200,6 +224,17 @@ class StorePostViewModel
     @Subscribe
     fun onPostChanged(event: OnPostChanged) {
         hideSavingProgressDialog()
+
+        // Refresh post content if needed
+        (event.causeOfChange as? CauseOfOnPostChanged.UpdatePost)?.let { updatePost ->
+            // if post update is only local do nothing
+            if (!updatePost.isLocalUpdate) {
+                // Post the result based on `event.isError`
+                _onPostUpdateResult.postValue(!event.isError)
+                // Hide updating post area
+                _onPostUpdateUiVisible.postValue(false)
+            }
+        }
     }
 
     sealed class UpdateResult {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
+import org.wordpress.android.ui.posts.IPostFreshnessChecker
 import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.ActivityFinishState.SAVED_LOCALLY
@@ -49,7 +50,8 @@ class StorePostViewModel
     private val uploadService: UploadServiceFacade,
     private val savePostToDbUseCase: SavePostToDbUseCase,
     private val networkUtils: NetworkUtilsWrapper,
-    private val dispatcher: Dispatcher
+    private val dispatcher: Dispatcher,
+    private val postFreshnessChecker: IPostFreshnessChecker
 ) : ScopedViewModel(uiCoroutineDispatcher), DialogVisibilityProvider {
     private var debounceCounter = 0
     private var saveJob: Job? = null
@@ -206,7 +208,7 @@ class StorePostViewModel
         editPostRepository.getPost()?.let { postModel ->
             if (!postModel.isLocalDraft
                     && !postModel.isLocallyChanged
-                    && postUtils.shouldRefreshPost(postModel)) {
+                    && postFreshnessChecker.shouldRefreshPost(postModel)) {
                 _onPostUpdateUiVisible.postValue(true)
                 val payload = RemotePostPayload(editPostRepository.getEditablePost(), site)
                 dispatcher.dispatch(PostActionBuilder.newFetchPostAction(payload))

--- a/WordPress/src/main/java/org/wordpress/android/util/config/SyncPublishingFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/SyncPublishingFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val SYNC_PUBLISHING_FEATURE_REMOTE_FIELD = "sync_publishing"
+
+@Feature(SYNC_PUBLISHING_FEATURE_REMOTE_FIELD, false)
+class SyncPublishingFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.SYNC_PUBLISHING,
+    SYNC_PUBLISHING_FEATURE_REMOTE_FIELD
+)

--- a/WordPress/src/main/res/layout/new_edit_post_activity.xml
+++ b/WordPress/src/main/res/layout/new_edit_post_activity.xml
@@ -65,6 +65,44 @@
                 tools:context=".ui.photopicker.PhotoPickerFragment"
                 tools:visibility="visible" />
 
+            <FrameLayout
+                android:id="@+id/updating"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="@color/post_editing_updating"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:padding="8dp"
+                    android:background="@color/post_editing_updating">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:text="@string/editor_updating_post"
+                        android:layout_marginBottom="8dp"
+                        android:textColor="@color/black"
+                        android:textAppearance="?attr/textAppearanceBody1"/>
+
+                    <ProgressBar
+                        style="?android:attr/progressBarStyle"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:indeterminateTint="@color/black"
+                       />
+
+                </LinearLayout>
+
+            </FrameLayout>
+
         </RelativeLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -158,4 +158,8 @@
     <!-- Gravatar Info Banners -->
     <color name="gravatar_info_banner">#F2F2F7</color>
     <color name="gravatar_sync_info_banner">#2C2C2E</color>
+
+    <!-- Post Editing -->
+    <color name="post_editing_updating">#EDD6C5</color>
+
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1720,6 +1720,8 @@
     <string name="editor_uploading_draft">Your draft is uploading</string>
     <string name="editor_post_converted_back_to_draft">Post converted back to draft</string>
     <string name="editor_failed_to_insert_media_tap_to_retry">Failed to insert media.\nPlease tap to retry.</string>
+    <string name="editor_updating_post">Updating post content</string>
+    <string name="editor_updating_post_failed">Failed to update post content</string>
 
     <!-- Post Settings -->
     <string name="post_settings">Post settings</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostFreshnessCheckerImplTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostFreshnessCheckerImplTest.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.posts
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PostFreshnessCheckerImplTest {
+    private val fixedCurrentTimeMillis = 100_000L // Example current time in milliseconds
+    private val timeProvider = object : TimeProvider {
+        override fun currentTimeMillis() = fixedCurrentTimeMillis
+    }
+
+    private val postFreshnessChecker = PostFreshnessCheckerImpl(timeProvider)
+
+    @Test
+    fun `should refresh post when post is older than cache validity`() {
+        // Post timestamp is set to simulate being older than the cache validity
+        val postTimestamp = fixedCurrentTimeMillis - PostFreshnessCheckerImpl.CACHE_VALIDITY_MILLIS - 1
+        val post = mock<PostImmutableModel> {
+            on { dbTimestamp }.thenReturn(postTimestamp)
+        }
+
+        // Adjust the system time or post creation time as needed to reflect the scenario being tested
+        assertTrue(postFreshnessChecker.shouldRefreshPost(post))
+    }
+
+    @Test
+    fun `should not refresh post when post is within cache validity`() {
+        // Post timestamp is set to simulate being within the cache validity period
+        val postTimestamp = fixedCurrentTimeMillis - PostFreshnessCheckerImpl.CACHE_VALIDITY_MILLIS + 1
+        val post = mock<PostImmutableModel> {
+            on { dbTimestamp }.thenReturn(postTimestamp)
+        }
+
+        assertFalse(postFreshnessChecker.shouldRefreshPost(post))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -27,6 +27,8 @@ class PostSettingsUtilsTest : BaseUnitTest() {
 
     @Mock
     lateinit var dateProvider: DateProvider
+    @Mock
+    lateinit var postFreshnessCheckerImpl: IPostFreshnessChecker
     private lateinit var postSettingsUtils: PostSettingsUtils
     private lateinit var postUtilsWrapper: PostUtilsWrapper
 
@@ -37,7 +39,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        postUtilsWrapper = PostUtilsWrapper(dateProvider)
+        postUtilsWrapper = PostUtilsWrapper(dateProvider, postFreshnessCheckerImpl)
         postSettingsUtils = PostSettingsUtils(resourceProvider, mStatsDateUtils, postUtilsWrapper)
         whenever(mStatsDateUtils.formatDateTime(any())).thenReturn(formattedDate)
         whenever(dateProvider.getCurrentDate()).thenReturn(DateTimeUtils.dateUTCFromIso8601(currentDate))

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostSettingsUtilsTest.kt
@@ -27,8 +27,6 @@ class PostSettingsUtilsTest : BaseUnitTest() {
 
     @Mock
     lateinit var dateProvider: DateProvider
-    @Mock
-    lateinit var postFreshnessCheckerImpl: IPostFreshnessChecker
     private lateinit var postSettingsUtils: PostSettingsUtils
     private lateinit var postUtilsWrapper: PostUtilsWrapper
 
@@ -39,7 +37,7 @@ class PostSettingsUtilsTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        postUtilsWrapper = PostUtilsWrapper(dateProvider, postFreshnessCheckerImpl)
+        postUtilsWrapper = PostUtilsWrapper(dateProvider)
         postSettingsUtils = PostSettingsUtils(resourceProvider, mStatsDateUtils, postUtilsWrapper)
         whenever(mStatsDateUtils.formatDateTime(any())).thenReturn(formattedDate)
         whenever(dateProvider.getCurrentDate()).thenReturn(DateTimeUtils.dateUTCFromIso8601(currentDate))

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.posts.EditPostRepository
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
+import org.wordpress.android.ui.posts.IPostFreshnessChecker
 import org.wordpress.android.ui.posts.PostUtilsWrapper
 import org.wordpress.android.ui.posts.SavePostToDbUseCase
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.ActivityFinishState.SAVED_LOCALLY
@@ -59,6 +60,9 @@ class StorePostViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var context: Context
 
+    @Mock
+    lateinit var postFreshnessChecker: IPostFreshnessChecker
+
     private lateinit var viewModel: StorePostViewModel
     private val title = "title"
     private val updatedTitle = "updatedTitle"
@@ -79,7 +83,8 @@ class StorePostViewModelTest : BaseUnitTest() {
             uploadService,
             savePostToDbUseCase,
             networkUtils,
-            dispatcher
+            dispatcher,
+            postFreshnessChecker
         )
         postModel.setId(postId)
         postModel.setTitle(title)

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2957-64735ca1008922a05c7cd0501b01b511784f87f1'
+    wordPressFluxCVersion = '2957-9f88cce9e2e2b9d57389ba574bd549392b3eab65'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2957-9f88cce9e2e2b9d57389ba574bd549392b3eab65'
+    wordPressFluxCVersion = 'trunk-ae15f6b0b21c0ee9e0f97741ea2e16545358eac3'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2.70.0'
+    wordPressFluxCVersion = '2957-64735ca1008922a05c7cd0501b01b511784f87f1'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'


### PR DESCRIPTION
Fixes #
#20189
-----

This PR adds a check when user tries to edit a post so we can determine if we need to refetch it. In this way we try to minimise the chances to have version conflicts. There are some modifications needed in the FluxC library so there is an associated https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2957.

**This PR targets trunk but we might need to merge this to a feature branch instead.** 



## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

#### Prerequisite
<details><summary>◐ Toggle the <code>sync-publishing</code> flag</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll to the `Remote features` section
3. Tap on the item corresponding to the flag
4. Tap `RESTART THE APP` button

</details>

1. Install and launch the JP app from this PR
2. Choose a site and create a new post. 
3. Check that everything works alright. 
4. Wait for more that 20 second in the post list screen. 
5. Tap on the post that you created. Check that a new message appears saying "Updating post content" and at the same time user cannot modify the post. 
6. Check that after a while this message disappears and user can edit the post. 
7. Make some changes in the content and update the post. 
8. While staying in the post list screen, use your laptop's browser to launch WordPress.com, find this post and update its content.
9. Go back to your mobile device and tap the same post in the list. 
10. Check that the "updating post" message appears and you see the updated content. 
11. Make some local changes and tap back without updating the post.
12. check that the "Local changes" label appears for this post.
13. Go to WordPress.com and make some changes in this post. 
14. Go back to your mobile device and tap on the same post from the list. 
15. Check that there is no "Updating" message and you see the local changes only and not the changes you made on web.


-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)