### PR TITLE
Fixes broken notification comments regression

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -133,8 +133,12 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             showErrorToastAndFinish()
         }
 
+        val animation = view?.findViewById<LottieAnimationView>(R.id.confetti)
         if (note?.isViewMilestoneType == true) {
-            view?.findViewById<LottieAnimationView>(R.id.confetti)?.playAnimation()
+            animation?.visibility = View.VISIBLE
+            animation?.playAnimation()
+        } else {
+            animation?.visibility = View.GONE
         }
     }
 

--- a/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
@@ -12,6 +12,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="top"
         android:scaleType="centerCrop"
+        android:visibility="gone"
         app:lottie_autoPlay="false"
         app:lottie_loop="false"
         app:lottie_rawRes="@raw/confetti" />


### PR DESCRIPTION
Fixes broken notification comments (see p1711097822404029-slack-C0180B5PRJ4)

## Description
This PR fixes a regression introduced by https://github.com/wordpress-mobile/WordPress-Android/pull/20452 were the notification comments did not appear

-----

## To Test:
1. Verify that notification comments appear
2. Verify that the confetti is shown (see https://github.com/wordpress-mobile/WordPress-Android/pull/20452)


https://github.com/wordpress-mobile/WordPress-Android/assets/304044/44565255-2c7a-4a0b-b005-3dcdd623ae4b

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

5. What automated tests I added (or what prevented me from doing so)

    - This part of the code is not easy to test without a major refactoring that would escape the scope of this PR

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)