### PR TITLE
[Hack] Add logic to BuildConfig to allow for announcement debugging.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugPrefs.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugPrefs.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.ui.debug.preferences
+
+import kotlin.reflect.KClass
+
+/**
+ * Class used to track
+ */
+enum class DebugPrefs(val key: String, val type: KClass<*>) {
+    ALWAYS_SHOW_ANNOUNCEMENT("prefs_always_show_announcement", Boolean::class)
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugPrefs.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugPrefs.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.debug.preferences
 import kotlin.reflect.KClass
 
 /**
- * Class used to track
+ * Class used to track debuggable shared preferences and will show up in [DebugSharedPreferenceFlagsActivity].
  */
 enum class DebugPrefs(val key: String, val type: KClass<*>) {
     ALWAYS_SHOW_ANNOUNCEMENT("prefs_always_show_announcement", Boolean::class)

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModel.kt
@@ -15,11 +15,16 @@ class DebugSharedPreferenceFlagsViewModel @Inject constructor(
     val uiStateFlow = _uiStateFlow.asStateFlow()
 
     init {
-        val flags = DebugPrefs.entries.mapNotNull {
+        val flags = prefsWrapper.getAllPrefs().mapNotNull { (key, value) ->
+            if (value is Boolean) key to value else null
+        }.toMap()
+
+        val explicitFlags = DebugPrefs.entries.mapNotNull {
             // Only supporting boolean for now.
             if (it.type == Boolean::class) it else null
         }.associate { it.key to prefsWrapper.getDebugBooleanPref(it.key, false) }
-        _uiStateFlow.value = flags
+        
+        _uiStateFlow.value = flags + explicitFlags
     }
 
     fun setFlag(key: String, value: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModel.kt
@@ -15,9 +15,10 @@ class DebugSharedPreferenceFlagsViewModel @Inject constructor(
     val uiStateFlow = _uiStateFlow.asStateFlow()
 
     init {
-        val flags = prefsWrapper.getAllPrefs().mapNotNull { (key, value) ->
-            if (value is Boolean) key to value else null
-        }.toMap()
+        val flags = DebugPrefs.entries.mapNotNull {
+            // Only supporting boolean for now.
+            if (it.type == Boolean::class) it else null
+        }.associate { it.key to prefsWrapper.getDebugBooleanPref(it.key, false) }
         _uiStateFlow.value = flags
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -387,6 +387,10 @@ public class AppPrefs {
         return Boolean.parseBoolean(value);
     }
 
+    public static boolean getRawBoolean(@NonNull final PrefKey key, boolean def) {
+        return prefs().getBoolean(key.name(), def);
+    }
+
     public static void putBoolean(final PrefKey key, final boolean value) {
         prefs().edit().putBoolean(key.name(), value).apply();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefsWrapper.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDa
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VIEWS
 import org.wordpress.android.ui.stats.refresh.lists.widget.configuration.StatsDataTypeSelectionViewModel.DataType.VISITORS
 import org.wordpress.android.usecase.social.JetpackSocialFlow
+import org.wordpress.android.util.BuildConfigWrapper
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -31,7 +32,7 @@ import javax.inject.Singleton
  *
  */
 @Singleton
-class AppPrefsWrapper @Inject constructor() {
+class AppPrefsWrapper @Inject constructor(val buildConfigWrapper: BuildConfigWrapper) {
     var featureAnnouncementShownVersion: Int
         get() = AppPrefs.getFeatureAnnouncementShownVersion()
         set(version) = AppPrefs.setFeatureAnnouncementShownVersion(version)
@@ -450,6 +451,9 @@ class AppPrefsWrapper @Inject constructor() {
         AppPrefs.getShouldHideDynamicCard(id)
 
     fun getAllPrefs(): Map<String, Any?> = AppPrefs.getAllPrefs()
+
+    fun getDebugBooleanPref(key: String, default: Boolean = false) =
+        buildConfigWrapper.isDebug() && AppPrefs.getRawBoolean({ key }, default)
 
     fun setString(prefKey: PrefKey, value: String) {
         AppPrefs.setString(prefKey, value)

--- a/WordPress/src/test/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModelTest.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.debug.preferences
 
 import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
@@ -19,11 +20,13 @@ class DebugSharedPreferenceFlagsViewModelTest {
 
     @Test
     fun `WHEN init THEN should load the flags from the prefs`() {
-        whenever(prefsWrapper.getAllPrefs()).thenReturn(mapOf("key" to true))
+        DebugPrefs.entries.forEach {
+            whenever(prefsWrapper.getDebugBooleanPref(it.key, false)).thenReturn(false)
+        }
 
         initViewModel()
 
-        assertTrue(viewModel.uiStateFlow.value["key"]!!)
+        assertFalse(viewModel.uiStateFlow.value.isEmpty())
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsViewModelTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.debug.preferences
 
 import junit.framework.TestCase.assertTrue
-import junit.framework.TestCase.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.eq
@@ -20,13 +19,15 @@ class DebugSharedPreferenceFlagsViewModelTest {
 
     @Test
     fun `WHEN init THEN should load the flags from the prefs`() {
+        whenever(prefsWrapper.getAllPrefs()).thenReturn(mapOf("key" to true))
         DebugPrefs.entries.forEach {
             whenever(prefsWrapper.getDebugBooleanPref(it.key, false)).thenReturn(false)
         }
 
         initViewModel()
 
-        assertFalse(viewModel.uiStateFlow.value.isEmpty())
+        assertTrue(viewModel.uiStateFlow.value["key"]!!)
+        assertTrue(viewModel.uiStateFlow.value.size >= 2)
     }
 
     @Test


### PR DESCRIPTION
The current announcement logic is a bit of a pain to test. Normally I'd add a feature flag. But I thought instead let's add something in build.gradle to use local.properties so it's a bit easier to test.

Now you can simply add `alwaysShowAnnouncement=true` to your `local.properties`, build the app in debug, and the announcements from your current release should be shown every time you load the app.

Thoughts?

-----

## To Test:

- [ ] Go to the Me tab
- [ ] Debug Settings
- [ ] Press the overflow menu and click `All shard preference flag`.
- [ ] You should see `prefs_always_show_announcement`. Make sure it's checked.
- [ ] When you exit the debug settings screen you will begin to see the announcement pop up often.

**Note**: I was going to add documentation, but instead decided against it until this PR is reviewed.

-----

## Regression Notes

1. Potential unintended areas of impact

    n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

