### PR TITLE
[WIP] [UI Tests] Run the Stats test for WP only.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsTests.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.util.StatsVisitsData
 class StatsTests : BaseTest() {
     @Before
     fun setUp() {
-        assumeTrue(BuildConfig.IS_JETPACK_APP)
+        assumeTrue(!BuildConfig.IS_JETPACK_APP)
         ComposeEspressoLink().unregister()
         logoutIfNecessary()
         wpLogin()
@@ -35,7 +35,7 @@ class StatsTests : BaseTest() {
             Espresso.pressBack()
         }
     }
-    
+
     @Test
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")

--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
@@ -148,8 +148,7 @@ class MySitesPage {
     fun goToStats(): StatsPage {
         val statsButton = Espresso.onView(
             Matchers.allOf(
-                ViewMatchers.withText(R.string.stats),
-                ViewMatchers.withId(R.id.quick_link_item)
+                ViewMatchers.withText(R.string.stats)
             )
         )
         WPSupportUtils.clickOn(statsButton)


### PR DESCRIPTION
Fixes #

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
