### PR TITLE
[Reader] Increase `Reader` comments like count disabled state alpha

### DIFF
--- a/WordPress/src/main/res/color/on_surface_medium_secondary_selector.xml
+++ b/WordPress/src/main/res/color/on_surface_medium_secondary_selector.xml
@@ -2,8 +2,8 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:alpha="@dimen/disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="false" />
-    <item android:alpha="@dimen/disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="true" />
+    <item android:alpha="@dimen/reader_comments_like_count_disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="false" />
+    <item android:alpha="@dimen/reader_comments_like_count_disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="true" />
     <item android:color="?attr/colorSecondary" android:state_enabled="true" android:state_selected="true" />
     <item android:alpha="@dimen/material_emphasis_medium" android:color="?attr/colorOnSurface" />
 

--- a/WordPress/src/main/res/color/on_surface_medium_secondary_selector.xml
+++ b/WordPress/src/main/res/color/on_surface_medium_secondary_selector.xml
@@ -2,8 +2,8 @@
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:alpha="@dimen/reader_comments_like_count_disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="false" />
-    <item android:alpha="@dimen/reader_comments_like_count_disabled_alpha" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="true" />
+    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="false" />
+    <item android:alpha="@dimen/material_emphasis_disabled" android:color="?attr/colorOnSurface" android:state_enabled="false" android:state_selected="true" />
     <item android:color="?attr/colorSecondary" android:state_enabled="true" android:state_selected="true" />
     <item android:alpha="@dimen/material_emphasis_medium" android:color="?attr/colorOnSurface" />
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -227,7 +227,6 @@
     <dimen name="reader_comments_actions_height">24dp</dimen>
     <dimen name="reader_comments_content_line_height">24dp</dimen>
     <dimen name="reader_comments_selected_indicator_width">6dp</dimen>
-    <item name="reader_comments_like_count_disabled_alpha" format="float" type="dimen">0.35</item>
 
     <!-- Increased touch targets to make views more accessible -->
     <dimen name="reader_discover_layout_extra_padding">16dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -227,6 +227,7 @@
     <dimen name="reader_comments_actions_height">24dp</dimen>
     <dimen name="reader_comments_content_line_height">24dp</dimen>
     <dimen name="reader_comments_selected_indicator_width">6dp</dimen>
+    <item name="reader_comments_like_count_disabled_alpha" format="float" type="dimen">0.35</item>
 
     <!-- Increased touch targets to make views more accessible -->
     <dimen name="reader_discover_layout_extra_padding">16dp</dimen>


### PR DESCRIPTION
Fixes #20443 


 
> [!IMPORTANT]  
> ✅ ~I'm concerned that the opacity for disabled state is too close to the enabled state, but if the opacity is lower than that it might not seem that the the like count is disabled (cc @osullivanchris in case you have any ideas). **Do not merge** until we have confirmation that this works from a design perspective.~

-----

## To Test:

1. Install Jetpack and sign in with a self-hosted site.
2. Open Reader.
3. Select "Discover" feed.
4. Open any post with comments.
5. 🔍 Open the comments list screen: the number of likes label and icon (e.g. 2 likes) should be visible.

### Before (like count with state disabled)
<p float="left">
<img width="300" alt="before_light_Screenshot 2024-03-11 at 4 23 54 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/64d5911a-0bfd-4d92-8a0e-421db143d67d">
<img width="300" alt="before_dark_Screenshot 2024-03-11 at 4 23 44 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/0183846b-c687-4a25-88d2-cd0b8ad6be35">
</p>


### After (like count with state disabled)
<p float="left">
<img width="300" alt="after_light_Screenshot 2024-03-11 at 4 20 22 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/2cbdd32a-f495-44ee-b84b-54a76bb7781a">
<img width="300" alt="after_dark_Screenshot 2024-03-11 at 4 20 30 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/fa29a1f5-ef00-4c70-b77e-11018657992a">
</p>

### Like count with state enabled (just for reference since there were no changes targeting this state)
<p float="left">
<img width="300" alt="Screenshot 2024-03-11 at 4 54 02 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/6f4d9003-c418-43d6-9549-034257e1c0ad">
<img width="300" alt="Screenshot 2024-03-11 at 4 54 15 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/06455d92-06e4-48e8-a78f-3e5449f02fc8">
</p>

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
