### PR TITLE
Fixes: NullPointerException in GutenbergEditorFragment

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1091,7 +1091,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     public void updateCapabilities(GutenbergPropsBuilder gutenbergPropsBuilder) {
         mCurrentGutenbergPropsBuilder = gutenbergPropsBuilder;
         if (isAdded()) {
-            getGutenbergContainerFragment().updateCapabilities(gutenbergPropsBuilder);
+            GutenbergContainerFragment containerFragment = getGutenbergContainerFragment();
+            if (containerFragment != null) {
+                containerFragment.updateCapabilities(gutenbergPropsBuilder);
+            }
         } else {
             mUpdateCapabilitiesOnCreate = true;
         }


### PR DESCRIPTION
Fixes #20473

This PR fixes addresses a null pointer exception that was tracked in Sentry. 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Checking the code is enough as I was not able to replicate the issue. 

-----
