### PR TITLE
Fixes: Site icon refresh issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -53,7 +53,7 @@ import org.wordpress.android.ui.mysite.cards.nocards.NoCardsMessageViewHolder
 import org.wordpress.android.ui.mysite.cards.personalize.PersonalizeCardViewHolder
 import org.wordpress.android.ui.mysite.cards.quicklinksitem.QuickLinkRibbonViewHolder
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartCardViewHolder
-import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardViewholder
+import org.wordpress.android.ui.mysite.cards.siteinfo.SiteInfoHeaderCardViewHolder
 import org.wordpress.android.ui.mysite.cards.sotw2023.WpSotw2023NudgeCardViewHolder
 import org.wordpress.android.ui.mysite.items.categoryheader.MySiteCategoryItemEmptyViewHolder
 import org.wordpress.android.ui.mysite.items.categoryheader.MySiteCategoryItemViewHolder
@@ -80,7 +80,7 @@ class MySiteAdapter(
     @Suppress("ComplexMethod")
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MySiteCardAndItemViewHolder<*> {
         return when (viewType) {
-            MySiteCardAndItem.Type.SITE_INFO_CARD.ordinal -> SiteInfoHeaderCardViewholder(parent, imageManager)
+            MySiteCardAndItem.Type.SITE_INFO_CARD.ordinal -> SiteInfoHeaderCardViewHolder(parent, imageManager)
             MySiteCardAndItem.Type.QUICK_LINK_RIBBON.ordinal -> QuickLinkRibbonViewHolder(parent)
             MySiteCardAndItem.Type.DOMAIN_REGISTRATION_CARD.ordinal -> DomainRegistrationViewHolder(parent)
             MySiteCardAndItem.Type.QUICK_START_CARD.ordinal -> QuickStartCardViewHolder(parent, uiHelpers)
@@ -136,7 +136,7 @@ class MySiteAdapter(
     @Suppress("ComplexMethod")
     override fun onBindViewHolder(holder: MySiteCardAndItemViewHolder<*>, position: Int) {
         when (holder) {
-            is SiteInfoHeaderCardViewholder -> holder.bind(getItem(position) as SiteInfoHeaderCard)
+            is SiteInfoHeaderCardViewHolder -> holder.bind(getItem(position) as SiteInfoHeaderCard)
             is QuickLinkRibbonViewHolder -> holder.bind(getItem(position) as QuickLinksItem)
             is DomainRegistrationViewHolder -> holder.bind(getItem(position) as DomainRegistrationCard)
             is QuickStartCardViewHolder -> holder.bind(getItem(position) as QuickStartCard)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -191,7 +191,7 @@ class MySiteViewModel @Inject constructor(
         isSiteSelected = false
         checkAndShowJetpackFullPluginInstallOnboarding()
         checkAndShowQuickStartNotice()
-
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
         selectedSiteRepository.getSelectedSite()?.let {
             buildDashboardOrSiteItems(it)
         } ?: run {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconUploadHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteIconUploadHandler.kt
@@ -74,8 +74,6 @@ class SiteIconUploadHandler
                 if (event.mediaModelList.size > 0) {
                     val media = event.mediaModelList[0]
                     selectedSiteRepository.updateSiteIconMediaId(media.mediaId.toInt(), true)
-                    selectedSiteRepository.showSiteIconProgressBar(false)
-                    selectedSiteRepository.refresh()
                 } else {
                     AppLog.w(
                         MAIN,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/siteinfo/SiteInfoHeaderCardViewHolder.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType.BLAVATAR
 
-class SiteInfoHeaderCardViewholder(
+class SiteInfoHeaderCardViewHolder(
     parent: ViewGroup,
     private val imageManager: ImageManager
 ) : MySiteCardAndItemViewHolder<MySiteInfoHeaderCardBinding>(parent.viewBinding(MySiteInfoHeaderCardBinding::inflate)) {


### PR DESCRIPTION
This PR fixes the issue with the site icon not refreshing properly. 

The problem was that `selectedSiteRepository.showSiteIconProgressBar(false)` was triggering a UI update with the old icon and so the `SiteInfoHeaderCardViewHolder.bind()` and `imageManager.load()` were called with the old icon's url and after a few milliseconds they were called again with the new icon's url. 

Testing steps: 
1. Tap on the site's icon and choose the "Change" option. 
2. Pick a new image from your device image library.
- [ ] Check that the loading indicator appears in the icon's placeholder and after a while the new site icon appears. 