### PR TITLE
Fix the stats screen issue that occurs with changing orientation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -157,7 +157,9 @@ abstract class StatsListViewModel(
     }
 
     fun start() {
-        if (!isInitialized) {
+        if (isInitialized) {
+            mutableUiSourceAdded.call()
+        } else {
             isInitialized = true
             setUiLiveData()
             launch {


### PR DESCRIPTION
Fixes #20343

This fixes the issue on the stats screen with changing orientation. When the orientation changed, the screen was showing an empty screen.

`StatsListViewModel` informs the view to observe the data, and `mutableUiSourceAdded` should be called for that. This PR calls `mutableUiSourceAdded` on orientation change and resolves the issue.

<details>
<summary>before video</summary>

[before.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/b9c3f41f-a809-4921-95d4-3408a25f8937)

</details>

<details>
<summary>after video</summary>

[after.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/2b2895c6-4db2-472b-b297-4902ea320090)

</details>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Enable `stats_traffic_tab` from "Me → Debug settings".
3. Navigate back.
4. Open "My Site → Stats".
5. Change the device orientation.
6. Verify that the screen still shows stats cards.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A
    
3. What automated tests I added (or what prevented me from doing so)

    - Testing orientation change with automated UI tests is possible, but it's a larger task that needs to be handled separately.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
