### PR TITLE
Integrate gutenberg-mobile release v1.114.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.4.0'
-    gutenbergMobileVersion = 'v1.114.0'
+    gutenbergMobileVersion = '6711-48c12f4016a573b72773863b6693929517e138c2'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = '2.70.1'
     wordPressLoginVersion = '1.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.4.0'
-    gutenbergMobileVersion = '6711-48c12f4016a573b72773863b6693929517e138c2'
+    gutenbergMobileVersion = 'v1.114.1'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = '2.70.1'
     wordPressLoginVersion = '1.14.1'


### PR DESCRIPTION
## Description
This PR incorporates the 1.114.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6711

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.