### PR TITLE
Adds thumbnails in achievement details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -160,10 +160,16 @@ public class NoteBlock {
         // Note image
         if (hasImageMediaItem()) {
             noteBlockHolder.getImageView().setVisibility(View.VISIBLE);
+
+            // for large 2x images, request a 1x thumbnail to display while the full image loads
+            String thumbnailUrl = null;
+            if (getNoteMediaItem().getUrl() != null && getNoteMediaItem().getUrl().endsWith("-2x.png")) {
+                thumbnailUrl = getNoteMediaItem().getUrl().replace("-2x.png", "-1x.png");
+            }
+
             // Request image, and animate it when loaded
-            mImageManager
-                    .loadWithResultListener(noteBlockHolder.getImageView(), ImageType.IMAGE,
-                            StringUtils.notNullStr(getNoteMediaItem().getUrl()), ScaleType.CENTER, null,
+            mImageManager.loadWithResultListener(noteBlockHolder.getImageView(), ImageType.IMAGE,
+                            StringUtils.notNullStr(getNoteMediaItem().getUrl()), ScaleType.CENTER, thumbnailUrl,
                             new ImageManager.RequestListener<Drawable>() {
                                 @Override
                                 public void onLoadFailed(@Nullable Exception e, @Nullable Object model) {


### PR DESCRIPTION
Fixes #12629

## Description
For large 2x images, request a 1x thumbnail to display while the full image loads. This seems to prevent failure on the first load.

-----

## To Test:
1. Uninstall previous versions of the app or purge the app cache
2. Install the Jetpack app from this branch
3. Login with an account that has achievements
4. Switch to the notification tab
5. Open an achievement
6. **Verify** that the image loads

### To reproduce:
I was able to reproduce the issue on `trunk` consistently with the steps above unrelated to the day/night mode (see https://github.com/wordpress-mobile/WordPress-Android/issues/12629#issuecomment-1976994225)

-----

## Regression Notes

1. Potential unintended areas of impact

    - Achievement notification details screen

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

9. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist:

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
