### PR TITLE
Redirects to the site creation failure flow when the endpoint fails

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManager.kt
@@ -136,7 +136,7 @@ class SiteCreationServiceManager @Inject constructor(
                          */
                         val errorMsg = "Site already exists - seems like an issue with domain suggestions endpoint"
                         AppLog.e(T.SITE_CREATION, errorMsg)
-                        throw IllegalStateException(errorMsg)
+                        executePhase(FAILURE)
                     }
                 } else {
                     executePhase(FAILURE)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceManagerTest.kt
@@ -135,6 +135,22 @@ class SiteCreationServiceManagerTest : BaseUnitTest() {
     }
 
     @Test
+    fun verifyFailureFlowWhenTheSiteExistsAndIsNotARetry() = test {
+        setSiteExistsErrorResponses()
+        val stateBeforeFailure = CREATE_SITE_STATE
+        whenever(serviceListener.getCurrentState()).thenReturn(stateBeforeFailure)
+
+        startFlow()
+        
+        argumentCaptor<SiteCreationServiceState>().apply {
+            verify(serviceListener, times(3)).updateState(capture())
+            assertThat(allValues[0]).isEqualTo(IDLE_STATE)
+            assertThat(allValues[1]).isEqualTo(CREATE_SITE_STATE)
+            assertThat(allValues[2]).isEqualTo(FAILURE_STATE.copy(payload = stateBeforeFailure))
+        }
+    }
+
+    @Test
     fun verifyRetryWorksWhenCreateSiteRequestFailed() = test {
         setGenericErrorResponses()
         startFlow()


### PR DESCRIPTION
Fixes #20479

## Description
Redirects to the site creation failure flow when the endpoint fails instead of an unhandled crash

-----

## To Test:
Since I was not able to reproduce this issue I would recommend a sanity check of the site creation flow

-----

## Regression Notes

1. Potential unintended areas of impact

    - Site Creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Added a test case

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
