### PR TITLE
Fix bar count issue with traffic chart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -58,9 +58,9 @@ class TrafficOverviewUseCase(
         else -> statsGranularity
     }
 
-    private val barCount = when (lowerGranularity) {
+    private val itemsToLoad = when (lowerGranularity) {
         StatsGranularity.DAYS -> 7
-        StatsGranularity.WEEKS -> 5
+        StatsGranularity.WEEKS -> 6
         StatsGranularity.MONTHS -> 12
         else -> OVERVIEW_ITEMS_TO_LOAD
     }
@@ -122,7 +122,7 @@ class TrafficOverviewUseCase(
         // Fetch lower granularity model for chart values
         val lowerGranularityResponse = if (statsGranularity != StatsGranularity.DAYS) {
             val selectedDate = getLastDate(model)
-            selectedDate?.let { fetchVisit(lowerGranularity, OVERVIEW_ITEMS_TO_LOAD, forced, it) }
+            selectedDate?.let { fetchVisit(lowerGranularity, itemsToLoad, forced, it) }
         } else {
             null
         }


### PR DESCRIPTION
This fixes the bar count on the Traffic tab when "By month" is selected. 

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/123841af-ee48-4e7e-8baf-a86649d78e57" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/c298d217-2a89-467b-8b89-f9148d7ab5b7" width=320>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Open "My Site → Stats"
3. Select "By month" granularity.
4. Select the previous month by tapping < button.
5. Verify that there is the correct number of bars on the chart.
6. Repeat 4 and 5 for more months.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

7. What automated tests I added (or what prevented me from doing so)

    - There aren't UI tests for stats currently. We will take of this with https://github.com/wordpress-mobile/WordPress-Android/issues/20289.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
