### PR TITLE
Fix incorrect date range on the traffic tab

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.stats.refresh.utils.trackWithGranularity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
@@ -110,9 +111,19 @@ class TrafficOverviewUseCase(
     }
 
     private fun getLastDate(model: VisitsAndViewsModel?): Date? {
-        selectedDateProvider.getSelectedDate(statsGranularity)?.let { return it }
+        selectedDateProvider.getSelectedDate(statsGranularity)?.let { return dateWithoutHour(it) }
+
         val lastDateString = model?.dates?.lastOrNull()?.period
-        return lastDateString?.let { statsDateFormatter.parseStatsDate(statsGranularity, it) }
+        return lastDateString?.let { dateWithoutHour(statsDateFormatter.parseStatsDate(statsGranularity, it)) }
+    }
+
+    // Remove the hour and minute from the date to avoid fetching incorrect dates caused by timezone differences
+    private fun dateWithoutHour(date: Date): Date {
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        return calendar.time
     }
 
     override suspend fun fetchRemoteData(forced: Boolean): State<TrafficOverviewUiModel> {


### PR DESCRIPTION
Fixes #20334

This fixes showing incorrect date range on the bar chart on TRAFFIC tab.

`StatsDateFormatter` adds "23:59" as time while parsing the day. In a case like the site timezone is 0, device timezone is -1, it fetches one day later from the current day.  Removing "23:59" and making the time "00:00" resolved the issue.


|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/69a8b8c6-c5e3-49f5-9dba-6bc3ffc41d5f" width=300>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/1a86ccb6-0c77-4c03-b71f-4c28052a185b" width=300>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in JP.
2. Select a site that has timezone 0.
3. Change the device timezone to -1.
4. Open the Stats Traffic tab
5. Tap "By day" and change it to "By week"
6. Verify that the date range of the date picker is same with the one shown on the chart

-----

## Regression Notes

1. Potential unintended areas of impact

    - None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A.

3. What automated tests I added (or what prevented me from doing so)

    - The issue was caused by a logic from 3rd party lib (FluxC). It's not possible to add automated test in WPAndroid.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
