### PR TITLE
Fix timezone issue with traffic charts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -81,7 +81,8 @@ class TrafficOverviewUseCase(
         val cachedData = visitsAndViewsStore.getVisits(
             statsSiteProvider.siteModel,
             statsGranularity,
-            LimitMode.All
+            LimitMode.All,
+            false
         )
 
         // Get lower granularity model for chart values
@@ -92,7 +93,8 @@ class TrafficOverviewUseCase(
                     statsSiteProvider.siteModel,
                     lowerGranularity,
                     LimitMode.Top(OVERVIEW_ITEMS_TO_LOAD),
-                    it
+                    it,
+                    false
                 )
             }
         } else {
@@ -176,7 +178,8 @@ class TrafficOverviewUseCase(
         statsSiteProvider.siteModel,
         granularity,
         LimitMode.Top(quantity),
-        forced
+        forced,
+        false
     ).apply {
         error?.let { return@apply }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -81,8 +81,7 @@ class TrafficOverviewUseCase(
         val cachedData = visitsAndViewsStore.getVisits(
             statsSiteProvider.siteModel,
             statsGranularity,
-            LimitMode.All,
-            false
+            LimitMode.All
         )
 
         // Get lower granularity model for chart values
@@ -178,8 +177,7 @@ class TrafficOverviewUseCase(
         statsSiteProvider.siteModel,
         granularity,
         LimitMode.Top(quantity),
-        forced,
-        false
+        forced
     ).apply {
         error?.let { return@apply }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2.70.0'
+    wordPressFluxCVersion = '2967-c3d64c87d04126b94fefca02e5c8299f88b30872'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2967-c80ad3ea9b05ae3dc9a1a4d70010a92fe4380a62'
+    wordPressFluxCVersion = 'trunk-28e35ae36fe90c3b7bafb4610e71b9cd3f4e2dc4'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2967-62b2bd003c13c1e2de3ea0cac312cd8a061e927e'
+    wordPressFluxCVersion = '2967-c80ad3ea9b05ae3dc9a1a4d70010a92fe4380a62'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2967-c3d64c87d04126b94fefca02e5c8299f88b30872'
+    wordPressFluxCVersion = '2967-62b2bd003c13c1e2de3ea0cac312cd8a061e927e'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'


### PR DESCRIPTION
Fixes #20412 

This fixes blank page on TRAFFIC tab for some timezones.

This is the following PR of https://github.com/wordpress-mobile/WordPress-Android/pull/20387 since it did not resolve the issue.

> [!WARNING]
> Before Merging
> - [x] Merge https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2967
> - [x] Update FluxC version to FluxC's trunk

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in to JP.
2. Change the device timezone to an edge, -1.
3. Open the Stats Traffic tab.
4. Tap "By day" and change granularity to "By week".
5. Verify that the page is not blank.
6. Tap "By week" and change granularity to "By month".
7. Verify that the page loads successfully.
8. Repeat 3-7 with timezone set to -12 and +14.

-----

## Screenshots
| Before | After | 
| - | - | 
| <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/1898325/32540151-da16-4a24-a096-06727aabc6d9" /> | <img src="https://github.com/wordpress-mobile/WordPress-Android/assets/1898325/32e3fbb1-962f-42fa-993e-5257e006ec5b" /> |

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - The issue was caused by a logic from 3rd party lib (FluxC). It's not possible to add automated tests in WPAndroid.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
