### PR TITLE
Add typography to theme + Fonts screen for the Design System

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemAppTypography.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemAppTypography.kt
@@ -1,0 +1,67 @@
+package org.wordpress.android.designsystem
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+/**
+ * Object containing static common typography used throughout the project.
+ */
+object DesignSystemAppTypography {
+    @Stable
+    val heading1 = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        letterSpacing = 0.sp
+    )
+    val heading2 = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp
+    )
+    val heading3 = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        letterSpacing = 0.sp
+    )
+    val heading4 = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    )
+    val bodyLargeEmphasized = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.25.sp
+    )
+    val bodyMediumEmphasized = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    )
+    val bodySmallEmphasized = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.25.sp
+    )
+    val footnote = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    val footnoteEmphasized = TextStyle(
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemDataSource.kt
@@ -8,7 +8,8 @@ object DesignSystemDataSource {
         Pair(R.string.design_system_components, DesignSystemScreen.Components.name),
     )
     val foundationScreenButtonOptions = listOf(
-        Pair(R.string.design_system_foundation_colors, DesignSystemScreen.Colors.name)
+        Pair(R.string.design_system_foundation_colors, DesignSystemScreen.Colors.name),
+        Pair(R.string.design_system_foundation_fonts, DesignSystemScreen.Fonts.name)
     )
     val componentsScreenButtonOptions = listOf(
         R.string.design_system_components_dsbutton

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -38,12 +38,12 @@ fun DesignSystemFontsScreen(
             FontCard(text = "Heading4", font = MaterialTheme.typography.heading4)
 
             FontsTitle("Body")
-            FontCard(text = "Body Large", font = MaterialTheme.typography.bodyLarge)
-            FontCard(text = "Body Large Emphasized", font = MaterialTheme.typography.bodyLargeEmphasized)
-            FontCard(text = "Body Medium", font = MaterialTheme.typography.bodyMedium)
-            FontCard(text = "Body Medium Emphasized", font = MaterialTheme.typography.bodyMediumEmphasized)
             FontCard(text = "Body Small", font = MaterialTheme.typography.bodySmall)
+            FontCard(text = "Body Medium", font = MaterialTheme.typography.bodyMedium)
+            FontCard(text = "Body Large", font = MaterialTheme.typography.bodyLarge)
             FontCard(text = "Body Small Emphasized", font = MaterialTheme.typography.bodySmallEmphasized)
+            FontCard(text = "Body Medium Emphasized", font = MaterialTheme.typography.bodyMediumEmphasized)
+            FontCard(text = "Body Large Emphasized", font = MaterialTheme.typography.bodyLargeEmphasized)
 
             FontsTitle("Miscellaneous")
             FontCard(text = "Footnote", font = MaterialTheme.typography.footnote)

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -32,8 +32,21 @@ fun DesignSystemFontsScreen(
     ) {
         item {
             FontsTitle("Heading")
+@Composable
+fun FontCard (text: String, font: TextStyle) {
+    Row (modifier = Modifier
+        .padding(10.dp, 3.dp)
+        .fillMaxWidth()) {
+        Column {
+            Text(
+                modifier = Modifier.padding(start = 25.dp, end = 40.dp),
+                style = font,
+                text = text,
+                color = MaterialTheme.colorScheme.primary,
+            )
         }
     }
+    Divider(modifier = Modifier.padding(start = 10.dp, end = 10.dp))
 }
 @Composable
 fun FontsTitle(title: String) {

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -1,0 +1,58 @@
+package org.wordpress.android.designsystem
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+
+@Composable
+fun DesignSystemFontsScreen(
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier,
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(
+            dimensionResource(id = R.dimen.reader_follow_sheet_button_margin_top)
+        )
+    ) {
+        item {
+            FontsTitle("Heading")
+        }
+    }
+}
+@Composable
+fun FontsTitle(title: String) {
+    Text(
+        modifier = Modifier.padding(start = 10.dp, top = 10.dp, bottom = 10.dp),
+        text = title,
+        style = MaterialTheme.typography.titleMedium.copy(color = MaterialTheme.colorScheme.primary),
+    )
+}
+@Preview(name = "Light Mode")
+@Preview(
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    showBackground = true,
+    name = "Dark Mode"
+)
+@Composable
+fun DesignSystemFontsScreenPreview() {
+    DesignSystemTheme {
+        DesignSystemFontsScreen()
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,7 +56,9 @@ fun DesignSystemFontsScreen(
 fun FontCard (text: String, font: TextStyle) {
     Row (modifier = Modifier
         .padding(10.dp, 3.dp)
-        .fillMaxWidth()) {
+        .defaultMinSize(minHeight = 30.dp)
+        .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically) {
         Column {
             Text(
                 modifier = Modifier.padding(start = 25.dp, end = 40.dp),

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -56,7 +56,7 @@ fun DesignSystemFontsScreen(
 fun FontCard (text: String, font: TextStyle) {
     Row (modifier = Modifier
         .padding(10.dp, 3.dp)
-        .defaultMinSize(minHeight = 30.dp)
+        .defaultMinSize(minHeight = 34.dp)
         .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically) {
         Column {

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemFontsScreen.kt
@@ -32,6 +32,25 @@ fun DesignSystemFontsScreen(
     ) {
         item {
             FontsTitle("Heading")
+            FontCard(text = "Heading1", font = MaterialTheme.typography.heading1)
+            FontCard(text = "Heading2", font = MaterialTheme.typography.heading2)
+            FontCard(text = "Heading3", font = MaterialTheme.typography.heading3)
+            FontCard(text = "Heading4", font = MaterialTheme.typography.heading4)
+
+            FontsTitle("Body")
+            FontCard(text = "Body Large", font = MaterialTheme.typography.bodyLarge)
+            FontCard(text = "Body Large Emphasized", font = MaterialTheme.typography.bodyLargeEmphasized)
+            FontCard(text = "Body Medium", font = MaterialTheme.typography.bodyMedium)
+            FontCard(text = "Body Medium Emphasized", font = MaterialTheme.typography.bodyMediumEmphasized)
+            FontCard(text = "Body Small", font = MaterialTheme.typography.bodySmall)
+            FontCard(text = "Body Small Emphasized", font = MaterialTheme.typography.bodySmallEmphasized)
+
+            FontsTitle("Miscellaneous")
+            FontCard(text = "Footnote", font = MaterialTheme.typography.footnote)
+            FontCard(text = "Footnote Emphasized", font = MaterialTheme.typography.footnoteEmphasized)
+        }
+    }
+}
 @Composable
 fun FontCard (text: String, font: TextStyle) {
     Row (modifier = Modifier

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemScreen.kt
@@ -32,7 +32,8 @@ enum class DesignSystemScreen {
     Start,
     Foundation,
     Components,
-    Colors
+    Colors,
+    Fonts
 }
 
 @Composable
@@ -66,6 +67,7 @@ private fun getTitleForRoute(route: String): String {
         "Foundation" -> "Foundation"
         "Components" -> "Components"
         "Colors" -> "Colors"
+        "Fonts" -> "Fonts"
         else -> ""
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemScreen.kt
@@ -133,6 +133,13 @@ fun DesignSystem(
                         .padding(innerPadding)
                 )
             }
+            composable(route = DesignSystemScreen.Fonts.name) {
+                DesignSystemFontsScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                )
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemTheme.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -12,8 +13,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
 private val localColors = staticCompositionLocalOf { extraPaletteLight }
+internal val localTypography = staticCompositionLocalOf { extraTypography }
 
 @Composable
 fun DesignSystemTheme(
@@ -35,14 +40,16 @@ fun DesignSystemThemeWithoutBackground(
     } else {
         extraPaletteLight
     }
-
-    CompositionLocalProvider (localColors provides extraColors) {
+    val extraTypography = extraTypography
+    CompositionLocalProvider (localColors provides extraColors, localTypography provides extraTypography) {
         MaterialTheme(
             colorScheme = if (isDarkTheme) paletteDarkScheme else paletteLightScheme,
+            typography = typography,
             content = content
         )
     }
 }
+
 private val paletteLightScheme = lightColorScheme(
     primary = DesignSystemAppColor.Black,
     primaryContainer = DesignSystemAppColor.White,
@@ -124,6 +131,27 @@ val ColorScheme.wpContainer
     @Composable
     @ReadOnlyComposable
     get() = localColors.current.wpContainer
+
+val typography = Typography(
+    bodyLarge = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodyMedium = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp
+    ),
+    bodySmall = TextStyle(
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.25.sp
+    ),
+)
 
 @Composable
 private fun ContentInSurface(

--- a/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemTheme.kt
+++ b/WordPress/src/main/java/org/wordpress/android/designsystem/DesignSystemTheme.kt
@@ -132,6 +132,77 @@ val ColorScheme.wpContainer
     @ReadOnlyComposable
     get() = localColors.current.wpContainer
 
+private val extraTypography = ExtraTypography(
+    heading1 = DesignSystemAppTypography.heading1,
+    heading2 = DesignSystemAppTypography.heading2,
+    heading3 = DesignSystemAppTypography.heading3,
+    heading4 = DesignSystemAppTypography.heading4,
+    bodyLargeEmphasized = DesignSystemAppTypography.bodyLargeEmphasized,
+    bodyMediumEmphasized = DesignSystemAppTypography.bodyMediumEmphasized,
+    bodySmallEmphasized = DesignSystemAppTypography.bodySmallEmphasized,
+    footnote = DesignSystemAppTypography.footnote,
+    footnoteEmphasized = DesignSystemAppTypography.footnoteEmphasized,
+    )
+
+data class ExtraTypography(
+    val heading1: TextStyle,
+    val heading2: TextStyle,
+    val heading3: TextStyle,
+    val heading4: TextStyle,
+    val bodyLargeEmphasized: TextStyle,
+    val bodyMediumEmphasized: TextStyle,
+    val bodySmallEmphasized: TextStyle,
+    val footnote: TextStyle,
+    val footnoteEmphasized: TextStyle,
+    )
+@Suppress("UnusedReceiverParameter")
+val Typography.heading1
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.heading1
+
+@Suppress("UnusedReceiverParameter")
+val Typography.heading2
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.heading2
+
+@Suppress("UnusedReceiverParameter")
+val Typography.heading3
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.heading3
+
+val Typography.heading4
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.heading4
+
+val Typography.bodyLargeEmphasized
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.bodyLargeEmphasized
+
+val Typography.bodyMediumEmphasized
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.bodyMediumEmphasized
+
+val Typography.bodySmallEmphasized
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.bodySmallEmphasized
+
+val Typography.footnote
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.footnote
+
+val Typography.footnoteEmphasized
+    @Composable
+    @ReadOnlyComposable
+    get() = localTypography.current.footnoteEmphasized
+
 val typography = Typography(
     bodyLarge = TextStyle(
         fontWeight = FontWeight.Normal,


### PR DESCRIPTION
Part of issue https://github.com/wordpress-mobile/WordPress-Android/issues/19802
Figma with Android definitions: LyzJJa6ANKToUswWmRrZee-fi-301_26 

This PR adds the `typography` definitions to the Design System theme as specified in the Figma above. This PR also adds in the `Fonts screen` which displays the new typography.

| New Font button option | Fonts Screen |
|------------------------|--------------|
|            <img width="234" alt="Screenshot 2024-03-18 at 10 49 59 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/d85bc8d9-a18a-4fda-bf77-caa7b444c986">            |       <img width="242" alt="Screenshot 2024-03-18 at 10 49 48 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/21c17f12-7947-46c6-9143-38253aabc869">       |

-----

## To Test:
1. Navigate to the Me tab. If you're on a debug build, you should see the Design System row.
2. Click `Foundation` -> `Fonts`.
3. Ensure you can see the theme fonts as shown in the screenshots above.
4. Check that the fonts match the specifications from the Figma.


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

6. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
