### PR TITLE
[Reader] Rename the label to edit/manage Tags and Sites 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/SubfilterBottomSheetFragment.kt
@@ -84,7 +84,7 @@ class SubfilterBottomSheetFragment : BottomSheetDialogFragment() {
         val pager = view.findViewById<ViewPager>(R.id.view_pager)
         val titleContainer = view.findViewById<View>(R.id.title_container)
         val title = view.findViewById<TextView>(R.id.title)
-        val editSubscriptions = view.findViewById<View>(R.id.edit_subscriptions)
+        val editSubscriptions = view.findViewById<View>(R.id.manage_subscriptions)
         title.text = bottomSheetTitle
         pager.adapter = SubfilterPagerAdapter(
             requireActivity(),

--- a/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
+++ b/WordPress/src/main/res/layout/subfilter_bottom_sheet.xml
@@ -26,11 +26,11 @@
             android:text="@string/reader_filter_by_blog_title" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/edit_subscriptions"
+            android:id="@+id/manage_subscriptions"
             style="@style/SiteTagBottomSheetAction"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/edit"/>
+            android:text="@string/manage"/>
     </LinearLayout>
 
     <androidx.viewpager.widget.ViewPager


### PR DESCRIPTION
Fixes #20454
This PR changes the `Edit` label to `Manage` in the bottom sheet that allows you to select Tags and Sites.

Ref: p1710330177642939-slack-C05N140C8H5

-----

## To Test:

- Open the Reader
-  Go to Subscriptions and tap on the Tag pill
- The bottom sheet that shows Your Tags, shows the `Manage` label on top-right.
- Tapping on Manage open the Manage Tags and Sites screen
- Repeat the steps above for Blogs

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)