### PR TITLE
[Reader] Improve analytics tracking for subscribed sites and followed tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -73,6 +73,8 @@ public class AppPrefs {
 
         READER_ANALYTICS_COUNT_TAGS_TIMESTAMP,
 
+        READER_ANALYTICS_COUNT_SITES_TIMESTAMP,
+
         // currently active tab on the main Reader screen when the user is in Reader
         READER_ACTIVE_TAB,
 
@@ -1170,6 +1172,14 @@ public class AppPrefs {
 
     public static void setReaderAnalyticsCountTagsTimestamp(long timestamp) {
         setLong(DeletablePrefKey.READER_ANALYTICS_COUNT_TAGS_TIMESTAMP, timestamp);
+    }
+
+    public static long getReaderAnalyticsCountSitesTimestamp() {
+        return getLong(DeletablePrefKey.READER_ANALYTICS_COUNT_SITES_TIMESTAMP, -1);
+    }
+
+    public static void setReaderAnalyticsCountSitesTimestamp(long timestamp) {
+        setLong(DeletablePrefKey.READER_ANALYTICS_COUNT_SITES_TIMESTAMP, timestamp);
     }
 
     public static long getReaderCssUpdatedTimestamp() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -63,6 +63,10 @@ class AppPrefsWrapper @Inject constructor() {
         get() = AppPrefs.getReaderTagsUpdatedTimestamp()
         set(timestamp) = AppPrefs.setReaderTagsUpdatedTimestamp(timestamp)
 
+    var readerAnalyticsCountTagsTimestamp: Long
+        get() = AppPrefs.getReaderAnalyticsCountTagsTimestamp()
+        set(timestamp) = AppPrefs.setReaderAnalyticsCountTagsTimestamp(timestamp)
+
     var readerCssUpdatedTimestamp: Long
         get() = AppPrefs.getReaderCssUpdatedTimestamp()
         set(timestamp) = AppPrefs.setReaderCssUpdatedTimestamp(timestamp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -29,15 +29,18 @@ public class ReaderEvents {
     public static class FollowedTagsFetched {
         private final boolean mDidSucceed;
         private final boolean mDidChange;
+        private final int mTotalTags;
 
-        public FollowedTagsFetched(boolean didSucceed) {
+        public FollowedTagsFetched(boolean didSucceed, int tagsFollowed) {
             mDidSucceed = didSucceed;
             mDidChange = true;
+            mTotalTags = tagsFollowed;
         }
 
-        public FollowedTagsFetched(boolean didSucceed, boolean didChange) {
+        public FollowedTagsFetched(boolean didSucceed, int tagsFollowed, boolean didChange) {
             mDidSucceed = didSucceed;
             mDidChange = didChange;
+            mTotalTags = tagsFollowed;
         }
 
         public boolean didSucceed() {
@@ -46,6 +49,9 @@ public class ReaderEvents {
 
         public boolean didChange() {
             return mDidChange;
+        }
+        public int getTotalTags() {
+            return mTotalTags;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -61,13 +61,19 @@ public class ReaderEvents {
         }
     }
 
-    public static class FollowedBlogsChanged {
+    public static class FollowedBlogsFetched {
         private final int mTotalSubscriptions;
+        private final boolean mDidChange;
+
+        public boolean didChange() {
+            return mDidChange;
+        }
         public int getTotalSubscriptions() {
             return mTotalSubscriptions;
         }
-        public FollowedBlogsChanged(int totalSubscriptions) {
+        public FollowedBlogsFetched(int totalSubscriptions, boolean didChange) {
             mTotalSubscriptions = totalSubscriptions;
+            mDidChange = didChange;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -84,6 +84,7 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.pages.SnackbarMessageHolder;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.reader.ReaderEvents.FollowedBlogsFetched;
 import org.wordpress.android.ui.reader.ReaderEvents.FollowedTagsFetched;
 import org.wordpress.android.ui.reader.ReaderEvents.TagAdded;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
@@ -118,7 +119,6 @@ import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.Site;
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem.SiteAll;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.reader.usecases.ReaderSiteFollowUseCase.FollowSiteState.FollowStatusChanged;
-import org.wordpress.android.ui.reader.utils.DateProvider;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.reader.viewmodels.ReaderModeInfo;
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostListViewModel;
@@ -949,28 +949,18 @@ public class ReaderPostListFragment extends ViewPagerFragment
                 updateCurrentTag();
             }
         }
-
-        // Check last time we've bumped tags followed analytics for this user,
-        // and bumping again if > 1 hrs
-        long tagsUpdatedTimestamp = AppPrefs.getReaderAnalyticsCountTagsTimestamp();
-        long now = new DateProvider().getCurrentDate().getTime();
-        if (now - tagsUpdatedTimestamp > 1000 * 60 * 60) { // 1 hr
-            ReaderTracker.trackFollowedTagsCount(ReaderTagTable.getFollowedTags().size());
-            AppPrefs.setReaderAnalyticsCountTagsTimestamp(now);
-        }
     }
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onEventMainThread(ReaderEvents.FollowedBlogsChanged event) {
+    public void onEventMainThread(FollowedBlogsFetched event) {
         // refresh posts if user is viewing "Followed Sites"
-        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED
+        if (event.didChange()
+            && getPostListType() == ReaderPostListType.TAG_FOLLOWED
             && hasCurrentTag()
             && (getCurrentTag().isFollowedSites() || getCurrentTag().isDefaultInMemoryTag())) {
             refreshPosts();
         }
-
-        ReaderTracker.trackSubscribedSitesCount(event.getTotalSubscriptions());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -41,6 +41,7 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.reader.ReaderEvents.FollowedBlogsFetched;
 import org.wordpress.android.ui.reader.ReaderEvents.FollowedTagsFetched;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -211,9 +212,11 @@ public class ReaderSubsActivity extends LocaleAwareActivity
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onEventMainThread(ReaderEvents.FollowedBlogsChanged event) {
-        AppLog.d(AppLog.T.READER, "reader subs > followed blogs changed");
-        getPageAdapter().refreshBlogFragments(ReaderBlogType.FOLLOWED);
+    public void onEventMainThread(FollowedBlogsFetched event) {
+        if (event.didChange()) {
+            AppLog.d(AppLog.T.READER, "reader subs > followed blogs changed");
+            getPageAdapter().refreshBlogFragments(ReaderBlogType.FOLLOWED);
+        }
     }
 
     private void performUpdate() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -51,7 +51,7 @@ public class ReaderTagActions {
     private static boolean deleteTagsLocallyOnly(ActionListener actionListener, ReaderTag tag) {
         ReaderTagTable.deleteTag(tag);
         ReaderActions.callActionListener(actionListener, true);
-        EventBus.getDefault().post(new FollowedTagsFetched(true));
+        EventBus.getDefault().post(new FollowedTagsFetched(true, ReaderTagTable.getFollowedTags().size()));
 
         return true;
     }
@@ -130,7 +130,7 @@ public class ReaderTagActions {
     private static boolean saveTagsLocallyOnly(ActionListener actionListener, ReaderTagList newTags) {
         ReaderTagTable.addOrUpdateTags(newTags);
         ReaderActions.callActionListener(actionListener, true);
-        EventBus.getDefault().post(new FollowedTagsFetched(true));
+        EventBus.getDefault().post(new FollowedTagsFetched(true, ReaderTagTable.getFollowedTags().size()));
 
         return true;
     }
@@ -147,7 +147,7 @@ public class ReaderTagActions {
             if (actionListener != null) {
                 ReaderActions.callActionListener(actionListener, true);
             }
-            EventBus.getDefault().post(new FollowedTagsFetched(true));
+            EventBus.getDefault().post(new FollowedTagsFetched(true, ReaderTagTable.getFollowedTags().size()));
         };
 
         RestRequest.ErrorListener errorListener = volleyError -> {
@@ -159,7 +159,7 @@ public class ReaderTagActions {
                 if (actionListener != null) {
                     ReaderActions.callActionListener(actionListener, true);
                 }
-                EventBus.getDefault().post(new FollowedTagsFetched(true));
+                EventBus.getDefault().post(new FollowedTagsFetched(true, ReaderTagTable.getFollowedTags().size()));
                 return;
             }
 
@@ -171,7 +171,7 @@ public class ReaderTagActions {
             if (actionListener != null) {
                 ReaderActions.callActionListener(actionListener, false);
             }
-            EventBus.getDefault().post(new FollowedTagsFetched(false));
+            EventBus.getDefault().post(new FollowedTagsFetched(false, ReaderTagTable.getFollowedTags().size()));
         };
 
         ReaderTagTable.addOrUpdateTags(newTags);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -23,7 +23,7 @@ import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderConstants;
-import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.ReaderEvents.FollowedBlogsFetched;
 import org.wordpress.android.ui.reader.ReaderEvents.FollowedTagsFetched;
 import org.wordpress.android.ui.reader.ReaderEvents.InterestTagsFetchEnded;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
@@ -327,6 +327,9 @@ public class ReaderUpdateLogic {
                 // but it's better to keep it separate since we aim to remove this check as soon as possible.
                 removeDuplicateBlogs(serverBlogs);
 
+                boolean sitesSubscribedChanged = false;
+                final int totalSites = jsonObject == null ? 0 : jsonObject.optInt("total_subscriptions", 0);
+
                 if (!localBlogs.isSameList(serverBlogs)) {
                     // always update the list of followed blogs if there are *any* changes between
                     // server and local (including subscription count, description, etc.)
@@ -335,13 +338,12 @@ public class ReaderUpdateLogic {
                     // changed if the server list doesn't have the same blogs as the local list
                     // (ie: a blog has been followed/unfollowed since local was last updated)
                     if (!localBlogs.hasSameBlogs(serverBlogs)) {
-                        final int totalSites = jsonObject == null ? 0 : jsonObject.optInt("total_subscriptions", 0);
                         ReaderPostTable.updateFollowedStatus();
                         AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed");
-                        EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged(totalSites));
+                        sitesSubscribedChanged = true;
                     }
                 }
-
+                EventBus.getDefault().post(new FollowedBlogsFetched(totalSites, sitesSubscribedChanged));
                 taskCompleted(UpdateTask.FOLLOWED_BLOGS);
             }
         }.start();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -193,7 +193,9 @@ public class ReaderUpdateLogic {
                     // broadcast the fact that there are changes
                     didChangeFollowedTags = true;
                 }
-                EventBus.getDefault().post(new FollowedTagsFetched(true, didChangeFollowedTags));
+                EventBus.getDefault().post(new FollowedTagsFetched(true,
+                        ReaderTagTable.getFollowedTags().size(),
+                        didChangeFollowedTags));
                 AppPrefs.setReaderTagsUpdatedTimestamp(new Date().getTime());
 
                 taskCompleted(UpdateTask.TAGS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -400,9 +400,11 @@ class SubFilterViewModel @Inject constructor(
 
     @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: ReaderEvents.FollowedBlogsChanged) {
-        AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")
-        loadSubFilters()
+    fun onEventMainThread(event: ReaderEvents.FollowedBlogsFetched) {
+        if(event.didChange()) {
+            AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")
+            loadSubFilters()
+        }
     }
 
     override fun onCleared() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/tracker/ReaderTracker.kt
@@ -399,6 +399,21 @@ class ReaderTracker @Inject constructor(
         }
     }
 
+    private fun trackFollowedCount(type: String, numberOfItems: Int) {
+        val props: MutableMap<String, String> = HashMap()
+        props["type"] = type
+        props["count"] = numberOfItems.toString()
+        AnalyticsTracker.track(Stat.READER_FOLLOWING_FETCHED, props)
+    }
+
+    fun trackFollowedTagsCount(numberOfItems: Int) {
+        trackFollowedCount("tags", numberOfItems)
+    }
+
+    fun trackSubscribedSitesCount(numberOfItems: Int) {
+        trackFollowedCount("sites", numberOfItems)
+    }
+
     /* HELPER */
 
     @JvmOverloads
@@ -464,23 +479,6 @@ class ReaderTracker @Inject constructor(
                 TAG_KEY to tag
             )
             AnalyticsTracker.track(stat, properties)
-        }
-
-        private fun trackFollowedCount(type: String, numberOfItems: Int) {
-            val props: MutableMap<String, String> = HashMap()
-            props["type"] = type
-            props["count"] = numberOfItems.toString()
-            AnalyticsTracker.track(Stat.READER_FOLLOWING_FETCHED, props)
-        }
-
-        @JvmStatic
-        fun trackFollowedTagsCount(numberOfItems: Int) {
-            trackFollowedCount("tags", numberOfItems)
-        }
-
-        @JvmStatic
-        fun trackSubscribedSitesCount(numberOfItems: Int) {
-            trackFollowedCount("sites", numberOfItems)
         }
 
         fun isUserProfileSource(source: String): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -18,7 +18,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode.MAIN
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
-import org.wordpress.android.datasets.ReaderTagTable
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.QuickStartStore
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask
@@ -54,6 +53,7 @@ import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UrlUtilsWrapper
 import org.wordpress.android.util.distinct
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -226,11 +226,11 @@ class ReaderViewModel @Inject constructor(
         // Determine if analytics should be bumped either due to tags changed or time elapsed since last bump
         val now = DateProvider().getCurrentDate().time
         val shouldBumpAnalytics = event.didChange()
-                || ( now - AppPrefs.getReaderAnalyticsCountTagsTimestamp() > ONE_HOUR_MILLIS)
+                || ( now - appPrefsWrapper.readerAnalyticsCountTagsTimestamp > ONE_HOUR_MILLIS)
 
         if (shouldBumpAnalytics) {
-            readerTracker.trackFollowedTagsCount(ReaderTagTable.getFollowedTags().size)
-            AppPrefs.setReaderAnalyticsCountTagsTimestamp(DateProvider().getCurrentDate().time)
+            readerTracker.trackFollowedTagsCount(event.totalTags)
+            appPrefsWrapper.readerAnalyticsCountTagsTimestamp = DateProvider().getCurrentDate().time
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -229,7 +229,7 @@ class ReaderViewModel @Inject constructor(
 
         if (shouldBumpAnalytics) {
             readerTracker.trackFollowedTagsCount(event.totalTags)
-            appPrefsWrapper.readerAnalyticsCountTagsTimestamp = DateProvider().getCurrentDate().time
+            appPrefsWrapper.readerAnalyticsCountTagsTimestamp = now
         }
     }
 
@@ -243,7 +243,7 @@ class ReaderViewModel @Inject constructor(
 
         if (shouldBumpAnalytics) {
             readerTracker.trackSubscribedSitesCount(event.totalSubscriptions)
-            AppPrefs.setReaderAnalyticsCountSitesTimestamp(DateProvider().getCurrentDate().time)
+            AppPrefs.setReaderAnalyticsCountSitesTimestamp(now)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -53,7 +53,6 @@ import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UrlUtilsWrapper
 import org.wordpress.android.util.distinct
-import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -223,7 +223,6 @@ class ReaderViewModel @Inject constructor(
     @Subscribe(threadMode = MAIN)
     fun onTagsUpdated(event: ReaderEvents.FollowedTagsFetched) {
         loadTabs()
-
         // Determine if analytics should be bumped either due to tags changed or time elapsed since last bump
         val now = DateProvider().getCurrentDate().time
         val shouldBumpAnalytics = event.didChange()

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/FetchFollowedTagsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/FetchFollowedTagsUseCaseTest.kt
@@ -64,7 +64,7 @@ class FetchFollowedTagsUseCaseTest : BaseUnitTest() {
     fun `Success returned when FollowedTagsFetched event is posted with success`() = test {
         // Given
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
-        val event = FollowedTagsFetched(true)
+        val event = FollowedTagsFetched(true, 10)
         whenever(readerUpdateServiceStarterWrapper.startService(contextProvider.getContext(), EnumSet.of(TAGS)))
             .then { useCase.onFollowedTagsFetched(event) }
 
@@ -79,7 +79,7 @@ class FetchFollowedTagsUseCaseTest : BaseUnitTest() {
     fun `RemoteRequestFailure returned when FollowedTagsFetched event is posted with failure`() = test {
         // Given
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
-        val event = FollowedTagsFetched(false)
+        val event = FollowedTagsFetched(false, 10)
         whenever(readerUpdateServiceStarterWrapper.startService(contextProvider.getContext(), EnumSet.of(TAGS)))
             .then { useCase.onFollowedTagsFetched(event) }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/repository/ReaderDiscoverDataProviderTest.kt
@@ -251,7 +251,8 @@ class ReaderDiscoverDataProviderTest : BaseUnitTest() {
         // Act
         dataProvider.onFollowedTagsFetched(
             FollowedTagsFetched(
-                true
+                true,
+                10
             )
         )
         // Assert


### PR DESCRIPTION
Improves the fix for https://github.com/wordpress-mobile/WordPress-Android/issues/19836
* Moved the logic to the view controller, as suggested in the https://github.com/wordpress-mobile/WordPress-Android/pull/20303 
* Both Followed Tags and Subscribed Sites analytics are bumped either due to Tags/Sites changed or time elapsed since last bump

-----
## To Test:

* Install Jetpack and sign-in
* Open Reader
* 🔍 Tags followed are correctly tracked
* 🔍 Sites subscribed analytics are tracked
* Open the reader on Web and add a tag
* Go back to the app and PTR
* 🔍 Tags followed are correctly tracked
* Open the reader on Web and add a new site
* Go back to the app and PTR
* 🔍 Sites subscribed analytics are tracked
* Navigate the app a bit
* Go back to the Reader and PTR (if it doesn't start automatically)
* 🔍 Sites subscribed  and Tags Followed analytics are *NOT* tracked

To check analytics you can use the Track Live view tool, use logcat and filter by Reader events, or set few breakpoints in the Reader Tracker.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)