### PR TITLE
Display the privacy popup for US users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/GeoRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/GeoRepository.kt
@@ -15,9 +15,13 @@ class GeoRepository @Inject constructor(
         wpComGeoRestClient.fetchCountryCode().map { it.orEmpty() }
     }
 
-    suspend fun isGdprComplianceRequired() = fetchCountryCode().fold(
+    /**
+     * @return true if the user is in a country where privacy policy compliance is required.
+     * Includes GDPR countries and the US.
+     */
+    suspend fun isPrivacyPolicyComplianceRequired() = fetchCountryCode().fold(
         onSuccess = { countryCode ->
-            countryCode.uppercase() in GDPR_COUNTRY_CODES
+            countryCode.uppercase() in (GDPR_COUNTRY_CODES + US_COUNTRY_CODE)
         },
         onFailure = {
             false
@@ -63,5 +67,7 @@ class GeoRepository @Inject constructor(
             "LI", // Liechtenstein
             "NO", // Norway
         )
+
+        private const val US_COUNTRY_CODE = "US" // United States
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsent.kt
@@ -16,7 +16,7 @@ class ShouldAskPrivacyConsent @Inject constructor(
     suspend operator fun invoke(): Boolean {
         return isLoggedIn &&
                 !appPrefs.savedPrivacyBannerSettings &&
-                geoRepository.isGdprComplianceRequired()
+                geoRepository.isPrivacyPolicyComplianceRequired()
     }
 
     private val isLoggedIn

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsentTest.kt
@@ -52,7 +52,7 @@ class ShouldAskPrivacyConsentTest: BaseUnitTest() {
     fun `it does not show the banner for non-GDPR countries`() = test {
         // Given
         whenever(appPrefs.savedPrivacyBannerSettings).thenReturn(false)
-        whenever(geoRepository.isGdprComplianceRequired()).thenReturn(false)
+        whenever(geoRepository.isPrivacyPolicyComplianceRequired()).thenReturn(false)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
 
         // When
@@ -66,7 +66,7 @@ class ShouldAskPrivacyConsentTest: BaseUnitTest() {
     fun `it does show the banner for GDPR countries`() = test {
         // Given
         whenever(appPrefs.savedPrivacyBannerSettings).thenReturn(false)
-        whenever(geoRepository.isGdprComplianceRequired()).thenReturn(true)
+        whenever(geoRepository.isPrivacyPolicyComplianceRequired()).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
 
         // When
@@ -82,7 +82,7 @@ class ShouldAskPrivacyConsentTest: BaseUnitTest() {
 
         // Given
         whenever(appPrefs.savedPrivacyBannerSettings).thenReturn(false)
-        whenever(geoRepository.isGdprComplianceRequired()).thenReturn(true)
+        whenever(geoRepository.isPrivacyPolicyComplianceRequired()).thenReturn(true)
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
         whenever(site.origin).thenReturn(SiteModel.ORIGIN_WPAPI)


### PR DESCRIPTION
Part of #19763

We should display the privacy popup for US users. This PR contains:
1. Add US as one of the countries should be required the privacy compliance
2. Rename a function
-----

## To Test:

Please prepare a VPN for mocking as an US user

1. Install and sign in the JP app
3. It should pop up the privacy window in the main screen.
4. Done, thank you!

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/3103ed2b-791d-4ff4-9c0c-d1335c44739b" width="400"/>


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - GDPR settings

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

7. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
