### PR TITLE
Fixes broken milestone notification confetti effect

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -76,7 +76,6 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
     private var commentListPosition = ListView.INVALID_POSITION
     private var onCommentStatusChangeListener: OnCommentStatusChangeListener? = null
     private var noteBlockAdapter: NoteBlockAdapter? = null
-    private var confettiShown = false
 
     @Inject
     lateinit var imageManager: ImageManager
@@ -625,6 +624,8 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
     companion object {
         private const val KEY_NOTE_ID = "noteId"
         private const val KEY_LIST_POSITION = "listPosition"
+
+        private var confettiShown = false
 
         @JvmStatic
         fun newInstance(noteId: String?): NotificationsDetailListFragment {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -133,10 +133,8 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             showErrorToastAndFinish()
         }
 
-        val confetti: LottieAnimationView = requireActivity().findViewById(R.id.confetti)
-        if (note?.isViewMilestoneType == true && !confettiShown) {
-            confetti.playAnimation()
-            confettiShown = true
+        if (note?.isViewMilestoneType == true) {
+            view?.findViewById<LottieAnimationView>(R.id.confetti)?.playAnimation()
         }
     }
 
@@ -160,9 +158,6 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         if (note == null) {
             showErrorToastAndFinish()
             return
-        }
-        if (noteId != note.id) {
-            confettiShown = false
         }
         notification = note
     }
@@ -624,8 +619,6 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
     companion object {
         private const val KEY_NOTE_ID = "noteId"
         private const val KEY_LIST_POSITION = "listPosition"
-
-        private var confettiShown = false
 
         @JvmStatic
         fun newInstance(noteId: String?): NotificationsDetailListFragment {

--- a/WordPress/src/main/res/layout/notifications_detail_activity.xml
+++ b/WordPress/src/main/res/layout/notifications_detail_activity.xml
@@ -15,16 +15,6 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:visibility="visible" />
 
-    <com.airbnb.lottie.LottieAnimationView
-        android:id="@+id/confetti"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="top"
-        android:scaleType="centerCrop"
-        app:lottie_autoPlay="false"
-        app:lottie_loop="false"
-        app:lottie_rawRes="@raw/confetti" />
-
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar_main"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="?attr/colorSurface">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/confetti"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="top"
+        android:scaleType="centerCrop"
+        app:lottie_autoPlay="false"
+        app:lottie_loop="false"
+        app:lottie_rawRes="@raw/confetti" />
 
     <!-- this container is needed in order to center the content of 'badge' notification types. -->
     <LinearLayout


### PR DESCRIPTION
Fixes #19573

## Description
Fixes broken milestone notification confetti effect by moving the LotieAnimationView from the activity to the fragment layout. 

Though I initially fixed the "animate once" logic with feafe791be70b5109be0ca851fc3f40fe5569bda I decided to simplify things 5ad2182df32dd4e2b7fb58aa39e6e6b4dfe712fa since I don't expect users to go back and forth in this screen. Even if they do celebrating more isn't a bad thing imo.

-----

## To Test:
1. Open a milestone notification
2. *Verify* that the confetti animation plays
~3. Browse back and reopen the milestone notification detail~
~4. *Verify* that the confetti animation is not played again~

https://github.com/wordpress-mobile/WordPress-Android/assets/304044/1c1b8fc5-2b41-4d98-9f58-2e039b62327c

-----

## Regression Notes

1. Potential unintended areas of impact

    - Milestone notification detail view

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

6. What automated tests I added (or what prevented me from doing so)

    - Since this involves UI code it would be hard to add tests without refactorings that escape the scope of the issue 

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
