### PR TITLE
Stats Traffic: Remove heading on Today card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficOverviewUseCase.kt
@@ -254,7 +254,6 @@ class TrafficOverviewUseCase(
         val likes = selectedItem?.likes ?: 0
         val comments = selectedItem?.comments ?: 0
 
-        items.add(BlockListItem.Title(R.string.stats_timeframe_today))
         items.add(
             BlockListItem.QuickScanItem(
                 BlockListItem.QuickScanItem.Column(


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/jetpack-issue-repo/issues/27

| Before | After |
|--------|--------|
| ![Screenshot_20240315_091156](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/88330a1a-5b83-424e-8403-e2807ca83f19) | ![Screenshot_20240318_123710](https://github.com/wordpress-mobile/WordPress-Android/assets/990349/076eedae-9c18-4f58-a0c1-8e601a1e5c20)
| 
-----

## To Test:

- `Install` Jetpack app, and launch
- `Go` to Stats
- `Switch` to Traffic tab, if not already on it
- `Verify` Today card has no title as in after image above


-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Existing tests

3. What automated tests I added (or what prevented me from doing so)

    - Existing tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.