### PR TITLE
Stats traffic fix label formatters

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartLabelFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartLabelFormatter.kt
@@ -10,7 +10,7 @@ class BarChartLabelFormatter @Inject constructor(
 ) : ValueFormatter() {
     override fun getAxisLabel(value: Float, axis: AxisBase?): String {
         val index = value.toInt()
-        return if (index in 0..entries.size) {
+        return if (entries.isNotEmpty() && index in 0..entries.size) {
             entries[index].label
         } else {
             ""

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartLabelFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/LineChartLabelFormatter.kt
@@ -10,7 +10,7 @@ class LineChartLabelFormatter @Inject constructor(
 ) : ValueFormatter() {
     override fun getAxisLabel(value: Float, axis: AxisBase?): String {
         val index = value.toInt()
-        return if (index in 0..entries.size) {
+        return if (entries.isNotEmpty() && index in 0..entries.size) {
             entries[index].label
         } else {
             ""


### PR DESCRIPTION
Fixes #

Stats graphs could crash when label entries are an empty list!

-----

## To Test:

- Enable `stats_traffic_tab` feature flag (Me -> Debug settings - Remote Features)
- **Restart** the app
- Choose a site that has empty stats
- Go to Stats
- `Verify` only Traffic tab, and Insights tabs are shown 
- `Select` By week, month or year
- `Ensure` it doesn't crash

#### Alternatively
- Install a version from trunk
- Enable the feature flag, if not already done so
- Check if it crashes when Stats is launched from dashboard.



-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testins

3. What automated tests I added (or what prevented me from doing so)

    - existing unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----