### PR TITLE
Use ConstraintLayout on date selector to fix large font size issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/DateSelectorViewUtils.kt
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.stats.refresh.utils
 
 import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
+import org.wordpress.android.R
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 
@@ -28,7 +30,17 @@ fun StatsListFragmentBinding.drawDateSelector(dateSelectorUiModel: DateSelectorU
             nextDateButton.isEnabled = enableNextButton
         }
         granularitySpinner.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible == true
-        granularitySpace.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible == true
-        dateSpace.isVisible = dateSelectorUiModel?.isGranularitySpinnerVisible != true
+
+        if (dateSelectorUiModel?.isGranularitySpinnerVisible != true) {
+            // StatsTrafficTabFeatureConfig is disabled.
+            with(selectedDateTextView.layoutParams as ConstraintLayout.LayoutParams) {
+                horizontalBias = 0f
+                marginStart = selectedDateTextView.resources.getDimensionPixelSize(R.dimen.margin_small)
+            }
+            with(currentSiteTimeZone.layoutParams as ConstraintLayout.LayoutParams) {
+                horizontalBias = 0f
+                marginStart = selectedDateTextView.resources.getDimensionPixelSize(R.dimen.margin_small)
+            }
+        }
     }
 }

--- a/WordPress/src/main/res/layout/stats_date_selector.xml
+++ b/WordPress/src/main/res/layout/stats_date_selector.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/date_selector_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
     android:minHeight="52dp"
-    android:orientation="horizontal"
     android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_large"
     android:paddingVertical="@dimen/margin_extra_small"
     tools:ignore="RtlSymmetry">
 
@@ -18,62 +17,64 @@
         android:layout_height="wrap_content"
         android:minHeight="@dimen/min_touch_target_sz"
         android:overlapAnchor="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight" />
-
-    <Space
-        android:id="@+id/granularity_space"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:gravity="center_vertical"
-        android:orientation="vertical">
-
-        <org.wordpress.android.widgets.MaterialTextViewWithNumerals
-            android:id="@+id/selectedDateTextView"
-            style="@style/StatsDateSelectorTitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/unknown" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/currentSiteTimeZone"
-            style="@style/StatsDateTimeZone"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/unknown"
-            android:visibility="gone" />
-    </LinearLayout>
-
-    <Space
-        android:id="@+id/date_space"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:visibility="gone" />
-
-    <ImageButton
-        android:id="@+id/previousDateButton"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_marginStart="@dimen/margin_medium"
-        android:background="?selectableItemBackgroundBorderless"
-        android:contentDescription="@string/stats_select_previous_period_description"
-        android:src="@drawable/ic_chevron_left_white_24dp"
-        android:tintMode="src_in"
-        app:tint="@color/on_surface_disabled_selector" />
 
     <ImageButton
         android:id="@+id/nextDateButton"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_marginStart="@dimen/margin_medium"
+        android:layout_height="@dimen/min_touch_target_sz"
         android:background="?selectableItemBackgroundBorderless"
         android:contentDescription="@string/stats_select_next_period_description"
         android:src="@drawable/ic_chevron_right_white_24dp"
         android:tintMode="src_in"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:tint="@color/on_surface_disabled_selector" />
-</LinearLayout>
+
+    <ImageButton
+        android:id="@+id/previousDateButton"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/min_touch_target_sz"
+        android:layout_marginEnd="@dimen/margin_large"
+        android:background="?selectableItemBackgroundBorderless"
+        android:contentDescription="@string/stats_select_previous_period_description"
+        android:src="@drawable/ic_chevron_left_white_24dp"
+        android:tintMode="src_in"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/nextDateButton"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/on_surface_disabled_selector" />
+
+    <org.wordpress.android.widgets.MaterialTextViewWithNumerals
+        android:id="@+id/selectedDateTextView"
+        style="@style/StatsDateSelectorTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:text="@string/unknown"
+        app:layout_constraintBottom_toTopOf="@id/currentSiteTimeZone"
+        app:layout_constraintEnd_toStartOf="@id/previousDateButton"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/granularity_spinner"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth="wrap_content_constrained" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/currentSiteTimeZone"
+        style="@style/StatsDateTimeZone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_medium"
+        android:text="@string/unknown"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/previousDateButton"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toEndOf="@id/granularity_spinner"
+        app:layout_constraintTop_toBottomOf="@id/selectedDateTextView"
+        app:layout_constraintWidth="wrap_content_constrained" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #20453

This fixes large font size issues on the stats date selector.

|default|large font|default, granularity tabs|large font, granularity tabs|
|-|-|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/75bb20b8-9367-439e-963d-2d415f7f7c9f" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/333ca146-a41a-4b81-b8b6-9260281dc76d" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/fb5108b1-c2a1-4408-a71b-bfa41c517378" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/973e8e23-2a13-4ef2-ac6a-fdb1c5c6985e" width=320>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

**Test 1:**
1. Log in to JP.
2. Open "My Site → Stats".
3. Verify that the date selector is displayed as expected.
4. Set the largest font size from the device's accessibility settings.
5. Verify that the date selector is displayed as expected.

**Test 2:**
1. Log in to JP.
2. Disable `stats_traffic_tab` config from "Me → Debug settings".
3. Open "My Site → Stats".
4. Verify that the date selector is displayed as expected.
5. Set the largest font size from the device's accessibility settings.
6. Verify that the date selector is displayed as expected.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

7. What automated tests I added (or what prevented me from doing so)

    - This only fixes an issue with certain accessibility settings. It's too specific for automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [x] Fonts: Larger, smaller and bold text.
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
