### PR TITLE
[WIP] [UI Tests] PTR if Stats card is not loaded.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -11,6 +11,7 @@ import org.hamcrest.Matchers
 import org.wordpress.android.R
 import org.wordpress.android.support.WPSupportUtils
 import org.wordpress.android.support.WPSupportUtils.isElementDisplayed
+import org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
 import org.wordpress.android.util.StatsKeyValueData
 import org.wordpress.android.util.StatsVisitsData
@@ -105,6 +106,8 @@ class StatsPage {
         if (!isElementDisplayed(cardStructure)) {
             cardStructure.perform(swipeDown());
         }
+
+        waitForElementToBeDisplayedWithoutFailure(cardStructure)
 
         cardStructure.check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         return this

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/StatsPage.kt
@@ -3,12 +3,14 @@ package org.wordpress.android.e2e.pages
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.swipeDown
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import org.hamcrest.Matchers
 import org.wordpress.android.R
 import org.wordpress.android.support.WPSupportUtils
+import org.wordpress.android.support.WPSupportUtils.isElementDisplayed
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel
 import org.wordpress.android.util.StatsKeyValueData
 import org.wordpress.android.util.StatsVisitsData
@@ -99,6 +101,11 @@ class StatsPage {
                 )
             )
         )
+
+        if (!isElementDisplayed(cardStructure)) {
+            cardStructure.perform(swipeDown());
+        }
+
         cardStructure.check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
         return this
     }


### PR DESCRIPTION
Fixes #

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
