### PR TITLE
Fixes: NumberFormatExcpetion in BlockProcessor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/AudioBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/AudioBlockProcessor.kt
@@ -23,7 +23,7 @@ class AudioBlockProcessor(localId: String?, mediaFile: MediaFile?) : BlockProces
 
         return if (id != null && !id.isJsonNull && id.asString == mLocalId) {
             jsonAttributes.apply {
-                addProperty(ID_ATTRIBUTE, Integer.parseInt(mRemoteId))
+                addIdPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
             }
             true
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/AudioBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/AudioBlockProcessor.kt
@@ -23,7 +23,7 @@ class AudioBlockProcessor(localId: String?, mediaFile: MediaFile?) : BlockProces
 
         return if (id != null && !id.isJsonNull && id.asString == mLocalId) {
             jsonAttributes.apply {
-                addIdPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
+                addIntPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
             }
             true
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
@@ -7,12 +7,14 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings;
 import org.wordpress.android.editor.Utils;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.util.regex.Matcher;
 
 import static org.wordpress.android.ui.posts.mediauploadcompletionprocessors.MediaUploadCompletionProcessorPatterns.PATTERN_BLOCK_CAPTURES;
 import static org.wordpress.android.ui.posts.mediauploadcompletionprocessors.MediaUploadCompletionProcessorPatterns.PATTERN_SELF_CLOSING_BLOCK_CAPTURES;
+import static org.wordpress.android.util.AppLog.T.MEDIA;
 
 /**
  * Abstract class to be extended for each enumerated {@link MediaBlockType}.
@@ -127,6 +129,14 @@ public abstract class BlockProcessor {
 
     String processBlock(String block) {
         return processBlock(block, false);
+    }
+
+     final void addIdPropertySafely(JsonObject jsonAttributes, String idName, String remoteId) {
+        try {
+            jsonAttributes.addProperty(idName, Integer.parseInt(remoteId));
+        } catch (NumberFormatException e) {
+            AppLog.e(MEDIA, e.getMessage());
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/BlockProcessor.java
@@ -131,9 +131,9 @@ public abstract class BlockProcessor {
         return processBlock(block, false);
     }
 
-     final void addIdPropertySafely(JsonObject jsonAttributes, String idName, String remoteId) {
+     final void addIntPropertySafely(JsonObject jsonAttributes, String propertyName, String value) {
         try {
-            jsonAttributes.addProperty(idName, Integer.parseInt(remoteId));
+            jsonAttributes.addProperty(propertyName, Integer.parseInt(value));
         } catch (NumberFormatException e) {
             AppLog.e(MEDIA, e.getMessage());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -55,7 +55,8 @@ public class CoverBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
-            jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId, 10));
+            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
+
             jsonAttributes.addProperty("url", mRemoteUrl);
 
             // check if background type is video

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/CoverBlockProcessor.java
@@ -55,7 +55,7 @@ public class CoverBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsInt() == Integer.parseInt(mLocalId, 10)) {
-            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
+            addIntPropertySafely(jsonAttributes, "id", mRemoteId);
 
             jsonAttributes.addProperty("url", mRemoteUrl);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/GalleryBlockProcessor.java
@@ -7,10 +7,13 @@ import com.google.gson.JsonPrimitive;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.wordpress.android.util.AppLog.T.MEDIA;
 
 public class GalleryBlockProcessor extends BlockProcessor {
     private final MediaUploadCompletionProcessor mMediaUploadCompletionProcessor;
@@ -93,7 +96,11 @@ public class GalleryBlockProcessor extends BlockProcessor {
         for (int i = 0; i < ids.size(); i++) {
             JsonElement id = ids.get(i);
             if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-                ids.set(i, new JsonPrimitive(Integer.parseInt(mRemoteId, 10)));
+                try {
+                    ids.set(i, new JsonPrimitive(Integer.parseInt(mRemoteId, 10)));
+                } catch (NumberFormatException e) {
+                    AppLog.e(MEDIA, e.getMessage());
+                }
                 return true;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
@@ -5,10 +5,8 @@ import com.google.gson.JsonObject;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.MediaFile;
 
-import static org.wordpress.android.util.AppLog.T.MEDIA;
 
 public class ImageBlockProcessor extends BlockProcessor {
     public ImageBlockProcessor(String localId, MediaFile mediaFile) {
@@ -37,14 +35,9 @@ public class ImageBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            try {
-                jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
-            } catch (NumberFormatException e) {
-                AppLog.e(MEDIA, e.getMessage());
-            }
+            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
             return true;
         }
-
         return false;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/ImageBlockProcessor.java
@@ -35,7 +35,7 @@ public class ImageBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
+            addIntPropertySafely(jsonAttributes, "id", mRemoteId);
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
@@ -47,7 +47,7 @@ public class MediaTextBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("mediaId");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            jsonAttributes.addProperty("mediaId", Integer.parseInt(mRemoteId));
+            addIdPropertySafely(jsonAttributes, "mediaId", mRemoteId);
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/MediaTextBlockProcessor.java
@@ -47,7 +47,7 @@ public class MediaTextBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("mediaId");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            addIdPropertySafely(jsonAttributes, "mediaId", mRemoteId);
+            addIntPropertySafely(jsonAttributes, "mediaId", mRemoteId);
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
@@ -31,10 +31,9 @@ public class VideoBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            jsonAttributes.addProperty("id", Integer.parseInt(mRemoteId));
+            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
             return true;
         }
-
         return false;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoBlockProcessor.java
@@ -31,7 +31,7 @@ public class VideoBlockProcessor extends BlockProcessor {
     @Override boolean processBlockJsonAttributes(JsonObject jsonAttributes) {
         JsonElement id = jsonAttributes.get("id");
         if (id != null && !id.isJsonNull() && id.getAsString().equals(mLocalId)) {
-            addIdPropertySafely(jsonAttributes, "id", mRemoteId);
+            addIntPropertySafely(jsonAttributes, "id", mRemoteId);
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
@@ -18,7 +18,7 @@ class VideoPressBlockProcessor(
 
         return if (id != null && !id.isJsonNull && id.asString == mLocalId) {
             jsonAttributes.apply {
-                addIdPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
+                addIntPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
                 addProperty(GUID_ATTRIBUTE, mRemoteGuid)
                 if (src?.startsWith("file:") == true) {
                     remove(SRC_ATTRIBUTE)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
@@ -18,7 +18,7 @@ class VideoPressBlockProcessor(
 
         return if (id != null && !id.isJsonNull && id.asString == mLocalId) {
             jsonAttributes.apply {
-                addProperty(ID_ATTRIBUTE, Integer.parseInt(mRemoteId))
+                addIdPropertySafely(this, ID_ATTRIBUTE, mRemoteId)
                 addProperty(GUID_ATTRIBUTE, mRemoteGuid)
                 if (src?.startsWith("file:") == true) {
                     remove(SRC_ATTRIBUTE)


### PR DESCRIPTION
Fixes #20494 

-----

This PR tries to prevent NumberFormatExpeption crashes that might occur in processBlockJsonAttributes() function of the classes that extend BlockProcessor. This crash might occur when why try to parse mRemoteId into an Integer. 

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Just review the code as I was not able to replicate the crash. Please feel free to test otherwise if you find a way.

-----
