### PR TITLE
[Stats] Fixed broken Stats UI tests.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -22,8 +21,6 @@ import org.wordpress.android.util.StatsVisitsData
 class StatsTests : BaseTest() {
     @Before
     fun setUp() {
-        // We're not running Stats tests for JP.
-        // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
         assumeTrue(BuildConfig.IS_JETPACK_APP)
         ComposeEspressoLink().unregister()
         logoutIfNecessary()
@@ -38,8 +35,7 @@ class StatsTests : BaseTest() {
             Espresso.pressBack()
         }
     }
-
-//    @Ignore("Will be taken care of in a future PR - scrollToPosts is not working")
+    
     @Test
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -24,7 +24,7 @@ class StatsTests : BaseTest() {
     fun setUp() {
         // We're not running Stats tests for JP.
         // See https://github.com/wordpress-mobile/WordPress-Android/issues/18065
-        assumeTrue(!BuildConfig.IS_JETPACK_APP)
+        assumeTrue(BuildConfig.IS_JETPACK_APP)
         ComposeEspressoLink().unregister()
         logoutIfNecessary()
         wpLogin()
@@ -39,7 +39,7 @@ class StatsTests : BaseTest() {
         }
     }
 
-    @Ignore("Will be taken care of in a future PR - scrollToPosts is not working")
+//    @Ignore("Will be taken care of in a future PR - scrollToPosts is not working")
     @Test
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
@@ -149,7 +149,7 @@ class MySitesPage {
         val statsButton = Espresso.onView(
             Matchers.allOf(
                 ViewMatchers.withText(R.string.stats),
-                ViewMatchers.withId(R.id.my_site_item_primary_text)
+                ViewMatchers.withId(R.id.quick_link_item)
             )
         )
         WPSupportUtils.clickOn(statsButton)
@@ -158,7 +158,7 @@ class MySitesPage {
         WPSupportUtils.waitForElementToBeDisplayedWithoutFailure(R.id.tabLayout)
 
         // Wait for the stats to load
-        WPSupportUtils.idleFor(8000)
+        WPSupportUtils.idleFor(4000)
         return StatsPage()
     }
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -168,7 +168,7 @@ class StatsPage {
         Espresso.onView(Matchers.allOf(
             ViewMatchers.withTagValue(Matchers.`is`(section.name))
         )).perform(
-            RecyclerViewActions.scrollToPosition<ViewHolder>(viewholderPosition) // This works
+            RecyclerViewActions.scrollToPosition<ViewHolder>(viewholderPosition)
         )
         WPSupportUtils.idleFor(2000)
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -1,12 +1,15 @@
 package org.wordpress.android.e2e.pages
 
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.Matchers
 import org.wordpress.android.R
 import org.wordpress.android.support.WPSupportUtils
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
 import org.wordpress.android.util.StatsKeyValueData
 import org.wordpress.android.util.StatsVisitsData
 
@@ -31,37 +34,37 @@ class StatsPage {
     }
 
     fun scrollToPosts(): StatsPage {
-        scrollToCard("Posts and Pages")
+        scrollToCard(1, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToReferrers(): StatsPage {
-        scrollToCard("Referrers")
+        scrollToCard(2, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToClicks(): StatsPage {
-        scrollToCard("Clicks")
+        scrollToCard(3, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToAuthors(): StatsPage {
-        scrollToCard("Authors")
+        scrollToCard(4, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToCountries(): StatsPage {
-        scrollToCard("Countries")
+        scrollToCard(5, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToVideos(): StatsPage {
-        scrollToCard("Videos")
+        scrollToCard(7, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
     fun scrollToFileDownloads(): StatsPage {
-        scrollToCard("File downloads")
+        scrollToCard(8, StatsListViewModel.StatsSection.DAYS)
         return this
     }
 
@@ -96,7 +99,7 @@ class StatsPage {
                 )
             )
         )
-        cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
+        cardStructure.check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         return this
     }
 
@@ -121,7 +124,7 @@ class StatsPage {
                     )
                 )
             )
-            cardStructure.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
+            cardStructure.check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         }
     }
 
@@ -160,15 +163,14 @@ class StatsPage {
         return this
     }
 
-    private fun scrollToCard(cardHeader: String) {
-        val card = Espresso.onView(
-            Matchers.allOf(
-                ViewMatchers.isDescendantOfA(visibleCoordinatorLayout),
-                ViewMatchers.withId(R.id.stats_block_list),
-                ViewMatchers.hasDescendant(ViewMatchers.withText(cardHeader))
-            )
+    private fun scrollToCard(viewholderPosition: Int, section: StatsListViewModel.StatsSection) {
+        WPSupportUtils.idleFor(2000)
+        Espresso.onView(Matchers.allOf(
+            ViewMatchers.withTagValue(Matchers.`is`(section.name))
+        )).perform(
+            RecyclerViewActions.scrollToPosition<ViewHolder>(viewholderPosition) // This works
         )
-        WPSupportUtils.scrollIntoView(R.id.statsPager, card, 0.5.toFloat())
+        WPSupportUtils.idleFor(2000)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -128,6 +128,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         }
 
         this@StatsListFragment.layoutManager = layoutManager
+        this.recyclerView.tag = statsSection.name
         recyclerView.layoutManager = this@StatsListFragment.layoutManager
         recyclerView.addItemDecoration(
             StatsListItemDecoration(


### PR DESCRIPTION
Fixes #

Our `StatsTests` UI test was being ignored due to past issues: https://github.com/wordpress-mobile/WordPress-Android/pull/18254. Since we are making updates I took this opportunity to learn how our UI tests are set up and try to get the old UI test working. It's been almost a year since this test was ignored, so changes were made that further broke tests. I updated them.

I think the part to pay close attention to is `StatsListFragment` and `StatsPage`. 

Firstly, I needed to add a tag to the RecyclerView on the tab because we re-use the screens. Espresso cannot differentiate which tab we are asking for. The tag is just the stat section, which should provide the filter we need for espresso. We wind up with the following:

```
Espresso.onView(Matchers.allOf(
            ViewMatchers.withTagValue(Matchers.`is`(section.name))
        ))
```

The biggest part that I just couldn't get working was scrolling to a specific viewholder using the stats title text. Rather than spend more time trying to figure it out, I simply scroll by index, which works well. It's not the most ideal since the index data could change, I figured it's ok because tests are mocked and won't change unless we make that change.

-----

## To Test:

- [ ] Load up an emulator.
- [ ] Go to `StatsTests` and run the class which runs the single test we have.
- [ ] Ensure it passes 100% of the time. We use to have flakiness, so I'd prefer to iron out any flakiness now.
- [ ] 🚬 test the current stats screen. I added a tag. Should be low risk, but good to test either way.

-----

## Regression Notes

1. Potential unintended areas of impact

    n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Ran `StatsTests`.

3. What automated tests I added (or what prevented me from doing so)

    Updated `StatsTests`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.