### PR TITLE
Adds null check in the UnrepliedCommentsUtils.isMyComment method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtils.kt
@@ -40,17 +40,17 @@ class UnrepliedCommentsUtils @Inject constructor(
         return topLevelComments
     }
 
-    private fun isMyComment(comment: CommentEntity): Boolean {
-        val myEmail: String
+    fun isMyComment(comment: CommentEntity): Boolean {
+        val myEmail: String?
         val selectedSite = selectedSiteRepository.getSelectedSite() ?: return false
 
         // if site is self hosted, we want to use email associate with it, even if we are logged into wpcom
         myEmail = if (!selectedSite.isUsingWpComRestApi) {
             selectedSite.email
         } else {
-            val account: AccountModel = accountStore.account
-            account.email
+            val account: AccountModel? = accountStore.account
+            account?.email
         }
-        return comment.authorEmail == myEmail
+        return myEmail != null && comment.authorEmail == myEmail
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtilsTest.kt
@@ -1,0 +1,118 @@
+package org.wordpress.android.ui.comments.unified
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao.CommentEntity
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class UnrepliedCommentsUtilsTest : BaseUnitTest() {
+    @Mock
+    private lateinit var accountStore: AccountStore
+
+    @Mock
+    private lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    private lateinit var utils: UnrepliedCommentsUtils
+
+    @Before
+    fun setup() {
+        utils = UnrepliedCommentsUtils(accountStore, selectedSiteRepository)
+    }
+
+    @Test
+    fun `WHEN the selected site cannot be retrieved THEN return false`() {
+        val comment: CommentEntity = mock()
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(null)
+
+        val result = utils.isMyComment(comment)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `WHEN a comment's author email matches a non-wpcom site's email THEN return true`() {
+        val authorEmail = "author@email.com"
+        val comment: CommentEntity = mock()
+        val site: SiteModel = mock()
+        whenever(comment.authorEmail).thenReturn(authorEmail)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        whenever(site.email).thenReturn(authorEmail)
+
+        val result = utils.isMyComment(comment)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `WHEN a non-wpcom site's email is null THEN return false`() {
+        val comment: CommentEntity = mock()
+        val site: SiteModel = mock()
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.isUsingWpComRestApi).thenReturn(false)
+        whenever(site.email).thenReturn(null)
+
+        val result = utils.isMyComment(comment)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `WHEN a comment's author email matches a wpcom account email THEN return true`() {
+        val authorEmail = "author@email.com"
+        val comment: CommentEntity = mock()
+        val site: SiteModel = mock()
+        val account: AccountModel = mock()
+        whenever(comment.authorEmail).thenReturn(authorEmail)
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.isUsingWpComRestApi).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.email).thenReturn(authorEmail)
+
+        val result = utils.isMyComment(comment)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `WHEN a wpcom account fails to be retrieved THEN return false`() {
+        val comment: CommentEntity = mock()
+        val site: SiteModel = mock()
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.isUsingWpComRestApi).thenReturn(true)
+        whenever(accountStore.account).thenReturn(null)
+
+        val result = utils.isMyComment(comment)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `WHEN a wpcom account email is null THEN return false`() {
+        val comment: CommentEntity = mock()
+        val site: SiteModel = mock()
+        val account: AccountModel = mock()
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(site)
+        whenever(site.isUsingWpComRestApi).thenReturn(true)
+        whenever(accountStore.account).thenReturn(account)
+        whenever(account.email).thenReturn(null)
+
+        val result = utils.isMyComment(comment)
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
Partially #15448

## Description
This PR adds null handling in the `UnrepliedCommentsUtils.isMyComment` which caused one of the top crashes according to Android Vitals for the latest versions of the app.

![Screenshot 2024-03-15 at 4 06 49 PM](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/bb2e4e70-9c81-4816-8d5d-7dba477073fb)
![Screenshot 2024-03-15 at 4 07 39 PM](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/c3f77d60-a0d9-4a1d-95c0-e995bfabd78a)

The crash stack trace is the following:
```
Exception java.lang.NullPointerException:
    at org.wordpress.android.ui.comments.unified.UnrepliedCommentsUtils.isMyComment (UnrepliedCommentsUtils.kt:48)
    at org.wordpress.android.ui.comments.unified.UnrepliedCommentsUtils.getUnrepliedComments (UnrepliedCommentsUtils.kt:24)
    at org.wordpress.android.models.usecases.PaginateCommentsUseCase$PaginateCommentsState$Idle.runAction (PaginateCommentsUseCase.kt:86)
    at org.wordpress.android.models.usecases.PaginateCommentsUseCase$PaginateCommentsState$Idle$runAction$1.invokeSuspend (PaginateCommentsUseCase.kt)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
    at kotlinx.coroutines.CoroutineContextKt.withContinuationContext (CoroutineContext.kt:108)
    at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:90)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:584)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:793)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:697)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:684)
```
-----

## To Test:
I wasn't able to reproduce the issue in real conditions and resorted into adding unit tests for the cases that may go wrong.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader comments

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual sanity check and unit tests

3. What automated tests I added (or what prevented me from doing so)

    - Added unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
