### PR TITLE
Fix the loading state of the traffic chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -83,13 +83,6 @@ class UiModelMapper
         return mapStatsWithOverview(PostDetailType.POST_OVERVIEW, useCaseModels, showError)
     }
 
-    fun mapViewsVisitorsDetailStats(
-        useCaseModels: List<UseCaseModel>,
-        showError: (Int) -> Unit
-    ): UiModel {
-        return mapStatsWithOverview(TimeStatsType.OVERVIEW, useCaseModels, showError)
-    }
-
     @Suppress("CyclomaticComplexMethod")
     private fun mapStatsWithOverview(
         overViewType: StatsType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -98,30 +98,30 @@ class UiModelMapper
         return if (!allFailing && (overviewHasData || !overviewIsFailing)) {
             if (useCaseModels.isNotEmpty()) {
                 UiModel.Success(useCaseModels.mapNotNull { useCaseModel ->
-                    if ((useCaseModel.type == overViewType) && useCaseModel.data != null) {
-                        StatsBlock.Success(useCaseModel.type, useCaseModel.data)
-                    } else {
-                        when (useCaseModel.state) {
-                            SUCCESS -> StatsBlock.Success(useCaseModel.type, useCaseModel.data ?: listOf())
-                            ERROR -> useCaseModel.stateData?.let {
-                                StatsBlock.Error(
-                                    useCaseModel.type,
-                                    useCaseModel.stateData
-                                )
-                            }
-                            LOADING -> useCaseModel.stateData?.let {
-                                StatsBlock.Loading(
-                                    useCaseModel.type,
-                                    useCaseModel.stateData
-                                )
-                            }
-                            EMPTY -> useCaseModel.stateData?.let {
-                                StatsBlock.EmptyBlock(
-                                    useCaseModel.type,
-                                    useCaseModel.stateData
-                                )
-                            }
+                    when {
+                        useCaseModel.type == overViewType && useCaseModel.data != null -> StatsBlock.Success(
+                            useCaseModel.type,
+                            useCaseModel.data
+                        )
+
+                        useCaseModel.state == SUCCESS -> StatsBlock.Success(
+                            useCaseModel.type,
+                            useCaseModel.data ?: listOf()
+                        )
+
+                        useCaseModel.state == LOADING -> useCaseModel.stateData?.let {
+                            StatsBlock.Loading(useCaseModel.type, useCaseModel.stateData)
                         }
+
+                        useCaseModel.state == ERROR -> useCaseModel.stateData?.let {
+                            StatsBlock.Error(useCaseModel.type, useCaseModel.stateData)
+                        }
+
+                        useCaseModel.state == EMPTY -> useCaseModel.stateData?.let {
+                            StatsBlock.EmptyBlock(useCaseModel.type, useCaseModel.stateData)
+                        }
+
+                        else -> null
                     }
                 })
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/UiModelMapper.kt
@@ -99,6 +99,10 @@ class UiModelMapper
             if (useCaseModels.isNotEmpty()) {
                 UiModel.Success(useCaseModels.mapNotNull { useCaseModel ->
                     when {
+                        useCaseModel.state == LOADING -> useCaseModel.stateData?.let {
+                            StatsBlock.Loading(useCaseModel.type, useCaseModel.stateData)
+                        }
+
                         useCaseModel.type == overViewType && useCaseModel.data != null -> StatsBlock.Success(
                             useCaseModel.type,
                             useCaseModel.data
@@ -108,10 +112,6 @@ class UiModelMapper
                             useCaseModel.type,
                             useCaseModel.data ?: listOf()
                         )
-
-                        useCaseModel.state == LOADING -> useCaseModel.stateData?.let {
-                            StatsBlock.Loading(useCaseModel.type, useCaseModel.stateData)
-                        }
 
                         useCaseModel.state == ERROR -> useCaseModel.stateData?.let {
                             StatsBlock.Error(useCaseModel.type, useCaseModel.stateData)


### PR DESCRIPTION
This fixes the loading state of the chart on the TRAFFIC tab. 
Before, `UiModelMapper` was mapping models to Success even though the state was LOADING. This caused bars to animate with the current data unnecessarily before animating with the new data.

<details>
<summary>before video</summary>

[before.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/871d1ce2-557a-4f7f-858f-c8b577c07f4d)
</details>

<details>
<summary>after video</summary>

[after.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/43797b34-9650-409e-a237-1b744dd55466)
</details>


-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in. 
2. Open the TRAFFIC tab from "My Site → Stats".
3. Change the selected date by tapping the left arrow.
4. Verify that there is no unnecessary loading animation for bars.
5. Navigate back.
6. Open "Me → Debug settings"
7. Switch `stats_traffic_tab` off.
8. Repeat 2-3.
9. Verify there is no issue with loading graphs and stats cards.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Disabled state of `stats_traffic_tab` feature.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually.

3. What automated tests I added (or what prevented me from doing so)

    - This simple logic change is not worth automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
