### PR TITLE
Fix dropdown menu back button content description

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -180,7 +181,7 @@ private fun CascadeColumnScope.SubMenuHeader(
                 }
                 Image(
                     painter = painterResource(backIconResource),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.reader_label_toolbar_back),
                     colorFilter = ColorFilter.tint(MenuColors.itemContentColor()),
                 )
             }


### PR DESCRIPTION
Fixes #20150

-----

## To Test:

[See the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/20150)

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
