### PR TITLE
Prevents crash on unexpected JP rest response

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
@@ -908,6 +908,10 @@ class WPComSiteSettings extends SiteSettingsInterface {
     private void deserializeJetpackRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
+        if (settingsObject == null) {
+            AppLog.e(AppLog.T.API, "Error: response doesn't contain settings object");
+            return;
+        }
         mRemoteJpSettings.emailNotifications = settingsObject.optBoolean(JP_MONITOR_EMAIL_NOTES_KEY, false);
         mRemoteJpSettings.wpNotifications = settingsObject.optBoolean(JP_MONITOR_WP_NOTES_KEY, false);
     }


### PR DESCRIPTION
Fixes #20439

## Description
Adds a null check on the settingObject to prevent a crash when the response is not the expected. The fix tries to handle the following exception.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean org.json.JSONObject.optBoolean(java.lang.String, boolean)' on a null object reference
    at org.wordpress.android.ui.prefs.WPComSiteSettings.deserializeJetpackRestResponse(WPComSiteSettings.java:911)
    at org.wordpress.android.ui.prefs.WPComSiteSettings.access$300(WPComSiteSettings.java:31)
    at org.wordpress.android.ui.prefs.WPComSiteSettings$7.onResponse(WPComSiteSettings.java:304)
    at org.wordpress.android.ui.prefs.WPComSiteSettings$7.onResponse(WPComSiteSettings.java:299)
```

Note that there is a similar null check on the same file https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java#L657

-----

## To Test:

I wasn't able to reproduce the issue to provide specific testing steps.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
