### PR TITLE
[Reader] Fix Globe icon wrong color

### DIFF
--- a/WordPress/src/main/res/drawable/ic_globe_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_globe_white_24dp.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="m12,4c-4.4,0 -8,3.6 -8,8s3.6,8 8,8 8,-3.6 8,-8 -3.6,-8 -8,-8zM12,18.5c-3.6,0 -6.5,-2.9 -6.5,-6.5s2.9,-6.5 6.5,-6.5 6.5,2.9 6.5,6.5 -2.9,6.5 -6.5,6.5zM9,16 L13.5,13 15,8.4 10.5,11.4z"
-      android:fillColor="#000"/>
+      android:fillColor="@color/white"/>
 </vector>


### PR DESCRIPTION
The globe icon used in several places around the Reader was supposed to be white but was currently black, which caused issues when tinting it in some places, such as the post list item and post details "more" menus. The issue was worse in dark mode since it resulted in a black icon on a dark background.

| Before | After |
|--------|--------|
| ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/1d9b24d0-4665-4567-9c46-bb1337c8c774) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/51d6326d-9ad8-45d4-bbbf-f8149e5b7f38) |

-----

## To Test:

- Go to Reader
- On any feed, tap the overflow "more" menu on any post item
- **Verify** the icon color for "visit site" matches other icons for similar options
- Open a post
- Tap the overflow "more" menu on the toolbar
- **Verify** the icon color for "visit site" matches other icons for similar options

-----

## Regression Notes

1. Potential unintended areas of impact

    - Wrong icon color

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A, just a resource icon base color change

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [x] Light and dark modes.
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
