### PR TITLE
Fix granularity issue with traffic widgets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsActivity.kt
@@ -63,6 +63,7 @@ class StatsActivity : LocaleAwareActivity() {
         const val INITIAL_SELECTED_PERIOD_KEY = "INITIAL_SELECTED_PERIOD_KEY"
         const val ARG_LAUNCHED_FROM = "ARG_LAUNCHED_FROM"
         const val ARG_DESIRED_TIMEFRAME = "ARG_DESIRED_TIMEFRAME"
+        const val ARG_GRANULARITY = "ARG_GRANULARITY"
 
         @JvmStatic
         @JvmOverloads

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -121,9 +121,18 @@ class StatsViewModel
 
         val launchedFrom = intent.getSerializableExtraCompat<StatsLaunchedFrom>(StatsActivity.ARG_LAUNCHED_FROM)
         val initialTimeFrame = getInitialTimeFrame(intent)
+        val initialGranularity = intent.getSerializableExtraCompat<StatsGranularity>(StatsActivity.ARG_GRANULARITY)
         val initialSelectedPeriod = intent.getStringExtra(StatsActivity.INITIAL_SELECTED_PERIOD_KEY)
         val notificationType = intent.getSerializableExtraCompat<NotificationType>(ARG_NOTIFICATION_TYPE)
-        start(localSiteId, launchedFrom, initialTimeFrame, initialSelectedPeriod, restart, notificationType)
+        start(
+            localSiteId,
+            launchedFrom,
+            initialTimeFrame,
+            initialSelectedPeriod,
+            restart,
+            notificationType,
+            initialGranularity
+        )
     }
 
     fun onSaveInstanceState(outState: Bundle) {
@@ -158,7 +167,8 @@ class StatsViewModel
         initialSection: StatsSection?,
         initialSelectedPeriod: String?,
         restart: Boolean,
-        notificationType: NotificationType?
+        notificationType: NotificationType?,
+        granularity: StatsGranularity? = null
     ) {
         if (restart) {
             selectedDateProvider.clear()
@@ -173,10 +183,11 @@ class StatsViewModel
             )
 
             initialSection?.let { statsSectionManager.setSelectedSection(it) }
+            granularity?.let { selectedTrafficGranularityManager.setSelectedTrafficGranularity(it) }
             updateSelectedSectionByTrafficTabFeatureConfig()
             trackSectionSelected(statsSectionManager.getSelectedSection())
 
-            val initialGranularity = initialSection?.toStatsGranularity()
+            val initialGranularity = granularity ?: initialSection?.toStatsGranularity()
             if (initialGranularity != null && initialSelectedPeriod != null) {
                 selectedDateProvider.setInitialSelectedPeriod(initialGranularity, initialSelectedPeriod)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -211,6 +211,14 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         super.onResume()
         @Suppress("DEPRECATION")
         setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
+
+        val viewModelGranularity = viewModel.dateSelector?.statsGranularity
+        val storedGranularity = selectedTrafficGranularityManager.getSelectedTrafficGranularity()
+        if (viewModelGranularity != storedGranularity) {
+            // Coming from widget
+            binding?.initializeViews(null)
+            (viewModel as? TrafficListViewModel)?.onGranularitySelected(storedGranularity)
+        }
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -216,7 +216,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         val storedGranularity = selectedTrafficGranularityManager.getSelectedTrafficGranularity()
         if (viewModelGranularity != storedGranularity) {
             // Coming from widget
-            binding?.initializeViews(null)
             (viewModel as? TrafficListViewModel)?.onGranularitySelected(storedGranularity)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -52,7 +52,7 @@ abstract class StatsListViewModel(
     defaultDispatcher: CoroutineDispatcher,
     protected var statsUseCase: BaseListUseCase,
     private val analyticsTracker: AnalyticsTrackerWrapper,
-    protected var dateSelector: StatsDateSelector?,
+    var dateSelector: StatsDateSelector?,
     popupMenuHandler: ItemPopupMenuHandler? = null,
     private val newsCardHandler: NewsCardHandler? = null,
     actionCardHandler: ActionCardHandler? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/minified/MinifiedWidgetUpdater.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.stats.insights.TodayInsightsStore
@@ -79,10 +80,11 @@ class MinifiedWidgetUpdater
             views.setViewVisibility(R.id.widget_retry_button, View.GONE)
 
             val timeframe = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
+            val granularity = if (statsTrafficTabFeatureConfig.isEnabled()) StatsGranularity.DAYS else null
 
             views.setOnClickPendingIntent(
                 R.id.widget_container,
-                widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
+                widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe, granularity)
             )
             showValue(widgetManager, appWidgetId, views, siteModel, dataType, isWideView)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/today/TodayWidgetUpdater.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -59,10 +60,11 @@ class TodayWidgetUpdater
             } else {
                 StatsTimeframe.INSIGHTS
             }
+            val granularity = if (statsTrafficTabFeatureConfig.isEnabled()) StatsGranularity.DAYS else null
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe, granularity)
                 )
             }
             widgetUtils.showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/utils/WidgetUtils.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel.PeriodData
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.StatsTimeframe
 import org.wordpress.android.ui.stats.refresh.StatsActivity
@@ -174,13 +175,15 @@ class WidgetUtils
     fun getPendingSelfIntent(
         context: Context,
         localSiteId: Int,
-        statsTimeframe: StatsTimeframe
+        statsTimeframe: StatsTimeframe,
+        granularity: StatsGranularity? = null
     ): PendingIntent {
         val intent = Intent(context, StatsActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.putExtra(WordPress.LOCAL_SITE_ID, localSiteId)
         intent.putExtra(StatsActivity.ARG_DESIRED_TIMEFRAME, statsTimeframe)
         intent.putExtra(StatsActivity.ARG_LAUNCHED_FROM, StatsLaunchedFrom.WIDGET)
+        intent.putExtra(StatsActivity.ARG_GRANULARITY, granularity)
         return PendingIntent.getActivity(
             context,
             getRandomId(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -53,7 +54,7 @@ class ViewsWidgetUpdater
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY, StatsGranularity.WEEKS)
                 )
             }
             widgetUtils.showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/views/ViewsWidgetUpdater.kt
@@ -54,7 +54,7 @@ class ViewsWidgetUpdater
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY, StatsGranularity.WEEKS)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, DAY, StatsGranularity.DAYS)
                 )
             }
             widgetUtils.showList(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetUpdater.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/widget/weeks/WeekViewsWidgetUpdater.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.RemoteViews
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
@@ -53,12 +54,13 @@ class WeekViewsWidgetUpdater @Inject constructor(
         val hasAccessToken = accountStore.hasAccessToken()
         val widgetHasData = appPrefsWrapper.hasAppWidgetData(appWidgetId)
         val timeframe = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
+        val granularity = if (statsTrafficTabFeatureConfig.isEnabled()) StatsGranularity.WEEKS else null
         if (networkAvailable && hasAccessToken && siteModel != null) {
             widgetUtils.setSiteIcon(siteModel, context, views, appWidgetId)
             siteModel.let {
                 views.setOnClickPendingIntent(
                     R.id.widget_title_container,
-                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe)
+                    widgetUtils.getPendingSelfIntent(context, siteModel.id, timeframe, granularity)
                 )
             }
             widgetUtils.showList(


### PR DESCRIPTION
This makes widgets open stats with correct granularity.

-----

## To Test:
- Enable stats_traffic_tab feature flag (Me -> Debug settings - Remote Features)
- Restart the app
- Go to Stats
- Long press on the app icon in the launcher on device home screen
- Select Widgets
- Long press on each of the widgets below
- Add it to home screen
- Follow the prompt to configure the widget with a Site, Colour, and a View as required

#### 1. At a glance widget
- `Ensure` it open in Traffic tab with 'By day' selected when feature flag is enabled

#### 2. Today widget
- `Ensure` it open in Traffic tab with 'By day' selected when feature flag is enabled

#### 3. Views this week widget
- `Ensure` it open in Traffic tab with 'By week' selected when feature flag is enabled

#### 4. Views widget
- `Ensure` it open in Traffic tab with 'By day' selected when feature flag is enabled
- `Tap` on each rows like Today or a date
- `Verify` that it open the respective date views

##### Finally
- Disable the feature flag
- Test each of the widgets opens in Insights or tabs respectively as before

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Widgets are not proper for automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
