### PR TITLE
The list is not refreshed after a mark all as read action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.notifications.adapters
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -45,15 +46,13 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
     /**
      * Add notes to the adapter and notify the change
      */
+    @SuppressLint("NotifyDataSetChanged")
     fun addAll(notes: List<Note>) = coroutineScope.launch {
-        val currentSize: Int = filteredNotes.size
         val newNotes = buildFilteredNotesList(notes, currentFilter)
-
         filteredNotes.clear()
         filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
-            notifyItemRangeRemoved(0, currentSize)
-            notifyItemRangeInserted(0, newNotes.size)
+            notifyDataSetChanged()
             onNotesLoaded(newNotes.size)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -47,20 +47,14 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
      * Add notes to the adapter and notify the change
      */
     fun addAll(notes: List<Note>) = coroutineScope.launch {
+        val currentSize: Int = filteredNotes.size
         val newNotes = buildFilteredNotesList(notes, currentFilter)
-        val result = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
-            override fun getOldListSize(): Int = filteredNotes.size
-            override fun getNewListSize(): Int = newNotes.size
-            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-                filteredNotes[oldItemPosition].id == newNotes[newItemPosition].id
 
-            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
-                filteredNotes[oldItemPosition].json.toString() == newNotes[newItemPosition].json.toString()
-        })
         filteredNotes.clear()
         filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
-            result.dispatchUpdatesTo(this@NotesAdapter)
+            notifyItemRangeRemoved(0, currentSize)
+            notifyItemRangeInserted(0, newNotes.size)
             onNotesLoaded(newNotes.size)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.notifications.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers


### PR DESCRIPTION
Fixes #20308

The root cause is that our differ didn't work correctly so I make it refresh the entire list every time.

-----

## To Test:
1. Sign in the JP app
2. Switch to the notifications tab
3. Create some unread notifications
4. Click the three dots icon at the top-right corner 
5. Click Mark all as read
6. The unread dots should be cleared
7. Done, thank you!
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications tab

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

9. What automated tests I added (or what prevented me from doing so)

    - none

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
