### PR TITLE
[Reader] Use `"follow"` for tag strings instead of `"subscribe"`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -300,7 +300,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         }
 
         if (ReaderTagTable.isFollowedTagName(entry)) {
-            showInfoSnackbar(getString(R.string.reader_toast_err_tag_already_subscribed));
+            showInfoSnackbar(getString(R.string.reader_toast_err_tag_already_following));
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -561,7 +561,7 @@ public class ReaderSubsActivity extends LocaleAwareActivity
         public CharSequence getPageTitle(int position) {
             switch (position) {
                 case TAB_IDX_FOLLOWED_TAGS:
-                    return getString(R.string.reader_page_followed_tags_title);
+                    return getString(R.string.reader_page_followed_tags_text_title);
                 case TAB_IDX_FOLLOWED_BLOGS:
                     return getString(R.string.reader_page_followed_blogs_title);
                 default:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -72,7 +72,7 @@ public class ReaderTagFragment extends Fragment
         }
 
         actionableEmptyView.image.setVisibility(View.GONE);
-        actionableEmptyView.title.setText(R.string.reader_no_followed_tags_title);
+        actionableEmptyView.title.setText(R.string.reader_no_followed_tags_text_title);
         actionableEmptyView.subtitle.setText(R.string.reader_empty_subscribed_tags_subtitle);
         actionableEmptyView.subtitle.setVisibility(View.VISIBLE);
         actionableEmptyView.setVisibility(hasTagAdapter() && getTagAdapter().isEmpty() ? View.VISIBLE : View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -567,7 +567,7 @@ class ReaderDiscoverViewModel @Inject constructor(
             data class ShowNoPostsUiState(override val action: () -> Unit) : EmptyUiState() {
                 override val titleResId = R.string.reader_discover_no_posts_title
                 override val buttonResId = R.string.reader_discover_no_posts_button_tags_text_follow
-                override val subTitleRes = R.string.reader_discover_no_posts_subscribe_subtitle
+                override val subTitleRes = R.string.reader_discover_no_posts_follow_subtitle
                 override val illustrationResId = R.drawable.illustration_reader_empty
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -566,7 +566,7 @@ class ReaderDiscoverViewModel @Inject constructor(
 
             data class ShowNoPostsUiState(override val action: () -> Unit) : EmptyUiState() {
                 override val titleResId = R.string.reader_discover_no_posts_title
-                override val buttonResId = R.string.reader_discover_no_posts_button_tags_text
+                override val buttonResId = R.string.reader_discover_no_posts_button_tags_text_follow
                 override val subTitleRes = R.string.reader_discover_no_posts_subscribe_subtitle
                 override val illustrationResId = R.drawable.illustration_reader_empty
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -560,7 +560,7 @@ class ReaderDiscoverViewModel @Inject constructor(
 
             data class ShowNoFollowedTagsUiState(override val action: () -> Unit) : EmptyUiState() {
                 override val titleResId = R.string.reader_discover_empty_title
-                override val subTitleRes = R.string.reader_discover_empty_subtitle_subscribe
+                override val subTitleRes = R.string.reader_discover_empty_subtitle_follow
                 override val buttonResId = R.string.reader_discover_empty_button_text
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
@@ -80,7 +80,7 @@ class SubfilterPageViewModel @Inject constructor(
                         }
                     } else {
                         if (accountStore.hasAccessToken()) {
-                            R.string.reader_filter_empty_tags_list_text
+                            R.string.reader_filter_empty_tags_list_follow_text
                         } else {
                             R.string.reader_filter_self_hosted_empty_tags_list
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/SubfilterPageViewModel.kt
@@ -58,7 +58,7 @@ class SubfilterPageViewModel @Inject constructor(
                 )
             } else {
                 VisibleEmptyUiState.Button(
-                    text = UiStringRes(R.string.reader_filter_empty_tags_action_subscribe),
+                    text = UiStringRes(R.string.reader_filter_empty_tags_action_follow),
                     action = ActionType.OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
                 )
             }

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -74,7 +74,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_toStartOf="@+id/btn_add"
-            android:hint="@string/reader_hint_add_tag_or_url_subscribe"
+            android:hint="@string/reader_hint_add_tag_or_url_follow"
             android:minHeight="@dimen/min_touch_target_sz"
             android:paddingStart="@dimen/margin_large"
             android:paddingEnd="@dimen/margin_medium"

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -34,7 +34,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone"
-        app:aevButton="@string/reader_discover_no_posts_button_tags_text"
+        app:aevButton="@string/reader_discover_no_posts_button_tags_text_follow"
         app:aevImage="@drawable/illustration_reader_empty"
         app:aevSubtitle="@string/reader_discover_no_posts_subscribe_subtitle"
         app:aevTitle="@string/reader_discover_no_posts_title"

--- a/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_discover_fragment_layout.xml
@@ -36,7 +36,7 @@
         android:visibility="gone"
         app:aevButton="@string/reader_discover_no_posts_button_tags_text_follow"
         app:aevImage="@drawable/illustration_reader_empty"
-        app:aevSubtitle="@string/reader_discover_no_posts_subscribe_subtitle"
+        app:aevSubtitle="@string/reader_discover_no_posts_follow_subtitle"
         app:aevTitle="@string/reader_discover_no_posts_title"
         app:aevButtonStyle="reader"
         tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/subfilter_page_fragment.xml
+++ b/WordPress/src/main/res/layout/subfilter_page_fragment.xml
@@ -66,7 +66,7 @@
             android:layout_gravity="center_horizontal"
             android:minHeight="@dimen/default_dialog_button_height"
             android:visibility="visible"
-            android:text="@string/reader_filter_empty_tags_action_subscribe" />
+            android:text="@string/reader_filter_empty_tags_action_follow" />
 
     </LinearLayout>
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/subfilter_page_fragment.xml
+++ b/WordPress/src/main/res/layout/subfilter_page_fragment.xml
@@ -42,7 +42,7 @@
             android:layout_width="wrap_content"
             android:layout_gravity="center_horizontal"
             android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
-            android:text="@string/reader_filter_empty_tags_list_text"
+            android:text="@string/reader_filter_empty_tags_list_follow_text"
             app:fixWidowWords="true" />
 
         <com.google.android.material.button.MaterialButton

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -69,7 +69,6 @@ Language: ar
     <string name="reader_dropdown_menu_subscriptions">الاشتراكات</string>
     <string name="reader_dropdown_menu_discover">اكتشاف</string>
     <string name="reader_search_content_description">البحث</string>
-    <string name="reader_discover_no_posts_button_tags_text">الاشتراك في الوسوم</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">محاولة الاشتراك في مزيد من الوسوم لتوسيع نطاق البحث</string>
     <string name="reader_discover_empty_subtitle_subscribe">الاشتراك في الوسوم لاكتشاف مدونات جديدة</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">المدونات المطلوب الاشتراك فيها</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -45,7 +45,6 @@ Language: ar
     <string name="reader_label_subscribe_count">%,d من المشتركين</string>
     <string name="reader_label_blog_subscribed">تم الاشتراك في المدونة</string>
     <string name="reader_hint_search_subscribed_blogs">البحث عن المدونات التي تم الاشتراك فيها</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">إدخال عنوان URL أو وسم للاشتراك فيها</string>
     <string name="reader_btn_subscribed">مشترك</string>
     <string name="reader_btn_subscribe">اشترك</string>
     <string name="reader_menu_block_this_blog">حظر هذه المدونة</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -72,7 +72,6 @@ Language: ar
     <string name="reader_discover_no_posts_subscribe_subtitle">محاولة الاشتراك في مزيد من الوسوم لتوسيع نطاق البحث</string>
     <string name="reader_discover_empty_subtitle_subscribe">الاشتراك في الوسوم لاكتشاف مدونات جديدة</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">المدونات المطلوب الاشتراك فيها</string>
-    <string name="reader_filter_empty_tags_action_subscribe">الاشتراك في وسم</string>
     <string name="reader_filter_empty_tags_action_suggested">الوسوم المقترحة</string>
     <string name="reader_filter_empty_blogs_action_search">البحث في مدونة</string>
     <string name="reader_dropdown_menu_automattic">Automattic</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -82,7 +82,6 @@ Language: ar
     <string name="reader_filter_empty_blogs_list_text">اشترك في المدونات ضمن \"اكتشاف\" وسترى أحدث تدوينات فيها هنا. أو ابحث عن مدونة تنال إعجابك بالفعل.</string>
     <string name="reader_filter_empty_blogs_list_title">لا توجد اشتراكات في المدونة</string>
     <string name="reader_filter_empty_blogs_action">الاشتراك في المدونة</string>
-    <string name="reader_filter_empty_tags_list_subscribe">يمكنك الاشتراك في التدوينات الموجودة حول موضوع معيَّن عن طريق إضافة وسم</string>
     <string name="reader_filter_by_tag_title">التصفية حسب الوسم</string>
     <string name="reader_filter_by_blog_title">التصفية حسب المدونة</string>
     <string name="stats_timeframe_by_year">حسب العام</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -69,7 +69,6 @@ Language: ar
     <string name="reader_dropdown_menu_subscriptions">الاشتراكات</string>
     <string name="reader_dropdown_menu_discover">اكتشاف</string>
     <string name="reader_search_content_description">البحث</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">محاولة الاشتراك في مزيد من الوسوم لتوسيع نطاق البحث</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">المدونات المطلوب الاشتراك فيها</string>
     <string name="reader_filter_empty_tags_action_suggested">الوسوم المقترحة</string>
     <string name="reader_filter_empty_blogs_action_search">البحث في مدونة</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -51,7 +51,6 @@ Language: ar
     <string name="reader_menu_block_this_blog">حظر هذه المدونة</string>
     <string name="reader_menu_tags_and_blogs">تحرير الوسوم والمدونات</string>
     <string name="reader_page_followed_blogs_title">المدونات التي تم الاشتراك فيها</string>
-    <string name="reader_page_followed_tags_title">الوسوم التي تم الاشتراك فيها</string>
     <string name="reader_title_tags">اتباع الوسوم</string>
     <string name="reader_activity_title_manage_tags_blogs">إدارة الوسوم والمدونات</string>
     <string name="reader_activity_title_tag_preview">الوسم</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -70,7 +70,6 @@ Language: ar
     <string name="reader_dropdown_menu_discover">اكتشاف</string>
     <string name="reader_search_content_description">البحث</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">محاولة الاشتراك في مزيد من الوسوم لتوسيع نطاق البحث</string>
-    <string name="reader_discover_empty_subtitle_subscribe">الاشتراك في الوسوم لاكتشاف مدونات جديدة</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">المدونات المطلوب الاشتراك فيها</string>
     <string name="reader_filter_empty_tags_action_suggested">الوسوم المقترحة</string>
     <string name="reader_filter_empty_blogs_action_search">البحث في مدونة</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -28,7 +28,6 @@ Language: ar
     <string name="reader_empty_followed_blogs_button_subscriptions">الانتقال إلى الاشتراكات</string>
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">لم تنشر المدونات التي اشتركتَ فيها أي شيء مؤخرًا</string>
     <string name="reader_no_followed_blogs_description_subs">اشترك في المدونات ضمن \"اكتشاف\" أو ابحث عن مدونة تنال إعجابك بالفعل.</string>
-    <string name="reader_no_followed_tags_title">لا توجد وسوم تم الاشتراك فيها</string>
     <string name="reader_no_posts_with_this_tag">لا توجد تدوينات تحمل هذا الوسم</string>
     <string name="reader_toast_err_unable_to_block_blog">يتعذر حظر هذه المدونة</string>
     <string name="reader_toast_posts_from_this_blog_blocked">لن تظهر التدوينات الواردة من هذه المدونة بعد الآن</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -75,7 +75,6 @@ Language: ar
     <string name="reader_filter_empty_tags_action_subscribe">الاشتراك في وسم</string>
     <string name="reader_filter_empty_tags_action_suggested">الوسوم المقترحة</string>
     <string name="reader_filter_empty_blogs_action_search">البحث في مدونة</string>
-    <string name="reader_filter_empty_tags_list_text">اشترك في وسم وستتمكن من الاطلاع على أفضل التدوينات الواردة منه هنا.</string>
     <string name="reader_dropdown_menu_automattic">Automattic</string>
     <string name="reader_filter_empty_tags_list_title">لا توجد وسوم</string>
     <string name="reader_filter_empty_blogs_list_text">اشترك في المدونات ضمن \"اكتشاف\" وسترى أحدث تدوينات فيها هنا. أو ابحث عن مدونة تنال إعجابك بالفعل.</string>

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -38,7 +38,6 @@ Language: ar
     <string name="reader_no_recommended_blogs_title">لا توجد مدونات موصى بها</string>
     <string name="reader_toast_err_already_follow_this_blog">لقد اشتركت في هذه المدونة بالفعل</string>
     <string name="reader_toast_err_show_blog">يتعذر إظهار هذه المدونة</string>
-    <string name="reader_toast_err_tag_already_subscribed">أنت مشترك بالفعل في هذه المدونة</string>
     <string name="reader_label_choose_interests">اختيار اهتماماتك</string>
     <string name="reader_label_subscribers_count_single">مشترك واحد</string>
     <string name="reader_label_subscribers_count">%s من المشتركين</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -73,7 +73,6 @@ Language: de
     <string name="reader_discover_no_posts_subscribe_subtitle">Versuche, mehr Schlagwörter zu abonnieren, um die Suche zu erweitern</string>
     <string name="reader_discover_empty_subtitle_subscribe">Abonniere Schlagwörter, um neue Blogs zu entdecken</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs, die du abonnieren kannst</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Ein Schlagwort abonnieren</string>
     <string name="reader_filter_empty_tags_action_suggested">Vorgeschlagene Schlagwörter</string>
     <string name="reader_filter_empty_blogs_action_search">Suche nach einem Blog</string>
     <string name="reader_filter_empty_tags_list_title">Keine Schlagwörter</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -51,7 +51,6 @@ Language: de
     <string name="reader_menu_block_this_blog">Dieses Blog blockieren</string>
     <string name="reader_menu_tags_and_blogs">Schlagwörter und Blogs bearbeiten</string>
     <string name="reader_page_followed_blogs_title">Abonnierte Blogs</string>
-    <string name="reader_page_followed_tags_title">Abonnierte Schlagwörter</string>
     <string name="reader_title_tags">Schlagwörtern folgen</string>
     <string name="reader_activity_title_manage_tags_blogs">Schlagwörter und Blogs verwalten</string>
     <string name="reader_activity_title_tag_preview">Schlagwort</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -76,7 +76,6 @@ Language: de
     <string name="reader_filter_empty_tags_action_subscribe">Ein Schlagwort abonnieren</string>
     <string name="reader_filter_empty_tags_action_suggested">Vorgeschlagene Schlagwörter</string>
     <string name="reader_filter_empty_blogs_action_search">Suche nach einem Blog</string>
-    <string name="reader_filter_empty_tags_list_text">Abonniere ein Schlagwort und du siehst hier die besten Beiträge dazu.</string>
     <string name="reader_filter_empty_tags_list_title">Keine Schlagwörter</string>
     <string name="reader_filter_empty_blogs_list_text">Abonniere Blogs in Entdecken und die neuesten Beiträge werden hier angezeigt. Oder suche nach einem Blog, den du bereits magst.</string>
     <string name="reader_filter_empty_blogs_list_title">Keine Blog-Abonnements</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -70,7 +70,6 @@ Language: de
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Entdecken</string>
     <string name="reader_search_content_description">Suche</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Versuche, mehr Schlagwörter zu abonnieren, um die Suche zu erweitern</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs, die du abonnieren kannst</string>
     <string name="reader_filter_empty_tags_action_suggested">Vorgeschlagene Schlagwörter</string>
     <string name="reader_filter_empty_blogs_action_search">Suche nach einem Blog</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -82,7 +82,6 @@ Language: de
     <string name="reader_filter_empty_blogs_list_text">Abonniere Blogs in Entdecken und die neuesten Beiträge werden hier angezeigt. Oder suche nach einem Blog, den du bereits magst.</string>
     <string name="reader_filter_empty_blogs_list_title">Keine Blog-Abonnements</string>
     <string name="reader_filter_empty_blogs_action">Einen Blog abonnieren</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Du kannst Beiträge zu einem bestimmten Thema abonnieren, indem du ein Schlagwort hinzufügst</string>
     <string name="reader_filter_empty_blogs_list">Sieh dir die neuesten Beiträge der Blogs an, die du abonniert hast</string>
     <string name="reader_filter_by_tag_title">Nach Schlagwort filtern</string>
     <string name="reader_filter_by_blog_title">Nach Blog filtern</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -70,7 +70,6 @@ Language: de
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Entdecken</string>
     <string name="reader_search_content_description">Suche</string>
-    <string name="reader_discover_no_posts_button_tags_text">Schlagwörter abonnieren</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Versuche, mehr Schlagwörter zu abonnieren, um die Suche zu erweitern</string>
     <string name="reader_discover_empty_subtitle_subscribe">Abonniere Schlagwörter, um neue Blogs zu entdecken</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs, die du abonnieren kannst</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -45,7 +45,6 @@ Language: de
     <string name="reader_label_subscribe_count">%,d Abonnenten</string>
     <string name="reader_label_blog_subscribed">Blog abonniert</string>
     <string name="reader_hint_search_subscribed_blogs">Suche in abonnierten Blogs</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Gib eine URL oder ein Schlagwort ein, das du abonnieren möchtest</string>
     <string name="reader_btn_subscribed">Abonniert</string>
     <string name="reader_btn_subscribe">Abonnieren</string>
     <string name="reader_menu_block_this_blog">Dieses Blog blockieren</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -38,7 +38,6 @@ Language: de
     <string name="reader_toast_err_unable_to_follow_blog">Dieser Blog kann nicht abonniert werden</string>
     <string name="reader_toast_err_already_follow_this_blog">Du hast diesen Blog bereits abonniert</string>
     <string name="reader_toast_err_show_blog">Dieser Blog kann nicht angezeigt werden</string>
-    <string name="reader_toast_err_tag_already_subscribed">Du hast dieses Schlagwort bereits abonniert</string>
     <string name="reader_label_choose_interests">Wähle deine Interessengebiete</string>
     <string name="reader_label_subscribers_count_single">1 Abonnent</string>
     <string name="reader_label_subscribers_count">%s Abonnenten</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -29,7 +29,6 @@ Language: de
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Die Blogs, die du abonniert hast, haben in letzter Zeit nichts veröffentlicht</string>
     <string name="reader_no_followed_blogs_description_subs">Abonniere Blogs in Entdecken oder suche nach einem Blog, den du bereits magst.</string>
     <string name="reader_no_recommended_blogs_title">Keine empfohlenen Blogs</string>
-    <string name="reader_no_followed_tags_title">Keine abonnierten Schlagwörter</string>
     <string name="reader_no_posts_with_this_tag">Keine Beiträge mit diesem Schlagwort</string>
     <string name="reader_toast_err_unable_to_block_blog">Dieser Blog kann nicht blockiert werden</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Beiträge aus diesem Blog werden nicht mehr angezeigt</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -71,7 +71,6 @@ Language: de
     <string name="reader_dropdown_menu_discover">Entdecken</string>
     <string name="reader_search_content_description">Suche</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Versuche, mehr Schlagwörter zu abonnieren, um die Suche zu erweitern</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Abonniere Schlagwörter, um neue Blogs zu entdecken</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs, die du abonnieren kannst</string>
     <string name="reader_filter_empty_tags_action_suggested">Vorgeschlagene Schlagwörter</string>
     <string name="reader_filter_empty_blogs_action_search">Suche nach einem Blog</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -57,7 +57,6 @@ Language: en_CA
     <string name="reader_page_followed_tags_title">Subscribed tags</string>
     <string name="reader_subscribed_display_name">Subscribed</string>
     <string name="reader_title_tags">Follow tags</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to subscribe to</string>
     <string name="reader_dropdown_menu_automattic">Automattic</string>
     <string name="reader_dropdown_menu_discover">Discover</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -28,7 +28,6 @@ Language: en_CA
     <string name="site_monitoring_tab_title_metrics">Metrics</string>
     <string name="site_monitoring_tab_title_php_logs">PHP Logs</string>
     <string name="site_monitoring_tab_title_web_server_logs">Web Server Logs</string>
-    <string name="reader_no_followed_tags_title">No subscribed tags</string>
     <string name="reader_no_posts_with_this_tag">No posts with this tag</string>
     <string name="reader_no_recommended_blogs_title">No recommended blogs</string>
     <string name="reader_toast_err_follow_not_authorized_to_access_blog">You are not authorized to access this blog</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -75,7 +75,6 @@ Language: en_CA
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
-    <string name="reader_filter_empty_tags_list_text">Subscribe to a tag and you’ll be able to see the best posts from it here.</string>
     <string name="reader_search_content_description">Search</string>
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>
     <string name="reader_filter_empty_tags_list_title">No tags</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -40,7 +40,6 @@ Language: en_CA
     <string name="reader_label_subscribers_count_single">1 subscriber</string>
     <string name="reader_toast_err_already_follow_this_blog">You are already subscribed to this blog</string>
     <string name="reader_toast_err_show_blog">Unable to show this blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">You\'re already subscribed to this tag</string>
     <string name="reader_activity_title_blog_preview">Reader Blog</string>
     <string name="reader_activity_title_manage_tags_blogs">Manage Tags &amp; Blogs</string>
     <string name="reader_activity_title_tag_preview">Tag</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -58,7 +58,6 @@ Language: en_CA
     <string name="reader_subscribed_display_name">Subscribed</string>
     <string name="reader_title_tags">Follow tags</string>
     <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
-    <string name="reader_discover_no_posts_button_tags_text">Subscribe to tags</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to subscribe to</string>
     <string name="reader_dropdown_menu_automattic">Automattic</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -85,7 +85,6 @@ Language: en_CA
     <string name="reader_filter_empty_blogs_action">Subscribe to a blog</string>
     <string name="reader_filter_empty_blogs_list">See the newest posts from blogs you\'re subscribed to</string>
     <string name="reader_filter_empty_blogs_list_title">No blog subscriptions</string>
-    <string name="reader_filter_empty_tags_list_subscribe">You can subscribe to posts on a specific subject by adding a tag</string>
     <string name="stats_timeframe_by_day">By day</string>
     <string name="stats_timeframe_by_month">By month</string>
     <string name="stats_timeframe_by_week">By week</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -46,7 +46,6 @@ Language: en_CA
     <string name="reader_activity_title_tag_preview">Tag</string>
     <string name="reader_btn_subscribe">Subscribe</string>
     <string name="reader_btn_subscribed">Subscribed</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Enter a URL or tag to subscribe to</string>
     <string name="reader_hint_search_subscribed_blogs">Search subscribed blogs</string>
     <string name="reader_label_blog_subscribed">Blog subscribed</string>
     <string name="reader_label_subscribe_count">%,d Subscribers</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -73,7 +73,6 @@ Language: en_CA
     <string name="reader_filter_chip_tag_other">%d Tags</string>
     <string name="reader_filter_chip_tag_zero">0 Tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_search_content_description">Search</string>
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -54,7 +54,6 @@ Language: en_CA
     <string name="reader_menu_block_this_blog">Block this blog</string>
     <string name="reader_menu_tags_and_blogs">Edit tags and blogs</string>
     <string name="reader_page_followed_blogs_title">Subscribed blogs</string>
-    <string name="reader_page_followed_tags_title">Subscribed tags</string>
     <string name="reader_subscribed_display_name">Subscribed</string>
     <string name="reader_title_tags">Follow tags</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to subscribe to</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -57,7 +57,6 @@ Language: en_CA
     <string name="reader_page_followed_tags_title">Subscribed tags</string>
     <string name="reader_subscribed_display_name">Subscribed</string>
     <string name="reader_title_tags">Follow tags</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to subscribe to</string>
     <string name="reader_dropdown_menu_automattic">Automattic</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -70,7 +70,6 @@ Language: en_GB
     <string name="reader_dropdown_menu_subscriptions">Subscriptions</string>
     <string name="reader_dropdown_menu_discover">Discover</string>
     <string name="reader_search_content_description">Search</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to which to subscribe</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -38,7 +38,6 @@ Language: en_GB
     <string name="reader_toast_err_unable_to_follow_blog">Unable to subscribe to this blog</string>
     <string name="reader_toast_err_already_follow_this_blog">You are already subscribed to this blog</string>
     <string name="reader_toast_err_show_blog">Unable to show this blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">You\'re already subscribed to this tag</string>
     <string name="reader_label_choose_interests">Choose your interests</string>
     <string name="reader_label_subscribers_count_single">1 subscriber</string>
     <string name="reader_label_subscribers_count">%s subscribers</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -73,7 +73,6 @@ Language: en_GB
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to which to subscribe</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_list_title">No tags</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -45,7 +45,6 @@ Language: en_GB
     <string name="reader_label_subscribe_count">%,d subscribers</string>
     <string name="reader_label_blog_subscribed">Blog subscribed</string>
     <string name="reader_hint_search_subscribed_blogs">Search subscribed blogs</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Enter a URL or tag to which to subscribe</string>
     <string name="reader_btn_subscribed">Subscribed</string>
     <string name="reader_btn_subscribe">Subscribe</string>
     <string name="reader_menu_block_this_blog">Block this blog</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -29,7 +29,6 @@ Language: en_GB
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">The blogs you\'re subscribed to haven\'t posted anything recently</string>
     <string name="reader_no_followed_blogs_description_subs">Subscribe to blogs in Discover or search for a blog that you like already.</string>
     <string name="reader_no_recommended_blogs_title">No recommended blogs</string>
-    <string name="reader_no_followed_tags_title">No subscribed tags</string>
     <string name="reader_no_posts_with_this_tag">No posts with this tag</string>
     <string name="reader_toast_err_unable_to_block_blog">Unable to block this blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Posts from this blog will no longer be shown</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -82,7 +82,6 @@ Language: en_GB
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>
     <string name="reader_filter_empty_blogs_list_title">No blog subscriptions</string>
     <string name="reader_filter_empty_blogs_action">Subscribe to a blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">You can subscribe to posts on a specific subject by adding a tag</string>
     <string name="reader_filter_empty_blogs_list">See the newest posts from blogs to which you\'re subscribed</string>
     <string name="reader_filter_by_tag_title">Filter by tag</string>
     <string name="reader_filter_by_blog_title">Filter by blog</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -70,7 +70,6 @@ Language: en_GB
     <string name="reader_dropdown_menu_subscriptions">Subscriptions</string>
     <string name="reader_dropdown_menu_discover">Discover</string>
     <string name="reader_search_content_description">Search</string>
-    <string name="reader_discover_no_posts_button_tags_text">Subscribe to tags</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to which to subscribe</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -71,7 +71,6 @@ Language: en_GB
     <string name="reader_dropdown_menu_discover">Discover</string>
     <string name="reader_search_content_description">Search</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs to which to subscribe</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -51,7 +51,6 @@ Language: en_GB
     <string name="reader_menu_block_this_blog">Block this blog</string>
     <string name="reader_menu_tags_and_blogs">Edit tags and blogs</string>
     <string name="reader_page_followed_blogs_title">Subscribed blogs</string>
-    <string name="reader_page_followed_tags_title">Subscribed tags</string>
     <string name="reader_title_tags">Follow tags</string>
     <string name="reader_activity_title_manage_tags_blogs">Manage Tags and Blogs</string>
     <string name="reader_activity_title_tag_preview">Tag</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -76,7 +76,6 @@ Language: en_GB
     <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
-    <string name="reader_filter_empty_tags_list_text">Subscribe to a tag and you’ll be able to see the best posts from it here.</string>
     <string name="reader_filter_empty_tags_list_title">No tags</string>
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>
     <string name="reader_filter_empty_blogs_list_title">No blog subscriptions</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -29,7 +29,6 @@ Language: es_CO
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Los blogs a los que estás suscrito no han publicado nada recientemente</string>
     <string name="reader_no_followed_blogs_description_subs">Suscríbete a blogs en Descubrir o busca un blog que ya te guste.</string>
     <string name="reader_no_recommended_blogs_title">No hay blogs recomendados</string>
-    <string name="reader_no_followed_tags_title">No hay suscripciones a etiquetas</string>
     <string name="reader_no_posts_with_this_tag">No hay entradas con esta etiqueta</string>
     <string name="reader_toast_err_unable_to_block_blog">No ha sido posible bloquear este blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Las entradas de este blog ya no se mostrarán</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -76,7 +76,6 @@ Language: es_CO
     <string name="reader_filter_empty_tags_action_subscribe">Suscribirse a una etiqueta</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Suscríbete a una etiqueta y podrás ve las mejores publicaciones asociadas a ella.</string>
     <string name="reader_filter_empty_tags_list_title">Sin etiquetas</string>
     <string name="reader_filter_empty_blogs_list_text">Suscríbete a blogs en Descubrir y verás sus últimas publicaciones aquí. O busca un blog que ya te guste.</string>
     <string name="reader_filter_empty_blogs_list_title">No hay suscripciones al blog</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -70,7 +70,6 @@ Language: es_CO
     <string name="reader_dropdown_menu_subscriptions">Suscripciones</string>
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -45,7 +45,6 @@ Language: es_CO
     <string name="reader_label_subscribe_count">%,d suscriptores</string>
     <string name="reader_label_blog_subscribed">Blog suscrito</string>
     <string name="reader_hint_search_subscribed_blogs">Buscar blogs suscritos</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Introduce una URL o etiqueta a la que suscribirte</string>
     <string name="reader_btn_subscribed">Suscrito</string>
     <string name="reader_btn_subscribe">Suscribirse</string>
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -70,7 +70,6 @@ Language: es_CO
     <string name="reader_dropdown_menu_subscriptions">Suscripciones</string>
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
-    <string name="reader_discover_no_posts_button_tags_text">Suscribirse a etiquetas</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -51,7 +51,6 @@ Language: es_CO
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>
     <string name="reader_menu_tags_and_blogs">Editar etiquetas y blogs</string>
     <string name="reader_page_followed_blogs_title">Blogs suscritos</string>
-    <string name="reader_page_followed_tags_title">Etiquetas suscritas</string>
     <string name="reader_title_tags">Seguir etiquetas</string>
     <string name="reader_activity_title_manage_tags_blogs">Gestionar etiquetas y blogs</string>
     <string name="reader_activity_title_tag_preview">Etiqueta</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -73,7 +73,6 @@ Language: es_CO
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Suscribirse a una etiqueta</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
     <string name="reader_filter_empty_tags_list_title">Sin etiquetas</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -82,7 +82,6 @@ Language: es_CO
     <string name="reader_filter_empty_blogs_list_text">Suscríbete a blogs en Descubrir y verás sus últimas publicaciones aquí. O busca un blog que ya te guste.</string>
     <string name="reader_filter_empty_blogs_list_title">No hay suscripciones al blog</string>
     <string name="reader_filter_empty_blogs_action">Suscríbete a un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Puedes suscribirte a publicaciones sobre un tema específico añadiendo una etiqueta</string>
     <string name="reader_filter_empty_blogs_list">Ver las últimas entradas de los blogs a los que estás suscrito</string>
     <string name="reader_filter_by_tag_title">Filtrar por etiqueta</string>
     <string name="reader_filter_by_blog_title">Filtrar por blog</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -38,7 +38,6 @@ Language: es_CO
     <string name="reader_toast_err_unable_to_follow_blog">No es posible suscribirse a este blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Ya estás suscrito a este blog.</string>
     <string name="reader_toast_err_show_blog">No se puede mostrar este blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Ya estás suscrito a esta etiqueta</string>
     <string name="reader_label_choose_interests">Elige tus intereses</string>
     <string name="reader_label_subscribers_count_single">1 suscriptor</string>
     <string name="reader_label_subscribers_count">%s suscriptores</string>

--- a/WordPress/src/main/res/values-es-rCO/strings.xml
+++ b/WordPress/src/main/res/values-es-rCO/strings.xml
@@ -71,7 +71,6 @@ Language: es_CO
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@ Language: es
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Los blogs a los que estás suscrito no han publicado nada recientemente</string>
     <string name="reader_no_followed_blogs_description_subs">Suscríbete a blogs en Descubrir o busca un blog que ya te guste.</string>
     <string name="reader_no_recommended_blogs_title">No hay blogs recomendados</string>
-    <string name="reader_no_followed_tags_title">No hay suscripciones a etiquetas</string>
     <string name="reader_no_posts_with_this_tag">No hay entradas con esta etiqueta</string>
     <string name="reader_toast_err_unable_to_block_blog">No ha sido posible bloquear este blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Las entradas de este blog ya no se mostrarán</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -71,7 +71,6 @@ Language: es
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -70,7 +70,6 @@ Language: es
     <string name="reader_dropdown_menu_subscriptions">Suscripciones</string>
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -82,7 +82,6 @@ Language: es
     <string name="reader_filter_empty_blogs_list_text">Suscríbete a blogs en Descubrir y verás sus últimas publicaciones aquí. O busca un blog que ya te guste.</string>
     <string name="reader_filter_empty_blogs_list_title">No hay suscripciones al blog</string>
     <string name="reader_filter_empty_blogs_action">Suscríbete a un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Puedes suscribirte a publicaciones sobre un tema específico añadiendo una etiqueta</string>
     <string name="reader_filter_empty_blogs_list">Ver las últimas entradas de los blogs a los que estás suscrito</string>
     <string name="reader_filter_by_tag_title">Filtrar por etiqueta</string>
     <string name="reader_filter_by_blog_title">Filtrar por blog</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -38,7 +38,6 @@ Language: es
     <string name="reader_toast_err_unable_to_follow_blog">No es posible suscribirse a este blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Ya estás suscrito a este blog.</string>
     <string name="reader_toast_err_show_blog">No se puede mostrar este blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Ya estás suscrito a esta etiqueta</string>
     <string name="reader_label_choose_interests">Elige tus intereses</string>
     <string name="reader_label_subscribers_count_single">1 suscriptor</string>
     <string name="reader_label_subscribers_count">%s suscriptores</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -45,7 +45,6 @@ Language: es
     <string name="reader_label_subscribe_count">%,d suscriptores</string>
     <string name="reader_label_blog_subscribed">Blog suscrito</string>
     <string name="reader_hint_search_subscribed_blogs">Buscar blogs suscritos</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Introduce una URL o etiqueta a la que suscribirte</string>
     <string name="reader_btn_subscribed">Suscrito</string>
     <string name="reader_btn_subscribe">Suscribirse</string>
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -51,7 +51,6 @@ Language: es
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>
     <string name="reader_menu_tags_and_blogs">Editar etiquetas y blogs</string>
     <string name="reader_page_followed_blogs_title">Blogs suscritos</string>
-    <string name="reader_page_followed_tags_title">Etiquetas suscritas</string>
     <string name="reader_title_tags">Seguir etiquetas</string>
     <string name="reader_activity_title_manage_tags_blogs">Gestionar etiquetas y blogs</string>
     <string name="reader_activity_title_tag_preview">Etiqueta</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -70,7 +70,6 @@ Language: es
     <string name="reader_dropdown_menu_subscriptions">Suscripciones</string>
     <string name="reader_dropdown_menu_discover">Descubrir</string>
     <string name="reader_search_content_description">Buscar</string>
-    <string name="reader_discover_no_posts_button_tags_text">Suscribirse a etiquetas</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -73,7 +73,6 @@ Language: es
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta suscribirte a más etiquetas para ampliar la búsqueda</string>
     <string name="reader_discover_empty_subtitle_subscribe">Suscríbete a etiquetas para descubrir nuevos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs a los que suscribirse</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Suscribirse a una etiqueta</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
     <string name="reader_filter_empty_tags_list_title">Sin etiquetas</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -76,7 +76,6 @@ Language: es
     <string name="reader_filter_empty_tags_action_subscribe">Suscribirse a una etiqueta</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Suscríbete a una etiqueta y podrás ve las mejores publicaciones asociadas a ella.</string>
     <string name="reader_filter_empty_tags_list_title">Sin etiquetas</string>
     <string name="reader_filter_empty_blogs_list_text">Suscríbete a blogs en Descubrir y verás sus últimas publicaciones aquí. O busca un blog que ya te guste.</string>
     <string name="reader_filter_empty_blogs_list_title">No hay suscripciones al blog</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -72,7 +72,6 @@ Language: fr
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
-    <string name="reader_filter_empty_tags_action_subscribe">S’abonner à une étiquette</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>
     <string name="reader_filter_empty_tags_list_title">Aucune étiquette</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -38,7 +38,6 @@ Language: fr
     <string name="reader_toast_err_unable_to_follow_blog">Impossible de s’abonner à ce blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Ce blog fait déjà partie de vos abonnements</string>
     <string name="reader_toast_err_show_blog">Impossible d’afficher ce blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Cette étiquette fait déjà partie de vos abonnements</string>
     <string name="reader_label_choose_interests">Choisissez vos centres d’intérêt</string>
     <string name="reader_label_subscribers_count_single">1 abonné</string>
     <string name="reader_label_subscribers_count">%s abonnés</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -45,7 +45,6 @@ Language: fr
     <string name="reader_label_subscribe_count">%,d abonnés</string>
     <string name="reader_label_blog_subscribed">Abonné(e) au blog</string>
     <string name="reader_hint_search_subscribed_blogs">Rechercher parmi les blogs auxquels vous êtes abonné(e)</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Saisir l’URL ou une étiquette auxquels s’abonner</string>
     <string name="reader_btn_subscribed">Abonné(e)</string>
     <string name="reader_btn_subscribe">S’abonner</string>
     <string name="reader_menu_block_this_blog">Bloquer ce blog</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -70,7 +70,6 @@ Language: fr
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
-    <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -69,7 +69,6 @@ Language: fr
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -69,7 +69,6 @@ Language: fr
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
-    <string name="reader_discover_no_posts_button_tags_text">S’abonner aux étiquettes</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -51,7 +51,6 @@ Language: fr
     <string name="reader_menu_block_this_blog">Bloquer ce blog</string>
     <string name="reader_menu_tags_and_blogs">Modifier les étiquettes et les blogs</string>
     <string name="reader_page_followed_blogs_title">Abonné(e) à ces blogs</string>
-    <string name="reader_page_followed_tags_title">Abonné(e) à ces étiquettes</string>
     <string name="reader_title_tags">Suivre les étiquettes</string>
     <string name="reader_activity_title_manage_tags_blogs">Gérer les étiquettes et les blogs</string>
     <string name="reader_activity_title_tag_preview">Étiquette</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -75,7 +75,6 @@ Language: fr
     <string name="reader_filter_empty_tags_action_subscribe">S’abonner à une étiquette</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Abonnez-vous à une étiquette et vous verrez les meilleurs articles sur le sujet apparaître ici.</string>
     <string name="reader_filter_empty_tags_list_title">Aucune étiquette</string>
     <string name="reader_filter_empty_blogs_list_text">Abonnez-vous à des blogs dans Découvrir et vous verrez apparaître ici leurs derniers articles. Ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_filter_empty_blogs_list_title">Aucun abonnement à un blog</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -29,7 +29,6 @@ Language: fr
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Les blogs auxquels vous êtes abonné(e) n’ont rien publié récemment</string>
     <string name="reader_no_followed_blogs_description_subs">Abonnez-vous à des blogs dans Découvrir ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_no_recommended_blogs_title">Aucun blog recommandé</string>
-    <string name="reader_no_followed_tags_title">Aucune étiquette dans vos abonnements</string>
     <string name="reader_no_posts_with_this_tag">Pas d’articles avec cette étiquette</string>
     <string name="reader_toast_err_unable_to_block_blog">Impossible de bloquer ce blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Les articles de ce blog ne seront plus affichés</string>

--- a/WordPress/src/main/res/values-fr-rCA/strings.xml
+++ b/WordPress/src/main/res/values-fr-rCA/strings.xml
@@ -81,7 +81,6 @@ Language: fr
     <string name="reader_filter_empty_blogs_list_text">Abonnez-vous à des blogs dans Découvrir et vous verrez apparaître ici leurs derniers articles. Ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_filter_empty_blogs_list_title">Aucun abonnement à un blog</string>
     <string name="reader_filter_empty_blogs_action">S’abonner à un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Vous pouvez vous abonner aux articles relatifs à un sujet particulier en ajoutant une étiquette</string>
     <string name="reader_filter_empty_blogs_list">Voir les articles les plus récents des blogs auxquels vous êtes abonné(e)</string>
     <string name="reader_filter_by_tag_title">Filtrer par étiquette</string>
     <string name="reader_filter_by_blog_title">Filtrer par blog</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -72,7 +72,6 @@ Language: fr
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
-    <string name="reader_filter_empty_tags_action_subscribe">S’abonner à une étiquette</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>
     <string name="reader_filter_empty_tags_list_title">Aucune étiquette</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -38,7 +38,6 @@ Language: fr
     <string name="reader_toast_err_unable_to_follow_blog">Impossible de s’abonner à ce blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Ce blog fait déjà partie de vos abonnements</string>
     <string name="reader_toast_err_show_blog">Impossible d’afficher ce blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Cette étiquette fait déjà partie de vos abonnements</string>
     <string name="reader_label_choose_interests">Choisissez vos centres d’intérêt</string>
     <string name="reader_label_subscribers_count_single">1 abonné</string>
     <string name="reader_label_subscribers_count">%s abonnés</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -45,7 +45,6 @@ Language: fr
     <string name="reader_label_subscribe_count">%,d abonnés</string>
     <string name="reader_label_blog_subscribed">Abonné(e) au blog</string>
     <string name="reader_hint_search_subscribed_blogs">Rechercher parmi les blogs auxquels vous êtes abonné(e)</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Saisir l’URL ou une étiquette auxquels s’abonner</string>
     <string name="reader_btn_subscribed">Abonné(e)</string>
     <string name="reader_btn_subscribe">S’abonner</string>
     <string name="reader_menu_block_this_blog">Bloquer ce blog</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -70,7 +70,6 @@ Language: fr
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
-    <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -69,7 +69,6 @@ Language: fr
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -69,7 +69,6 @@ Language: fr
     <string name="reader_dropdown_menu_subscriptions">Abonnements</string>
     <string name="reader_dropdown_menu_discover">Découvrir</string>
     <string name="reader_search_content_description">Rechercher</string>
-    <string name="reader_discover_no_posts_button_tags_text">S’abonner aux étiquettes</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Essayer de s’abonner à d’autres étiquettes pour élargir la recherche</string>
     <string name="reader_discover_empty_subtitle_subscribe">S’abonner à des étiquettes pour découvrir de nouveaux blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs auxquels s’abonner</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -51,7 +51,6 @@ Language: fr
     <string name="reader_menu_block_this_blog">Bloquer ce blog</string>
     <string name="reader_menu_tags_and_blogs">Modifier les étiquettes et les blogs</string>
     <string name="reader_page_followed_blogs_title">Abonné(e) à ces blogs</string>
-    <string name="reader_page_followed_tags_title">Abonné(e) à ces étiquettes</string>
     <string name="reader_title_tags">Suivre les étiquettes</string>
     <string name="reader_activity_title_manage_tags_blogs">Gérer les étiquettes et les blogs</string>
     <string name="reader_activity_title_tag_preview">Étiquette</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -75,7 +75,6 @@ Language: fr
     <string name="reader_filter_empty_tags_action_subscribe">S’abonner à une étiquette</string>
     <string name="reader_filter_empty_tags_action_suggested">Étiquettes suggérées</string>
     <string name="reader_filter_empty_blogs_action_search">Chercher un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Abonnez-vous à une étiquette et vous verrez les meilleurs articles sur le sujet apparaître ici.</string>
     <string name="reader_filter_empty_tags_list_title">Aucune étiquette</string>
     <string name="reader_filter_empty_blogs_list_text">Abonnez-vous à des blogs dans Découvrir et vous verrez apparaître ici leurs derniers articles. Ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_filter_empty_blogs_list_title">Aucun abonnement à un blog</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -29,7 +29,6 @@ Language: fr
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Les blogs auxquels vous êtes abonné(e) n’ont rien publié récemment</string>
     <string name="reader_no_followed_blogs_description_subs">Abonnez-vous à des blogs dans Découvrir ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_no_recommended_blogs_title">Aucun blog recommandé</string>
-    <string name="reader_no_followed_tags_title">Aucune étiquette dans vos abonnements</string>
     <string name="reader_no_posts_with_this_tag">Pas d’articles avec cette étiquette</string>
     <string name="reader_toast_err_unable_to_block_blog">Impossible de bloquer ce blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Les articles de ce blog ne seront plus affichés</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -81,7 +81,6 @@ Language: fr
     <string name="reader_filter_empty_blogs_list_text">Abonnez-vous à des blogs dans Découvrir et vous verrez apparaître ici leurs derniers articles. Ou cherchez un blog que vous aimez déjà.</string>
     <string name="reader_filter_empty_blogs_list_title">Aucun abonnement à un blog</string>
     <string name="reader_filter_empty_blogs_action">S’abonner à un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Vous pouvez vous abonner aux articles relatifs à un sujet particulier en ajoutant une étiquette</string>
     <string name="reader_filter_empty_blogs_list">Voir les articles les plus récents des blogs auxquels vous êtes abonné(e)</string>
     <string name="reader_filter_by_tag_title">Filtrer par étiquette</string>
     <string name="reader_filter_by_blog_title">Filtrer par blog</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -22,7 +22,6 @@ Language: gl_ES
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Os blogs aos que estás subscrito non publicaron nada recientemente</string>
     <string name="reader_no_followed_blogs_description_subs">Subscríbete a blogs en Descubrir ou busca un blog que xa che guste.</string>
     <string name="quick_start_dialog_follow_sites_message_short_discover_and_subscriptions">Utiliza &lt;b&gt;Descubrir&lt;/b&gt; para encontrar sitios e etiquetas. Proba a seleccionar &lt;b&gt;Subscricións&lt;/b&gt; para ver o contido subscrito e xestionar as túas subscricións.</string>
-    <string name="reader_no_followed_tags_title">Non hai subscricións a etiquetas</string>
     <string name="reader_no_recommended_blogs_title">Non hai blogs recomendados</string>
     <string name="reader_no_posts_with_this_tag">Non hai entradas con esta etiqueta</string>
     <string name="reader_toast_err_unable_to_block_blog">Non se puido bloquear este blog</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -67,7 +67,6 @@ Language: gl_ES
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs aos que subscribirse</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscríbete a etiquetas para descubrir novos blogs</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta subscribirte a máis etiquetas para ampliar a busca</string>
     <string name="reader_filter_empty_tags_list_title">Sen etiquetas</string>
     <string name="reader_filter_empty_blogs_list_text">Subscríbete a blogs en Descubrir e verás as súas últimas publicacións aquí. Ou busca un blog que xa che guste.</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -45,7 +45,6 @@ Language: gl_ES
     <string name="reader_label_subscribe_count">%,d subscritores</string>
     <string name="reader_label_blog_subscribed">Blog subscrito</string>
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>
-    <string name="reader_page_followed_tags_title">Etiquetas subscritas</string>
     <string name="reader_page_followed_blogs_title">Blogs subscritos</string>
     <string name="reader_menu_tags_and_blogs">Editar etiquetas e blogs</string>
     <string name="reader_activity_title_manage_tags_blogs">Xestionar etiquetas e blogs</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -67,7 +67,6 @@ Language: gl_ES
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs aos que subscribirse</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Intenta subscribirte a máis etiquetas para ampliar a busca</string>
     <string name="reader_filter_empty_tags_list_title">Sen etiquetas</string>
     <string name="reader_filter_empty_blogs_list_text">Subscríbete a blogs en Descubrir e verás as súas últimas publicacións aquí. Ou busca un blog que xa che guste.</string>
     <string name="reader_filter_by_tag_title">Filtrar por etiqueta</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -33,7 +33,6 @@ Language: gl_ES
     <string name="reader_label_subscribers_count_single">1 subscritor</string>
     <string name="reader_label_choose_interests">Elixe os teus intereses</string>
     <string name="reader_toast_err_show_blog">Non se pode amosar este blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Xa estás subscrito a esta etiqueta</string>
     <string name="reader_toast_err_already_follow_this_blog">Xa estás subscrito a este blog.</string>
     <string name="reader_activity_title_tag_preview">Etiqueta</string>
     <string name="reader_btn_subscribe">Subscribirse</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -65,7 +65,6 @@ Language: gl_ES
     <string name="reader_dropdown_menu_automattic">Automattic</string>
     <string name="reader_dropdown_menu_subscriptions">Subscricións</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
-    <string name="reader_discover_no_posts_button_tags_text">Subscribirse a etiquetas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
     <string name="reader_filter_empty_tags_action_subscribe">Subscribirse a unha etiqueta</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs aos que subscribirse</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -70,7 +70,6 @@ Language: gl_ES
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs aos que subscribirse</string>
     <string name="reader_discover_empty_subtitle_subscribe">Subscríbete a etiquetas para descubrir novos blogs</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta subscribirte a máis etiquetas para ampliar a busca</string>
-    <string name="reader_filter_empty_tags_list_text">Subscríbete a unha etiqueta e poderás ve as mellores publicacións asociadas a ela.</string>
     <string name="reader_filter_empty_tags_list_title">Sen etiquetas</string>
     <string name="reader_filter_empty_blogs_list_text">Subscríbete a blogs en Descubrir e verás as súas últimas publicacións aquí. Ou busca un blog que xa che guste.</string>
     <string name="reader_filter_by_tag_title">Filtrar por etiqueta</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -66,7 +66,6 @@ Language: gl_ES
     <string name="reader_dropdown_menu_subscriptions">Subscricións</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiquetas recomendadas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar un blog</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Subscribirse a unha etiqueta</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs aos que subscribirse</string>
     <string name="reader_discover_empty_subtitle_subscribe">Subscríbete a etiquetas para descubrir novos blogs</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Intenta subscribirte a máis etiquetas para ampliar a busca</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -49,7 +49,6 @@ Language: gl_ES
     <string name="reader_menu_tags_and_blogs">Editar etiquetas e blogs</string>
     <string name="reader_activity_title_manage_tags_blogs">Xestionar etiquetas e blogs</string>
     <string name="reader_hint_search_subscribed_blogs">Buscar blogs subscritos</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Introduce unha URL ou etiqueta á que subscribirte</string>
     <string name="reader_filter_chip_tag_one">1 etiqueta</string>
     <string name="reader_dropdown_menu_lists">Listas</string>
     <string name="reader_dropdown_menu_liked">Gustoume</string>

--- a/WordPress/src/main/res/values-gl/strings.xml
+++ b/WordPress/src/main/res/values-gl/strings.xml
@@ -79,7 +79,6 @@ Language: gl_ES
     <string name="reader_filter_empty_blogs_action">Subscríbete a un blog</string>
     <string name="reader_filter_empty_blogs_list_title">Non hai subscricións ao blog</string>
     <string name="reader_filter_empty_blogs_list">Ver as últimas entradas dos blogs aos que estás subscrito</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Podes subscribirte a publicacións sobre un tema específico engadindo unha etiqueta</string>
     <string name="stats_timeframe_by_day">Por día</string>
     <string name="stats_timeframe_by_year">Por ano</string>
     <string name="stats_timeframe_by_week">Por semana</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -69,7 +69,6 @@ Language: he_IL
     <string name="reader_dropdown_menu_subscriptions">מינויים</string>
     <string name="reader_dropdown_menu_discover">היכרות</string>
     <string name="reader_search_content_description">חיפוש</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">כדאי להירשם לתגיות נוספות כדי להרחיב את החיפוש</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">בלוגים שכדאי להירשם לעדכונים מהם</string>
     <string name="reader_filter_empty_tags_action_suggested">תגיות מומלצות</string>
     <string name="reader_filter_empty_blogs_action_search">לחפש בלוג</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -81,7 +81,6 @@ Language: he_IL
     <string name="reader_filter_empty_blogs_list_text">ניתן להירשם לעדכונים מבלוגים במקטע \'היכרות\' כדי להציג את הפוסטים האחרונים שלהם כאן. לחלופין, אפשר לחפש בלוג שכבר מצא חן בעיניך.</string>
     <string name="reader_filter_empty_blogs_list_title">אין מינויים לבלוגים</string>
     <string name="reader_filter_empty_blogs_action">להירשם לעדכונים מבלוג</string>
-    <string name="reader_filter_empty_tags_list_subscribe">אפשר להירשם לעדכונים מפוסטים לגבי נושא מסוים על ידי הוספת תגית</string>
     <string name="reader_filter_empty_blogs_list">ניתן לראות את הפוסטים החדשים ביותר מבלוגים שנרשמת לעדכונים מהם</string>
     <string name="reader_filter_by_tag_title">לסנן לפי תגית</string>
     <string name="reader_filter_by_blog_title">לסנן לפי בלוג</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -70,7 +70,6 @@ Language: he_IL
     <string name="reader_dropdown_menu_discover">היכרות</string>
     <string name="reader_search_content_description">חיפוש</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">כדאי להירשם לתגיות נוספות כדי להרחיב את החיפוש</string>
-    <string name="reader_discover_empty_subtitle_subscribe">להירשם לעדכונים מתגיות כדי להיחשף לבלוגים חדשים</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">בלוגים שכדאי להירשם לעדכונים מהם</string>
     <string name="reader_filter_empty_tags_action_suggested">תגיות מומלצות</string>
     <string name="reader_filter_empty_blogs_action_search">לחפש בלוג</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -75,7 +75,6 @@ Language: he_IL
     <string name="reader_filter_empty_tags_action_subscribe">להירשם לעדכונים מתגית</string>
     <string name="reader_filter_empty_tags_action_suggested">תגיות מומלצות</string>
     <string name="reader_filter_empty_blogs_action_search">לחפש בלוג</string>
-    <string name="reader_filter_empty_tags_list_text">ניתן להירשם לקבלת עדכונים מתגית והפוסטים המומלצים עם התגית הזאת יוצגו כאן.</string>
     <string name="reader_filter_empty_tags_list_title">ללא תגיות</string>
     <string name="reader_filter_empty_blogs_list_text">ניתן להירשם לעדכונים מבלוגים במקטע \'היכרות\' כדי להציג את הפוסטים האחרונים שלהם כאן. לחלופין, אפשר לחפש בלוג שכבר מצא חן בעיניך.</string>
     <string name="reader_filter_empty_blogs_list_title">אין מינויים לבלוגים</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -69,7 +69,6 @@ Language: he_IL
     <string name="reader_dropdown_menu_subscriptions">מינויים</string>
     <string name="reader_dropdown_menu_discover">היכרות</string>
     <string name="reader_search_content_description">חיפוש</string>
-    <string name="reader_discover_no_posts_button_tags_text">להירשם לעדכונים מתגיות</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">כדאי להירשם לתגיות נוספות כדי להרחיב את החיפוש</string>
     <string name="reader_discover_empty_subtitle_subscribe">להירשם לעדכונים מתגיות כדי להיחשף לבלוגים חדשים</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">בלוגים שכדאי להירשם לעדכונים מהם</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -29,7 +29,6 @@ Language: he_IL
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">הבלוגים שנרשמת אליהם לא פרסמו תוכן לאחרונה</string>
     <string name="reader_no_followed_blogs_description_subs">אפשר להירשם לעדכונים מבלוגים דרך \'היכרות\' או לחפש בלוג שכבר מצא חן בעיניך.</string>
     <string name="reader_no_recommended_blogs_title">אין בלוגים מומלצים</string>
-    <string name="reader_no_followed_tags_title">אין תגיות שנרשמת לקבלת עדכונים מהן</string>
     <string name="reader_no_posts_with_this_tag">אין פוסטים עם התגית הזו</string>
     <string name="reader_toast_err_unable_to_block_blog">לא ניתן לחסום את הבלוג הזה</string>
     <string name="reader_toast_posts_from_this_blog_blocked">פוסטים מהבלוג הזה לא יוצגו עוד</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -38,7 +38,6 @@ Language: he_IL
     <string name="reader_toast_err_unable_to_follow_blog">לא ניתן להירשם לעדכונים מהבלוג הזה</string>
     <string name="reader_toast_err_already_follow_this_blog">כבר נרשמת לעדכונים מבלוג זה</string>
     <string name="reader_toast_err_show_blog">לא ניתן להציג בלוג זה</string>
-    <string name="reader_toast_err_tag_already_subscribed">כבר נרשמת לקבלת עדכונים מתגית זו</string>
     <string name="reader_label_choose_interests">לבחור את תחומי העניין שלך</string>
     <string name="reader_label_subscribers_count_single">מנוי אחד</string>
     <string name="reader_label_subscribers_count">%s מנויים</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -72,7 +72,6 @@ Language: he_IL
     <string name="reader_discover_no_posts_subscribe_subtitle">כדאי להירשם לתגיות נוספות כדי להרחיב את החיפוש</string>
     <string name="reader_discover_empty_subtitle_subscribe">להירשם לעדכונים מתגיות כדי להיחשף לבלוגים חדשים</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">בלוגים שכדאי להירשם לעדכונים מהם</string>
-    <string name="reader_filter_empty_tags_action_subscribe">להירשם לעדכונים מתגית</string>
     <string name="reader_filter_empty_tags_action_suggested">תגיות מומלצות</string>
     <string name="reader_filter_empty_blogs_action_search">לחפש בלוג</string>
     <string name="reader_filter_empty_tags_list_title">ללא תגיות</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -51,7 +51,6 @@ Language: he_IL
     <string name="reader_menu_block_this_blog">לחסום את הבלוג הזה</string>
     <string name="reader_menu_tags_and_blogs">לערוך תגיות ובלוגים</string>
     <string name="reader_page_followed_blogs_title">בלוגים שרשומים לעדכונים</string>
-    <string name="reader_page_followed_tags_title">תגיות שרשומות לעדכונים</string>
     <string name="reader_title_tags">לעקוב אחרי תגיות</string>
     <string name="reader_activity_title_manage_tags_blogs">לנהל תגיות ובלוגים</string>
     <string name="reader_activity_title_tag_preview">תגית</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -45,7 +45,6 @@ Language: he_IL
     <string name="reader_label_subscribe_count">%,d מנויים</string>
     <string name="reader_label_blog_subscribed">הבלוג רשום לעדכונים</string>
     <string name="reader_hint_search_subscribed_blogs">לחפש בלוגים שרשומים לעדכונים</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">יש להזין כתובת URL או תגית שברצונך להירשם לעדכונים מהן</string>
     <string name="reader_btn_subscribed">רשום לעדכונים</string>
     <string name="reader_btn_subscribe">להירשם לעדכונים</string>
     <string name="reader_menu_block_this_blog">לחסום את הבלוג הזה</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -70,7 +70,6 @@ Language: id
     <string name="reader_filter_empty_tags_action_subscribe">Berlangganan tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag yang diusulkan</string>
     <string name="reader_filter_empty_blogs_action_search">Cari blog</string>
-    <string name="reader_filter_empty_tags_list_text">Berlangganan tag dan Anda akan dapat melihat pos terbaik dari tag tersebut di sini.</string>
     <string name="reader_filter_empty_tags_list_title">Tidak ada tag</string>
     <string name="reader_filter_empty_blogs_list_text">Berlangganan blog di Temukan dan Anda akan melihat pos terbarunya di sini. Atau, cari blog yang sudah Anda sukai.</string>
     <string name="reader_filter_empty_blogs_list_title">Tidak ada langganan blog</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -35,7 +35,6 @@ Language: id
     <string name="reader_toast_err_unable_to_follow_blog">Tidak dapat berlangganan blog ini</string>
     <string name="reader_toast_err_already_follow_this_blog">Anda sudah berlangganan blog ini</string>
     <string name="reader_toast_err_show_blog">Tidak dapat menampilkan blog ini</string>
-    <string name="reader_toast_err_tag_already_subscribed">Anda telah berlangganan tag ini</string>
     <string name="reader_label_subscribers_count_single">1 pelanggan</string>
     <string name="reader_label_subscribers_count">%s pelanggan</string>
     <string name="reader_label_subscribe_count">%,d Pelanggan</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -46,7 +46,6 @@ Language: id
     <string name="reader_btn_subscribe">Berlangganan</string>
     <string name="reader_menu_tags_and_blogs">Sunting tag dan blog</string>
     <string name="reader_page_followed_blogs_title">Telah berlangganan blog</string>
-    <string name="reader_page_followed_tags_title">Telah berlangganan tag</string>
     <string name="reader_title_tags">Ikuti tag</string>
     <string name="reader_activity_title_manage_tags_blogs">Kelola Tag &amp; Blog</string>
     <string name="reader_activity_title_blog_preview">Blog Pembaca</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -41,7 +41,6 @@ Language: id
     <string name="reader_label_subscribe_count">%,d Pelanggan</string>
     <string name="reader_label_blog_subscribed">Blog langganan</string>
     <string name="reader_hint_search_subscribed_blogs">Cari blog langganan</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Masukkan URL atau tag untuk dijadikan langganan</string>
     <string name="reader_btn_subscribed">Telah berlangganan</string>
     <string name="reader_btn_subscribe">Berlangganan</string>
     <string name="reader_menu_tags_and_blogs">Sunting tag dan blog</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -67,7 +67,6 @@ Language: id
     <string name="reader_discover_no_posts_subscribe_subtitle">Coba berlangganan lebih banyak tag untuk memperluas pencarian</string>
     <string name="reader_discover_empty_subtitle_subscribe">Langganan tag untuk menemukan blog baru</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog untuk dijadikan langganan</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Berlangganan tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag yang diusulkan</string>
     <string name="reader_filter_empty_blogs_action_search">Cari blog</string>
     <string name="reader_filter_empty_tags_list_title">Tidak ada tag</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -64,7 +64,6 @@ Language: id
     <string name="reader_dropdown_menu_subscriptions">Langganan</string>
     <string name="reader_dropdown_menu_discover">Temukan</string>
     <string name="reader_search_content_description">Pencarian</string>
-    <string name="reader_discover_no_posts_button_tags_text">Berlangganan tag</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Coba berlangganan lebih banyak tag untuk memperluas pencarian</string>
     <string name="reader_discover_empty_subtitle_subscribe">Langganan tag untuk menemukan blog baru</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog untuk dijadikan langganan</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -27,7 +27,6 @@ Language: id
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Blog langganan Anda belum mengeposkan apa pun akhir-akhir ini</string>
     <string name="reader_no_followed_blogs_description_subs">Langganan blog di Temukan atau cari blog yang sudah Anda sukai.</string>
     <string name="reader_no_recommended_blogs_title">Tidak ada blog rekomendasi</string>
-    <string name="reader_no_followed_tags_title">Tidak ada tag langganan</string>
     <string name="reader_toast_err_unable_to_block_blog">Tidak dapat memblokir blog ini</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Pos dari blog ini tidak akan ditampilkan lagi</string>
     <string name="reader_toast_err_unable_to_unfollow_blog">Tidak dapat berhenti berlangganan blog</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -65,7 +65,6 @@ Language: id
     <string name="reader_dropdown_menu_discover">Temukan</string>
     <string name="reader_search_content_description">Pencarian</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Coba berlangganan lebih banyak tag untuk memperluas pencarian</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Langganan tag untuk menemukan blog baru</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog untuk dijadikan langganan</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag yang diusulkan</string>
     <string name="reader_filter_empty_blogs_action_search">Cari blog</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -76,7 +76,6 @@ Language: id
     <string name="reader_filter_empty_blogs_list_text">Berlangganan blog di Temukan dan Anda akan melihat pos terbarunya di sini. Atau, cari blog yang sudah Anda sukai.</string>
     <string name="reader_filter_empty_blogs_list_title">Tidak ada langganan blog</string>
     <string name="reader_filter_empty_blogs_action">Berlangganan blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Anda dapat berlangganan pos dengan subjek tertentu dengan menambahkan tag</string>
     <string name="reader_filter_empty_blogs_list">Lihat pos terbaru dari blog langganan Anda</string>
     <string name="reader_filter_by_tag_title">Saring berdasarkan tag</string>
     <string name="reader_filter_by_blog_title">Saring berdasarkan blog</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -64,7 +64,6 @@ Language: id
     <string name="reader_dropdown_menu_subscriptions">Langganan</string>
     <string name="reader_dropdown_menu_discover">Temukan</string>
     <string name="reader_search_content_description">Pencarian</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Coba berlangganan lebih banyak tag untuk memperluas pencarian</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog untuk dijadikan langganan</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag yang diusulkan</string>
     <string name="reader_filter_empty_blogs_action_search">Cari blog</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -38,7 +38,6 @@ Language: it
     <string name="reader_toast_err_unable_to_follow_blog">Non è possibile seguire questo blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Segui già questo blog</string>
     <string name="reader_toast_err_show_blog">Impossibile mostrare questo blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Segui già questo tag</string>
     <string name="reader_label_choose_interests">Scegli i tuoi interessi</string>
     <string name="reader_label_subscribers_count_single">1 abbonato</string>
     <string name="reader_label_subscribers_count">%s abbonati</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -51,7 +51,6 @@ Language: it
     <string name="reader_menu_block_this_blog">Blocca questo blog</string>
     <string name="reader_menu_tags_and_blogs">Modifica tag e blog</string>
     <string name="reader_page_followed_blogs_title">Blog che segui</string>
-    <string name="reader_page_followed_tags_title">Tag che segui</string>
     <string name="reader_title_tags">Segui tag</string>
     <string name="reader_activity_title_manage_tags_blogs">Gestisci tag e blog</string>
     <string name="reader_activity_title_tag_preview">Tag</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -82,7 +82,6 @@ Language: it
     <string name="reader_filter_empty_blogs_list_text">Segui i blog della sezione Scopri e vedrai i loro ultimi articoli qui. Oppure cerca un blog che già ti piace.</string>
     <string name="reader_filter_empty_blogs_list_title">Nessun abbonamento ai blog</string>
     <string name="reader_filter_empty_blogs_action">Segui un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Puoi seguire gli articoli su uno specifico argomento aggiungendo un tag</string>
     <string name="reader_filter_empty_blogs_list">Vedi i nuovi articoli dei blog che segui</string>
     <string name="reader_filter_by_tag_title">Filtra per tag</string>
     <string name="reader_filter_by_blog_title">Filtra per blog</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -29,7 +29,6 @@ Language: it
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">I blog che segui non hanno pubblicato articoli di recente</string>
     <string name="reader_no_followed_blogs_description_subs">Segui i blog in Scopri, oppure cerca un blog che già ti piace.</string>
     <string name="reader_no_recommended_blogs_title">Nessun blog consigliato</string>
-    <string name="reader_no_followed_tags_title">Nessun tag che segui</string>
     <string name="reader_no_posts_with_this_tag">Nessun articolo con questo tag</string>
     <string name="reader_toast_err_unable_to_block_blog">Non è possibile bloccare questo blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Gli articoli di questo blog non verranno più mostrati</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -70,7 +70,6 @@ Language: it
     <string name="reader_dropdown_menu_subscriptions">Abbonamenti</string>
     <string name="reader_dropdown_menu_discover">Scopri</string>
     <string name="reader_search_content_description">Cerca</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Prova a seguire più tag per ampliare la ricerca</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog da seguire</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag suggeriti</string>
     <string name="reader_filter_empty_blogs_action_search">Cerca un blog</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -76,7 +76,6 @@ Language: it
     <string name="reader_filter_empty_tags_action_subscribe">Segui un tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag suggeriti</string>
     <string name="reader_filter_empty_blogs_action_search">Cerca un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Inizia a seguire un tag e potrai vedere qui i migliori articoli correlati.</string>
     <string name="reader_filter_empty_tags_list_title">Nessun tag</string>
     <string name="reader_filter_empty_blogs_list_text">Segui i blog della sezione Scopri e vedrai i loro ultimi articoli qui. Oppure cerca un blog che già ti piace.</string>
     <string name="reader_filter_empty_blogs_list_title">Nessun abbonamento ai blog</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -71,7 +71,6 @@ Language: it
     <string name="reader_dropdown_menu_discover">Scopri</string>
     <string name="reader_search_content_description">Cerca</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova a seguire più tag per ampliare la ricerca</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Segui i tag per scoprire nuovi blog</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog da seguire</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag suggeriti</string>
     <string name="reader_filter_empty_blogs_action_search">Cerca un blog</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -70,7 +70,6 @@ Language: it
     <string name="reader_dropdown_menu_subscriptions">Abbonamenti</string>
     <string name="reader_dropdown_menu_discover">Scopri</string>
     <string name="reader_search_content_description">Cerca</string>
-    <string name="reader_discover_no_posts_button_tags_text">Segui tag</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova a seguire più tag per ampliare la ricerca</string>
     <string name="reader_discover_empty_subtitle_subscribe">Segui i tag per scoprire nuovi blog</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog da seguire</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -73,7 +73,6 @@ Language: it
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova a seguire più tag per ampliare la ricerca</string>
     <string name="reader_discover_empty_subtitle_subscribe">Segui i tag per scoprire nuovi blog</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blog da seguire</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Segui un tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tag suggeriti</string>
     <string name="reader_filter_empty_blogs_action_search">Cerca un blog</string>
     <string name="reader_filter_empty_tags_list_title">Nessun tag</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -45,7 +45,6 @@ Language: it
     <string name="reader_label_subscribe_count">%,d Abbonati</string>
     <string name="reader_label_blog_subscribed">Blog che segui</string>
     <string name="reader_hint_search_subscribed_blogs">Cerca blog che segui</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Inserisci un URL o un tag da seguire</string>
     <string name="reader_btn_subscribed">Stai seguendo</string>
     <string name="reader_btn_subscribe">Segui</string>
     <string name="reader_menu_block_this_blog">Blocca questo blog</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -51,7 +51,6 @@ Language: ja_JP
     <string name="reader_menu_block_this_blog">このブログをブロック</string>
     <string name="reader_menu_tags_and_blogs">タグとブログを編集</string>
     <string name="reader_page_followed_blogs_title">購読済みのブログ</string>
-    <string name="reader_page_followed_tags_title">購読済みのタグ</string>
     <string name="reader_title_tags">タグをフォロー</string>
     <string name="reader_activity_title_manage_tags_blogs">タグとブログを管理</string>
     <string name="reader_activity_title_tag_preview">タグ</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -82,7 +82,6 @@ Language: ja_JP
     <string name="reader_filter_empty_blogs_list_text">「ディスカバー」でブログを購読すると、最新の投稿がこちらに表示されます。 またはすでに気に入っているブログを検索します。</string>
     <string name="reader_filter_empty_blogs_list_title">ブログ購読はありません</string>
     <string name="reader_filter_empty_blogs_action">ブログを購読</string>
-    <string name="reader_filter_empty_tags_list_subscribe">タグを追加することで、特定の内容に関する投稿を購読できます</string>
     <string name="reader_filter_empty_blogs_list">購読しているブログの最新の投稿を表示</string>
     <string name="reader_filter_by_tag_title">タグで絞り込む</string>
     <string name="reader_filter_by_blog_title">ブログで絞り込む</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -45,7 +45,6 @@ Language: ja_JP
     <string name="reader_label_subscribe_count">%,d人の購読者</string>
     <string name="reader_label_blog_subscribed">購読済みのブログ</string>
     <string name="reader_hint_search_subscribed_blogs">購読済みのブログを検索</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">購読する URL またはタグを入力</string>
     <string name="reader_btn_subscribed">購読済み</string>
     <string name="reader_btn_subscribe">購読</string>
     <string name="reader_menu_block_this_blog">このブログをブロック</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -38,7 +38,6 @@ Language: ja_JP
     <string name="reader_toast_err_unable_to_follow_blog">このブログを購読できません</string>
     <string name="reader_toast_err_already_follow_this_blog">このブログをすでに購読済みです</string>
     <string name="reader_toast_err_show_blog">このブログを表示できません</string>
-    <string name="reader_toast_err_tag_already_subscribed">このタグをすでに購読済みです</string>
     <string name="reader_label_choose_interests">関心のあるものを選択</string>
     <string name="reader_label_subscribers_count_single">1人の購読者</string>
     <string name="reader_label_subscribers_count">%s人の購読者</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@ Language: ja_JP
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">購読しているブログには、最近の投稿はありません</string>
     <string name="reader_no_followed_blogs_description_subs">「ディスカバー」でブログを購読するか、すでに気に入っているブログを検索します。</string>
     <string name="reader_no_recommended_blogs_title">おすすめのブログはありません</string>
-    <string name="reader_no_followed_tags_title">購読しているタグはありません</string>
     <string name="reader_no_posts_with_this_tag">このタグを使った投稿はありません</string>
     <string name="reader_toast_err_unable_to_block_blog">このブログをブロックできませんでした</string>
     <string name="reader_toast_posts_from_this_blog_blocked">このブログからの投稿は今後表示されません</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -70,7 +70,6 @@ Language: ja_JP
     <string name="reader_dropdown_menu_subscriptions">サブスクリプション</string>
     <string name="reader_dropdown_menu_discover">ディスカバー</string>
     <string name="reader_search_content_description">検索</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">もっと多くのタグを購読して、検索を広げてみてください</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">購読するブログ</string>
     <string name="reader_filter_empty_tags_action_suggested">おすすめのタグ</string>
     <string name="reader_filter_empty_blogs_action_search">ブログを検索</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -76,7 +76,6 @@ Language: ja_JP
     <string name="reader_filter_empty_tags_action_subscribe">タグを購読</string>
     <string name="reader_filter_empty_tags_action_suggested">おすすめのタグ</string>
     <string name="reader_filter_empty_blogs_action_search">ブログを検索</string>
-    <string name="reader_filter_empty_tags_list_text">タグを購読すると、そのタグで最適の投稿がこちらに表示されます。</string>
     <string name="reader_filter_empty_tags_list_title">タグなし</string>
     <string name="reader_filter_empty_blogs_list_text">「ディスカバー」でブログを購読すると、最新の投稿がこちらに表示されます。 またはすでに気に入っているブログを検索します。</string>
     <string name="reader_filter_empty_blogs_list_title">ブログ購読はありません</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -73,7 +73,6 @@ Language: ja_JP
     <string name="reader_discover_no_posts_subscribe_subtitle">もっと多くのタグを購読して、検索を広げてみてください</string>
     <string name="reader_discover_empty_subtitle_subscribe">タグを購読して新しいブログを見つける</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">購読するブログ</string>
-    <string name="reader_filter_empty_tags_action_subscribe">タグを購読</string>
     <string name="reader_filter_empty_tags_action_suggested">おすすめのタグ</string>
     <string name="reader_filter_empty_blogs_action_search">ブログを検索</string>
     <string name="reader_filter_empty_tags_list_title">タグなし</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -71,7 +71,6 @@ Language: ja_JP
     <string name="reader_dropdown_menu_discover">ディスカバー</string>
     <string name="reader_search_content_description">検索</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">もっと多くのタグを購読して、検索を広げてみてください</string>
-    <string name="reader_discover_empty_subtitle_subscribe">タグを購読して新しいブログを見つける</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">購読するブログ</string>
     <string name="reader_filter_empty_tags_action_suggested">おすすめのタグ</string>
     <string name="reader_filter_empty_blogs_action_search">ブログを検索</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -70,7 +70,6 @@ Language: ja_JP
     <string name="reader_dropdown_menu_subscriptions">サブスクリプション</string>
     <string name="reader_dropdown_menu_discover">ディスカバー</string>
     <string name="reader_search_content_description">検索</string>
-    <string name="reader_discover_no_posts_button_tags_text">タグを購読</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">もっと多くのタグを購読して、検索を広げてみてください</string>
     <string name="reader_discover_empty_subtitle_subscribe">タグを購読して新しいブログを見つける</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">購読するブログ</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -72,7 +72,6 @@ Language: ko_KR
     <string name="reader_discover_no_posts_subscribe_subtitle">추가 태그를 구독하여 검색 범위 확대하기</string>
     <string name="reader_discover_empty_subtitle_subscribe">태그를 구독하여 새 블로그 발견하기</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">구독할 블로그</string>
-    <string name="reader_filter_empty_tags_action_subscribe">태그 구독</string>
     <string name="reader_filter_empty_tags_action_suggested">제안된 태그</string>
     <string name="reader_filter_empty_blogs_action_search">블로그 검색</string>
     <string name="reader_filter_empty_tags_list_title">태그 없음</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -69,7 +69,6 @@ Language: ko_KR
     <string name="reader_dropdown_menu_subscriptions">구독</string>
     <string name="reader_dropdown_menu_discover">발견</string>
     <string name="reader_search_content_description">검색</string>
-    <string name="reader_discover_no_posts_button_tags_text">태그 구독</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">추가 태그를 구독하여 검색 범위 확대하기</string>
     <string name="reader_discover_empty_subtitle_subscribe">태그를 구독하여 새 블로그 발견하기</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">구독할 블로그</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -51,7 +51,6 @@ Language: ko_KR
     <string name="reader_menu_block_this_blog">이 블로그 차단</string>
     <string name="reader_menu_tags_and_blogs">태그 및 블로그 편집</string>
     <string name="reader_page_followed_blogs_title">구독한 블로그</string>
-    <string name="reader_page_followed_tags_title">구독한 태그</string>
     <string name="reader_title_tags">태그 팔로우</string>
     <string name="reader_activity_title_manage_tags_blogs">블로그 및 블로그 관리</string>
     <string name="reader_activity_title_tag_preview">태그</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -29,7 +29,6 @@ Language: ko_KR
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">구독하는 블로그에 최근 발행된 내용이 없습니다.</string>
     <string name="reader_no_followed_blogs_description_subs">발견에서 블로그를 구독하거나 이미 좋아하는 블로그를 검색하세요.</string>
     <string name="reader_no_recommended_blogs_title">추천 블로그 없음</string>
-    <string name="reader_no_followed_tags_title">구독한 태그 없음</string>
     <string name="reader_no_posts_with_this_tag">이 태그가 지정된 글 없음</string>
     <string name="reader_toast_err_unable_to_block_blog">이 블로그를 차단할 수 없음</string>
     <string name="reader_toast_posts_from_this_blog_blocked">이 블로그의 글은 이제 표시되지 않음</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -75,7 +75,6 @@ Language: ko_KR
     <string name="reader_filter_empty_tags_action_subscribe">태그 구독</string>
     <string name="reader_filter_empty_tags_action_suggested">제안된 태그</string>
     <string name="reader_filter_empty_blogs_action_search">블로그 검색</string>
-    <string name="reader_filter_empty_tags_list_text">태그를 구독하면 여기에서 인기 글을 확인할 수 있습니다.</string>
     <string name="reader_filter_empty_tags_list_title">태그 없음</string>
     <string name="reader_filter_empty_blogs_list_text">발견에서 블로그를 구독하면 여기에 최신 글이 표시됩니다. 아니면 이미 좋아하는 블로그를 검색하세요.</string>
     <string name="reader_filter_empty_blogs_list_title">블로그 구독 없음</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -70,7 +70,6 @@ Language: ko_KR
     <string name="reader_dropdown_menu_discover">발견</string>
     <string name="reader_search_content_description">검색</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">추가 태그를 구독하여 검색 범위 확대하기</string>
-    <string name="reader_discover_empty_subtitle_subscribe">태그를 구독하여 새 블로그 발견하기</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">구독할 블로그</string>
     <string name="reader_filter_empty_tags_action_suggested">제안된 태그</string>
     <string name="reader_filter_empty_blogs_action_search">블로그 검색</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -38,7 +38,6 @@ Language: ko_KR
     <string name="reader_toast_err_unable_to_follow_blog">이 블로그를 구독할 수 없음</string>
     <string name="reader_toast_err_already_follow_this_blog">이 블로그를 이미 구독하고 있음</string>
     <string name="reader_toast_err_show_blog">이 블로그를 표시할 수 없음</string>
-    <string name="reader_toast_err_tag_already_subscribed">이 태그를 이미 구독하고 있음</string>
     <string name="reader_label_choose_interests">관심사 선택</string>
     <string name="reader_label_subscribers_count_single">구독자 1명</string>
     <string name="reader_label_subscribers_count">구독자 %s명</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -69,7 +69,6 @@ Language: ko_KR
     <string name="reader_dropdown_menu_subscriptions">구독</string>
     <string name="reader_dropdown_menu_discover">발견</string>
     <string name="reader_search_content_description">검색</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">추가 태그를 구독하여 검색 범위 확대하기</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">구독할 블로그</string>
     <string name="reader_filter_empty_tags_action_suggested">제안된 태그</string>
     <string name="reader_filter_empty_blogs_action_search">블로그 검색</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -81,7 +81,6 @@ Language: ko_KR
     <string name="reader_filter_empty_blogs_list_text">발견에서 블로그를 구독하면 여기에 최신 글이 표시됩니다. 아니면 이미 좋아하는 블로그를 검색하세요.</string>
     <string name="reader_filter_empty_blogs_list_title">블로그 구독 없음</string>
     <string name="reader_filter_empty_blogs_action">블로그 구독</string>
-    <string name="reader_filter_empty_tags_list_subscribe">태그를 추가하여 특정 주제의 글을 구독할 수 있습니다</string>
     <string name="reader_filter_empty_blogs_list">구독하는 블로그의 최신 글 확인</string>
     <string name="reader_filter_by_tag_title">태그로 필터링</string>
     <string name="reader_filter_by_blog_title">블로그로 필터링</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -45,7 +45,6 @@ Language: ko_KR
     <string name="reader_label_subscribe_count">구독자 %,d명</string>
     <string name="reader_label_blog_subscribed">구독하는 블로그</string>
     <string name="reader_hint_search_subscribed_blogs">구독하는 블로그 검색</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">구독할 블로그의 URL 또는 태그 입력</string>
     <string name="reader_btn_subscribed">구독됨</string>
     <string name="reader_btn_subscribe">구독</string>
     <string name="reader_menu_block_this_blog">이 블로그 차단</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -33,7 +33,6 @@ Language: nl
     <string name="reader_label_subscribe_count">%,d Abonnees</string>
     <string name="reader_label_blog_subscribed">Blog subscribed</string>
     <string name="reader_hint_search_subscribed_blogs">Search subscribed blogs</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Voer de URL in van een blog waarop je je wilt abonneren</string>
     <string name="reader_menu_block_this_blog">Deze blog blokkeren</string>
     <string name="reader_menu_tags_and_blogs">Tags en blogs bijwerken</string>
     <string name="reader_page_followed_blogs_title">Geabonneerd op blog</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -47,7 +47,6 @@ Language: nl
     <string name="reader_filter_chip_blog_one">1 Blog</string>
     <string name="reader_filter_chip_blog_zero">0 Blogs</string>
     <string name="reader_dropdown_menu_liked">Geliket</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_filter_empty_blogs_list_text">Abonneer je op blogs in Ontdek en je ziet hun nieuwste berichten hier. Of zoek een blog die je al leuk vindt.</string>
     <string name="reader_filter_empty_blogs_list_title">Geen blog-abonnementen</string>
     <string name="reader_filter_empty_blogs_action">Abonneren op blog</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -37,7 +37,6 @@ Language: nl
     <string name="reader_menu_block_this_blog">Deze blog blokkeren</string>
     <string name="reader_menu_tags_and_blogs">Tags en blogs bijwerken</string>
     <string name="reader_page_followed_blogs_title">Geabonneerd op blog</string>
-    <string name="reader_page_followed_tags_title">Abonneren op tags</string>
     <string name="reader_title_tags">Tag volgen</string>
     <string name="reader_activity_title_manage_tags_blogs">Blogs beheren</string>
     <string name="reader_activity_title_blog_preview">Reader-blog</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -52,7 +52,6 @@ Language: nl
     <string name="reader_filter_empty_blogs_list_text">Abonneer je op blogs in Ontdek en je ziet hun nieuwste berichten hier. Of zoek een blog die je al leuk vindt.</string>
     <string name="reader_filter_empty_blogs_list_title">Geen blog-abonnementen</string>
     <string name="reader_filter_empty_blogs_action">Abonneren op blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Je kan berichten over een bepaald onderwerp volgen door een label toe te voegen</string>
     <string name="reader_filter_empty_blogs_list">See the newest posts from blogs you\'re subscribed to</string>
     <string name="stats_traffic">Bezoekersaantallen</string>
     <string name="gutenberg_native_working_offline">Werk offline</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -28,7 +28,6 @@ Language: nl
     <string name="reader_toast_err_follow_not_authorized_to_access_blog">Je hebt geen rechten om dit blog te openen</string>
     <string name="reader_toast_err_unable_to_follow_blog">Kan niet abonneren op blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Je bent al geabonneerd op deze blog.</string>
-    <string name="reader_toast_err_tag_already_subscribed">Je hebt je al geabonneerd op deze site!</string>
     <string name="reader_label_subscribers_count_single">(1 abonnee)</string>
     <string name="reader_label_subscribe_count">%,d Abonnees</string>
     <string name="reader_label_blog_subscribed">Blog subscribed</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -48,7 +48,6 @@ Language: nl
     <string name="reader_filter_chip_blog_zero">0 Blogs</string>
     <string name="reader_dropdown_menu_liked">Geliket</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_filter_empty_blogs_list_text">Abonneer je op blogs in Ontdek en je ziet hun nieuwste berichten hier. Of zoek een blog die je al leuk vindt.</string>
     <string name="reader_filter_empty_blogs_list_title">Geen blog-abonnementen</string>
     <string name="reader_filter_empty_blogs_action">Abonneren op blog</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -22,7 +22,6 @@ Language: nl
     <string name="quick_start_dialog_follow_sites_message_short_discover_and_subscriptions">Gebruik &lt;b&gt; Ontdekken &lt;/b&gt; om sites en tags te zoeken. Try selecting &lt;b&gt;Subscriptions&lt;/b&gt; to view subscribed content and manage your subscriptions.</string>
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">The blogs you\'re subscribed to haven\'t posted anything recently</string>
     <string name="reader_no_followed_blogs_description_subs">Of zoek een blog die je al leuk vindt.</string>
-    <string name="reader_no_followed_tags_title">No subscribed tags</string>
     <string name="reader_toast_err_unable_to_block_blog">Kan blog niet blokkeren</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Berichten van deze site zullen niet meer getoond worden</string>
     <string name="reader_toast_err_follow_not_authorized_to_access_blog">Je hebt geen rechten om dit blog te openen</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -23,7 +23,6 @@ Language: pt_BR
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Os blogs que você assinou não postaram nada recentemente</string>
     <string name="reader_no_followed_blogs_description_subs">Assine blogs em Descobrir ou busque um blog que você já gosta.</string>
     <string name="reader_no_recommended_blogs_title">Nenhum blog recomendado</string>
-    <string name="reader_no_followed_tags_title">Nenhuma tag assinada</string>
     <string name="reader_no_posts_with_this_tag">Nenhum post com esta tag</string>
     <string name="reader_toast_err_unable_to_block_blog">Não foi possível bloquear este blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Os posts deste blog não serão mais exibidos</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -32,7 +32,6 @@ Language: pt_BR
     <string name="reader_toast_err_unable_to_follow_blog">Não foi possível assinar este blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Você já assinou este blog</string>
     <string name="reader_toast_err_show_blog">Não foi possível mostrar este blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Você já é assinante desta tag</string>
     <string name="reader_label_choose_interests">Escolher seus interesses</string>
     <string name="reader_label_subscribers_count_single">1 assinante</string>
     <string name="reader_label_subscribers_count">%s assinantes</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -39,7 +39,6 @@ Language: pt_BR
     <string name="reader_label_subscribe_count">%,d assinantes</string>
     <string name="reader_label_blog_subscribed">Blog assinado</string>
     <string name="reader_hint_search_subscribed_blogs">Pesquisar blogs assinados</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Digite uma URL ou tag para assinar</string>
     <string name="reader_btn_subscribed">Assinado</string>
     <string name="reader_btn_subscribe">Assinar</string>
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -64,7 +64,6 @@ Language: pt_BR
     <string name="reader_dropdown_menu_subscriptions">Assinaturas</string>
     <string name="reader_dropdown_menu_discover">Descobrir</string>
     <string name="reader_search_content_description">Pesquisar</string>
-    <string name="reader_discover_no_posts_button_tags_text">Assinar tags</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Tente assinar mais tags para melhorar a pesquisa</string>
     <string name="reader_discover_empty_subtitle_subscribe">Assine tags para descobrir novos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs para assinar</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -67,7 +67,6 @@ Language: pt_BR
     <string name="reader_discover_no_posts_subscribe_subtitle">Tente assinar mais tags para melhorar a pesquisa</string>
     <string name="reader_discover_empty_subtitle_subscribe">Assine tags para descobrir novos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs para assinar</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Assinar uma tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tags sugeridas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar um blog</string>
     <string name="reader_filter_empty_tags_list_title">Nenhuma tag</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -65,7 +65,6 @@ Language: pt_BR
     <string name="reader_dropdown_menu_discover">Descobrir</string>
     <string name="reader_search_content_description">Pesquisar</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Tente assinar mais tags para melhorar a pesquisa</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Assine tags para descobrir novos blogs</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs para assinar</string>
     <string name="reader_filter_empty_tags_action_suggested">Tags sugeridas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar um blog</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -64,7 +64,6 @@ Language: pt_BR
     <string name="reader_dropdown_menu_subscriptions">Assinaturas</string>
     <string name="reader_dropdown_menu_discover">Descobrir</string>
     <string name="reader_search_content_description">Pesquisar</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Tente assinar mais tags para melhorar a pesquisa</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogs para assinar</string>
     <string name="reader_filter_empty_tags_action_suggested">Tags sugeridas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar um blog</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -76,7 +76,6 @@ Language: pt_BR
     <string name="reader_filter_empty_blogs_list_text">Assine blogs em Descobrir e você verá suas postagens mais recentes aqui. Ou procure por um blog que você já goste.</string>
     <string name="reader_filter_empty_blogs_list_title">Nenhuma assinatura de blog</string>
     <string name="reader_filter_empty_blogs_action">Assinar um blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Você pode assinar posts de um assunto específico adicionando uma tag</string>
     <string name="reader_filter_empty_blogs_list">Veja os posts mais recentes de blogs de que você é assinante</string>
     <string name="reader_filter_by_tag_title">Filtrar por tag</string>
     <string name="reader_filter_by_blog_title">Filtrar por blog</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -45,7 +45,6 @@ Language: pt_BR
     <string name="reader_menu_block_this_blog">Bloquear este blog</string>
     <string name="reader_menu_tags_and_blogs">Editar tags e blogs</string>
     <string name="reader_page_followed_blogs_title">Blogs assinados</string>
-    <string name="reader_page_followed_tags_title">Tags assinadas</string>
     <string name="reader_title_tags">Seguir tags</string>
     <string name="reader_activity_title_manage_tags_blogs">Gerenciar tags e blogs</string>
     <string name="reader_activity_title_tag_preview">Tag</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -70,7 +70,6 @@ Language: pt_BR
     <string name="reader_filter_empty_tags_action_subscribe">Assinar uma tag</string>
     <string name="reader_filter_empty_tags_action_suggested">Tags sugeridas</string>
     <string name="reader_filter_empty_blogs_action_search">Buscar um blog</string>
-    <string name="reader_filter_empty_tags_list_text">Assine uma tag para ver aqui os melhores posts com ela.</string>
     <string name="reader_filter_empty_tags_list_title">Nenhuma tag</string>
     <string name="reader_filter_empty_blogs_list_text">Assine blogs em Descobrir e você verá suas postagens mais recentes aqui. Ou procure por um blog que você já goste.</string>
     <string name="reader_filter_empty_blogs_list_title">Nenhuma assinatura de blog</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -70,7 +70,6 @@ Language: ro
     <string name="reader_dropdown_menu_subscriptions">Abonamente</string>
     <string name="reader_dropdown_menu_discover">Descoperă</string>
     <string name="reader_search_content_description">Caută</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Încearcă să te abonezi la mai multe etichete ca să extinzi căutarea</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloguri la care să te abonezi</string>
     <string name="reader_filter_empty_tags_action_suggested">Etichete sugerate</string>
     <string name="reader_filter_empty_blogs_action_search">Caută un blog</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -29,7 +29,6 @@ Language: ro
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Blogurile la care te-ai abonat nu au publicat nimic recent</string>
     <string name="reader_no_followed_blogs_description_subs">Abonează-te la bloguri în Descoperă sau caută un blog care ți-a plăcut.</string>
     <string name="reader_no_recommended_blogs_title">Niciun blog recomandat</string>
-    <string name="reader_no_followed_tags_title">Nu te-ai abonat la nicio etichetă</string>
     <string name="reader_no_posts_with_this_tag">Nu există articole cu această etichetă</string>
     <string name="reader_toast_err_unable_to_block_blog">Nu pot să blochez acest blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Articolele din acest blog nu vor mai fi arătate</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -82,7 +82,6 @@ Language: ro
     <string name="reader_filter_empty_blogs_list_text">Abonează-te la bloguri în Descoperă și vei vedea aici ultimele articole publicate pe ele. Sau caută un blog care ți-a plăcut.</string>
     <string name="reader_filter_empty_blogs_list_title">Niciun abonament la bloguri</string>
     <string name="reader_filter_empty_blogs_action">Abonează-te la un blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Poți să te abonezi la articole despre un anumit subiect prin adăugarea unei etichete</string>
     <string name="reader_filter_empty_blogs_list">Vezi cele mai noi articole pe blogurile la care te-ai abonat</string>
     <string name="reader_filter_by_tag_title">Filtrează după etichetă</string>
     <string name="reader_filter_by_blog_title">Filtrează după blog</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -71,7 +71,6 @@ Language: ro
     <string name="reader_dropdown_menu_discover">Descoperă</string>
     <string name="reader_search_content_description">Caută</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Încearcă să te abonezi la mai multe etichete ca să extinzi căutarea</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Abonează-te la etichete ca să descoperi bloguri noi</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloguri la care să te abonezi</string>
     <string name="reader_filter_empty_tags_action_suggested">Etichete sugerate</string>
     <string name="reader_filter_empty_blogs_action_search">Caută un blog</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -45,7 +45,6 @@ Language: ro
     <string name="reader_label_subscribe_count">%d abonați</string>
     <string name="reader_label_blog_subscribed">Blog la care te-ai abonat</string>
     <string name="reader_hint_search_subscribed_blogs">Caută bloguri la care te-ai abonat</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Introdu un URL-ul sau o etichetă la care să te abonezi</string>
     <string name="reader_btn_subscribed">Te-ai abonat</string>
     <string name="reader_btn_subscribe">Abonează-te</string>
     <string name="reader_menu_block_this_blog">Blochează acest blog</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -51,7 +51,6 @@ Language: ro
     <string name="reader_menu_block_this_blog">Blochează acest blog</string>
     <string name="reader_menu_tags_and_blogs">Editează etichetele și blogurile</string>
     <string name="reader_page_followed_blogs_title">Bloguri la care te-ai abonat</string>
-    <string name="reader_page_followed_tags_title">Etichete la care te-ai abonat</string>
     <string name="reader_title_tags">Urmărește etichetele</string>
     <string name="reader_activity_title_manage_tags_blogs">Administrează etichetele și blogurile</string>
     <string name="reader_activity_title_tag_preview">Etichetă</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -76,7 +76,6 @@ Language: ro
     <string name="reader_filter_empty_tags_action_subscribe">Abonează-te la o etichetă</string>
     <string name="reader_filter_empty_tags_action_suggested">Etichete sugerate</string>
     <string name="reader_filter_empty_blogs_action_search">Caută un blog</string>
-    <string name="reader_filter_empty_tags_list_text">Abonează-te la o etichetă și vei putea să vezi aici cele mai bune articole cu această etichetă.</string>
     <string name="reader_filter_empty_tags_list_title">Nicio etichetă</string>
     <string name="reader_filter_empty_blogs_list_text">Abonează-te la bloguri în Descoperă și vei vedea aici ultimele articole publicate pe ele. Sau caută un blog care ți-a plăcut.</string>
     <string name="reader_filter_empty_blogs_list_title">Niciun abonament la bloguri</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -73,7 +73,6 @@ Language: ro
     <string name="reader_discover_no_posts_subscribe_subtitle">Încearcă să te abonezi la mai multe etichete ca să extinzi căutarea</string>
     <string name="reader_discover_empty_subtitle_subscribe">Abonează-te la etichete ca să descoperi bloguri noi</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloguri la care să te abonezi</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Abonează-te la o etichetă</string>
     <string name="reader_filter_empty_tags_action_suggested">Etichete sugerate</string>
     <string name="reader_filter_empty_blogs_action_search">Caută un blog</string>
     <string name="reader_filter_empty_tags_list_title">Nicio etichetă</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -70,7 +70,6 @@ Language: ro
     <string name="reader_dropdown_menu_subscriptions">Abonamente</string>
     <string name="reader_dropdown_menu_discover">Descoperă</string>
     <string name="reader_search_content_description">Caută</string>
-    <string name="reader_discover_no_posts_button_tags_text">Abonează-te la etichete</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Încearcă să te abonezi la mai multe etichete ca să extinzi căutarea</string>
     <string name="reader_discover_empty_subtitle_subscribe">Abonează-te la etichete ca să descoperi bloguri noi</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloguri la care să te abonezi</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -38,7 +38,6 @@ Language: ro
     <string name="reader_toast_err_unable_to_follow_blog">Nu pot face abonarea la acest blog</string>
     <string name="reader_toast_err_already_follow_this_blog">Te-ai abonat deja la acest blog</string>
     <string name="reader_toast_err_show_blog">Nu pot să arăt acest blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Te-ai abonat deja la această etichetă</string>
     <string name="reader_label_choose_interests">Alege ce te interesează</string>
     <string name="reader_label_subscribers_count_single">1 abonat</string>
     <string name="reader_label_subscribers_count">%s abonați</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -29,7 +29,6 @@ Language: ru
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">В блогах, на которые вы подписаны, в последнее время ничего нового не публиковалось.</string>
     <string name="reader_no_followed_blogs_description_subs">Подписывайтесь на блоги с помощью раздела «Поиск» или найдите блог, который вам уже понравился.</string>
     <string name="reader_no_recommended_blogs_title">Нет рекомендуемых блогов</string>
-    <string name="reader_no_followed_tags_title">Нет подписок на теги</string>
     <string name="reader_no_posts_with_this_tag">Нет записей с этой меткой</string>
     <string name="reader_toast_err_unable_to_block_blog">Не удалось заблокировать этот блог</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Записи из этого блога больше не будут отображаться</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -81,7 +81,6 @@ Language: ru
     <string name="reader_filter_empty_blogs_list_text">Подписывайтесь на блоги в разделе «Поиск», и последние записи из них будут отображаться здесь. Или найдите блог, который вам уже понравился.</string>
     <string name="reader_filter_empty_blogs_list_title">Нет подписок на блоги</string>
     <string name="reader_filter_empty_blogs_action">Подписаться на блог</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Вы можете подписаться на определенную тему, добавив тег</string>
     <string name="reader_filter_empty_blogs_list">Просмотреть последние записи из блогов, на которые вы подписаны</string>
     <string name="reader_filter_by_tag_title">Фильтровать по тегу</string>
     <string name="reader_filter_by_blog_title">Фильтровать по блогу</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -51,7 +51,6 @@ Language: ru
     <string name="reader_menu_block_this_blog">Заблокировать этот блог</string>
     <string name="reader_menu_tags_and_blogs">Редактировать теги и блоги</string>
     <string name="reader_page_followed_blogs_title">Подписки на блоги</string>
-    <string name="reader_page_followed_tags_title">Подписки на теги</string>
     <string name="reader_title_tags">Подписаться на теги</string>
     <string name="reader_activity_title_manage_tags_blogs">Управление тегами и блогами</string>
     <string name="reader_activity_title_tag_preview">Метка</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -69,7 +69,6 @@ Language: ru
     <string name="reader_dropdown_menu_subscriptions">Подписки</string>
     <string name="reader_dropdown_menu_discover">Раздел «Поиск»</string>
     <string name="reader_search_content_description">Поиск</string>
-    <string name="reader_discover_no_posts_button_tags_text">Подписаться на теги</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Подпишитесь на другие теги, чтобы расширить область поиска</string>
     <string name="reader_discover_empty_subtitle_subscribe">Подписывайтесь на теги, чтобы находить новые блоги</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Блоги, на которые можно подписаться</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -72,7 +72,6 @@ Language: ru
     <string name="reader_discover_no_posts_subscribe_subtitle">Подпишитесь на другие теги, чтобы расширить область поиска</string>
     <string name="reader_discover_empty_subtitle_subscribe">Подписывайтесь на теги, чтобы находить новые блоги</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Блоги, на которые можно подписаться</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Подписаться на тег</string>
     <string name="reader_filter_empty_tags_action_suggested">Рекомендуемые теги</string>
     <string name="reader_filter_empty_blogs_action_search">Искать блог</string>
     <string name="reader_filter_empty_tags_list_title">Нет тегов</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -70,7 +70,6 @@ Language: ru
     <string name="reader_dropdown_menu_discover">Раздел «Поиск»</string>
     <string name="reader_search_content_description">Поиск</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Подпишитесь на другие теги, чтобы расширить область поиска</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Подписывайтесь на теги, чтобы находить новые блоги</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Блоги, на которые можно подписаться</string>
     <string name="reader_filter_empty_tags_action_suggested">Рекомендуемые теги</string>
     <string name="reader_filter_empty_blogs_action_search">Искать блог</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -45,7 +45,6 @@ Language: ru
     <string name="reader_label_subscribe_count">Подписчиков: %,d</string>
     <string name="reader_label_blog_subscribed">Подписка на блог оформлена</string>
     <string name="reader_hint_search_subscribed_blogs">Поиск подписок на блоги</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Введите URL-адрес или тег, на который хотите подписаться</string>
     <string name="reader_btn_subscribed">Подписка оформлена</string>
     <string name="reader_btn_subscribe">Подписаться</string>
     <string name="reader_menu_block_this_blog">Заблокировать этот блог</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -69,7 +69,6 @@ Language: ru
     <string name="reader_dropdown_menu_subscriptions">Подписки</string>
     <string name="reader_dropdown_menu_discover">Раздел «Поиск»</string>
     <string name="reader_search_content_description">Поиск</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Подпишитесь на другие теги, чтобы расширить область поиска</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Блоги, на которые можно подписаться</string>
     <string name="reader_filter_empty_tags_action_suggested">Рекомендуемые теги</string>
     <string name="reader_filter_empty_blogs_action_search">Искать блог</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -75,7 +75,6 @@ Language: ru
     <string name="reader_filter_empty_tags_action_subscribe">Подписаться на тег</string>
     <string name="reader_filter_empty_tags_action_suggested">Рекомендуемые теги</string>
     <string name="reader_filter_empty_blogs_action_search">Искать блог</string>
-    <string name="reader_filter_empty_tags_list_text">Подпишитесь на тег, и лучшие записи с ним станут отображаться здесь.</string>
     <string name="reader_filter_empty_tags_list_title">Нет тегов</string>
     <string name="reader_filter_empty_blogs_list_text">Подписывайтесь на блоги в разделе «Поиск», и последние записи из них будут отображаться здесь. Или найдите блог, который вам уже понравился.</string>
     <string name="reader_filter_empty_blogs_list_title">Нет подписок на блоги</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -38,7 +38,6 @@ Language: ru
     <string name="reader_toast_err_unable_to_follow_blog">Не удалось подписаться на этот блог</string>
     <string name="reader_toast_err_already_follow_this_blog">Вы уже подписаны на этот блог</string>
     <string name="reader_toast_err_show_blog">Не удалось отобразить этот блог</string>
-    <string name="reader_toast_err_tag_already_subscribed">Вы уже подписаны на этот тег</string>
     <string name="reader_label_choose_interests">Выберите ваши интересы</string>
     <string name="reader_label_subscribers_count_single">1 подписчик</string>
     <string name="reader_label_subscribers_count">Подписчиков: %s</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -38,7 +38,6 @@ Language: sq_AL
     <string name="reader_toast_err_unable_to_follow_blog">S’arrihet të pajtoheni te ky blogu</string>
     <string name="reader_toast_err_already_follow_this_blog">Jeni tashmë i pajtuar te ky blog</string>
     <string name="reader_toast_err_show_blog">S’arrihet të shfaqet ky blog</string>
-    <string name="reader_toast_err_tag_already_subscribed">Jeni i pajtuar tashmë te kjo etiketë</string>
     <string name="reader_label_choose_interests">Zgjidhni ç’ju intereson</string>
     <string name="reader_label_subscribers_count_single">1 pajtimtar</string>
     <string name="reader_label_subscribers_count">%s pajtimtarë</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -71,7 +71,6 @@ Language: sq_AL
     <string name="reader_dropdown_menu_discover">Zbuloni</string>
     <string name="reader_search_content_description">Kërko</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Provoni të pajtoheni në më tepër etiketa, për të zgjeruar kërkimin</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Që të zbuloni blogje të rinj, pajtohuni te etiketa</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogje ku të pajtoheni</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiketa të sugjeruara</string>
     <string name="reader_filter_empty_blogs_action_search">Kërkoni për një blog</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -76,7 +76,6 @@ Language: sq_AL
     <string name="reader_filter_empty_tags_action_subscribe">Pajtohuni te një etiketë</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiketa të sugjeruara</string>
     <string name="reader_filter_empty_blogs_action_search">Kërkoni për një blog</string>
-    <string name="reader_filter_empty_tags_list_text">Pajtohuni te një etiketë dhe do të jeni në gjendje të shihni këtu postimet më të mira.</string>
     <string name="reader_filter_empty_tags_list_title">Pa etiketa</string>
     <string name="reader_filter_empty_blogs_list_text">Pajtohuni në blogje te Zbuloni dhe do të shihni këtu postimet e tyre më të reja. Ose kërkoni për një blog që ju pëlqen tashmë.</string>
     <string name="reader_filter_empty_blogs_list_title">S’ka pajtime në blog</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -45,7 +45,6 @@ Language: sq_AL
     <string name="reader_label_subscribe_count">%,d Pajtimtarë</string>
     <string name="reader_label_blog_subscribed">U pajtuat në blog</string>
     <string name="reader_hint_search_subscribed_blogs">Kërkoni te blogje të pajtuar</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Jepni një URL, ose një etiketë ku të pajtohet</string>
     <string name="reader_btn_subscribed">I pajtuar</string>
     <string name="reader_btn_subscribe">Pajtohuni</string>
     <string name="reader_menu_block_this_blog">Bllokoje këtë blog</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -51,7 +51,6 @@ Language: sq_AL
     <string name="reader_menu_block_this_blog">Bllokoje këtë blog</string>
     <string name="reader_menu_tags_and_blogs">Përpunoni etiketa dhe blogje</string>
     <string name="reader_page_followed_blogs_title">Blogje me pajtime</string>
-    <string name="reader_page_followed_tags_title">Etiketa me pajtime</string>
     <string name="reader_title_tags">Ndiqni etiketa</string>
     <string name="reader_activity_title_manage_tags_blogs">Administroni Etiketa &amp; Blogje</string>
     <string name="reader_activity_title_tag_preview">Etiketë</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -70,7 +70,6 @@ Language: sq_AL
     <string name="reader_dropdown_menu_subscriptions">Pajtime</string>
     <string name="reader_dropdown_menu_discover">Zbuloni</string>
     <string name="reader_search_content_description">Kërko</string>
-    <string name="reader_discover_no_posts_button_tags_text">Pajtohuni te etiketa</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Provoni të pajtoheni në më tepër etiketa, për të zgjeruar kërkimin</string>
     <string name="reader_discover_empty_subtitle_subscribe">Që të zbuloni blogje të rinj, pajtohuni te etiketa</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogje ku të pajtoheni</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -73,7 +73,6 @@ Language: sq_AL
     <string name="reader_discover_no_posts_subscribe_subtitle">Provoni të pajtoheni në më tepër etiketa, për të zgjeruar kërkimin</string>
     <string name="reader_discover_empty_subtitle_subscribe">Që të zbuloni blogje të rinj, pajtohuni te etiketa</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogje ku të pajtoheni</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Pajtohuni te një etiketë</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiketa të sugjeruara</string>
     <string name="reader_filter_empty_blogs_action_search">Kërkoni për një blog</string>
     <string name="reader_filter_empty_tags_list_title">Pa etiketa</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -70,7 +70,6 @@ Language: sq_AL
     <string name="reader_dropdown_menu_subscriptions">Pajtime</string>
     <string name="reader_dropdown_menu_discover">Zbuloni</string>
     <string name="reader_search_content_description">Kërko</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Provoni të pajtoheni në më tepër etiketa, për të zgjeruar kërkimin</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Blogje ku të pajtoheni</string>
     <string name="reader_filter_empty_tags_action_suggested">Etiketa të sugjeruara</string>
     <string name="reader_filter_empty_blogs_action_search">Kërkoni për një blog</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -82,7 +82,6 @@ Language: sq_AL
     <string name="reader_filter_empty_blogs_list_text">Pajtohuni në blogje te Zbuloni dhe do të shihni këtu postimet e tyre më të reja. Ose kërkoni për një blog që ju pëlqen tashmë.</string>
     <string name="reader_filter_empty_blogs_list_title">S’ka pajtime në blog</string>
     <string name="reader_filter_empty_blogs_action">Pajtohuni te një blog</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Mund të pajtoheni te postime lidhur me një subjekt të caktuar, duke dhënë një etiketë</string>
     <string name="reader_filter_empty_blogs_list">Shihni postimet më të reja prej blogjesh ku jeni pajtuar</string>
     <string name="reader_filter_by_tag_title">Filtroji sipas etiketash</string>
     <string name="reader_filter_by_blog_title">Filtroji sipas blogjesh</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -29,7 +29,6 @@ Language: sq_AL
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Blogjet ku jeni pajtuar s’kanë postuar gjë tani së fundi</string>
     <string name="reader_no_followed_blogs_description_subs">Pajtohuni te blogje në Zbuloni, ose kërkoni për një blog që ju pëlqen tashmë.</string>
     <string name="reader_no_recommended_blogs_title">S’ka blogje të rekomanduar</string>
-    <string name="reader_no_followed_tags_title">S’ka etiketa me pajtime</string>
     <string name="reader_no_posts_with_this_tag">S’ka postime me këtë etiketë</string>
     <string name="reader_toast_err_unable_to_block_blog">S’arrihet të bllokohet ky blog</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Postimet prej këtij blogu s’do të shfaqen më</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -70,7 +70,6 @@ Language: sv_SE
     <string name="reader_dropdown_menu_subscriptions">Prenumerationer</string>
     <string name="reader_dropdown_menu_discover">Upptäck</string>
     <string name="reader_search_content_description">Sök</string>
-    <string name="reader_discover_no_posts_button_tags_text">Prenumerera på etiketter</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova att prenumerera på fler etiketter för att bredda sökningen</string>
     <string name="reader_discover_empty_subtitle_subscribe">Prenumerera på etiketter för att upptäcka nya bloggar</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloggar att prenumerera på</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -71,7 +71,6 @@ Language: sv_SE
     <string name="reader_dropdown_menu_discover">Upptäck</string>
     <string name="reader_search_content_description">Sök</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova att prenumerera på fler etiketter för att bredda sökningen</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Prenumerera på etiketter för att upptäcka nya bloggar</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloggar att prenumerera på</string>
     <string name="reader_filter_empty_tags_action_suggested">Föreslagna etiketter</string>
     <string name="reader_filter_empty_blogs_action_search">Sök efter en blogg</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -76,7 +76,6 @@ Language: sv_SE
     <string name="reader_filter_empty_tags_action_subscribe">Prenumerera på en etikett</string>
     <string name="reader_filter_empty_tags_action_suggested">Föreslagna etiketter</string>
     <string name="reader_filter_empty_blogs_action_search">Sök efter en blogg</string>
-    <string name="reader_filter_empty_tags_list_text">Prenumerera på en etikett så kommer du att se de bästa inläggen från den här.</string>
     <string name="reader_filter_empty_tags_list_title">Inga etiketter</string>
     <string name="reader_filter_empty_blogs_list_text">Prenumerera på bloggar i Upptäck så kommer du att se deras senaste inlägg här. Eller så kan du söka efter en blogg som du redan gillar.</string>
     <string name="reader_filter_empty_blogs_list_title">Inga bloggprenumerationer</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -51,7 +51,6 @@ Language: sv_SE
     <string name="reader_menu_block_this_blog">Blockera denna blogg</string>
     <string name="reader_menu_tags_and_blogs">Redigera etiketter och bloggar</string>
     <string name="reader_page_followed_blogs_title">Du prenumererar på de här bloggarna</string>
-    <string name="reader_page_followed_tags_title">Du prenumererar på de här etiketterna</string>
     <string name="reader_title_tags">Följ etiketter</string>
     <string name="reader_activity_title_manage_tags_blogs">Hantera etiketter och bloggar</string>
     <string name="reader_activity_title_tag_preview">Etikett</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -38,7 +38,6 @@ Language: sv_SE
     <string name="reader_toast_err_unable_to_follow_blog">Kan inte prenumerera på denna blogg</string>
     <string name="reader_toast_err_already_follow_this_blog">Du prenumererar redan på denna blogg</string>
     <string name="reader_toast_err_show_blog">Kan inte visa denna blogg</string>
-    <string name="reader_toast_err_tag_already_subscribed">Du prenumererar redan på denna etikett</string>
     <string name="reader_label_choose_interests">Välj dina intressen</string>
     <string name="reader_label_subscribers_count_single">1 prenumerant</string>
     <string name="reader_label_subscribers_count">%s prenumeranter</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -73,7 +73,6 @@ Language: sv_SE
     <string name="reader_discover_no_posts_subscribe_subtitle">Prova att prenumerera på fler etiketter för att bredda sökningen</string>
     <string name="reader_discover_empty_subtitle_subscribe">Prenumerera på etiketter för att upptäcka nya bloggar</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloggar att prenumerera på</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Prenumerera på en etikett</string>
     <string name="reader_filter_empty_tags_action_suggested">Föreslagna etiketter</string>
     <string name="reader_filter_empty_blogs_action_search">Sök efter en blogg</string>
     <string name="reader_filter_empty_tags_list_title">Inga etiketter</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -82,7 +82,6 @@ Language: sv_SE
     <string name="reader_filter_empty_blogs_list_text">Prenumerera på bloggar i Upptäck så kommer du att se deras senaste inlägg här. Eller så kan du söka efter en blogg som du redan gillar.</string>
     <string name="reader_filter_empty_blogs_list_title">Inga bloggprenumerationer</string>
     <string name="reader_filter_empty_blogs_action">Prenumerera på en blogg</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Du kan prenumerera på inlägg om ett specifikt ämne genom att lägga till en etikett</string>
     <string name="reader_filter_empty_blogs_list">Se de nyaste inläggen från bloggar du prenumererar på</string>
     <string name="reader_filter_by_tag_title">Filtrera efter etikett</string>
     <string name="reader_filter_by_blog_title">Filtrera efter blogg</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -29,7 +29,6 @@ Language: sv_SE
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Bloggarna som du prenumererar på har inte publicerat något den senaste tiden</string>
     <string name="reader_no_followed_blogs_description_subs">Prenumerera på bloggar i Upptäck eller sök efter en blogg som du redan gillar.</string>
     <string name="reader_no_recommended_blogs_title">Inga rekommenderade bloggar</string>
-    <string name="reader_no_followed_tags_title">Du prenumererar inte på några etiketter</string>
     <string name="reader_no_posts_with_this_tag">Inga inlägg med denna etikett</string>
     <string name="reader_toast_err_unable_to_block_blog">Kan inte blockera denna blogg</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Inlägg från denna blogg kommer inte längre att visas</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -70,7 +70,6 @@ Language: sv_SE
     <string name="reader_dropdown_menu_subscriptions">Prenumerationer</string>
     <string name="reader_dropdown_menu_discover">Upptäck</string>
     <string name="reader_search_content_description">Sök</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Prova att prenumerera på fler etiketter för att bredda sökningen</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Bloggar att prenumerera på</string>
     <string name="reader_filter_empty_tags_action_suggested">Föreslagna etiketter</string>
     <string name="reader_filter_empty_blogs_action_search">Sök efter en blogg</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -45,7 +45,6 @@ Language: sv_SE
     <string name="reader_label_subscribe_count">%,d prenumeranter</string>
     <string name="reader_label_blog_subscribed">Du prenumererar på den här bloggen</string>
     <string name="reader_hint_search_subscribed_blogs">Sök efter bloggar som du prenumererar på</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Ange en URL eller etikett att prenumerera på</string>
     <string name="reader_btn_subscribed">Prenumererad</string>
     <string name="reader_btn_subscribe">Prenumerera</string>
     <string name="reader_menu_block_this_blog">Blockera denna blogg</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -71,7 +71,6 @@ Language: tr
     <string name="reader_dropdown_menu_discover">Keşfet</string>
     <string name="reader_search_content_description">Ara</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Aramayı genişletmek için daha fazla etikete abone olmayı deneyin</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Yeni bloglar keşfetmek için etiketlere abone olun</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Abone olunacak bloglar</string>
     <string name="reader_filter_empty_tags_action_suggested">Önerilen etiketler</string>
     <string name="reader_filter_empty_blogs_action_search">Blog ara</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -45,7 +45,6 @@ Language: tr
     <string name="reader_label_subscribe_count">%,d Abone</string>
     <string name="reader_label_blog_subscribed">Bloga abone olundu</string>
     <string name="reader_hint_search_subscribed_blogs">Abone olunan bloglarda arayın</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Abone olunacak bir adres veya etiket yazın</string>
     <string name="reader_btn_subscribed">Abone olundu</string>
     <string name="reader_btn_subscribe">Abone ol</string>
     <string name="reader_menu_block_this_blog">Bu blogu engelle</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -76,7 +76,6 @@ Language: tr
     <string name="reader_filter_empty_tags_action_subscribe">Bir etikete abone olun</string>
     <string name="reader_filter_empty_tags_action_suggested">Önerilen etiketler</string>
     <string name="reader_filter_empty_blogs_action_search">Blog ara</string>
-    <string name="reader_filter_empty_tags_list_text">Bir etikete abone olduğunuzda en iyi yazılar burada görüntülenir.</string>
     <string name="reader_filter_empty_tags_list_title">Etiket yok</string>
     <string name="reader_filter_empty_blogs_list_text">Keşfet bölümünden bloglara abone olduğunuzda en son yazılar burada görüntülenir. Zaten sevdiğiniz bir blogu da arayabilirsiniz.</string>
     <string name="reader_filter_empty_blogs_list_title">Abone olunan blog yok</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -51,7 +51,6 @@ Language: tr
     <string name="reader_menu_block_this_blog">Bu blogu engelle</string>
     <string name="reader_menu_tags_and_blogs">Etiketleri ve blogları düzenle</string>
     <string name="reader_page_followed_blogs_title">Abone olunan bloglar</string>
-    <string name="reader_page_followed_tags_title">Abone olunan etiketler</string>
     <string name="reader_title_tags">Etiketleri takip edin</string>
     <string name="reader_activity_title_manage_tags_blogs">Etiket ve blog yönetimi</string>
     <string name="reader_activity_title_tag_preview">Etiket</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -73,7 +73,6 @@ Language: tr
     <string name="reader_discover_no_posts_subscribe_subtitle">Aramayı genişletmek için daha fazla etikete abone olmayı deneyin</string>
     <string name="reader_discover_empty_subtitle_subscribe">Yeni bloglar keşfetmek için etiketlere abone olun</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Abone olunacak bloglar</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Bir etikete abone olun</string>
     <string name="reader_filter_empty_tags_action_suggested">Önerilen etiketler</string>
     <string name="reader_filter_empty_blogs_action_search">Blog ara</string>
     <string name="reader_filter_empty_tags_list_title">Etiket yok</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -29,7 +29,6 @@ Language: tr
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">Abone olduğunuz bloglar yakın zamanda herhangi bir yazı yayınlamadı</string>
     <string name="reader_no_followed_blogs_description_subs">Keşfette bloglara abone olun veya zaten sevdiğiniz bir blogu arayın.</string>
     <string name="reader_no_recommended_blogs_title">Önerilen bir blog yok</string>
-    <string name="reader_no_followed_tags_title">Abone olunan etiket yok</string>
     <string name="reader_no_posts_with_this_tag">Bu etiketi taşıyan bir yazı yok</string>
     <string name="reader_toast_err_unable_to_block_blog">Bu blog engellenemiyor</string>
     <string name="reader_toast_posts_from_this_blog_blocked">Bu bloğun yazıları artık görüntülenmeyecek</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -38,7 +38,6 @@ Language: tr
     <string name="reader_toast_err_unable_to_follow_blog">Bu bloga abone olunamadı</string>
     <string name="reader_toast_err_already_follow_this_blog">Bu bloga zaten abonesiniz</string>
     <string name="reader_toast_err_show_blog">Bu blog görüntülenemiyor</string>
-    <string name="reader_toast_err_tag_already_subscribed">Bu etikete zaten abonesiniz</string>
     <string name="reader_label_choose_interests">İlgi alanlarınızı seçin</string>
     <string name="reader_label_subscribers_count_single">1 abone</string>
     <string name="reader_label_subscribers_count">%s abone</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -70,7 +70,6 @@ Language: tr
     <string name="reader_dropdown_menu_subscriptions">Abonelikler</string>
     <string name="reader_dropdown_menu_discover">Keşfet</string>
     <string name="reader_search_content_description">Ara</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Aramayı genişletmek için daha fazla etikete abone olmayı deneyin</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Abone olunacak bloglar</string>
     <string name="reader_filter_empty_tags_action_suggested">Önerilen etiketler</string>
     <string name="reader_filter_empty_blogs_action_search">Blog ara</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -70,7 +70,6 @@ Language: tr
     <string name="reader_dropdown_menu_subscriptions">Abonelikler</string>
     <string name="reader_dropdown_menu_discover">Keşfet</string>
     <string name="reader_search_content_description">Ara</string>
-    <string name="reader_discover_no_posts_button_tags_text">Etiketleri takip et</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Aramayı genişletmek için daha fazla etikete abone olmayı deneyin</string>
     <string name="reader_discover_empty_subtitle_subscribe">Yeni bloglar keşfetmek için etiketlere abone olun</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">Abone olunacak bloglar</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -82,7 +82,6 @@ Language: tr
     <string name="reader_filter_empty_blogs_list_text">Keşfet bölümünden bloglara abone olduğunuzda en son yazılar burada görüntülenir. Zaten sevdiğiniz bir blogu da arayabilirsiniz.</string>
     <string name="reader_filter_empty_blogs_list_title">Abone olunan blog yok</string>
     <string name="reader_filter_empty_blogs_action">Bloga abone ol</string>
-    <string name="reader_filter_empty_tags_list_subscribe">Bir etiket ekleyerek belirli bir konudaki yazılara abone olabilirsiniz</string>
     <string name="reader_filter_empty_blogs_list">Abone olduğunuz bloglardaki en iyi yazıları görün</string>
     <string name="reader_filter_by_tag_title">Etikete göre süz</string>
     <string name="reader_filter_by_blog_title">Bloğa göre süz</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -69,7 +69,6 @@ Language: zh_CN
     <string name="reader_dropdown_menu_subscriptions">订阅</string>
     <string name="reader_dropdown_menu_discover">发现</string>
     <string name="reader_search_content_description">搜索</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">尝试订阅更多标签，以扩大搜索范围</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">要订阅的博客</string>
     <string name="reader_filter_empty_tags_action_suggested">建议标签</string>
     <string name="reader_filter_empty_blogs_action_search">搜索博客</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -70,7 +70,6 @@ Language: zh_CN
     <string name="reader_dropdown_menu_discover">发现</string>
     <string name="reader_search_content_description">搜索</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">尝试订阅更多标签，以扩大搜索范围</string>
-    <string name="reader_discover_empty_subtitle_subscribe">订阅标签以发现新的博客</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">要订阅的博客</string>
     <string name="reader_filter_empty_tags_action_suggested">建议标签</string>
     <string name="reader_filter_empty_blogs_action_search">搜索博客</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -29,7 +29,6 @@ Language: zh_CN
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">您订阅的博客最近未发布任何内容</string>
     <string name="reader_no_followed_blogs_description_subs">在“搜索”中订阅博客，或者搜索一个您已点赞过的博客。</string>
     <string name="reader_no_recommended_blogs_title">无推荐博客</string>
-    <string name="reader_no_followed_tags_title">无订阅的标签</string>
     <string name="reader_no_posts_with_this_tag">无包含此标签的文章</string>
     <string name="reader_toast_err_unable_to_block_blog">无法阻止此博客</string>
     <string name="reader_toast_posts_from_this_blog_blocked">此博客中的文章不会再显示</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -72,7 +72,6 @@ Language: zh_CN
     <string name="reader_discover_no_posts_subscribe_subtitle">尝试订阅更多标签，以扩大搜索范围</string>
     <string name="reader_discover_empty_subtitle_subscribe">订阅标签以发现新的博客</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">要订阅的博客</string>
-    <string name="reader_filter_empty_tags_action_subscribe">订阅一个标签</string>
     <string name="reader_filter_empty_tags_action_suggested">建议标签</string>
     <string name="reader_filter_empty_blogs_action_search">搜索博客</string>
     <string name="reader_filter_empty_tags_list_title">无标签</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -51,7 +51,6 @@ Language: zh_CN
     <string name="reader_menu_block_this_blog">阻止此博客</string>
     <string name="reader_menu_tags_and_blogs">编辑标签和博客</string>
     <string name="reader_page_followed_blogs_title">已订阅的博客</string>
-    <string name="reader_page_followed_tags_title">已订阅的标签</string>
     <string name="reader_title_tags">关注标签</string>
     <string name="reader_activity_title_manage_tags_blogs">管理标签和博客</string>
     <string name="reader_activity_title_tag_preview">标签</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -69,7 +69,6 @@ Language: zh_CN
     <string name="reader_dropdown_menu_subscriptions">订阅</string>
     <string name="reader_dropdown_menu_discover">发现</string>
     <string name="reader_search_content_description">搜索</string>
-    <string name="reader_discover_no_posts_button_tags_text">订阅标签</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">尝试订阅更多标签，以扩大搜索范围</string>
     <string name="reader_discover_empty_subtitle_subscribe">订阅标签以发现新的博客</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">要订阅的博客</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -38,7 +38,6 @@ Language: zh_CN
     <string name="reader_toast_err_unable_to_follow_blog">无法订阅此博客</string>
     <string name="reader_toast_err_already_follow_this_blog">您已订阅此博客</string>
     <string name="reader_toast_err_show_blog">无法显示此博客</string>
-    <string name="reader_toast_err_tag_already_subscribed">您已订阅此标签</string>
     <string name="reader_label_choose_interests">选择您的兴趣</string>
     <string name="reader_label_subscribers_count_single">1 位订阅者</string>
     <string name="reader_label_subscribers_count">%s 位订阅者</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -45,7 +45,6 @@ Language: zh_CN
     <string name="reader_label_subscribe_count">%,d 位订阅者</string>
     <string name="reader_label_blog_subscribed">已订阅博客</string>
     <string name="reader_hint_search_subscribed_blogs">搜索已订阅的博客</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">输入要订阅的 URL 或标签</string>
     <string name="reader_btn_subscribed">已订阅</string>
     <string name="reader_btn_subscribe">订阅</string>
     <string name="reader_menu_block_this_blog">阻止此博客</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -75,7 +75,6 @@ Language: zh_CN
     <string name="reader_filter_empty_tags_action_subscribe">订阅一个标签</string>
     <string name="reader_filter_empty_tags_action_suggested">建议标签</string>
     <string name="reader_filter_empty_blogs_action_search">搜索博客</string>
-    <string name="reader_filter_empty_tags_list_text">订阅一个标签，您就能在此处看到该标签下的最佳文章。</string>
     <string name="reader_filter_empty_tags_list_title">无标签</string>
     <string name="reader_filter_empty_blogs_list_text">在“发现”中订阅博客，您就能在此处看到他们的最新文章。 或者搜索一个您已点赞过的博客。</string>
     <string name="reader_filter_empty_blogs_list_title">无博客订阅</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -81,7 +81,6 @@ Language: zh_CN
     <string name="reader_filter_empty_blogs_list_text">在“发现”中订阅博客，您就能在此处看到他们的最新文章。 或者搜索一个您已点赞过的博客。</string>
     <string name="reader_filter_empty_blogs_list_title">无博客订阅</string>
     <string name="reader_filter_empty_blogs_action">订阅博客</string>
-    <string name="reader_filter_empty_tags_list_subscribe">您可以通过添加标签的方式来订阅特定主题的文章</string>
     <string name="reader_filter_empty_blogs_list">查看您所订阅的博客的最新文章</string>
     <string name="reader_filter_by_tag_title">按标签筛选</string>
     <string name="reader_filter_by_blog_title">按博客筛选</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -70,7 +70,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_subscriptions">訂閱</string>
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -45,7 +45,6 @@ Language: zh_TW
     <string name="reader_label_subscribe_count">%,d 名訂閱者</string>
     <string name="reader_label_blog_subscribed">網誌已訂閱</string>
     <string name="reader_hint_search_subscribed_blogs">搜尋已訂閱的網誌</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">輸入要訂閱的 URL 或標籤</string>
     <string name="reader_btn_subscribed">已訂閱</string>
     <string name="reader_btn_subscribe">訂閱</string>
     <string name="reader_menu_block_this_blog">封鎖此網誌</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -71,7 +71,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
-    <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -38,7 +38,6 @@ Language: zh_TW
     <string name="reader_toast_err_unable_to_follow_blog">無法訂閱此網誌</string>
     <string name="reader_toast_err_already_follow_this_blog">你已訂閱此網誌</string>
     <string name="reader_toast_err_show_blog">無法顯示此網誌</string>
-    <string name="reader_toast_err_tag_already_subscribed">你已訂閱此標籤</string>
     <string name="reader_label_choose_interests">選擇你的興趣</string>
     <string name="reader_label_subscribers_count_single">1 名訂閱者</string>
     <string name="reader_label_subscribers_count">%s 名訂閱者</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -51,7 +51,6 @@ Language: zh_TW
     <string name="reader_menu_block_this_blog">封鎖此網誌</string>
     <string name="reader_menu_tags_and_blogs">編輯標籤和網誌</string>
     <string name="reader_page_followed_blogs_title">已訂閱的網誌</string>
-    <string name="reader_page_followed_tags_title">已訂閱的標籤</string>
     <string name="reader_title_tags">關注標籤</string>
     <string name="reader_activity_title_manage_tags_blogs">管理標籤和網誌</string>
     <string name="reader_activity_title_tag_preview">標籤</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -73,7 +73,6 @@ Language: zh_TW
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
-    <string name="reader_filter_empty_tags_action_subscribe">訂閱標籤</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>
     <string name="reader_filter_empty_tags_list_title">無標籤</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -70,7 +70,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_subscriptions">訂閱</string>
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
-    <string name="reader_discover_no_posts_button_tags_text">訂閱標籤</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -29,7 +29,6 @@ Language: zh_TW
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">你訂閱的網誌最近未張貼任何文章</string>
     <string name="reader_no_followed_blogs_description_subs">訂閱「探索」中的網誌或搜尋你已按讚的網誌。</string>
     <string name="reader_no_recommended_blogs_title">沒有推薦的網誌</string>
-    <string name="reader_no_followed_tags_title">沒有訂閱的標籤</string>
     <string name="reader_no_posts_with_this_tag">沒有任何含有此標籤的文章</string>
     <string name="reader_toast_err_unable_to_block_blog">無法封鎖此網誌</string>
     <string name="reader_toast_posts_from_this_blog_blocked">將不再顯示此網誌的文章</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -76,7 +76,6 @@ Language: zh_TW
     <string name="reader_filter_empty_tags_action_subscribe">訂閱標籤</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>
-    <string name="reader_filter_empty_tags_list_text">只要訂閱標籤，就能從此處看到最佳文章。</string>
     <string name="reader_filter_empty_tags_list_title">無標籤</string>
     <string name="reader_filter_empty_blogs_list_text">在「探索」中訂閱網誌，就會於此處看到網誌的最新文章。 或者搜尋你已按讚的網誌。</string>
     <string name="reader_filter_empty_blogs_list_title">無網誌訂閱</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -82,7 +82,6 @@ Language: zh_TW
     <string name="reader_filter_empty_blogs_list_text">在「探索」中訂閱網誌，就會於此處看到網誌的最新文章。 或者搜尋你已按讚的網誌。</string>
     <string name="reader_filter_empty_blogs_list_title">無網誌訂閱</string>
     <string name="reader_filter_empty_blogs_action">訂閱網誌</string>
-    <string name="reader_filter_empty_tags_list_subscribe">你可以新增標籤以訂閱特定主題的文章</string>
     <string name="reader_filter_empty_blogs_list">查看你已訂閱網誌的最新文章</string>
     <string name="reader_filter_by_tag_title">依標籤篩選</string>
     <string name="reader_filter_by_blog_title">依網誌篩選</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -70,7 +70,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_subscriptions">訂閱</string>
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -45,7 +45,6 @@ Language: zh_TW
     <string name="reader_label_subscribe_count">%,d 名訂閱者</string>
     <string name="reader_label_blog_subscribed">網誌已訂閱</string>
     <string name="reader_hint_search_subscribed_blogs">搜尋已訂閱的網誌</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">輸入要訂閱的 URL 或標籤</string>
     <string name="reader_btn_subscribed">已訂閱</string>
     <string name="reader_btn_subscribe">訂閱</string>
     <string name="reader_menu_block_this_blog">封鎖此網誌</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -71,7 +71,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
-    <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -38,7 +38,6 @@ Language: zh_TW
     <string name="reader_toast_err_unable_to_follow_blog">無法訂閱此網誌</string>
     <string name="reader_toast_err_already_follow_this_blog">你已訂閱此網誌</string>
     <string name="reader_toast_err_show_blog">無法顯示此網誌</string>
-    <string name="reader_toast_err_tag_already_subscribed">你已訂閱此標籤</string>
     <string name="reader_label_choose_interests">選擇你的興趣</string>
     <string name="reader_label_subscribers_count_single">1 名訂閱者</string>
     <string name="reader_label_subscribers_count">%s 名訂閱者</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -51,7 +51,6 @@ Language: zh_TW
     <string name="reader_menu_block_this_blog">封鎖此網誌</string>
     <string name="reader_menu_tags_and_blogs">編輯標籤和網誌</string>
     <string name="reader_page_followed_blogs_title">已訂閱的網誌</string>
-    <string name="reader_page_followed_tags_title">已訂閱的標籤</string>
     <string name="reader_title_tags">關注標籤</string>
     <string name="reader_activity_title_manage_tags_blogs">管理標籤和網誌</string>
     <string name="reader_activity_title_tag_preview">標籤</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -73,7 +73,6 @@ Language: zh_TW
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>
-    <string name="reader_filter_empty_tags_action_subscribe">訂閱標籤</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>
     <string name="reader_filter_empty_tags_list_title">無標籤</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -70,7 +70,6 @@ Language: zh_TW
     <string name="reader_dropdown_menu_subscriptions">訂閱</string>
     <string name="reader_dropdown_menu_discover">探索</string>
     <string name="reader_search_content_description">搜尋</string>
-    <string name="reader_discover_no_posts_button_tags_text">訂閱標籤</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">嘗試訂閱更多標籤，即可擴大搜尋範圍</string>
     <string name="reader_discover_empty_subtitle_subscribe">訂閱標籤即可探索新網誌</string>
     <string name="reader_discover_recommended_blogs_to_subscribe_header">可訂閱的網誌</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@ Language: zh_TW
     <string name="reader_empty_followed_blogs_subscribed_no_recent_posts_description">你訂閱的網誌最近未張貼任何文章</string>
     <string name="reader_no_followed_blogs_description_subs">訂閱「探索」中的網誌或搜尋你已按讚的網誌。</string>
     <string name="reader_no_recommended_blogs_title">沒有推薦的網誌</string>
-    <string name="reader_no_followed_tags_title">沒有訂閱的標籤</string>
     <string name="reader_no_posts_with_this_tag">沒有任何含有此標籤的文章</string>
     <string name="reader_toast_err_unable_to_block_blog">無法封鎖此網誌</string>
     <string name="reader_toast_posts_from_this_blog_blocked">將不再顯示此網誌的文章</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -76,7 +76,6 @@ Language: zh_TW
     <string name="reader_filter_empty_tags_action_subscribe">訂閱標籤</string>
     <string name="reader_filter_empty_tags_action_suggested">已建議的標籤</string>
     <string name="reader_filter_empty_blogs_action_search">搜尋網誌</string>
-    <string name="reader_filter_empty_tags_list_text">只要訂閱標籤，就能從此處看到最佳文章。</string>
     <string name="reader_filter_empty_tags_list_title">無標籤</string>
     <string name="reader_filter_empty_blogs_list_text">在「探索」中訂閱網誌，就會於此處看到網誌的最新文章。 或者搜尋你已按讚的網誌。</string>
     <string name="reader_filter_empty_blogs_list_title">無網誌訂閱</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -82,7 +82,6 @@ Language: zh_TW
     <string name="reader_filter_empty_blogs_list_text">在「探索」中訂閱網誌，就會於此處看到網誌的最新文章。 或者搜尋你已按讚的網誌。</string>
     <string name="reader_filter_empty_blogs_list_title">無網誌訂閱</string>
     <string name="reader_filter_empty_blogs_action">訂閱網誌</string>
-    <string name="reader_filter_empty_tags_list_subscribe">你可以新增標籤以訂閱特定主題的文章</string>
     <string name="reader_filter_empty_blogs_list">查看你已訂閱網誌的最新文章</string>
     <string name="reader_filter_by_tag_title">依標籤篩選</string>
     <string name="reader_filter_by_blog_title">依網誌篩選</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1643,7 +1643,7 @@
     <string name="reader_filter_empty_blogs_list_title">No blog subscriptions</string>
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>
     <string name="reader_filter_empty_tags_list_title">No tags</string>
-    <string name="reader_filter_empty_tags_list_text">Subscribe to a tag and you’ll be able to see the best posts from it here.</string>
+    <string name="reader_filter_empty_tags_list_follow_text">Follow a tag and you’ll be able to see the best posts from it here.</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2145,7 +2145,7 @@
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>
     <string name="reader_hint_comment_on_comment">Reply to comment…</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Enter a URL or tag to subscribe to</string>
+    <string name="reader_hint_add_tag_or_url_follow">Enter a URL or tag to follow</string>
     <string name="reader_hint_post_search">Search WordPress</string>
     <string name="reader_hint_search_subscribed_blogs">Search subscribed blogs</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2196,7 +2196,7 @@
 
     <!-- toast messages -->
     <string name="reader_toast_err_comment_failed">Couldn\'t post your comment</string>
-    <string name="reader_toast_err_tag_already_subscribed">You\'re already subscribed to this tag</string>
+    <string name="reader_toast_err_tag_already_following">You\'re already following this tag</string>
     <string name="reader_toast_err_tag_not_valid">That isn\'t a valid tag</string>
     <string name="reader_toast_err_adding_tag">Unable to add this tag</string>
     <string name="reader_toast_err_removing_tag">Unable to remove this tag</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2102,7 +2102,7 @@
     <string name="reader_title_tags">Follow tags</string>
 
     <!-- view pager titles -->
-    <string name="reader_page_followed_tags_title">Subscribed tags</string>
+    <string name="reader_page_followed_tags_text_title">Followed tags</string>
     <string name="reader_page_followed_blogs_title">Subscribed blogs</string>
 
     <!-- menu text -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1636,7 +1636,6 @@
     <string name="reader_filter_by_blog_title">Filter by blog</string>
     <string name="reader_filter_by_tag_title">Filter by tag</string>
     <string name="reader_filter_empty_blogs_list">See the newest posts from blogs you\'re subscribed to</string>
-    <string name="reader_filter_empty_tags_list_subscribe">You can subscribe to posts on a specific subject by adding a tag</string>
     <string name="reader_filter_self_hosted_empty_blogs_list">Log in to WordPress.com to see the latest posts from blogs you\'re subscribed to</string>
     <string name="reader_filter_self_hosted_empty_tags_list">Log in to WordPress.com to see the latest posts from tags you\'re subscribed to</string>
     <string name="reader_filter_empty_blogs_action">Subscribe to a blog</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1663,7 +1663,7 @@
     <string name="reader_discover_no_posts_title">No recent posts</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
-    <string name="reader_discover_no_posts_button_tags_text">Subscribe to tags</string>
+    <string name="reader_discover_no_posts_button_tags_text_follow">Follow tags</string>
     <string name="reader_author_with_blog_name" translatable="false">%1$s ▸ %2$s</string>
     <string name="reader_follow_comments_null_response">No response received</string>
     <string name="reader_follow_comments_bad_format_response">Invalid response received</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2237,7 +2237,7 @@
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_blogs_posts_in_custom_list">The blogs in this list have not posted anything recently</string>
     <string name="reader_empty_subscribed_tags_subtitle">Add tags here to find posts about your favorite topics</string>
-    <string name="reader_no_followed_tags_title">No subscribed tags</string>
+    <string name="reader_no_followed_tags_text_title">No followed tags</string>
     <string name="reader_no_recommended_blogs_title">No recommended blogs</string>
     <string name="reader_no_followed_blogs_title" translatable="false">@string/reader_filter_empty_blogs_list_title</string>
     <string name="reader_no_followed_blogs_search_title">No blogs matching your search</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1661,7 +1661,7 @@
     <string name="reader_discover_empty_title">Welcome!</string>
     <string name="reader_discover_empty_subtitle_follow">Follow tags to discover new blogs</string>
     <string name="reader_discover_no_posts_title">No recent posts</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
+    <string name="reader_discover_no_posts_follow_subtitle">Try following more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
     <string name="reader_discover_no_posts_button_tags_text_follow">Follow tags</string>
     <string name="reader_author_with_blog_name" translatable="false">%1$s ▸ %2$s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1659,7 +1659,7 @@
     <string name="reader_post_details_header_by_author_name">By</string>
     <string name="show_n_hidden_items_desc">%1$s more items</string>
     <string name="reader_discover_empty_title">Welcome!</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
+    <string name="reader_discover_empty_subtitle_follow">Follow tags to discover new blogs</string>
     <string name="reader_discover_no_posts_title">No recent posts</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1646,7 +1646,7 @@
     <string name="reader_filter_empty_tags_list_follow_text">Follow a tag and you’ll be able to see the best posts from it here.</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
+    <string name="reader_filter_empty_tags_action_follow">Follow a tag</string>
     <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
     <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
     <string name="reader_error_request_failed_title">There was a problem handling the request. Please try again later.</string>

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
@@ -71,7 +71,7 @@ class SubfilterPageViewModelTest : BaseUnitTest() {
 
         with(viewModel.emptyState.value as VisibleEmptyUiState) {
             assertThat(title).isEqualTo(UiStringRes(R.string.reader_filter_empty_tags_list_title))
-            assertThat(text).isEqualTo(UiStringRes(R.string.reader_filter_empty_tags_list_text))
+            assertThat(text).isEqualTo(UiStringRes(R.string.reader_filter_empty_tags_list_follow_text))
             assertThat(primaryButton).isEqualTo(
                 VisibleEmptyUiState.Button(
                     text = UiStringRes(R.string.reader_filter_empty_tags_action_suggested),

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/reader/SubfilterPageViewModelTest.kt
@@ -80,7 +80,7 @@ class SubfilterPageViewModelTest : BaseUnitTest() {
             )
             assertThat(secondaryButton).isEqualTo(
                 VisibleEmptyUiState.Button(
-                    text = UiStringRes(R.string.reader_filter_empty_tags_action_subscribe),
+                    text = UiStringRes(R.string.reader_filter_empty_tags_action_follow),
                     action = ActionType.OpenSubsAtPage(ReaderSubsActivity.TAB_IDX_FOLLOWED_TAGS)
                 )
             )

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1663,7 +1663,6 @@
     <string name="reader_discover_no_posts_title">No recent posts</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
-    <string name="reader_discover_no_posts_button_tags_text">Subscribe to tags</string>
     <string name="reader_author_with_blog_name" translatable="false">%1$s ▸ %2$s</string>
     <string name="reader_follow_comments_null_response">No response received</string>
     <string name="reader_follow_comments_bad_format_response">Invalid response received</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1657,7 +1657,6 @@
     <string name="reader_post_details_header_by_author_name">By</string>
     <string name="show_n_hidden_items_desc">%1$s more items</string>
     <string name="reader_discover_empty_title">Welcome!</string>
-    <string name="reader_discover_empty_subtitle_subscribe">Subscribe to tags to discover new blogs</string>
     <string name="reader_discover_no_posts_title">No recent posts</string>
     <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1658,7 +1658,6 @@
     <string name="show_n_hidden_items_desc">%1$s more items</string>
     <string name="reader_discover_empty_title">Welcome!</string>
     <string name="reader_discover_no_posts_title">No recent posts</string>
-    <string name="reader_discover_no_posts_subscribe_subtitle">Try subscribing to more tags to broaden the search</string>
     <string name="reader_discover_empty_button_text">Get Started</string>
     <string name="reader_author_with_blog_name" translatable="false">%1$s ▸ %2$s</string>
     <string name="reader_follow_comments_null_response">No response received</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1645,7 +1645,6 @@
     <string name="reader_filter_empty_tags_list_title">No tags</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
-    <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>
     <string name="reader_filter_self_hosted_empty_sites_tags_action">Log in to WordPress.com</string>
     <string name="reader_dot_separator" translatable="false">\u0020\u2022\u0020</string>
     <string name="reader_error_request_failed_title">There was a problem handling the request. Please try again later.</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1636,7 +1636,6 @@
     <string name="reader_filter_by_blog_title">Filter by blog</string>
     <string name="reader_filter_by_tag_title">Filter by tag</string>
     <string name="reader_filter_empty_blogs_list">See the newest posts from blogs you\'re subscribed to</string>
-    <string name="reader_filter_empty_tags_list_subscribe">You can subscribe to posts on a specific subject by adding a tag</string>
     <string name="reader_filter_self_hosted_empty_blogs_list">Log in to WordPress.com to see the latest posts from blogs you\'re subscribed to</string>
     <string name="reader_filter_self_hosted_empty_tags_list">Log in to WordPress.com to see the latest posts from tags you\'re subscribed to</string>
     <string name="reader_filter_empty_blogs_action">Subscribe to a blog</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2139,7 +2139,6 @@
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>
     <string name="reader_hint_comment_on_comment">Reply to comment…</string>
-    <string name="reader_hint_add_tag_or_url_subscribe">Enter a URL or tag to subscribe to</string>
     <string name="reader_hint_post_search">Search WordPress</string>
     <string name="reader_hint_search_subscribed_blogs">Search subscribed blogs</string>
 

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2189,7 +2189,6 @@
 
     <!-- toast messages -->
     <string name="reader_toast_err_comment_failed">Couldn\'t post your comment</string>
-    <string name="reader_toast_err_tag_already_subscribed">You\'re already subscribed to this tag</string>
     <string name="reader_toast_err_tag_not_valid">That isn\'t a valid tag</string>
     <string name="reader_toast_err_adding_tag">Unable to add this tag</string>
     <string name="reader_toast_err_removing_tag">Unable to remove this tag</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2229,7 +2229,6 @@
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_blogs_posts_in_custom_list">The blogs in this list have not posted anything recently</string>
     <string name="reader_empty_subscribed_tags_subtitle">Add tags here to find posts about your favorite topics</string>
-    <string name="reader_no_followed_tags_title">No subscribed tags</string>
     <string name="reader_no_recommended_blogs_title">No recommended blogs</string>
     <string name="reader_no_followed_blogs_title" translatable="false">@string/reader_filter_empty_blogs_list_title</string>
     <string name="reader_no_followed_blogs_search_title">No blogs matching your search</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -1643,7 +1643,6 @@
     <string name="reader_filter_empty_blogs_list_title">No blog subscriptions</string>
     <string name="reader_filter_empty_blogs_list_text">Subscribe to blogs in Discover and you’ll see their latest posts here. Or search for a blog that you like already.</string>
     <string name="reader_filter_empty_tags_list_title">No tags</string>
-    <string name="reader_filter_empty_tags_list_text">Subscribe to a tag and you’ll be able to see the best posts from it here.</string>
     <string name="reader_filter_empty_blogs_action_search">Search for a blog</string>
     <string name="reader_filter_empty_tags_action_suggested">Suggested tags</string>
     <string name="reader_filter_empty_tags_action_subscribe">Subscribe to a tag</string>

--- a/fastlane/resources/values/strings.xml
+++ b/fastlane/resources/values/strings.xml
@@ -2097,7 +2097,6 @@
     <string name="reader_title_tags">Follow tags</string>
 
     <!-- view pager titles -->
-    <string name="reader_page_followed_tags_title">Subscribed tags</string>
     <string name="reader_page_followed_blogs_title">Subscribed blogs</string>
 
     <!-- menu text -->


### PR DESCRIPTION
Fixes #20297 

-----

## To Test:

1. Launch Jetpack and login
2. Do a general smoke test of Reader screens
3. All tag related strings should be using `"follow"` instead of `"subscribe"`
-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
