### PR TITLE
[Reader] Fix for Incomplete subscribed sites list 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -313,7 +313,7 @@ public class ReaderUpdateLogic {
             }
         };
 
-        AppLog.d(AppLog.T.READER, "reader service > updating followed blogs");
+        AppLog.d(AppLog.T.READER, "reader service > updating followed blogs. Page requested: " + page);
         // request using ?meta=site,feed to get extra info
         WordPress.getRestClientUtilsV1_2()
                  .get("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener, errorListener);
@@ -351,7 +351,8 @@ public class ReaderUpdateLogic {
                         // (ie: a blog has been followed/unfollowed since local was last updated)
                         if (!localBlogs.hasSameBlogs(serverBlogs)) {
                             ReaderPostTable.updateFollowedStatus();
-                            AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed");
+                            AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed: "
+                                                      + totalSites);
                             sitesSubscribedChanged = true;
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -81,7 +81,7 @@ public class ReaderUpdateLogic {
             fetchInterestTags();
         }
         if (tasks.contains(UpdateTask.FOLLOWED_BLOGS)) {
-            updateFollowedBlogs();
+            updateFollowedBlogs(1, new ReaderBlogList());
         }
     }
 
@@ -297,56 +297,68 @@ public class ReaderUpdateLogic {
     /***
      * request the list of blogs the current user is following
      */
-    private void updateFollowedBlogs() {
+    private void updateFollowedBlogs(final int page, final ReaderBlogList serverBlogs) {
         RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
-                handleFollowedBlogsResponse(jsonObject);
+                handleFollowedBlogsResponse(serverBlogs, jsonObject);
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(AppLog.T.READER, volleyError);
+                serverBlogs.clear();
                 taskCompleted(UpdateTask.FOLLOWED_BLOGS);
             }
         };
 
         AppLog.d(AppLog.T.READER, "reader service > updating followed blogs");
         // request using ?meta=site,feed to get extra info
-        WordPress.getRestClientUtilsV1_2().get("read/following/mine?meta=site%2Cfeed", listener, errorListener);
+        WordPress.getRestClientUtilsV1_2()
+                 .get("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener, errorListener);
     }
 
-    private void handleFollowedBlogsResponse(final JSONObject jsonObject) {
+    private void handleFollowedBlogsResponse(final ReaderBlogList serverBlogs, final JSONObject jsonObject) {
         new Thread() {
             @Override
             public void run() {
-                ReaderBlogList serverBlogs = ReaderBlogList.fromJson(jsonObject);
-                ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
+                ReaderBlogList currentPageServerResponse = ReaderBlogList.fromJson(jsonObject);
 
                 // This is required because under rare circumstances the server can return duplicates.
                 // We could have modified the function isSameList to eliminate the length check,
                 // but it's better to keep it separate since we aim to remove this check as soon as possible.
-                removeDuplicateBlogs(serverBlogs);
+                removeDuplicateBlogs(currentPageServerResponse);
 
                 boolean sitesSubscribedChanged = false;
                 final int totalSites = jsonObject == null ? 0 : jsonObject.optInt("total_subscriptions", 0);
-
-                if (!localBlogs.isSameList(serverBlogs)) {
-                    // always update the list of followed blogs if there are *any* changes between
-                    // server and local (including subscription count, description, etc.)
-                    ReaderBlogTable.setFollowedBlogs(serverBlogs);
-                    // ...but only update the follow status and alert that followed blogs have
-                    // changed if the server list doesn't have the same blogs as the local list
-                    // (ie: a blog has been followed/unfollowed since local was last updated)
-                    if (!localBlogs.hasSameBlogs(serverBlogs)) {
-                        ReaderPostTable.updateFollowedStatus();
-                        AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed");
-                        sitesSubscribedChanged = true;
+                final int page = jsonObject == null ? 1 : jsonObject.optInt("page", 1);
+                final int numberOfSitesReturned = jsonObject == null ? 0 : jsonObject.optInt("number", 0);
+                serverBlogs.addAll(currentPageServerResponse);
+                if (numberOfSitesReturned > 90) {
+                    // 90 appears to be a magic number here, and in a way, it is.
+                    // The server doesn't always return the exact number of requested sites, likely due to deleted or
+                    // suspended sites. In the worst-case scenario, we might make an additional request that returns 0.
+                    updateFollowedBlogs(page + 1, serverBlogs);
+                } else {
+                    ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
+                    if (!localBlogs.isSameList(serverBlogs)) {
+                        // always update the list of followed blogs if there are *any* changes between
+                        // server and local (including subscription count, description, etc.)
+                        ReaderBlogTable.setFollowedBlogs(serverBlogs);
+                        // ...but only update the follow status and alert that followed blogs have
+                        // changed if the server list doesn't have the same blogs as the local list
+                        // (ie: a blog has been followed/unfollowed since local was last updated)
+                        if (!localBlogs.hasSameBlogs(serverBlogs)) {
+                            ReaderPostTable.updateFollowedStatus();
+                            AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed");
+                            sitesSubscribedChanged = true;
+                        }
                     }
+                    EventBus.getDefault().post(new FollowedBlogsFetched(totalSites, sitesSubscribedChanged));
+                    serverBlogs.clear();
+                    taskCompleted(UpdateTask.FOLLOWED_BLOGS);
                 }
-                EventBus.getDefault().post(new FollowedBlogsFetched(totalSites, sitesSubscribedChanged));
-                taskCompleted(UpdateTask.FOLLOWED_BLOGS);
             }
         }.start();
     }


### PR DESCRIPTION
Fixes #13989 &  #20218

-----

## Test Scenario 1
* Test using an account with fewer than 100 followed sites.
* The server should correctly retrieve the number of sites.
* Only one or two network calls should be made, with the first call's page parameter set to 1.

## Test Scenario 2
* Test using an account with more than 100 followed sites.
* The server should correctly retrieve the number of sites.
* At least two network calls should be made, with the first call's page parameter set to 1.
* Tap on "XX Blogs" and open the bottom sheet. It should list all your blogs.
* Tap on "Edit." The Manage screen should display all the blogs.


Note 1: In the event of a network issue during the request chain, the entire call is marked as an error. We can consider refining this behavior in a future PR. Maybe in the first sync, right after login, we can accept the partial results?

Note 2: I've set the pagination stop threshold when the number of returned items is less than 90. This number may seem arbitrary, but it is chosen based on server behavior, where the exact number of requested sites might not be returned, often due to deleted or suspended sites. Consequently, we might end up making an extra request that returns 0. There are also situations where we might stop earlier, especially if you follow more than 100 Sites, and more than 10 sites are missing from the server's response due to their suspensions. This is another edge case we can address in a subsequent PR.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)