### PR TITLE
Fixes dynamic dashboard cards ordering in the new MySiteViewModel Architecture

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
@@ -144,6 +144,8 @@ class DashboardCardsViewModelSlice @Inject constructor(
     ): List<MySiteCardAndItem> {
         val cards = mutableListOf<MySiteCardAndItem>()
         migrationSuccessCard?.let { cards.add(it) }
+        jpFullInstallFullPlugin?.let { cards.add(it) }
+        domainRegistrationCard?.let { cards.add(it) }
         quicklinks?.let { cards.add(it) }
         quickStart?.let { cards.add(it) }
         cardsState?.let {
@@ -151,21 +153,17 @@ class DashboardCardsViewModelSlice @Inject constructor(
                 cards.addAll(cardsState.topCards)
             }
         }
-        blazeCard?.let { cards.add(it) }
-        plansCard?.let { cards.add(it) }
-        domainRegistrationCard?.let { cards.add(it) }
         bloganuaryNudgeCard?.let { cards.add(it) }
         bloggingPromptCard?.let { cards.add(it) }
+        blazeCard?.let { cards.add(it) }
+        plansCard?.let { cards.add(it) }
         cardsState?.let {
             when (cardsState) {
-                is CardsState.Success -> cards.addAll(cardsState.cards)
+                is CardsState.Success -> {
+                    cards.addAll(cardsState.cards)
+                    cards.addAll(cardsState.bottomCards)
+                }
                 is CardsState.ErrorState -> cards.add(cardsState.error)
-            }
-        }
-        jpFullInstallFullPlugin?.let { cards.add(it) }
-        cardsState?.let {
-            if (cardsState is CardsState.Success) {
-                cards.addAll(cardsState.bottomCards)
             }
         }
         // when clearing the values of all child VM Slices,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/DashboardCardsViewModelSlice.kt
@@ -146,6 +146,11 @@ class DashboardCardsViewModelSlice @Inject constructor(
         migrationSuccessCard?.let { cards.add(it) }
         quicklinks?.let { cards.add(it) }
         quickStart?.let { cards.add(it) }
+        cardsState?.let {
+            if (cardsState is CardsState.Success) {
+                cards.addAll(cardsState.topCards)
+            }
+        }
         blazeCard?.let { cards.add(it) }
         plansCard?.let { cards.add(it) }
         domainRegistrationCard?.let { cards.add(it) }
@@ -158,6 +163,11 @@ class DashboardCardsViewModelSlice @Inject constructor(
             }
         }
         jpFullInstallFullPlugin?.let { cards.add(it) }
+        cardsState?.let {
+            if (cardsState is CardsState.Success) {
+                cards.addAll(cardsState.bottomCards)
+            }
+        }
         // when clearing the values of all child VM Slices,
         // the no cards message will still be shown and hence we need to check if the personalize card
         // is shown or not, if the personalize card is not shown, then it means that

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardViewModelSlice.kt
@@ -212,7 +212,10 @@ class CardViewModelSlice @Inject constructor(
     }
 
     private fun isUiModelEmpty(): Boolean {
-        return (uiModel.value is CardsState.Success) && (uiModel.value as CardsState.Success).cards.isEmpty()
+        return (uiModel.value is CardsState.Success)
+                && (uiModel.value as CardsState.Success).topCards.isEmpty()
+                && (uiModel.value as CardsState.Success).cards.isEmpty()
+                && (uiModel.value as CardsState.Success).bottomCards.isEmpty()
     }
 
     private fun onDashboardErrorRetry() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/CardViewModelSlice.kt
@@ -89,13 +89,11 @@ class CardViewModelSlice @Inject constructor(
         bottomDynamicCards: List<MySiteCardAndItem.Card>?
     ): CardsState {
         val cards = mutableListOf<MySiteCardAndItem.Card>()
-        topDynamicCards?.let { cards.addAll(topDynamicCards) }
         todaysStatsCard?.let { cards.add(todaysStatsCard) }
         postsCard?.let { cards.addAll(postsCard) }
         pagesCard?.let { cards.add(pagesCard) }
         activityCard?.let { cards.add(activityCard) }
-        bottomDynamicCards?.let { cards.addAll(bottomDynamicCards) }
-        return CardsState.Success(cards)
+        return CardsState.Success(topDynamicCards ?: emptyList(), cards, bottomDynamicCards ?: emptyList())
     }
 
     private val _onNavigation = MutableLiveData<Event<SiteNavigationAction>>()
@@ -224,7 +222,7 @@ class CardViewModelSlice @Inject constructor(
     fun postState(cards: List<CardModel>?) {
         _isRefreshing.postValue(false)
         if (cards.isNullOrEmpty()) {
-            uiModel.postValue(CardsState.Success(emptyList()))
+            uiModel.postValue(CardsState.Success(emptyList(), emptyList(), emptyList()))
             return
         }
         scope.launch(bgDispatcher) {
@@ -256,7 +254,7 @@ class CardViewModelSlice @Inject constructor(
     }
 
     fun clearValue() {
-        uiModel.postValue(CardsState.Success(emptyList()))
+        uiModel.postValue(CardsState.Success(emptyList(), emptyList(), emptyList()))
         collectJob?.cancel()
         fetchJob?.cancel()
         dynamicCardsViewModelSlice.clearValue()
@@ -280,6 +278,10 @@ class CardViewModelSlice @Inject constructor(
 }
 
 sealed class CardsState {
-    data class Success(val cards: List<MySiteCardAndItem.Card>) : CardsState()
+    data class Success(
+        val topCards: List<MySiteCardAndItem.Card>,
+        val cards: List<MySiteCardAndItem.Card>,
+        val bottomCards: List<MySiteCardAndItem.Card>
+    ) : CardsState()
     data class ErrorState(val error: MySiteCardAndItem) : CardsState()
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/pull/19869#pullrequestreview-1948972666

**Based on:** https://github.com/wordpress-mobile/WordPress-Android/pull/19869

## Description
Separates the dynamic cards so that they could be displayed at the top and bottom of the dashboard

-----

## To Test:

See pc8HXX-1sr-p2)

-----

## Regression Notes

1. Potential unintended areas of impact

    - Dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Relied on existing `DynamicCardsViewModelSliceTest` and `CardsViewModelSliceTest`

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)