### PR TITLE
Fix accessibility issue on the traffic chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -270,9 +270,6 @@ sealed class BlockListItem(val type: Type) {
 
     data class TrafficBarChartItem(
         val entries: List<Bar>,
-        val overlappingEntries: List<Bar>? = null,
-        val selectedItem: String? = null,
-        val onBarSelected: ((period: String?) -> Unit)? = null,
         val onBarChartDrawn: ((visibleBarCount: Int) -> Unit)? = null,
         val entryContentDescriptions: List<String>
     ) : BlockListItem(TRAFFIC_BAR_CHART) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -42,18 +42,6 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             val barCount = chart.draw(item)
             if (hasData(item.entries)) {
                 chart.post {
-                    val accessibilityEvent = object : BarChartAccessibilityHelper.BarChartAccessibilityEvent {
-                        override fun onHighlight(
-                            entry: BarEntry,
-                            index: Int
-                        ) {
-                            val value = entry.data as? String
-                            value?.let {
-                                item.onBarSelected?.invoke(it)
-                            }
-                        }
-                    }
-
                     val cutContentDescriptions = takeEntriesWithinGraphWidth(barCount, item.entryContentDescriptions)
                     accessibilityHelper = BarChartAccessibilityHelper(
                         chart,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -43,11 +43,7 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             if (hasData(item.entries)) {
                 chart.post {
                     val cutContentDescriptions = takeEntriesWithinGraphWidth(barCount, item.entryContentDescriptions)
-                    accessibilityHelper = BarChartAccessibilityHelper(
-                        chart,
-                        contentDescriptions = cutContentDescriptions,
-                        accessibilityEvent = accessibilityEvent
-                    )
+                    accessibilityHelper = BarChartAccessibilityHelper(chart, cutContentDescriptions)
 
                     ViewCompat.setAccessibilityDelegate(chart, accessibilityHelper)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewMapper.kt
@@ -82,10 +82,8 @@ class TrafficOverviewMapper @Inject constructor(
     fun buildChart(
         dates: List<VisitsAndViewsModel.PeriodData>,
         statsGranularity: StatsGranularity,
-        onBarSelected: (String?) -> Unit,
         onBarChartDrawn: (visibleBarCount: Int) -> Unit,
-        selectedType: Int,
-        selectedItemPeriod: String
+        selectedType: Int
     ): List<BlockListItem> {
         val chartItems = dates.map {
             val value = when (SelectedType.valueOf(selectedType)) {
@@ -116,15 +114,7 @@ class TrafficOverviewMapper @Inject constructor(
             chartItems
         )
 
-        result.add(
-            BlockListItem.TrafficBarChartItem(
-                chartItems,
-                selectedItem = selectedItemPeriod,
-                onBarSelected = onBarSelected,
-                onBarChartDrawn = onBarChartDrawn,
-                entryContentDescriptions = contentDescriptions
-            )
-        )
+        result.add(BlockListItem.TrafficBarChartItem(chartItems, onBarChartDrawn, contentDescriptions))
         return result
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -19,7 +19,6 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.WidgetUpdater
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
-import org.wordpress.android.ui.stats.refresh.utils.trackGranular
 import org.wordpress.android.ui.stats.refresh.utils.trackWithGranularity
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -269,14 +268,7 @@ class TrafficOverviewUseCase(
         selectedItem: VisitsAndViewsModel.PeriodData
     ) {
         items.addAll(
-            trafficOverviewMapper.buildChart(
-                dates,
-                lowerGranularity,
-                this::onBarSelected,
-                this::onBarChartDrawn,
-                uiState.selectedPosition,
-                selectedItem.period
-            )
+            trafficOverviewMapper.buildChart(dates, lowerGranularity, this::onBarChartDrawn, uiState.selectedPosition)
         )
         items.add(
             trafficOverviewMapper.buildColumns(
@@ -285,20 +277,6 @@ class TrafficOverviewUseCase(
                 uiState.selectedPosition
             )
         )
-    }
-
-    private fun onBarSelected(period: String?) {
-        analyticsTracker.trackGranular(
-            AnalyticsTracker.Stat.STATS_OVERVIEW_BAR_CHART_TAPPED,
-            lowerGranularity
-        )
-        if (period != null && period != "empty") {
-            val selectedDate = statsDateFormatter.parseStatsDate(lowerGranularity, period)
-            selectedDateProvider.selectDate(
-                selectedDate,
-                lowerGranularity
-            )
-        }
     }
 
     @Suppress("MagicNumber")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/BarChartAccessibilityHelper.kt
@@ -12,7 +12,7 @@ import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
 class BarChartAccessibilityHelper(
     private val barChart: BarChart,
     private val contentDescriptions: List<String>,
-    private val accessibilityEvent: BarChartAccessibilityEvent
+    private val accessibilityEvent: BarChartAccessibilityEvent? = null
 ) : ExploreByTouchHelper(barChart) {
     private val dataSet: IBarDataSet = barChart.data.dataSets.first()
 
@@ -51,7 +51,7 @@ class BarChartAccessibilityHelper(
         when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
                 val entry = dataSet.getEntryForIndex(virtualViewId)
-                accessibilityEvent.onHighlight(entry, virtualViewId)
+                accessibilityEvent?.onHighlight(entry, virtualViewId)
                 return true
             }
         }
@@ -74,7 +74,7 @@ class BarChartAccessibilityHelper(
             }
         }
 
-        node.addAction(AccessibilityActionCompat.ACTION_CLICK)
+        accessibilityEvent?.let { node.addAction(AccessibilityActionCompat.ACTION_CLICK) }
         val entryRectF = barChart.getBarBounds(dataSet.getEntryForIndex(virtualViewId))
         val entryRect = Rect()
         entryRectF.round(entryRect)


### PR DESCRIPTION
Fixes #20363 

This fixes Talkback to prompt "Double tap to activate" when highlighting bars on the TRAFFIC tab. Since bars are not selectable on the TRAFFIC tab, it shouldn't prompt "Double tap to activate".

<details>
<summary>before video</summary>

https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/16d1458c-465d-4122-b3a3-483995f1936e

</details>

<details>
<summary>after video</summary>

[after.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/160ec13c-0403-4237-a2fc-ac1ea61502a5)

</details>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Enable `traffic_stats_tab` from "Me → Debug settings".
4. Navigate back.
4. Open "My Site → Stats"
3. Enable Talkback from the device settings.
6. Open the TRAFFIC tab and select By week, By month or By year.
7. Tap on a bar.
8. Verify Talkback does not prompt "Double tap to activate".

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Talkback prompts are not available for automated testing.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
