### PR TITLE
[Reader] Fix IllegalStateException in ReaderPostListFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -745,6 +745,9 @@ public class ReaderPostListFragment extends ViewPagerFragment
     @Override
     public void onResume() {
         super.onResume();
+        if (!isAdded() || getView() == null) {
+            return;
+        }
         /*
          * This is a workaround for https://github.com/wordpress-mobile/WordPress-Android/issues/11985.
          * The RecyclerView doesn't get redrawn correctly when the adapter finishes its initialization in onStart.

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -2321,14 +2321,19 @@ public class ReaderPostListFragment extends ViewPagerFragment
         new Thread() {
             @Override
             public void run() {
-                // Check the fragment is attached to the activity when this Thread starts.
-                FragmentActivity activity = getActivity();
-                if (activity == null) {
-                    return;
-                }
                 if (ReaderTagTable.shouldAutoUpdateTag(getCurrentTag()) && isAdded()) {
+                    // Check the fragment is attached right after `shouldAutoUpdateTag`
+                    FragmentActivity activity = getActivity();
+                    if (activity == null) {
+                        return;
+                    }
                     activity.runOnUiThread(() -> updateCurrentTag());
                 } else {
+                    // Check the fragment is attached to the activity when this Thread starts.
+                    FragmentActivity activity = getActivity();
+                    if (activity == null) {
+                        return;
+                    }
                     activity.runOnUiThread(() -> {
                         if (isBookmarksList() && isPostAdapterEmpty() && isAdded()) {
                             setEmptyTitleAndDescriptionForBookmarksList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -28,6 +28,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
+import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
@@ -745,9 +746,6 @@ public class ReaderPostListFragment extends ViewPagerFragment
     @Override
     public void onResume() {
         super.onResume();
-        if (!isAdded() || getView() == null) {
-            return;
-        }
         /*
          * This is a workaround for https://github.com/wordpress-mobile/WordPress-Android/issues/11985.
          * The RecyclerView doesn't get redrawn correctly when the adapter finishes its initialization in onStart.
@@ -2323,10 +2321,15 @@ public class ReaderPostListFragment extends ViewPagerFragment
         new Thread() {
             @Override
             public void run() {
+                // Check the fragment is attached to the activity when this Thread starts.
+                FragmentActivity activity = getActivity();
+                if (activity == null) {
+                    return;
+                }
                 if (ReaderTagTable.shouldAutoUpdateTag(getCurrentTag()) && isAdded()) {
-                    requireActivity().runOnUiThread(() -> updateCurrentTag());
+                    activity.runOnUiThread(() -> updateCurrentTag());
                 } else {
-                    requireActivity().runOnUiThread(() -> {
+                    activity.runOnUiThread(() -> {
                         if (isBookmarksList() && isPostAdapterEmpty() && isAdded()) {
                             setEmptyTitleAndDescriptionForBookmarksList();
                             mActionableEmptyView.image.setImageResource(


### PR DESCRIPTION
Fixes #20228

I was unable to reproduce the problem, and the occurrences of it ([JETPACK-ANDROID-JMJ](https://a8c.sentry.io/issues/4999358916/?referrer=github_integration)) are very low. Ensuring that the Fragment is still attached to the Activity in onResume should fix the problem.

-----

## To Test:

* Smoke test the Reader.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
