### PR TITLE
Fixes PhotonUtils.getPhotonImageUrl crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     wordPressFluxCVersion = 'trunk-b9ecc708dde74d6cc95aeab42e56fb8067640039'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '143-cc8c040c6168ab5b5ac48eae57037ebd2dd791b5'
+    wordPressUtilsVersion = 'trunk-4d6cb9a20bfda0dfe2310cf8275cbdcfb0d42ba7'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     wordPressFluxCVersion = 'trunk-b9ecc708dde74d6cc95aeab42e56fb8067640039'
     wordPressLoginVersion = '1.14.1'
     wordPressPersistentEditTextVersion = '1.0.2'
-    wordPressUtilsVersion = '3.13.0'
+    wordPressUtilsVersion = '143-cc8c040c6168ab5b5ac48eae57037ebd2dd791b5'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
 
     // debug


### PR DESCRIPTION
Fixes #18626

**Depends on:** https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/143

-----

## To Test:

See https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/143

⚠️  **Please merge after:**
* WPUtils PR is https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/143 into `trunk`
* The `wordPressUtilsVersion` reference on this PR is updated to point to the latest WPUtils `trunk`

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Added test in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/143

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)