### PR TITLE
[Reader] Tags chip should appear before blogs chip in "Subscriptions" feed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -65,10 +65,23 @@ fun ReaderFilterChipGroup(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        val isBlogSelected = selectedItem?.type == ReaderFilterType.BLOG
         val isTagSelected = selectedItem?.type == ReaderFilterType.TAG
-        val isBlogChipVisible = showBlogsFilter && (selectedItem == null || isBlogSelected)
+        val isBlogSelected = selectedItem?.type == ReaderFilterType.BLOG
         val isTagChipVisible = showTagsFilter && (selectedItem == null || isTagSelected)
+        val isBlogChipVisible = showBlogsFilter && (selectedItem == null || isBlogSelected)
+
+        val tagChipText: UiString = remember(selectedItem, tagsFilterCount) {
+            if (isTagSelected) {
+                selectedItem?.text ?: UiString.UiStringText("")
+            } else {
+                UiString.UiStringPluralRes(
+                    zeroRes = R.string.reader_filter_chip_tag_zero,
+                    oneRes = R.string.reader_filter_chip_tag_one,
+                    otherRes = R.string.reader_filter_chip_tag_other,
+                    count = tagsFilterCount,
+                )
+            }
+        }
 
         val blogChipText: UiString = remember(selectedItem, blogsFilterCount) {
             if (isBlogSelected) {
@@ -83,17 +96,18 @@ fun ReaderFilterChipGroup(
             }
         }
 
-        val tagChipText: UiString = remember(selectedItem, tagsFilterCount) {
-            if (isTagSelected) {
-                selectedItem?.text ?: UiString.UiStringText("")
-            } else {
-                UiString.UiStringPluralRes(
-                    zeroRes = R.string.reader_filter_chip_tag_zero,
-                    oneRes = R.string.reader_filter_chip_tag_one,
-                    otherRes = R.string.reader_filter_chip_tag_other,
-                    count = tagsFilterCount,
-                )
-            }
+        // tags filter chip
+        AnimatedVisibility(
+            modifier = Modifier.clip(roundedShape),
+            visible = isTagChipVisible,
+        ) {
+            ReaderFilterChip(
+                text = tagChipText,
+                onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
+                onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
+                isSelectedItem = isTagSelected,
+                height = chipHeight,
+            )
         }
 
         // blogs filter chip
@@ -112,20 +126,6 @@ fun ReaderFilterChipGroup(
 
         AnimatedVisibility(visible = isBlogChipVisible && isTagChipVisible) {
             Spacer(Modifier.width(Margin.Medium.value))
-        }
-
-        // tags filter chip
-        AnimatedVisibility(
-            modifier = Modifier.clip(roundedShape),
-            visible = isTagChipVisible,
-        ) {
-            ReaderFilterChip(
-                text = tagChipText,
-                onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
-                onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
-                isSelectedItem = isTagSelected,
-                height = chipHeight,
-            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -110,6 +110,10 @@ fun ReaderFilterChipGroup(
             )
         }
 
+        AnimatedVisibility(visible = isBlogChipVisible && isTagChipVisible) {
+            Spacer(Modifier.width(Margin.Medium.value))
+        }
+
         // blogs filter chip
         AnimatedVisibility(
             modifier = Modifier.clip(roundedShape),
@@ -122,10 +126,6 @@ fun ReaderFilterChipGroup(
                 isSelectedItem = isBlogSelected,
                 height = chipHeight,
             )
-        }
-
-        AnimatedVisibility(visible = isBlogChipVisible && isTagChipVisible) {
-            Spacer(Modifier.width(Margin.Medium.value))
         }
     }
 }


### PR DESCRIPTION
Fixes #20300

-----

## To Test:

1. Install Jetpack and sign-in;
2. Open Reader;
3. Select "Subscriptions" feed;
4. 🔍 Tags chip should appear before blogs chip. Also try it with a RTL language;
5. 🔍 Verify if tags and blogs bottom sheets appear as expected.

### Before
<img width="344" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/82ca9476-a0ea-413b-9a12-a85cd865971b">

### After
<img width="346" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/08e3a182-87d3-4ee8-9db5-cae94176ef37">

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

7. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
