### PR TITLE
Fix pull to refresh Stats bug

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsModule.kt
@@ -457,7 +457,11 @@ class StatsModule {
         return if (trafficTabFeatureConfig.isEnabled()) {
             mapOf(
                 StatsSection.TRAFFIC to trafficUseCase,
-                StatsSection.INSIGHTS to insightsUseCase
+                StatsSection.INSIGHTS to insightsUseCase,
+                StatsSection.DAYS to dayStatsUseCase,
+                StatsSection.WEEKS to weekStatsUseCase,
+                StatsSection.MONTHS to monthStatsUseCase,
+                StatsSection.YEARS to yearStatsUseCase
             )
         } else {
             mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -302,8 +302,32 @@ class StatsViewModel
         if (networkUtilsWrapper.isNetworkAvailable()) {
             loadData {
                 val baseListUseCase = listUseCases[statsSectionManager.getSelectedSection()]
+                val statsSection = statsSectionManager.getSelectedSection()
+                val baseListUseCase = listUseCases[statsSection]
                 baseListUseCase?.refreshTypes()
                 baseListUseCase?.refreshData(true)
+
+                if (statsTrafficTabFeatureConfig.isEnabled()) {
+                    val statsGranularity =
+                        selectedTrafficGranularityManager.getSelectedTrafficGranularity()
+                    if (statsGranularity == StatsGranularity.DAYS) {
+                        val currentUseCase = listUseCases[StatsSection.DAYS]
+                        currentUseCase?.refreshTypes()
+                        currentUseCase?.refreshData(true)
+                    } else if (statsGranularity == StatsGranularity.WEEKS) {
+                        val currentUseCase = listUseCases[StatsSection.WEEKS]
+                        currentUseCase?.refreshTypes()
+                        currentUseCase?.refreshData(true)
+                    } else if (statsGranularity == StatsGranularity.MONTHS) {
+                        val currentUseCase = listUseCases[StatsSection.MONTHS]
+                        currentUseCase?.refreshTypes()
+                        currentUseCase?.refreshData(true)
+                    } else {
+                        val currentUseCase = listUseCases[StatsSection.YEARS]
+                        currentUseCase?.refreshTypes()
+                        currentUseCase?.refreshData(true)
+                    }
+                }
             }
         } else {
             _isRefreshing.value = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -301,32 +301,23 @@ class StatsViewModel
         statsSiteProvider.clear()
         if (networkUtilsWrapper.isNetworkAvailable()) {
             loadData {
-                val baseListUseCase = listUseCases[statsSectionManager.getSelectedSection()]
-                val statsSection = statsSectionManager.getSelectedSection()
-                val baseListUseCase = listUseCases[statsSection]
-                baseListUseCase?.refreshTypes()
-                baseListUseCase?.refreshData(true)
-
                 if (statsTrafficTabFeatureConfig.isEnabled()) {
-                    val statsGranularity =
-                        selectedTrafficGranularityManager.getSelectedTrafficGranularity()
-                    if (statsGranularity == StatsGranularity.DAYS) {
-                        val currentUseCase = listUseCases[StatsSection.DAYS]
-                        currentUseCase?.refreshTypes()
-                        currentUseCase?.refreshData(true)
-                    } else if (statsGranularity == StatsGranularity.WEEKS) {
-                        val currentUseCase = listUseCases[StatsSection.WEEKS]
-                        currentUseCase?.refreshTypes()
-                        currentUseCase?.refreshData(true)
-                    } else if (statsGranularity == StatsGranularity.MONTHS) {
-                        val currentUseCase = listUseCases[StatsSection.MONTHS]
-                        currentUseCase?.refreshTypes()
-                        currentUseCase?.refreshData(true)
-                    } else {
-                        val currentUseCase = listUseCases[StatsSection.YEARS]
-                        currentUseCase?.refreshTypes()
-                        currentUseCase?.refreshData(true)
+                    val currentUseCase: BaseListUseCase?
+                    val statsGranularity = selectedTrafficGranularityManager.getSelectedTrafficGranularity()
+
+                    currentUseCase = when (statsGranularity) {
+                        StatsGranularity.DAYS -> listUseCases[StatsSection.DAYS]
+                        StatsGranularity.WEEKS -> listUseCases[StatsSection.WEEKS]
+                        StatsGranularity.MONTHS -> listUseCases[StatsSection.MONTHS]
+                        else -> listUseCases[StatsSection.YEARS]
                     }
+                    currentUseCase?.refreshTypes()
+                    currentUseCase?.refreshData(true)
+                } else {
+                    val statsSection = statsSectionManager.getSelectedSection()
+                    val baseListUseCase = listUseCases[statsSection]
+                    baseListUseCase?.refreshTypes()
+                    baseListUseCase?.refreshData(true)
                 }
             }
         } else {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20397

This PR fixes an issue where pull to refresh wouldn't update Stats. This was happening because `statsSection` was being set to `TRAFFIC` with no information on time granularity. This PR maps `StatsGranularity` to its corresponding `StatsSection` so that we can refresh the correct `useCase`. For example, it maps `StatsGranularity.DAYS` to `StatsSection.DAYS` so the correct data can be refreshed. 
Alternatively, we could choose to refresh `all` granularities on pull to refresh which would remove the need for mapping with the feature flag on, but would also be less efficient.

-----

## To Test:

1. With the Stats feature flag on, navigate to the Stats page.
2. Turn data off and change the granularity or time period. 
3. You should see `There was a problem loading your data, refresh your page to try again`:
<img width="313" alt="Screenshot 2024-03-25 at 2 17 18 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/3b8d7312-8baa-47ff-a9e2-81297122280d">

4. Turn data on again. Refresh the page and it should display data.
5. Repeat steps 1-4 with the feature flag off. 


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

7. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
