### PR TITLE
[UI Tests] Disabled the e2eAllDayStatsLoad granular test for JP.

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsGranularTabsTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/StatsGranularTabsTest.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
@@ -37,6 +38,7 @@ class StatsGranularTabsTest : BaseTest() {
     }
 
     @Test
+    @Ignore("The 'Days' screen might occasionally not load. Disabled until tests rerun is implemented.")
     fun e2eAllDayStatsLoad() {
         val todayVisits = StatsVisitsData("97", "28", "14", "11")
         val postsList: List<StatsKeyValueData> = StatsMocksReader().readDayTopPostsToList()


### PR DESCRIPTION
### Why

Quite often, the very first stats card in "Days" stats might not be loaded in JP:

| Card Loaded | Card not loaded |
| ----------- | ----------- |
| <img width="286" alt="Screenshot 2024-03-12 at 15 13 25" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/ff956422-92bb-4ab4-98f5-bab266cd0761"> | <img width="285" alt="Screenshot 2024-03-12 at 15 13 16" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/9f3b0d7a-b1f9-4b9c-b556-19abf6f20a23"> |

This caused an influx of `e2eAllDayStatsLoad` test fails once it was enabled for JP recently. Unfortunately, disabling just the check for the very first stats card presence does not solve the issue completely, because sometimes (much more seldomly than for the one card only), the _whole_ screen might not be loaded:

<img width="284" alt="Screenshot 2024-03-18 at 15 35 13" src="https://github.com/wordpress-mobile/WordPress-Android/assets/73365754/3b5669aa-32c3-492c-b3cd-772b960395a0">

So, the only available _stable_ solution for now is disabling this test for JP, until automatic reruns of failed tests are implemented.

## To Test:

- The `e2eAllDayStatsLoad` from `StatsGranularTabsTest` is not executed.
- The rest of the tests is 🟢 