### PR TITLE
Filters free themes using the theme_tier field of the response

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [*] Block editor: Prevent crash when autoscrolling to blocks [https://github.com/WordPress/gutenberg/pull/59110]
 * [*] Block editor: Remove opacity change when images are being uploaded [https://github.com/WordPress/gutenberg/pull/59264]
 * [*] Block editor: Media & Text blocks correctly show an error message when the attached video upload fails [https://github.com/WordPress/gutenberg/pull/59288]
+* [*] [Jetpack-only] Themes: Filters themes that are not available due to tier to prevent activation errors. [https://github.com/wordpress-mobile/WordPress-Android/pull/20425]
 
 24.3
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticTracksVersion = '3.4.0'
     gutenbergMobileVersion = 'v1.114.0'
     wordPressAztecVersion = 'v2.0'
-    wordPressFluxCVersion = '2.70.0'
+    wordPressFluxCVersion = '2969-4a14dd8f82ee56ea9e3d46549ff45d5f5f11c0a5'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.13.0'


### PR DESCRIPTION
Fixes #20419

**Depends on:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2969

-----

## To Test:

Check steps at https://github.com/wordpress-mobile/WordPress-Android/issues/20419 and verify that the non-free themes are not listed

⚠️ Since this PR is targeting a beta the merge process is tracked in p1709801508524249/1709801487.743599-slack-CC7L49W13

-----

## Regression Notes

1. Potential unintended areas of impact

    - Themes

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - The change is on the api layer

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
