### PR TITLE
Integrate gutenberg-mobile release v1.114.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,9 @@
 -----
 [***] [Jetpack-only] Improved Notifications experience with richer UI elements and interactions [https://github.com/wordpress-mobile/WordPress-Android/pull/20072]
 * [**] [Jetpack-only] Block editor: Introduce VideoPress v5 support, to fix issues using video block with dotcom and Jetpack sites [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6634]
+* [*] Block editor: Prevent crash when autoscrolling to blocks [https://github.com/WordPress/gutenberg/pull/59110]
+* [*] Block editor: Remove opacity change when images are being uploaded [https://github.com/WordPress/gutenberg/pull/59264]
+* [*] Block editor: Media & Text blocks correctly show an error message when the attached video upload fails [https://github.com/WordPress/gutenberg/pull/59288]
 
 24.3
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.4.0'
-    gutenbergMobileVersion = '6687-d25601eddc3030ebc76b453cf86f5d79a7aa716a'
+    gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = 'trunk-8b930418a49b0d0846ed56ebf8fd8adad5011901'
     wordPressLoginVersion = '1.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticStoriesVersion = '2.4.0'
     automatticTracksVersion = '3.4.0'
-    gutenbergMobileVersion = 'v1.113.0-alpha1'
+    gutenbergMobileVersion = '6687-d25601eddc3030ebc76b453cf86f5d79a7aa716a'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = 'trunk-8b930418a49b0d0846ed56ebf8fd8adad5011901'
     wordPressLoginVersion = '1.14.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.114.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6687

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.