### PR TITLE
Fix showing wrong data for a short time on the traffic tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -247,7 +247,6 @@ class TrafficListViewModel @Inject constructor(
                     BaseStatsUseCase.UseCaseMode.BLOCK
                 )
             }
-            statsUseCase.onCleared()
             statsUseCase = statsUseCase.clone(newUseCases) // Create new BaseListUseCase with updated useCases
             launch {
                 statsUseCase.loadData()


### PR DESCRIPTION
Fixes #20288 

This fixes showing wrong data when changing granularity. It seems that `statsUseCase.onCleared()` was unnecessary.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Open "My Site → Stats".
3. Change the granularity.
4. Notice that new pages are loaded properly.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - This change fixes a slight issue, and it is not practical to test it through UI tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
