### PR TITLE
[Stats Traffic Tab] Fix flashing previous data momentarily after changing granularity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -338,10 +338,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
     }
 
     private fun StatsListFragmentBinding.updateInsights(statsState: List<StatsBlock>) {
-        recyclerView.visibility = View.VISIBLE
-        errorView.statsErrorView.visibility = View.GONE
-        emptyView.statsEmptyView.visibility = View.GONE
-
         val adapter: StatsBlockAdapter
         if (recyclerView.adapter == null) {
             adapter = StatsBlockAdapter(imageManager, statsTrafficTabFeatureConfig.isEnabled())
@@ -354,6 +350,11 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         val recyclerViewState = layoutManager?.onSaveInstanceState()
         adapter.update(statsState)
         recyclerView.scrollToPosition(0)
+
+        errorView.statsErrorView.isGone = true
+        emptyView.statsEmptyView.isGone = true
+        recyclerView.isVisible = true
+
         layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import androidx.core.view.isInvisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -317,9 +318,9 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 emptyView.statsEmptyView.visibility = View.GONE
             }
             is Empty -> {
-                recyclerView.visibility = View.GONE
                 emptyView.statsEmptyView.visibility = View.VISIBLE
                 errorView.statsErrorView.visibility = View.GONE
+                recyclerView.isInvisible = true
                 emptyView.statsEmptyView.title.setText(it.title)
                 if (it.subtitle != null) {
                     emptyView.statsEmptyView.subtitle.setText(it.subtitle)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -8,7 +8,9 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import androidx.core.view.isGone
 import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -313,14 +315,14 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 updateInsights(it.data)
             }
             is Error, null -> {
-                recyclerView.visibility = View.GONE
-                errorView.statsErrorView.visibility = View.VISIBLE
-                emptyView.statsEmptyView.visibility = View.GONE
+                recyclerView.isGone = true
+                emptyView.statsEmptyView.isGone = true
+                errorView.statsErrorView.isVisible = true
             }
             is Empty -> {
-                emptyView.statsEmptyView.visibility = View.VISIBLE
-                errorView.statsErrorView.visibility = View.GONE
                 recyclerView.isInvisible = true
+                errorView.statsErrorView.isGone = true
+                emptyView.statsEmptyView.isVisible = true
                 emptyView.statsEmptyView.title.setText(it.title)
                 if (it.subtitle != null) {
                     emptyView.statsEmptyView.subtitle.setText(it.subtitle)


### PR DESCRIPTION
Fixes #20424 
This fixes the issue of momentarily flashing previous data after changing granularity.

Technically, the only change is making the recycler view's visibility invisible instead of gone.

<details>
  <summary>before video</summary>
 
https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/fd64d542-5b24-487a-9870-aadd5e633f34
</details>

<details>
  <summary>after video</summary>
 
[after.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/7ce554ff-78ce-4e36-9e31-cc220621ebd2)
</details>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Open "My Site → Stats".
3. Change granularity.
4. Repeat 3 a couple of times.
5. Verify that previous views on the list do not momentarily flash.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

7. What automated tests I added (or what prevented me from doing so)

    - This PR introduces a minor change in the code, no need to consider automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
