### PR TITLE
[Reader] Fix like button responsiveness in "Discover" feed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -132,6 +132,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.DisplayUtilsWrapper;
 import org.wordpress.android.util.JetpackBrandingUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.NetworkUtilsWrapper;
 import org.wordpress.android.util.QuickStartUtilsWrapper;
 import org.wordpress.android.util.SnackbarItem;
 import org.wordpress.android.util.SnackbarItem.Action;
@@ -180,6 +181,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
     @Inject Dispatcher mDispatcher;
     @Inject ImageManager mImageManager;
     @Inject UiHelpers mUiHelpers;
+    @Inject NetworkUtilsWrapper mNetworkUtilsWrapper;
     @Inject TagUpdateClientUtilsProvider mTagUpdateClientUtilsProvider;
     @Inject QuickStartUtilsWrapper mQuickStartUtilsWrapper;
     @Inject SeenUnseenWithCounterFeatureConfig mSeenUnseenWithCounterFeatureConfig;
@@ -1991,6 +1993,7 @@ public class ReaderPostListFragment extends ViewPagerFragment
                     getPostListType(),
                     mImageManager,
                     mUiHelpers,
+                    mNetworkUtilsWrapper,
                     mIsTopLevel
             );
             mPostAdapter.setOnFollowListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -61,6 +61,7 @@ import org.wordpress.android.util.ColorUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.NetworkUtilsWrapper;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig;
@@ -82,6 +83,7 @@ import kotlin.jvm.functions.Function3;
 public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private final ImageManager mImageManager;
     private final UiHelpers mUiHelpers;
+    private final NetworkUtilsWrapper mNetworkUtilsWrapper;
     private ReaderTag mCurrentTag;
     private long mCurrentBlogId;
     private long mCurrentFeedId;
@@ -258,7 +260,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 return new ReaderRemovedPostViewHolder(postView);
             default:
                 return mReaderImprovementsFeatureConfig.isEnabled()
-                        ? new ReaderPostNewViewHolder(mUiHelpers, mImageManager, mReaderTracker, parent)
+                        ? new ReaderPostNewViewHolder(mUiHelpers, mImageManager, mReaderTracker, mNetworkUtilsWrapper,
+                        parent)
                         : new ReaderPostViewHolder(mUiHelpers, mImageManager, mReaderTracker, parent);
         }
     }
@@ -644,6 +647,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             ReaderPostListType postListType,
             ImageManager imageManager,
             UiHelpers uiHelpers,
+            @NonNull final NetworkUtilsWrapper networkUtilsWrapper,
             boolean isMainReader
     ) {
         super();
@@ -652,6 +656,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mPostListType = postListType;
         mSource = mReaderTracker.getSource(mPostListType);
         mUiHelpers = uiHelpers;
+        mNetworkUtilsWrapper = networkUtilsWrapper;
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
         mIsMainReader = isMainReader;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverAdapter.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.reader.discover.viewholders.ReaderViewHolder
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.utils.HideItemDivider
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.image.ImageManager
 
 private const val POST_VIEW_TYPE: Int = 1
@@ -28,13 +29,20 @@ class ReaderDiscoverAdapter(
     private val uiHelpers: UiHelpers,
     private val imageManager: ImageManager,
     private val readerTracker: ReaderTracker,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
     private val isReaderImprovementsEnabled: Boolean,
 ) : Adapter<ReaderViewHolder<*>>() {
     private val items = mutableListOf<ReaderCardUiState>()
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReaderViewHolder<*> {
         return when (viewType) {
             POST_VIEW_TYPE -> ReaderPostViewHolder(uiHelpers, imageManager, readerTracker, parent)
-            POST_NEW_VIEW_TYPE -> ReaderPostNewViewHolder(uiHelpers, imageManager, readerTracker, parent)
+            POST_NEW_VIEW_TYPE -> ReaderPostNewViewHolder(
+                uiHelpers,
+                imageManager,
+                readerTracker,
+                networkUtilsWrapper,
+                parent
+            )
             INTEREST_VIEW_TYPE -> {
                 if (isReaderImprovementsEnabled) {
                     ReaderInterestsCardNewViewHolder(uiHelpers, parent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.ui.utils.addItemDivider
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.WPSwipeToRefreshHelper
 import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig
 import org.wordpress.android.util.image.ImageManager
@@ -72,6 +73,10 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
 
     @Inject
     lateinit var readerTracker: ReaderTracker
+
+    @Inject
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
+
     private lateinit var parentViewModel: ReaderViewModel
 
     @Inject
@@ -90,7 +95,11 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
             recyclerView.layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
             recyclerView.adapter =
                 ReaderDiscoverAdapter(
-                    uiHelpers, imageManager, readerTracker, readerImprovementsFeatureConfig.isEnabled()
+                    uiHelpers,
+                    imageManager,
+                    readerTracker,
+                    networkUtilsWrapper,
+                    readerImprovementsFeatureConfig.isEnabled()
                 )
 
             // set the background color as we have different colors for the new and legacy designs that are not easy to

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostNewViewHolder.kt
@@ -15,6 +15,7 @@ import org.wordpress.android.ui.reader.discover.ReaderCardUiState
 import org.wordpress.android.ui.reader.discover.ReaderCardUiState.ReaderPostNewUiState
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction
 import org.wordpress.android.ui.reader.discover.ReaderPostCardAction.PrimaryAction
+import org.wordpress.android.ui.reader.discover.ReaderPostCardActionType
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
@@ -164,7 +165,15 @@ class ReaderPostNewViewHolder(
         view.isVisible = state.isEnabled
         view.isSelected = state.isSelected
         view.contentDescription = state.contentDescription?.let { uiHelpers.getTextOfUiString(view.context, it) }
-        view.setOnClickListener { state.onClicked?.invoke(postId, blogId, state.type) }
+        view.setOnClickListener {
+            // If it's a like action, we want to update the UI right away. If there's an error, we'll revert
+            // the UI change.
+            // TODO revert UI when there's an error (e.g. no internet connection)
+            if (state.type == ReaderPostCardActionType.LIKE) {
+                view.isSelected = !view.isSelected
+            }
+            state.onClicked?.invoke(postId, blogId, state.type)
+        }
     }
 
     private fun loadVideoThumbnail(state: ReaderPostNewUiState) = with(binding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostNewViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/viewholders/ReaderPostNewViewHolder.kt
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils
 import org.wordpress.android.ui.reader.utils.ReaderVideoUtils.VideoThumbnailUrlListener
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.util.extensions.expandTouchTargetArea
 import org.wordpress.android.util.extensions.viewBinding
 import org.wordpress.android.util.image.ImageManager
@@ -32,6 +33,7 @@ class ReaderPostNewViewHolder(
     private val uiHelpers: UiHelpers,
     private val imageManager: ImageManager,
     private val readerTracker: ReaderTracker,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
     parentView: ViewGroup
 ) : ReaderViewHolder<ReaderCardviewPostNewBinding>(parentView.viewBinding(ReaderCardviewPostNewBinding::inflate)) {
     init {
@@ -168,8 +170,7 @@ class ReaderPostNewViewHolder(
         view.setOnClickListener {
             // If it's a like action, we want to update the UI right away. If there's an error, we'll revert
             // the UI change.
-            // TODO revert UI when there's an error (e.g. no internet connection)
-            if (state.type == ReaderPostCardActionType.LIKE) {
+            if (state.type == ReaderPostCardActionType.LIKE && networkUtilsWrapper.isNetworkAvailable()) {
                 view.isSelected = !view.isSelected
             }
             state.onClicked?.invoke(postId, blogId, state.type)


### PR DESCRIPTION
Fixes #19533 

-----

## To Test:

1. Install JP and sign in.
2. Open Reader and select "Discover".
3. 🔍 Like a post with internet connection available: it should work as expected.
4. 🔍 Tap the like button again to remove the like with internet connection available: it should work as expected.
5. 🔍 Repeat steps 3 and 4 with no internet connection (e.g. airplane mode) and bad internet connection (e.g. 100% loss on Network Link Conditioner). If there's no connection, the like button state shouldn't change and if there's bad network connection the button should change right away and then when the request fails return to the previous state.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader post list like button

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
