### PR TITLE
Add a timezone label to the date on the TRAFFIC tab of the stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateSelector.kt
@@ -6,7 +6,6 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider
 import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDateProvider.SelectedDate
-import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.util.perform
 import javax.inject.Inject
 
@@ -16,8 +15,7 @@ constructor(
     private val statsDateFormatter: StatsDateFormatter,
     private val siteProvider: StatsSiteProvider,
     var statsGranularity: StatsGranularity,
-    private val isGranularitySpinnerVisible: Boolean,
-    private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+    private val isGranularitySpinnerVisible: Boolean
 ) {
     private val _dateSelectorUiModel = MutableLiveData<DateSelectorUiModel>()
     val dateSelectorData: LiveData<DateSelectorUiModel> = _dateSelectorUiModel
@@ -35,18 +33,13 @@ constructor(
     fun updateDateSelector() {
         val updatedDate = getDateLabelForSection()
         val currentState = dateSelectorData.value
-        val timeZone = if (statsTrafficTabFeatureConfig.isEnabled()) {
-            null
-        } else {
-            statsDateFormatter.printTimeZone(siteProvider.siteModel)
-        }
         val updatedState = DateSelectorUiModel(
             true,
             isGranularitySpinnerVisible,
             updatedDate,
             enableSelectPrevious = selectedDateProvider.hasPreviousDate(statsGranularity),
             enableSelectNext = selectedDateProvider.hasNextDate(statsGranularity),
-            timeZone = timeZone
+            timeZone = statsDateFormatter.printTimeZone(siteProvider.siteModel)
         )
         emitValue(currentState, updatedState)
     }
@@ -87,8 +80,7 @@ constructor(
     @Inject constructor(
         private val selectedDateProvider: SelectedDateProvider,
         private val siteProvider: StatsSiteProvider,
-        private val statsDateFormatter: StatsDateFormatter,
-        private val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+        private val statsDateFormatter: StatsDateFormatter
     ) {
         fun build(statsGranularity: StatsGranularity, isGranularitySpinnerVisible: Boolean = false): StatsDateSelector {
             return StatsDateSelector(
@@ -96,8 +88,7 @@ constructor(
                 statsDateFormatter,
                 siteProvider,
                 statsGranularity,
-                isGranularitySpinnerVisible,
-                statsTrafficTabFeatureConfig
+                isGranularitySpinnerVisible
             )
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/StatsDateSelectorTest.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.granular.SelectedDa
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsDateSelector
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import java.util.Date
 
 @ExperimentalCoroutinesApi
@@ -29,8 +28,6 @@ class StatsDateSelectorTest : BaseUnitTest() {
     @Mock
     lateinit var siteProvider: StatsSiteProvider
 
-    @Mock
-    lateinit var statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
     private val selectedDate = Date(0)
     private val selectedDateLabel = "Jan 1"
     private val statsGranularity = StatsGranularity.DAYS
@@ -52,13 +49,11 @@ class StatsDateSelectorTest : BaseUnitTest() {
             statsDateFormatter,
             siteProvider,
             statsGranularity,
-            false,
-            statsTrafficTabFeatureConfig
+            false
         )
         whenever(selectedDateProvider.getSelectedDate(statsGranularity)).thenReturn(selectedDate)
         whenever(statsDateFormatter.printGranularDate(selectedDate, statsGranularity)).thenReturn(selectedDateLabel)
         whenever(statsDateFormatter.printGranularDate(updatedDate, statsGranularity)).thenReturn(updatedLabel)
-        whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
     }
 
     @Test


### PR DESCRIPTION
This brings back the timezone label to the TRAFFIC tab. It already existed in granularity tabs that were disabled with the `stats_traffic_tab` config.

This label is visible if the site timezone differs from the device timezone.

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/143e94b0-002f-4abe-9081-89f3b9588129" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/0536960a-098f-40c6-a0b4-1d4b1433ce78" width=320>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Select a site with a timezone that is different from your device timezone. (You can manage the site timezone from "My Site → More → Site Settings)
3. Open the TRAFFIC tab from "My Site → Stats".
4. Notice the timezone label below the date.
5. Navigate back and change the site timezone to your device timezone.
5. Notice that there is no timezone label.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None.

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

8. What automated tests I added (or what prevented me from doing so)

    - Updated `StatsDateSelectorTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [x] Fonts: Larger, smaller and bold text.
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
