### PR TITLE
Fix bars turning green issue when switching from a graph with empty data 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -177,16 +177,8 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {
         val dataSet = BarDataSet(cut, "Data")
+        chart.renderer.paintRender.shader = null
         dataSet.color = ContextCompat.getColor(context, R.color.blue_50)
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                R.color.blue_50
-            ), ContextCompat.getColor(
-                context,
-                R.color.blue_50
-            )
-        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -178,6 +178,15 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {
         val dataSet = BarDataSet(cut, "Data")
         dataSet.color = ContextCompat.getColor(context, R.color.blue_50)
+        dataSet.setGradientColor(
+            ContextCompat.getColor(
+                context,
+                R.color.blue_50
+            ), ContextCompat.getColor(
+                context,
+                R.color.blue_50
+            )
+        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -229,16 +229,8 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {
         val dataSet = BarDataSet(cut, "Data")
+        chart.renderer.paintRender.shader = null
         dataSet.color = ContextCompat.getColor(context, R.color.stats_bar_chart_top)
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                R.color.stats_bar_chart_top
-            ), ContextCompat.getColor(
-                context,
-                R.color.stats_bar_chart_top
-            )
-        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = true
@@ -252,16 +244,8 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     private fun buildOverlappingDataSet(context: Context, cut: List<BarEntry>): BarDataSet {
         val dataSet = BarDataSet(cut, "Overlapping data")
+        chart.renderer.paintRender.shader = null
         dataSet.color = ContextCompat.getColor(context, R.color.primary_60)
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                R.color.stats_bar_chart_bottom
-            ), ContextCompat.getColor(
-                context,
-                R.color.stats_bar_chart_bottom
-            )
-        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = true
@@ -279,16 +263,8 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             BarEntry(it.x, maxEntry.y, it.data)
         }
         val dataSet = BarDataSet(highlightedDataSet, "Highlight")
+        chart.renderer.paintRender.shader = null
         dataSet.color = ContextCompat.getColor(context, AndroidR.color.transparent)
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                AndroidR.color.transparent
-            ), ContextCompat.getColor(
-                context,
-                AndroidR.color.transparent
-            )
-        )
         dataSet.formLineWidth = 0f
         dataSet.isHighlightEnabled = true
         dataSet.highLightColor = ContextCompat.getColor(


### PR DESCRIPTION
Fixes #20413

This PR fixes an issue where bars for all graphs would turn a `gradient green` after navigating to a graph with empty data. Only categories with no data should display the `gradient green` bars and all other categories with data should have `blue` bars.

-----

## To Test:

1. While on the Stats Traffic tab, click a category with empty data. You can use the `mobile.blog` site for testing which currently has `0 comments` in the month view.
2. You should see a green gradient bar for any category with empty data. 
3. Navigate to `views` or any other category with data. The bars should change to `blue` and not remain `gradient green`.

Video of bug occurring after clicking `likes` or `comments` (empty data) and then navigating back to `views` or `visitors`: 

https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/1d41751e-0de2-4628-a3bf-e4005b5ca3e0



<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

6. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
