### PR TITLE
build: bump measure builds version to 2.1.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
     gradle.ext.daggerVersion = "2.50"
     gradle.ext.detektVersion = '1.23.0'
     gradle.ext.violationCommentsVersion = '1.70.0'
-    gradle.ext.measureBuildsVersion = '2.0.3'
+    gradle.ext.measureBuildsVersion = '2.1.2'
     gradle.ext.koverVersion = '0.7.5'
 
     plugins {


### PR DESCRIPTION
### Description
This PR updates measure-builds to `2.1.2`, which brings configuration phase duration metric and local report files.
 
### Testing instructions
Not needed.