### PR TITLE
Ignore enums in null annotation detector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ ext {
 
     // other
     androidDesugarVersion = '2.0.4'
-    wordPressLintVersion = '2.0.0'
+    wordPressLintVersion = '19-4746f01f57f9ed7a0a24dd670cb8fb096bd8bbc4'
 }
 
 measureBuilds {

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ ext {
 
     // other
     androidDesugarVersion = '2.0.4'
-    wordPressLintVersion = '19-4746f01f57f9ed7a0a24dd670cb8fb096bd8bbc4'
+    wordPressLintVersion = '2.1.0'
 }
 
 measureBuilds {


### PR DESCRIPTION
### Description

This PR updates the WordPress-Lint-Android version to remove false positives in the missing null annotation check (for Java enums).

Related PR: https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/19

-----

## To Test:

* Open Android Studio with this PR checked out
* Navigate to a any Java file which has an enum
* Observe that there is no longer a lint warning about missing null annotations for the enum

-----

## Regression Notes

1. Potential unintended areas of impact

Lint rules

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual and unit tests

4. What automated tests I added (or what prevented me from doing so)

Unit tests in the related PR: https://github.com/wordpress-mobile/WordPress-Lint-Android/pull/19

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if nesessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
