### PR TITLE
Fix crash on the domain selection screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -130,11 +130,10 @@ class SiteCreationDomainsViewModel @Inject constructor(
     }
 
     fun onCreateSiteBtnClicked() {
-        val domain = requireNotNull(selectedDomain) {
-            "Create site button should not be visible if a domain is not selected"
-        }
-        tracker.trackDomainSelected(domain.domainName, currentQuery?.value.orEmpty(), domain.cost, domain.isFree)
-        _createSiteBtnClicked.value = domain
+        selectedDomain?.let { domain ->
+            tracker.trackDomainSelected(domain.domainName, currentQuery?.value.orEmpty(), domain.cost, domain.isFree)
+            _createSiteBtnClicked.value = domain
+        } // selectedDomain is null if the query has been asynchronously updated and the domain list has been changed.
     }
 
     fun onClearTextBtnClicked() = _clearBtnClicked.call()


### PR DESCRIPTION
Fixes #20354 

[crash.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/b8d0179d-c1a1-45e4-9958-86b174eb8a3d)

I ignored the case of null `selectedDomain`. It doesn't break anything. The user will need to reselect the domain from the updated domain list.

#### Steps to reproduce the crash

1. Log in.
2. Tap ⌄ button near the site name at the top of the screen.
3. Tap + button.
4. Tap the "Create WordPress.com site" button.
5. SKIP topic and theme screens.
6. Type a domain name on the domain selection screen.
7. Delete the last letter and tap the "Purchase domain" button at the same time. Repeat this step a couple of times until you can reproduce the crash.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Follow "Steps to reproduce the crash" and verify that there is no crash.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

10. What automated tests I added (or what prevented me from doing so)

    - This doesn't introduce a change.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
