### PR TITLE
Handles NullPointerException in Plugin configuration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -963,8 +963,14 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSitePluginConfigured(OnSitePluginConfigured event) {
+    public void onSitePluginConfigured(@NonNull OnSitePluginConfigured event) {
         if (isFinishing()) {
+            return;
+        }
+
+        if (event.site == null || event.pluginName == null) {
+            ToastUtils.showToast(this, getString(R.string.plugin_configuration_failed,
+                    event.isError() ? event.error.message : getString(R.string.unknown)));
             return;
         }
 
@@ -1061,8 +1067,14 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSitePluginUpdated(OnSitePluginUpdated event) {
+    public void onSitePluginUpdated(@NonNull OnSitePluginUpdated event) {
         if (isFinishing()) {
+            return;
+        }
+
+        if (event.site == null || event.pluginName == null) {
+            ToastUtils.showToast(this, getString(R.string.plugin_updated_failed,
+                    event.isError() ? event.error.message : getString(R.string.unknown)));
             return;
         }
 
@@ -1129,8 +1141,14 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSitePluginDeleted(OnSitePluginDeleted event) {
+    public void onSitePluginDeleted(@NonNull OnSitePluginDeleted event) {
         if (isFinishing()) {
+            return;
+        }
+
+        if (event.site == null || event.pluginName == null) {
+            ToastUtils.showToast(this, getString(R.string.plugin_remove_failed,
+                    event.isError() ? event.error.message : getString(R.string.unknown)));
             return;
         }
 
@@ -1165,8 +1183,8 @@ public class PluginDetailActivity extends LocaleAwareActivity implements OnDomai
 
     // This check should only handle events for already installed plugins - onSitePluginConfigured,
     // onSitePluginUpdated, onSitePluginDeleted
-    private boolean shouldHandleFluxCSitePluginEvent(SiteModel eventSite, String eventPluginName) {
-        return mSite.getId() == eventSite.getId() // correct site
+    private boolean shouldHandleFluxCSitePluginEvent(@NonNull SiteModel eventSite, @NonNull String eventPluginName) {
+        return mSite != null && mSite.getId() == eventSite.getId() // correct site
                && mPlugin.isInstalled() // needs plugin to be already installed
                && mPlugin.getName() != null // sanity check for NPE since if plugin is installed it'll have the name
                && mPlugin.getName().equals(eventPluginName); // event is for the plugin we are showing


### PR DESCRIPTION
Fixes #18652

## Description
Since I was not able to reproduce the issue the proposed fix tries to handle the reported crash below.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int org.wordpress.android.fluxc.model.SiteModel.getId()' on a null object reference
    at org.wordpress.android.ui.plugins.PluginDetailActivity.shouldHandleFluxCSitePluginEvent(PluginDetailActivity.java:1169)
    at org.wordpress.android.ui.plugins.PluginDetailActivity.onSitePluginConfigured(PluginDetailActivity.java:971)
    at java.lang.reflect.Method.invoke(Method.java)
    at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:517)
    at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:511)
    at org.greenrobot.eventbus.HandlerPoster.handleMessage(HandlerPoster.java:67)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loopOnce(Looper.java:230)
    at android.os.Looper.loop(Looper.java:319)
    at android.app.ActivityThread.main(ActivityThread.java:8893)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:608)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```

-----

## To Test:
_I was not able to reproduce a crash. The following steps provide a sanity check of the functionality._
1. Add a site with plugins (e.g. a new JN site PCYsg-g6b-p2)
2. Select Plugins > MANAGE from the menu
3. **Verify** no crashes when changing a plugin configuration
4. **Verify** no crashes when updating a plugin
5. **Verify** no crashes when deleting a plugin

_Optionally you can fake the error case with [nullplugin.patch](https://github.com/wordpress-mobile/WordPress-Android/files/14603016/nullplugin.patch) and repeat the steps above._

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/304044/5c16d8ec-72c9-43b9-b1e5-e0d4f08314b2" width=320/>


-----

## Regression Notes

1. Potential unintended areas of impact

    - Plugin management

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

8. What automated tests I added (or what prevented me from doing so)

    - Adding tests on the specific UI/Activity code would require refactoring beyond the scope of this fix

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)