### PR TITLE
Integrate gutenberg-mobile release v1.115.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.5.0'
-    gutenbergMobileVersion = 'v1.115.0-alpha5'
+    gutenbergMobileVersion = '6737-2b69fbe8afe308da98ab164b417290b064d99709'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = 'trunk-b9ecc708dde74d6cc95aeab42e56fb8067640039'
     wordPressLoginVersion = '1.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.5.0'
-    gutenbergMobileVersion = '6737-2b69fbe8afe308da98ab164b417290b064d99709'
+    gutenbergMobileVersion = 'v1.115.0'
     wordPressAztecVersion = 'v2.0'
     wordPressFluxCVersion = 'trunk-b9ecc708dde74d6cc95aeab42e56fb8067640039'
     wordPressLoginVersion = '1.14.1'


### PR DESCRIPTION
## Description
This PR incorporates the 1.115.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6737

Release Submission Checklist

Release notes [were already updated ](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/RELEASE-NOTES.txt#L3-L7)in previous PRs. There's [one entry](https://github.com/wordpress-mobile/gutenberg-mobile/pull/6737/files#diff-558ce8820a544da19f7fccdb2d1d661e46d68c130a1a39abdd222aa3484a5873R8) from the Gutenberg release that I think we should not include as a user-facing change.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.