### PR TITLE
[Reader][Discover] Move first recommendation card to be card number three

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -199,7 +199,6 @@ class ReaderDiscoverLogic @Inject constructor(
      */
     @Suppress("NestedBlockDepth")
     private fun createSimplifiedJson(cardsJsonArray: JSONArray, discoverTasks: DiscoverTasks): JSONArray {
-        var index = 0
         val simplifiedJsonList = mutableListOf<JSONObject>()
         var firstYouMayLikeCard: JSONObject? = null
         for (i in 0 until cardsJsonArray.length()) {
@@ -208,7 +207,7 @@ class ReaderDiscoverLogic @Inject constructor(
                 JSON_CARD_RECOMMENDED_BLOGS -> {
                     cardJson.optJSONArray(JSON_CARD_DATA)?.let { recommendedBlogsCardJson ->
                         if (recommendedBlogsCardJson.length() > 0) {
-                            simplifiedJsonList.add(index++, createSimplifiedRecommendedBlogsCardJson(cardJson))
+                            simplifiedJsonList.add(createSimplifiedRecommendedBlogsCardJson(cardJson))
                         }
                     }
                 }
@@ -218,10 +217,10 @@ class ReaderDiscoverLogic @Inject constructor(
                         firstYouMayLikeCard = cardJson
                         continue
                     }
-                    simplifiedJsonList.add(index++, cardJson)
+                    simplifiedJsonList.add(cardJson)
                 }
                 JSON_CARD_POST -> {
-                    simplifiedJsonList.add(index++, createSimplifiedPostJson(cardJson))
+                    simplifiedJsonList.add(createSimplifiedPostJson(cardJson))
                 }
             }
         }


### PR DESCRIPTION
Fixes #20314

-----

## To Test:

- Install Jetpack and sign-in;
- Open Reader;
- Select "Discover" feed;
- 🔍 The first recommendation card should be seen as the third element in the feed. The first 6 elements should look like this:
```
1 - Post card;
2 - Post card;
3 - Recommendation card;
4 - Post card;
5 - Post card;
6 - Recommendation card
```
The following pages should have the same standard of having a recommendation card every 4 posts.

-----

## Regression Notes

1. Potential unintended areas of impact

    - "Discover" feed

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
