### PR TITLE
[Reader] Fix `Reader` showing posts from a language different than the selected one

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -185,9 +185,11 @@ public class ReaderPost {
         // if there's no featured image, check if featured media has been set to an image
         if (!post.hasFeaturedImage() && json.has("featured_media")) {
             JSONObject jsonMedia = json.optJSONObject("featured_media");
-            String type = JSONUtils.getString(jsonMedia, "type");
-            if (type.equals("image")) {
-                post.mFeaturedImage = JSONUtils.getString(jsonMedia, "uri");
+            if (jsonMedia != null) {
+                String type = JSONUtils.getString(jsonMedia, "type");
+                if (type.equals("image")) {
+                    post.mFeaturedImage = JSONUtils.getString(jsonMedia, "uri");
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/recommend/RecommendApiCallsProvider.kt
@@ -51,7 +51,7 @@ class RecommendApiCallsProvider @Inject constructor(
                 cont.resume(Failure(errorMessage))
             }
 
-            restClientProvider.getRestClientUtilsV2().get(
+            restClientProvider.getRestClientUtilsV2().getWithLocale(
                 endPointPath,
                 listener,
                 errorListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -87,7 +87,7 @@ public class NotificationsUtils {
         if (!TextUtils.isEmpty(deviceID)) {
             settingsEndpoint += "?device_id=" + deviceID;
         }
-        WordPress.getRestClientUtilsV1_1().get(settingsEndpoint, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(settingsEndpoint, listener, errorListener);
     }
 
     public static void registerDeviceForPushNotifications(final Context ctx, String token) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/InviteLinksApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/InviteLinksApiCallsProvider.kt
@@ -39,7 +39,7 @@ class InviteLinksApiCallsProvider @Inject constructor(
             cont.resume(Failure(error))
         }
 
-        WordPress.getRestClientUtilsV1_1().get(
+        WordPress.getRestClientUtilsV1_1().getWithLocale(
             endPointPath,
             listener,
             errorListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -62,7 +62,7 @@ public class PeopleUtils {
         params.put("order_by", "display_name");
         params.put("order", "ASC");
         String path = String.format(Locale.US, "sites/%d/users", site.getSiteId());
-        WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, params, null, listener, errorListener);
     }
 
     public static void fetchAuthors(final SiteModel site, final int offset, final FetchUsersCallback callback) {
@@ -95,7 +95,7 @@ public class PeopleUtils {
         params.put("order", "ASC");
         params.put("authors_only", "true");
         String path = String.format(Locale.US, "sites/%d/users", site.getSiteId());
-        WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, params, null, listener, errorListener);
     }
 
     public static void fetchRevisionAuthorsDetails(final SiteModel site, List<String> authors,
@@ -144,7 +144,7 @@ public class PeopleUtils {
                             site.getSiteId(), authors.get(i)));
         }
 
-        WordPress.getRestClientUtilsV1_1().get("batch/", batchParams, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale("batch/", batchParams, null, listener, errorListener);
     }
 
     public static void fetchFollowers(final SiteModel site, final int page, final FetchFollowersCallback callback) {
@@ -195,7 +195,7 @@ public class PeopleUtils {
         params.put("page", Integer.toString(page));
         params.put("type", isEmailFollower ? "email" : "wp_com");
         String path = String.format(Locale.US, "sites/%d/stats/followers", site.getSiteId());
-        WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, params, null, listener, errorListener);
     }
 
     public static void fetchViewers(final SiteModel site, final int offset, final FetchViewersCallback callback) {
@@ -233,7 +233,7 @@ public class PeopleUtils {
         params.put("number", Integer.toString(FETCH_LIMIT));
         params.put("page", Integer.toString(page));
         String path = String.format(Locale.US, "sites/%d/viewers", site.getSiteId());
-        WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, params, null, listener, errorListener);
     }
 
     public static void updateRole(final SiteModel site, long personID, String newRole, final int localTableBlogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeActions.java
@@ -153,7 +153,7 @@ public class PublicizeActions {
         };
 
         String path = "/me/keyring-connections";
-        WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, listener, errorListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateServicesV2.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateServicesV2.kt
@@ -27,7 +27,7 @@ class PublicizeUpdateServicesV2 @Inject constructor(
         }
         val errorListener = RestRequest.ErrorListener { volleyError -> failure(volleyError) }
         val path = "sites/$siteId/external-services?type=publicize"
-        restClientProvider.getRestClientUtilsV2().get(path, listener, errorListener)
+        restClientProvider.getRestClientUtilsV2().getWithLocale(path, listener, errorListener)
     }
 
     /*
@@ -45,6 +45,6 @@ class PublicizeUpdateServicesV2 @Inject constructor(
         }
         val errorListener = RestRequest.ErrorListener { volleyError -> failure(volleyError) }
         val path = String.format(Locale.ROOT, "sites/%d/publicize-connections", siteId)
-        restClientProvider.getRestClientUtilsV1_1().get(path, listener, errorListener)
+        restClientProvider.getRestClientUtilsV1_1().getWithLocale(path, listener, errorListener)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -398,10 +398,10 @@ public class ReaderBlogActions {
         };
 
         if (hasBlogId) {
-            WordPress.getRestClientUtilsV1_1().get("read/sites/" + blogId, listener, errorListener);
+            WordPress.getRestClientUtilsV1_1().getWithLocale("read/sites/" + blogId, listener, errorListener);
         } else {
             WordPress.getRestClientUtilsV1_1()
-                     .get("read/sites/" + UrlUtils.urlEncode(UrlUtils.getHost(blogUrl)), listener, errorListener);
+                     .getWithLocale("read/sites/" + UrlUtils.urlEncode(UrlUtils.getHost(blogUrl)), listener, errorListener);
         }
     }
 
@@ -438,7 +438,7 @@ public class ReaderBlogActions {
         } else {
             path = "read/feed/" + UrlUtils.urlEncode(feedUrl);
         }
-        WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, listener, errorListener);
     }
 
     private static void handleUpdateBlogInfoResponse(JSONObject jsonObject, UpdateBlogInfoListener infoListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -401,7 +401,8 @@ public class ReaderBlogActions {
             WordPress.getRestClientUtilsV1_1().getWithLocale("read/sites/" + blogId, listener, errorListener);
         } else {
             WordPress.getRestClientUtilsV1_1()
-                     .getWithLocale("read/sites/" + UrlUtils.urlEncode(UrlUtils.getHost(blogUrl)), listener, errorListener);
+                     .getWithLocale("read/sites/" + UrlUtils.urlEncode(UrlUtils.getHost(blogUrl)), listener,
+                             errorListener);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -159,7 +159,7 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "updating post");
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(path, null, null, listener, errorListener);
     }
 
     private static void handleUpdatePostResponse(@NonNull final ReaderPost localPost,
@@ -320,7 +320,7 @@ public class ReaderPostActions {
         };
 
         AppLog.d(T.READER, "requesting post");
-        restClientUtils.get(path, null, null, listener, errorListener);
+        restClientUtils.getWithLocale(path, null, null, listener, errorListener);
     }
 
     private static String getTrackingPixelForPost(@NonNull ReaderPost post) {
@@ -417,7 +417,7 @@ public class ReaderPostActions {
                       + "?size_local=" + NUM_RELATED_POSTS_TO_REQUEST
                       + "&size_global=" + NUM_RELATED_POSTS_TO_REQUEST
                       + "&fields=" + ReaderSimplePost.SIMPLE_POST_FIELDS;
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(path, null, null, listener, errorListener);
     }
 
     private static void handleRelatedPostsResponse(final ReaderPost sourcePost,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/usecases/ParseDiscoverCardsJsonUseCase.kt
@@ -78,7 +78,7 @@ class ParseDiscoverCardsJsonUseCase @Inject constructor(
     }
 
     fun parseNextPageHandle(jsonObject: JSONObject): String =
-        jsonObject.getString(ReaderConstants.JSON_NEXT_PAGE_HANDLE)
+        jsonObject.optString(ReaderConstants.JSON_NEXT_PAGE_HANDLE)
 
     fun convertListOfJsonArraysIntoSingleJsonArray(jsons: List<String>): JSONArray {
         val arrays = jsons.map { JSONArray(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/comment/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/comment/ReaderCommentService.java
@@ -201,7 +201,7 @@ public class ReaderCommentService extends Service {
             }
         };
         AppLog.d(AppLog.T.READER, "updating comments");
-        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().getWithLocale(path, null, null, listener, errorListener);
     }
 
     private static void handleUpdateCommentsResponse(final JSONObject jsonObject,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -241,7 +241,11 @@ class ReaderDiscoverLogic @Inject constructor(
         // If we've received a recommended tags or blogs card as the first element,
         // it should be displayed as the third card.
         if (firstRecommendationCard != null) {
-            simplifiedJsonList.add(2, firstRecommendationCard)
+            if (simplifiedJsonList.size >=2) {
+                simplifiedJsonList.add(2, firstRecommendationCard)
+            } else {
+                simplifiedJsonList.add(firstRecommendationCard)
+            }
         }
 
         return JSONArray(simplifiedJsonList)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.Dis
 import org.wordpress.android.ui.reader.services.discover.ReaderDiscoverLogic.DiscoverTasks.REQUEST_MORE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.READER
+import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.util.config.ReaderDiscoverNewEndpointFeatureConfig
 import javax.inject.Inject
 
@@ -59,6 +60,7 @@ class ReaderDiscoverLogic @Inject constructor(
     private val getDiscoverCardsUseCase: GetDiscoverCardsUseCase,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val readerDiscoverNewEndpointFeatureConfig: ReaderDiscoverNewEndpointFeatureConfig,
+    private val localeManagerWrapper: LocaleManagerWrapper,
 ) {
     enum class DiscoverTasks {
         REQUEST_MORE, REQUEST_FIRST_PAGE
@@ -118,12 +120,12 @@ class ReaderDiscoverLogic @Inject constructor(
                 AppLog.e(READER, volleyError)
                 resultListener.onUpdateResult(FAILED)
             }
-            val endpoint = if (readerDiscoverNewEndpointFeatureConfig.isEnabled()) {
-                "read/streams/discover"
+            if (readerDiscoverNewEndpointFeatureConfig.isEnabled()) {
+                params["_locale"] = localeManagerWrapper.getLanguage()
+                WordPress.getRestClientUtilsV2().get("read/streams/discover", params, null, listener, errorListener)
             } else {
-                "read/tags/cards"
+                WordPress.getRestClientUtilsV2().getWithLocale("read/tags/cards", params, null, listener, errorListener)
             }
-            WordPress.getRestClientUtilsV2().getWithLocale(endpoint, params, null, listener, errorListener)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -123,7 +123,7 @@ class ReaderDiscoverLogic @Inject constructor(
             } else {
                 "read/tags/cards"
             }
-            WordPress.getRestClientUtilsV2()[endpoint, params, null, listener, errorListener]
+            WordPress.getRestClientUtilsV2().getWithLocale(endpoint, params, null, listener, errorListener)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -153,7 +153,9 @@ class ReaderDiscoverLogic @Inject constructor(
             insertCardsJsonIntoDb(simplifiedCardsJson)
 
             val nextPageHandle = parseDiscoverCardsJsonUseCase.parseNextPageHandle(json)
-            appPrefsWrapper.readerCardsPageHandle = nextPageHandle
+            if (nextPageHandle.isNotEmpty()) {
+                appPrefsWrapper.readerCardsPageHandle = nextPageHandle
+            }
 
             if (cards.isEmpty()) {
                 readerTagTableWrapper.clearTagLastUpdated(ReaderTag.createDiscoverPostCardsTag())

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/discover/ReaderDiscoverLogic.kt
@@ -120,12 +120,13 @@ class ReaderDiscoverLogic @Inject constructor(
                 AppLog.e(READER, volleyError)
                 resultListener.onUpdateResult(FAILED)
             }
-            if (readerDiscoverNewEndpointFeatureConfig.isEnabled()) {
-                params["_locale"] = localeManagerWrapper.getLanguage()
-                WordPress.getRestClientUtilsV2().get("read/streams/discover", params, null, listener, errorListener)
+            params["_locale"] = localeManagerWrapper.getLanguage()
+            val endpoint = if (readerDiscoverNewEndpointFeatureConfig.isEnabled()) {
+                "read/streams/discover"
             } else {
-                WordPress.getRestClientUtilsV2().getWithLocale("read/tags/cards", params, null, listener, errorListener)
+                "read/tags/cards"
             }
+            WordPress.getRestClientUtilsV2().get(endpoint, params, null, listener, errorListener)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.services.post;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.os.PersistableBundle;
@@ -10,6 +11,9 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManagerWrapper;
+
+import javax.inject.Inject;
 
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
@@ -26,8 +30,11 @@ import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceSta
  * EventBus to alert of update status
  */
 
+@AndroidEntryPoint
 public class ReaderPostJobService extends JobService implements ServiceCompletionListener {
     private ReaderPostLogic mReaderPostLogic;
+
+    @Inject LocaleManagerWrapper mLocaleManagerWrapper;
 
     @Override public boolean onStartJob(JobParameters params) {
         AppLog.i(AppLog.T.READER, "reader post job service > started");
@@ -66,7 +73,7 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
     @Override
     public void onCreate() {
         super.onCreate();
-        mReaderPostLogic = new ReaderPostLogic(this);
+        mReaderPostLogic = new ReaderPostLogic(this, mLocaleManagerWrapper);
         AppLog.i(AppLog.T.READER, "reader post job service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.services.post;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 import android.os.PersistableBundle;
@@ -14,6 +13,8 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManagerWrapper;
 
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -25,15 +25,19 @@ import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManagerWrapper;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 
 public class ReaderPostLogic {
     private ServiceCompletionListener mCompletionListener;
+    private final LocaleManagerWrapper mLocaleManagerWrapper;
     private Object mListenerCompanion;
 
-    public ReaderPostLogic(ServiceCompletionListener listener) {
+    public ReaderPostLogic(@NonNull final ServiceCompletionListener listener,
+                           @NonNull final LocaleManagerWrapper localeManagerWrapper) {
         mCompletionListener = listener;
+        mLocaleManagerWrapper = localeManagerWrapper;
     }
 
     public void performTask(Object companion, UpdateAction action,
@@ -87,7 +91,7 @@ public class ReaderPostLogic {
         requestPostsForFeed(feedId, action, listener);
     }
 
-    private static void requestPostsWithTag(final ReaderTag tag,
+    private void requestPostsWithTag(final ReaderTag tag,
                                             final UpdateAction updateAction,
                                             final ReaderActions.UpdateResultListener resultListener) {
         String path = getRelativeEndpointForTag(tag);
@@ -126,25 +130,21 @@ public class ReaderPostLogic {
 
         sb.append("&meta=site,likes");
 
-        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                // remember when this tag was updated if newer posts were requested
-                if (updateAction == UpdateAction.REQUEST_NEWER || updateAction == UpdateAction.REQUEST_REFRESH) {
-                    ReaderTagTable.setTagLastUpdated(tag);
-                }
-                handleUpdatePostsResponse(tag, jsonObject, updateAction, resultListener);
+        sb.append("&lang=").append(mLocaleManagerWrapper.getLanguage());
+
+        com.wordpress.rest.RestRequest.Listener listener = jsonObject -> {
+            // remember when this tag was updated if newer posts were requested
+            if (updateAction == UpdateAction.REQUEST_NEWER || updateAction == UpdateAction.REQUEST_REFRESH) {
+                ReaderTagTable.setTagLastUpdated(tag);
             }
+            handleUpdatePostsResponse(tag, jsonObject, updateAction, resultListener);
         };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(AppLog.T.READER, volleyError);
-                resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
-            }
+        RestRequest.ErrorListener errorListener = volleyError -> {
+            AppLog.e(AppLog.T.READER, volleyError);
+            resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
         };
 
-        WordPress.getRestClientUtilsV1_2().getWithLocale(sb.toString(), null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().get(sb.toString(), null, null, listener, errorListener);
     }
 
     private static void requestPostsForBlog(final long blogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostLogic.java
@@ -144,7 +144,7 @@ public class ReaderPostLogic {
             }
         };
 
-        WordPress.getRestClientUtilsV1_2().get(sb.toString(), null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(sb.toString(), null, null, listener, errorListener);
     }
 
     private static void requestPostsForBlog(final long blogId,
@@ -174,7 +174,7 @@ public class ReaderPostLogic {
             }
         };
         AppLog.d(AppLog.T.READER, "updating posts in blog " + blogId);
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(path, null, null, listener, errorListener);
     }
 
     private static void requestPostsForFeed(final long feedId,
@@ -203,7 +203,7 @@ public class ReaderPostLogic {
         };
 
         AppLog.d(AppLog.T.READER, "updating posts in feed " + feedId);
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(path, null, null, listener, errorListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.services.post;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
@@ -9,6 +10,9 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManagerWrapper;
+
+import javax.inject.Inject;
 
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
@@ -21,8 +25,11 @@ import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceSta
  * EventBus to alert of update status
  */
 
+@AndroidEntryPoint
 public class ReaderPostService extends Service implements ServiceCompletionListener {
     private ReaderPostLogic mReaderPostLogic;
+
+    @Inject LocaleManagerWrapper mLocaleManagerWrapper;
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -32,7 +39,7 @@ public class ReaderPostService extends Service implements ServiceCompletionListe
     @Override
     public void onCreate() {
         super.onCreate();
-        mReaderPostLogic = new ReaderPostLogic(this);
+        mReaderPostLogic = new ReaderPostLogic(this, mLocaleManagerWrapper);
         AppLog.i(AppLog.T.READER, "reader post service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.services.post;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
@@ -13,6 +12,8 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManagerWrapper;
 
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.services.search;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 
@@ -9,6 +8,8 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LocaleManagerWrapper;
 
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_OFFSET;
 import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_QUERY;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
@@ -1,10 +1,14 @@
 package org.wordpress.android.ui.reader.services.search;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
 
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManagerWrapper;
+
+import javax.inject.Inject;
 
 import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_OFFSET;
 import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_QUERY;
@@ -13,8 +17,11 @@ import static org.wordpress.android.ui.reader.services.search.ReaderSearchServic
  * service which searches for reader posts on wordpress.com
  */
 
+@AndroidEntryPoint
 public class ReaderSearchJobService extends JobService implements ServiceCompletionListener {
     private ReaderSearchLogic mReaderSearchLogic;
+
+    @Inject LocaleManagerWrapper mLocaleManagerWrapper;
 
     @Override public boolean onStartJob(JobParameters params) {
         if (params.getExtras() != null && params.getExtras().getString(ARG_QUERY) != null) {
@@ -34,7 +41,7 @@ public class ReaderSearchJobService extends JobService implements ServiceComplet
     @Override
     public void onCreate() {
         super.onCreate();
-        mReaderSearchLogic = new ReaderSearchLogic(this);
+        mReaderSearchLogic = new ReaderSearchLogic(this, mLocaleManagerWrapper);
         AppLog.i(AppLog.T.READER, "reader search job service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
@@ -55,7 +55,7 @@ public class ReaderSearchLogic {
 
         AppLog.d(AppLog.T.READER, "reader search service > starting search for " + query);
         EventBus.getDefault().post(new ReaderEvents.SearchPostsStarted(query, offset));
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_2().getWithLocale(path, null, null, listener, errorListener);
     }
 
     private void handleSearchResponse(final String query, final int offset, final JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -1,22 +1,29 @@
 package org.wordpress.android.ui.reader.services.search;
 
+import dagger.hilt.android.AndroidEntryPoint;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
 
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.LocaleManagerWrapper;
 import org.wordpress.android.util.StringUtils;
+
+import javax.inject.Inject;
 
 /**
  * service which searches for reader posts on wordpress.com
  */
 
+@AndroidEntryPoint
 public class ReaderSearchService extends Service implements ServiceCompletionListener {
     private static final String ARG_QUERY = "query";
     private static final String ARG_OFFSET = "offset";
 
     private ReaderSearchLogic mReaderSearchLogic;
+
+    @Inject LocaleManagerWrapper mLocaleManagerWrapper;
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -26,7 +33,7 @@ public class ReaderSearchService extends Service implements ServiceCompletionLis
     @Override
     public void onCreate() {
         super.onCreate();
-        mReaderSearchLogic = new ReaderSearchLogic(this);
+        mReaderSearchLogic = new ReaderSearchLogic(this, mLocaleManagerWrapper);
         AppLog.i(AppLog.T.READER, "reader search service > created");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.services.search;
 
-import dagger.hilt.android.AndroidEntryPoint;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
@@ -11,6 +10,8 @@ import org.wordpress.android.util.LocaleManagerWrapper;
 import org.wordpress.android.util.StringUtils;
 
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * service which searches for reader posts on wordpress.com

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -279,7 +279,7 @@ public class ReaderUpdateLogic {
         HashMap<String, String> params = new HashMap<>();
         params.put("_locale", mLanguage);
         mClientUtilsProvider.getRestClientForInterestTags()
-                            .getWithLocale("read/interests", params, null, listener, errorListener);
+                            .get("read/interests", params, null, listener, errorListener);
     }
 
     private void handleInterestTagsResponse(final JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -316,7 +316,8 @@ public class ReaderUpdateLogic {
         AppLog.d(AppLog.T.READER, "reader service > updating followed blogs. Page requested: " + page);
         // request using ?meta=site,feed to get extra info
         WordPress.getRestClientUtilsV1_2()
-                 .getWithLocale("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener, errorListener);
+                 .getWithLocale("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener,
+                         errorListener);
     }
 
     private void handleFollowedBlogsResponse(final ReaderBlogList serverBlogs, final JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -120,7 +120,7 @@ public class ReaderUpdateLogic {
         HashMap<String, String> params = new HashMap<>();
         params.put("locale", mLanguage);
         mClientUtilsProvider.getRestClientForTagUpdate()
-                            .get("read/menu", params, null, listener, errorListener);
+                            .getWithLocale("read/menu", params, null, listener, errorListener);
     }
 
     /**
@@ -279,7 +279,7 @@ public class ReaderUpdateLogic {
         HashMap<String, String> params = new HashMap<>();
         params.put("_locale", mLanguage);
         mClientUtilsProvider.getRestClientForInterestTags()
-                            .get("read/interests", params, null, listener, errorListener);
+                            .getWithLocale("read/interests", params, null, listener, errorListener);
     }
 
     private void handleInterestTagsResponse(final JSONObject jsonObject) {
@@ -316,7 +316,7 @@ public class ReaderUpdateLogic {
         AppLog.d(AppLog.T.READER, "reader service > updating followed blogs. Page requested: " + page);
         // request using ?meta=site,feed to get extra info
         WordPress.getRestClientUtilsV1_2()
-                 .get("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener, errorListener);
+                 .getWithLocale("read/following/mine?number=100&page=" + page + "&meta=site%2Cfeed", listener, errorListener);
     }
 
     private void handleFollowedBlogsResponse(final ReaderBlogList serverBlogs, final JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/PostSubscribersApiCallsProvider.kt
@@ -38,7 +38,7 @@ class PostSubscribersApiCallsProvider @Inject constructor(
             cont.resume(false)
         }
 
-        WordPress.getRestClientUtilsV1_1().get(
+        WordPress.getRestClientUtilsV1_1().getWithLocale(
             endPointPath,
             listener,
             errorListener
@@ -64,7 +64,7 @@ class PostSubscribersApiCallsProvider @Inject constructor(
             cont.resume(Failure(error))
         }
 
-        WordPress.getRestClientUtilsV1_1().get(
+        WordPress.getRestClientUtilsV1_1().getWithLocale(
             endPointPath,
             listener,
             errorListener

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/service/SuggestionService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/service/SuggestionService.java
@@ -91,7 +91,7 @@ public class SuggestionService extends Service {
 
         AppLog.d(AppLog.T.SUGGESTION, "suggestion service > updating suggestions for siteId: " + siteId);
         String path = "/users/suggest" + "?site_id=" + siteId;
-        WordPress.getRestClientUtils().get(path, listener, errorListener);
+        WordPress.getRestClientUtils().getWithLocale(path, listener, errorListener);
     }
 
     private void handleSuggestionsUpdatedResponse(final long siteId, final JSONObject jsonObject) {
@@ -136,7 +136,7 @@ public class SuggestionService extends Service {
 
         AppLog.d(AppLog.T.SUGGESTION, "suggestion service > updating tags for siteId: " + siteId);
         String path = "/sites/" + siteId + "/tags";
-        WordPress.getRestClientUtils().get(path, listener, errorListener);
+        WordPress.getRestClientUtils().getWithLocale(path, listener, errorListener);
     }
 
     private void handleTagsUpdatedResponse(final long siteId, final JSONObject jsonObject) {

--- a/WordPress/src/test/java/org/wordpress/android/models/recommend/RecommendApiCallsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/recommend/RecommendApiCallsProviderTest.kt
@@ -109,7 +109,7 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
         val error = "Invalid response received"
         whenever(jsonObject.toString()).thenReturn("{name:\"wordpress\",message=[]}")
         whenever(context.getString(R.string.recommend_app_bad_format_response)).thenReturn(error)
-        whenever(restClientUtils.get(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
             listenerCaptor.lastValue.onResponse(jsonObject)
             null
         }
@@ -127,7 +127,7 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
         val error = "Invalid response received"
         whenever(jsonObject.optString("name")).thenReturn("jetpack")
         whenever(context.getString(R.string.recommend_app_bad_format_response)).thenReturn(error)
-        whenever(restClientUtils.get(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
             listenerCaptor.lastValue.onResponse(jsonObject)
             null
         }
@@ -144,7 +144,7 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
     fun `error is tracked on null net response`() = test {
         val error = "No response received"
         whenever(context.getString(R.string.recommend_app_null_response)).thenReturn(error)
-        whenever(restClientUtils.get(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
             listenerCaptor.lastValue.onResponse(null)
             null
         }
@@ -161,7 +161,7 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
     fun `error is tracked on volley error`() = test {
         val error = "Unknown error fetching recommend app template"
         whenever(context.getString(R.string.recommend_app_generic_get_template_error)).thenReturn(error)
-        whenever(restClientUtils.get(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
             errorListenerCaptor.lastValue.onErrorResponse(mock())
             null
         }

--- a/WordPress/src/test/java/org/wordpress/android/models/recommend/RecommendApiCallsProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/recommend/RecommendApiCallsProviderTest.kt
@@ -109,7 +109,13 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
         val error = "Invalid response received"
         whenever(jsonObject.toString()).thenReturn("{name:\"wordpress\",message=[]}")
         whenever(context.getString(R.string.recommend_app_bad_format_response)).thenReturn(error)
-        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(
+            restClientUtils.getWithLocale(
+                anyString(),
+                listenerCaptor.capture(),
+                errorListenerCaptor.capture()
+            )
+        ).doAnswer {
             listenerCaptor.lastValue.onResponse(jsonObject)
             null
         }
@@ -127,7 +133,13 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
         val error = "Invalid response received"
         whenever(jsonObject.optString("name")).thenReturn("jetpack")
         whenever(context.getString(R.string.recommend_app_bad_format_response)).thenReturn(error)
-        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(
+            restClientUtils.getWithLocale(
+                anyString(),
+                listenerCaptor.capture(),
+                errorListenerCaptor.capture()
+            )
+        ).doAnswer {
             listenerCaptor.lastValue.onResponse(jsonObject)
             null
         }
@@ -144,7 +156,13 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
     fun `error is tracked on null net response`() = test {
         val error = "No response received"
         whenever(context.getString(R.string.recommend_app_null_response)).thenReturn(error)
-        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(
+            restClientUtils.getWithLocale(
+                anyString(),
+                listenerCaptor.capture(),
+                errorListenerCaptor.capture()
+            )
+        ).doAnswer {
             listenerCaptor.lastValue.onResponse(null)
             null
         }
@@ -161,7 +179,13 @@ class RecommendApiCallsProviderTest : BaseUnitTest() {
     fun `error is tracked on volley error`() = test {
         val error = "Unknown error fetching recommend app template"
         whenever(context.getString(R.string.recommend_app_generic_get_template_error)).thenReturn(error)
-        whenever(restClientUtils.getWithLocale(anyString(), listenerCaptor.capture(), errorListenerCaptor.capture())).doAnswer {
+        whenever(
+            restClientUtils.getWithLocale(
+                anyString(),
+                listenerCaptor.capture(),
+                errorListenerCaptor.capture()
+            )
+        ).doAnswer {
             errorListenerCaptor.lastValue.onErrorResponse(mock())
             null
         }

--- a/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -103,7 +103,7 @@ public class RestClientUtils {
 
     public void getCategories(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/categories", siteId);
-        get(path, null, null, listener, errorListener);
+        getWithLocale(path, null, null, listener, errorListener);
     }
 
     /**
@@ -112,7 +112,7 @@ public class RestClientUtils {
      * <a href="https://developer.wordpress.com/docs/api/1/get/notifications/">api/1/get/notifications</a>
      */
     public void getNotifications(Map<String, String> params, Listener listener, ErrorListener errorListener) {
-        get("notifications", params, null, listener, errorListener);
+        getWithLocale("notifications", params, null, listener, errorListener);
     }
 
     /**
@@ -123,7 +123,7 @@ public class RestClientUtils {
                                 Listener listener, ErrorListener errorListener) {
         params.put("fields", NOTIFICATION_FIELDS);
         String path = String.format(Locale.US, "notifications/%s/", noteId);
-        get(path, params, null, listener, errorListener);
+        getWithLocale(path, params, null, listener, errorListener);
     }
 
     /**
@@ -135,7 +135,7 @@ public class RestClientUtils {
         HashMap<String, String> params = new HashMap<>();
         params.put("fields", NOTIFICATION_FIELDS);
         String path = String.format("notifications/%s", noteId);
-        get(path, params, null, listener, errorListener);
+        getWithLocale(path, params, null, listener, errorListener);
     }
 
     /**
@@ -166,23 +166,23 @@ public class RestClientUtils {
 
     public void getJetpackSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "jetpack-blogs/%d/rest-api/?path=/jetpack/v4/settings", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
     public void getGeneralSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/settings", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
     public void getJetpackMonitorSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
 
     public void getJetpackModuleSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/jetpack/modules", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
     public void setGeneralSiteSettings(long siteId, JSONObject params, Listener listener, ErrorListener errorListener) {
@@ -228,7 +228,7 @@ public class RestClientUtils {
 
     public void getSitePurchases(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/purchases", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
     public void exportContentAll(long siteId, Listener listener, ErrorListener errorListener) {
@@ -238,7 +238,7 @@ public class RestClientUtils {
 
     public void getSharingButtons(String siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format("sites/%s/sharing-buttons", siteId);
-        get(path, listener, errorListener);
+        getWithLocale(path, listener, errorListener);
     }
 
     public void setSharingButtons(String siteId, JSONObject params, Listener listener, ErrorListener errorListener) {
@@ -249,29 +249,38 @@ public class RestClientUtils {
     /**
      * Make GET request
      */
-    public Request<JSONObject> get(String path, Listener listener, ErrorListener errorListener) {
-        return get(path, null, null, listener, errorListener);
+    public Request<JSONObject> getWithLocale(final String path, final Listener listener,
+                                             final ErrorListener errorListener) {
+        return getWithLocale(path, null, null, listener, errorListener);
     }
 
     /**
-     * Make GET request with params
+     * Make GET request with params. Locale param is added automatically.
      */
-    public Request<JSONObject> get(String path, Map<String, String> params, RetryPolicy retryPolicy, Listener listener,
-                    ErrorListener errorListener) {
+    public Request<JSONObject> getWithLocale(final String path, final Map<String, String> params,
+                                             RetryPolicy retryPolicy, final Listener listener,
+                                             final ErrorListener errorListener) {
         // turn params into query string
         HashMap<String, String> paramsWithLocale = getRestLocaleParams(mContext);
         if (params != null) {
             paramsWithLocale.putAll(params);
         }
+        return get(path, paramsWithLocale, retryPolicy, listener, errorListener);
+    }
 
+    /**
+     * Make GET request with params.
+     */
+    public Request<JSONObject> get(final String path, final Map<String, String> params, RetryPolicy retryPolicy,
+                                   final Listener listener, final ErrorListener errorListener) {
         String realPath = getSanitizedPath(path);
         if (TextUtils.isEmpty(realPath)) {
             realPath = path;
         }
-        paramsWithLocale.putAll(getSanitizedParameters(path));
+        params.putAll(getSanitizedParameters(path));
 
         RestRequest request = mRestClient.makeRequest(Method.GET, mRestClient
-                        .getAbsoluteURL(realPath, paramsWithLocale), null, listener, errorListener);
+                .getAbsoluteURL(realPath, params), null, listener, errorListener);
 
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_GET, REST_BACKOFF_MULT);

--- a/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -273,14 +273,20 @@ public class RestClientUtils {
      */
     public Request<JSONObject> get(final String path, final Map<String, String> params, RetryPolicy retryPolicy,
                                    final Listener listener, final ErrorListener errorListener) {
+        final Map<String, String> paramsWithPath = new HashMap<>();
+        if (params != null) {
+            paramsWithPath.putAll(params);
+        }
         String realPath = getSanitizedPath(path);
         if (TextUtils.isEmpty(realPath)) {
             realPath = path;
         }
-        params.putAll(getSanitizedParameters(path));
+        if (path != null) {
+            paramsWithPath.putAll(getSanitizedParameters(path));
+        }
 
         RestRequest request = mRestClient.makeRequest(Method.GET, mRestClient
-                .getAbsoluteURL(realPath, params), null, listener, errorListener);
+                .getAbsoluteURL(realPath, paramsWithPath), null, listener, errorListener);
 
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_GET, REST_BACKOFF_MULT);


### PR DESCRIPTION
Fixes #19969 

-----

There are many testing steps, but basically the goal of this PR is to make sure the content shown in the Reader matches the app selected language. If you see any `Reader` content using the wrong language, please let me know.

## To Test:

1. Install Jetpack and sign in.
2. Open "Me" screen.
3. Tap "App Settings".
4. Change the "Interface Language" to a language **different than English and different than the one selected in `wordpress.com`** (it seems like when the language query parameter is missing, the response defaults to the language selected in web. Thanks @thomashorta  for the tip).
5. Open "Reader".
6. Make sure you're following at least one tag and open "Discover" feed.
7. 🔍 Verify the posts list: they should be posts matching the selected language in step 4.
8. Open the search screen (tap on 🔍).
9. 🔍 Search for something: the results should match the selected language in step 4 even if you search use words from a different language (e.g. searching for the word "football" while having Portuguese selected). **Ideally this step should be tested using a version before and after Android O (see [here](https://github.com/wordpress-mobile/WordPress-Android/blob/ac56c495d4f5cecf2a50f349576f23515679d8b1/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java#L26))**.
10. Open "My Site" tab with a blog selected.
11. Look for the daily prompts card and tap "View all responses".
12. 🔍 The posts should match the selected language in step 4. **Ideally this step should be tested using a version before and after Android O (see [here](https://github.com/wordpress-mobile/WordPress-Android/blob/7843d4e88d4b6ded2656df769e305c9c7f326d0b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java#L42))**
13. Open "Reader" and select "Discover".
14. Scroll until you find a tags card and select any tag.
15. 🔍 The posts should match the selected language in step 4. **Ideally this step should be tested using a version before and after Android O (see [here](https://github.com/wordpress-mobile/WordPress-Android/blob/7843d4e88d4b6ded2656df769e305c9c7f326d0b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java#L42))**
16. Unfollow all tags using "Subscriptions" feed.
17. Open "Discover" feed: the empty state should be triggered and you'll see a button (the label in English is "Get Started")
<img width="343" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/e00fb1ee-207f-4166-886b-2884f2b2a64b">


18. 🔍  Tap the button: the suggested tags should match the language selected in step 4.

Feel free to change to pick language at any point: things should work as expected. Just be sure that the selected language is not the same as the one in `wordpress.com`.


-----

## Regression Notes

1. Potential unintended areas of impact

    - Language of "Reader" results

20. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

21. What automated tests I added (or what prevented me from doing so)

    - Had to update legacy code, which is not testable without a significant refactor.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
