### PR TITLE
Fix bar size issue on traffic tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -139,7 +139,6 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             setDrawTopYLabelEntry(true)
             setDrawZeroLine(false)
             setDrawAxisLine(true)
-            granularity = 1f
             axisMinimum = 0f
             axisMaximum = if (maxYValue < minYValue) {
                 minYValue
@@ -156,7 +155,6 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     private fun configureXAxis(item: BlockListItem.BarChartItem) {
         chart.xAxis.apply {
-            granularity = 1f
             setDrawAxisLine(false)
             setDrawGridLines(false)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -131,6 +131,12 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             setDrawZeroLine(false)
             setDrawLabels(false)
             setDrawAxisLine(false)
+            axisMinimum = 0f
+            axisMaximum = if (maxYValue < minYValue) {
+                minYValue
+            } else {
+                roundUp(maxYValue.toFloat())
+            }
         }
 
         chart.axisRight.apply {


### PR DESCRIPTION
Fixes #20335

This fixes the incorrect bar height issue on the traffic tab.

- Removed granularity as it was necessary for the zoom feature, which we don't use. 8394773791fcfb02ef475077987fb6a5d264bbf4
- Set min-max values for the left axis since the data depends on the left axis. 10bbe8e30c147283af2c0e711e6c83b26211216d

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/38047f20-9b16-43f4-b4bd-8e4ad5846cff" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ca5960fd-bd22-49fc-a34b-ea278865938f" width=300>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Open the Stats Traffic tab (currently behind a feature flag)
2. Switch to By week and compare the View count to WP.com
3. Switch to By month and compare the View count to WP.com

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - This issue is caused by the settings of a 3rd part lib for the chart. It's not proper to add UI tests for this minor issue.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
