### PR TITLE
fix: React Native bundle source map copy task

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -717,7 +717,7 @@ if (project.hasProperty("debugStoreFile")) {
 // Copy React Native JavaScript bundle and source map so they can be upload it to the Crash logging
 // service during the build process.
 android {
-    applicationVariants.all { variant ->
+    applicationVariants.configureEach { variant ->
         def variantAssets = "${buildDir}/intermediates/assets/${variant.name}"
 
         tasks.register("delete${variant.name.capitalize()}ReactNativeBundleSourceMap", Delete) {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -725,7 +725,7 @@ android {
         }
 
         tasks.register("copy${variant.name.capitalize()}ReactNativeBundleSourceMap", Copy) {
-            from("${buildDir}/intermediates/assets/${variant.name}")
+            from(variantAssets)
             into("${buildDir}/react-native-bundle-source-map")
             include("*.bundle", "*.bundle.map")
             finalizedBy("delete${variant.name.capitalize()}ReactNativeBundleSourceMap")

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -718,7 +718,7 @@ if (project.hasProperty("debugStoreFile")) {
 // service during the build process.
 android {
     applicationVariants.configureEach { variant ->
-        def variantAssets = "${buildDir}/intermediates/assets/${variant.name}"
+        def variantAssets = variant.mergeAssetsProvider.get().outputDir.get()
 
         tasks.register("delete${variant.name.capitalize()}ReactNativeBundleSourceMap", Delete) {
             delete(fileTree(dir: variantAssets, includes: ['**/*.bundle.map']))

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -718,18 +718,14 @@ if (project.hasProperty("debugStoreFile")) {
 // service during the build process.
 android {
     applicationVariants.all { variant ->
-        variant.mergeAssetsProvider.configure {
-            doLast {
-                // Copy bundle and source map files
-                copy {
-                    from(outputDir)
-                    into("${buildDir}/react-native-bundle-source-map")
-                    include("*.bundle", "*.bundle.map")
-                }
+        tasks.register("copy${variant.name.capitalize()}ReactNativeBundleSourceMap", Copy) {
+            from("${buildDir}/intermediates/assets/${variant.name}")
+            into("${buildDir}/react-native-bundle-source-map")
+            include("*.bundle", "*.bundle.map")
+        }
 
-                // Delete source maps
-                delete(fileTree(dir: outputDir, includes: ['**/*.bundle.map']))
-            }
+        variant.mergeAssetsProvider.configure {
+            finalizedBy("copy${variant.name.capitalize()}ReactNativeBundleSourceMap")
         }
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -718,10 +718,17 @@ if (project.hasProperty("debugStoreFile")) {
 // service during the build process.
 android {
     applicationVariants.all { variant ->
+        def variantAssets = "${buildDir}/intermediates/assets/${variant.name}"
+
+        tasks.register("delete${variant.name.capitalize()}ReactNativeBundleSourceMap", Delete) {
+            delete(fileTree(dir: variantAssets, includes: ['**/*.bundle.map']))
+        }
+
         tasks.register("copy${variant.name.capitalize()}ReactNativeBundleSourceMap", Copy) {
             from("${buildDir}/intermediates/assets/${variant.name}")
             into("${buildDir}/react-native-bundle-source-map")
             include("*.bundle", "*.bundle.map")
+            finalizedBy("delete${variant.name.capitalize()}ReactNativeBundleSourceMap")
         }
 
         variant.mergeAssetsProvider.configure {


### PR DESCRIPTION
## Description

### Problem statement
The React Native bundle source map copying operation doesn't declare input and outputs of the operation, making it out of loop for up to date or cached checks. In the result, this operation might not be executed.

### Details
Currently, to copy React Native bundle files, we use `merge<variant>Assets` task, provided by `variant.mergeAssetsProvider` in the diff. After this task is executed, we copy bundle files from the build directory to our custom `react-native-bundle-source-map`. As this custom directory is not provided as output, in case of scenarios when `merge<variant>Assets` is up-to-date or cached (e.g. build cache or incremental build), bundle files won't be copied, and in result the CI build will fail.

It happened to me when working on #20483: the changes I provided were not changing any app source code and `merge<variant>Assets` wasn't executed (it was taken from cache). In the result, [the build failed](https://buildkite.com/automattic/wordpress-android/builds/17663#018e4271-f47b-4ba1-a4a8-5a68c371292d/228-551).

Below, a fragment of [build scan](https://scans.gradle.com/s/fwg3c6fwcv7dy/timeline?details=oym3oa4wl5zxq&expanded=WyIxIl0&show=details) of the failed build. As you can see, the task was from cache and was not executed, so bundle files were not copied to `react-native-bundle-source-map`

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/b90ab756-d003-4055-9f14-ef1f45c9dd70)

### Why don't we see build failures right now and/or locally?
It's a coincidence. Sentry Gradle plugin in currently used version has a bug (fixed in https://github.com/getsentry/sentry-android-gradle-plugin/issues/653). It invalidates up-to-date checks for `merge<variant>Assets` task.

![Screenshot 2024-03-18 at 17 23 07](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/4e30f593-5aed-4354-a43b-bbc8e0c06059)

Each run, `sentry-debug-meta.properties` is different, so `merge<variant>Assets` task has to run and copy files to `react-native-bundle-source-map` directory.

## Fix
Instead of "injecting" into `merge<variant>Assets` task, I propose creating a new task that runs after it. This new task has its input and output declared, so any change in them will trigger the copy operation.

Also, the task will be executed even if `merge<variant>Assets` task is not executed (cached or up-to-date).

## How to test

### Reproduce the issue

1. On `trunk`, disable Sentry Gradle plugin, so we won't pollute our test results with incorrect behavior of running `merge<variant>Assets` every single build

<details>
<summary>Disable Sentry PATCH</summary>

```PATCH
Subject: [PATCH] fix: when copying React Native bundle source map, rely on input/output of copy task

It worked previously, as Sentry Gradle plugin was making the merge<variant>Assets run every time (breaking up to date state)
---
Index: WordPress/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/WordPress/build.gradle b/WordPress/build.gradle
--- a/WordPress/build.gradle	(revision 2f20fb63e8937fac5bf13c03bcd3eeca4d3c4fe1)
+++ b/WordPress/build.gradle	(date 1710785906769)
@@ -6,7 +6,6 @@
     id "org.jetbrains.kotlin.android"
     id "org.jetbrains.kotlin.plugin.parcelize"
     id "org.jetbrains.kotlin.plugin.allopen"
-    id "io.sentry.android.gradle"
     id "se.bjurr.violations.violation-comments-to-github-gradle-plugin"
     id "com.google.gms.google-services"
     id "com.google.dagger.hilt.android"
@@ -14,19 +13,6 @@
     id "com.google.devtools.ksp"
 }
 
-sentry {
-    tracingInstrumentation {
-        enabled = true
-        features = [io.sentry.android.gradle.extensions.InstrumentationFeature.DATABASE]
-        logcat {
-            enabled = false
-        }
-    }
-    autoInstallation {
-        enabled = false
-    }
-}
-
 repositories {
     maven {
         url "https://a8c-libs.s3.amazonaws.com/android"
```

</details>

3. Run `assembleJetpackJalapenoDebug`
4. Delete one or two generated files generated in `WordPress/build/react-native-bundle-source-map`
5. Run `assembleJetpackJalapenoDebug`
6. **Assert no new files were added** - this means there's bug

### Check the fix

Repeat all the steps as above, but on this branch. In step 5, all files should be generated each build.

If you want to check scan (adding `--scan` at the end of task), you can see reason why the copy task was performed 
![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/48cae8e3-c6c7-4be1-8040-0cae5935f71c)

what is expected.
