### PR TITLE
[Reader] Persist feed selection across sessions and fix text overlapping post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -149,10 +149,11 @@ public class AppPrefs {
         READER_CARDS_ENDPOINT_PAGE_HANDLE,
         // used to tell the server to return a different set of data so the content on discover tab doesn't look static
         READER_CARDS_ENDPOINT_REFRESH_COUNTER,
-
         // Used to delete recommended tags saved as followed tags in tbl_tags
         // Need to be done just once for a logged out user
         READER_RECOMMENDED_TAGS_DELETED_FOR_LOGGED_OUT_USER,
+        // Selected Reader feed ID for persisting user preferred feed
+        READER_TOP_BAR_SELECTED_FEED_ITEM_ID,
         MANUAL_FEATURE_CONFIG,
         SITE_JETPACK_CAPABILITIES,
         REMOVED_QUICK_START_CARD_TYPE,
@@ -1191,6 +1192,19 @@ public class AppPrefs {
 
     public static void setReaderRecommendedTagsDeletedForLoggedOutUser(boolean deleted) {
         setBoolean(DeletablePrefKey.READER_RECOMMENDED_TAGS_DELETED_FOR_LOGGED_OUT_USER, deleted);
+    }
+
+    @Nullable
+    public static String getReaderTopBarSelectedFeedItemId() {
+        return getString(DeletablePrefKey.READER_TOP_BAR_SELECTED_FEED_ITEM_ID, null);
+    }
+
+    public static void setReaderTopBarSelectedFeedItemId(@Nullable String selectedFeedItemId) {
+        if (selectedFeedItemId == null) {
+            remove(DeletablePrefKey.READER_TOP_BAR_SELECTED_FEED_ITEM_ID);
+        } else {
+            setString(DeletablePrefKey.READER_TOP_BAR_SELECTED_FEED_ITEM_ID, selectedFeedItemId);
+        }
     }
 
     public static void setShouldShowStoriesIntro(boolean shouldShow) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -71,6 +71,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getReaderCardsPageHandle()
         set(pageHandle) = AppPrefs.setReaderCardsPageHandle(pageHandle)
 
+    var readerTopBarSelectedFeedItemId: String?
+        get() = AppPrefs.getReaderTopBarSelectedFeedItemId()
+        set(selectedFeedItemId) = AppPrefs.setReaderTopBarSelectedFeedItemId(selectedFeedItemId)
+
     var shouldShowStoriesIntro: Boolean
         get() = AppPrefs.shouldShowStoriesIntro()
         set(shouldShow) = AppPrefs.setShouldShowStoriesIntro(shouldShow)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2332,6 +2332,8 @@ public class ReaderPostListFragment extends ViewPagerFragment
                                     R.drawable.illustration_reader_empty);
                             mActionableEmptyView.title.setText(
                                     getString(R.string.reader_empty_blogs_posts_in_custom_list));
+                            mActionableEmptyView.image.setVisibility(View.VISIBLE);
+                            mActionableEmptyView.title.setVisibility(View.VISIBLE);
                             mActionableEmptyView.button.setVisibility(View.GONE);
                             mActionableEmptyView.subtitle.setVisibility(View.GONE);
                             showEmptyView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1948,7 +1948,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     private final ReaderInterfaces.DataLoadedListener mDataLoadedListener = new ReaderInterfaces.DataLoadedListener() {
         @Override
         public void onDataLoaded(boolean isEmpty) {
-            if (!isAdded() || !mHasUpdatedPosts) {
+            if (!isAdded() || (isEmpty && !mHasUpdatedPosts)) {
                 return;
             }
             if (isEmpty) {
@@ -2322,7 +2322,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     requireActivity().runOnUiThread(() -> updateCurrentTag());
                 } else {
                     requireActivity().runOnUiThread(() -> {
-                        if ((isBookmarksList()) && isPostAdapterEmpty() && isAdded()) {
+                        if (isBookmarksList() && isPostAdapterEmpty() && isAdded()) {
                             setEmptyTitleAndDescriptionForBookmarksList();
                             mActionableEmptyView.image.setImageResource(
                                     R.drawable.illustration_reader_empty);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -182,6 +182,8 @@ class ReaderViewModel @Inject constructor(
 
     fun updateSelectedContent(selectedTag: ReaderTag) {
         getMenuItemFromReaderTag(selectedTag)?.let { newSelectedMenuItem ->
+            // Persist selected feed to app prefs
+            appPrefsWrapper.readerTopBarSelectedFeedItemId = newSelectedMenuItem.id
             // Update top bar UI state so menu is updated with new selected item
             _topBarUiState.value?.let {
                 _topBarUiState.value = it.copy(
@@ -311,27 +313,33 @@ class ReaderViewModel @Inject constructor(
             // if menu is exactly the same as before, don't update
             if (_topBarUiState.value?.menuItems == menuItems) return@withContext
 
-
-            // if there's already a selected item, use it, otherwise use the first item, also try to use the saved state
+            // choose selected item, either from current, saved state, or persisted, falling back to first item
             val savedStateSelectedId = savedInstanceState?.getString(KEY_TOP_BAR_UI_STATE_SELECTED_ITEM_ID)
+
+            val persistedSelectedId = appPrefsWrapper.readerTopBarSelectedFeedItemId
+
             val selectedItem = _topBarUiState.value?.selectedItem
                 ?: menuItems.filterSingleItems()
                     .let { singleItems ->
-                        singleItems.firstOrNull { it.id == savedStateSelectedId } ?: singleItems.first()
+                        singleItems.firstOrNull { it.id == savedStateSelectedId }
+                            ?: singleItems.firstOrNull { it.id == persistedSelectedId }
+                            ?: singleItems.first()
                     }
 
             // if there's a selected item and filter state, also use the filter state, also try to use the saved state
+            val savedStateFilterUiState = savedInstanceState
+                ?.let {
+                    BundleCompat.getParcelable(
+                        it,
+                        KEY_TOP_BAR_UI_STATE_FILTER_UI_STATE,
+                        TopBarUiState.FilterUiState::class.java
+                    )
+                }
+                ?.takeIf { selectedItem.id == savedStateSelectedId }
+
             val filterUiState = _topBarUiState.value?.filterUiState
                 ?.takeIf { _topBarUiState.value?.selectedItem != null }
-                ?: savedInstanceState
-                    ?.let {
-                        BundleCompat.getParcelable(
-                            it,
-                            KEY_TOP_BAR_UI_STATE_FILTER_UI_STATE,
-                            TopBarUiState.FilterUiState::class.java
-                        )
-                    }
-                    ?.takeIf { selectedItem.id == savedStateSelectedId }
+                ?: savedStateFilterUiState
 
             _topBarUiState.postValue(
                 TopBarUiState(


### PR DESCRIPTION
Fixes #20127 
Fixes #20183

This PR ends up fixing 2 issues since fixing #20127 made the problem from #20183 happen more often. Both fixes are on the small side so I decided to do both in the same PR.

-----

## To Test:

### Testing Reader feed selection persistence
1. Open the Jetpack app
2. Go to Reader
3. Select any feed that's not `Discover`
4. Close the app and kill it from the "Recent Apps" screen
5. Open the Jetpack app again
6. **Verify** the same feed is still selected

Other test steps can be found here as well: https://github.com/wordpress-mobile/WordPress-Android/issues/20127#issuecomment-1966927290

### Testing "empty state" text showing up even when there are posts in the list
This is a bit trickier to test, but the steps listed by @daniloercoli in the original issue should do:
1. Open the Reader on a list or a feed that doesn't have content
2. Move to another feed
3. **Verify** the empty state message is hidden

-----

## Regression Notes

1. Potential unintended areas of impact

    - Problems in the "empty state" visibility state

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

9. What automated tests I added (or what prevented me from doing so)

    - N/A, the unit tests are still not up-to-date in this part of the code so it was not possible to add it currently

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
