### PR TITLE
Make traffic tab default

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -11,12 +11,17 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
+import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TRAFFIC
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import javax.inject.Inject
 
 const val SELECTED_SECTION_KEY = "SELECTED_STATS_SECTION_KEY"
 
 class SelectedSectionManager
-@Inject constructor(private val sharedPrefs: SharedPreferences) {
+@Inject constructor(
+    private val sharedPrefs: SharedPreferences,
+    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+) {
     private val _liveSelectedSection = MutableLiveData<StatsSection>()
     val liveSelectedSection: LiveData<StatsSection>
         get() {
@@ -28,7 +33,8 @@ class SelectedSectionManager
         }
 
     fun getSelectedSection(): StatsSection {
-        val value = sharedPrefs.getString(SELECTED_SECTION_KEY, INSIGHTS.name)
+        val defaultValue = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
+        val value = sharedPrefs.getString(SELECTED_SECTION_KEY, defaultValue.name)
         return value?.let { StatsSection.valueOf(value) } ?: INSIGHTS
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManagerTest.kt
@@ -13,9 +13,13 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.MONTHS
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 
 @ExperimentalCoroutinesApi
 class SelectedSectionManagerTest : BaseUnitTest() {
+    @Mock
+    private lateinit var trafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
     @Mock
     lateinit var sharedPreferences: SharedPreferences
 
@@ -25,7 +29,7 @@ class SelectedSectionManagerTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        selectedSectionManager = SelectedSectionManager(sharedPreferences)
+        selectedSectionManager = SelectedSectionManager(sharedPreferences, trafficTabFeatureConfig)
         whenever(sharedPreferences.edit()).thenReturn(sharedPreferencesEditor)
     }
 


### PR DESCRIPTION
This makes TRAFFIC tab default.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Make a clean install or clear the data storage of the app.
2. Log in.
3. Enable `stats_traffic_tab` from "Me → Debug settings".
4. Navigate back.
5. Open "My Site → Stats".
6. Verify that the TRAFFIC tab is selected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

6. What automated tests I added (or what prevented me from doing so)

    - Updated `SelectedSectionManagerTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
