### PR TITLE
Fix open traffic tab from today's stats card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -657,7 +657,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         is SiteNavigationAction.OpenStatsByDay -> ActivityLauncher.viewBlogStatsForTimeframe(
             requireActivity(),
             action.site,
-            StatsTimeframe.INSIGHTS,
+            StatsTimeframe.DAY,
             StatsLaunchedFrom.TODAY_STATS_CARD
         )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -654,7 +654,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         is SiteNavigationAction.EditScheduledPost ->
             ActivityLauncher.viewCurrentBlogPostsOfType(requireActivity(), action.site, PostListType.SCHEDULED)
 
-        is SiteNavigationAction.OpenStatsInsights -> ActivityLauncher.viewBlogStatsForTimeframe(
+        is SiteNavigationAction.OpenStatsByDay -> ActivityLauncher.viewBlogStatsForTimeframe(
             requireActivity(),
             action.site,
             StatsTimeframe.INSIGHTS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -64,7 +64,7 @@ sealed class SiteNavigationAction {
     data class OpenScheduledPosts(val site: SiteModel) : SiteNavigationAction()
     data class EditDraftPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
-    data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
+    data class OpenStatsByDay(val site: SiteModel) : SiteNavigationAction()
     data class OpenExternalUrl(val url: String) : SiteNavigationAction()
     data class OpenUrlInWebView(val url: String) : SiteNavigationAction()
     data class OpenDeepLink(val url: String) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSlice.kt
@@ -90,7 +90,7 @@ class TodaysStatsViewModelSlice @Inject constructor(
         if (jetpackFeatureRemovalPhaseHelper.shouldShowStaticPage()) {
             _onNavigation.value = Event(SiteNavigationAction.ShowJetpackRemovalStaticPostersView)
         } else {
-            _onNavigation.value = Event(SiteNavigationAction.OpenStatsInsights(selectedSite))
+            _onNavigation.value = Event(SiteNavigationAction.OpenStatsByDay(selectedSite))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsViewModel.kt
@@ -196,7 +196,14 @@ class StatsViewModel
                 tapSource = launchedFrom?.value ?: ""
             )
 
-            initialSection?.let { statsSectionManager.setSelectedSection(it) }
+            initialSection?.let {
+                statsSectionManager.setSelectedSection(it)
+
+                val trafficGranularity = it.toStatsGranularity()
+                if (statsTrafficTabFeatureConfig.isEnabled() && trafficGranularity != null) {
+                    selectedTrafficGranularityManager.setSelectedTrafficGranularity(trafficGranularity)
+                }
+            }
             granularity?.let {
                 if (it != selectedTrafficGranularityManager.getSelectedTrafficGranularity()) {
                     selectedTrafficGranularityManager.setSelectedTrafficGranularity(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -10,8 +10,6 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.INSIGHTS
-import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection.TRAFFIC
 import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import javax.inject.Inject
 
@@ -33,9 +31,9 @@ class SelectedSectionManager
         }
 
     fun getSelectedSection(): StatsSection {
-        val defaultValue = if (statsTrafficTabFeatureConfig.isEnabled()) TRAFFIC else INSIGHTS
+        val defaultValue = if (statsTrafficTabFeatureConfig.isEnabled()) StatsSection.TRAFFIC else StatsSection.INSIGHTS
         val value = sharedPrefs.getString(SELECTED_SECTION_KEY, defaultValue.name)
-        return value?.let { StatsSection.valueOf(value) } ?: INSIGHTS
+        return value?.let { StatsSection.valueOf(value) } ?: StatsSection.INSIGHTS
     }
 
     fun setSelectedSection(selectedSection: StatsSection) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/SelectedSectionManager.kt
@@ -63,15 +63,6 @@ fun StatsSection.toStatsGranularity(): StatsGranularity? {
     }
 }
 
-fun StatsGranularity.toStatsSection(): StatsSection {
-    return when (this) {
-        DAYS -> StatsSection.DAYS
-        WEEKS -> StatsSection.WEEKS
-        MONTHS -> StatsSection.MONTHS
-        YEARS -> StatsSection.YEARS
-    }
-}
-
 fun StatsGranularity.toNameResource() = when {
     this == DAYS -> R.string.stats_timeframe_by_day
     this == WEEKS -> R.string.stats_timeframe_by_week

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/todaysstats/TodaysStatsViewModelSliceTest.kt
@@ -74,7 +74,7 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
 
             params.onTodaysStatsCardClick()
 
-            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
+            assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsByDay(site))
             verify(cardsTracker).trackCardItemClicked(
                 CardsTracker.Type.STATS.label,
                 CardsTracker.StatsSubtype.TODAYS_STATS.label
@@ -120,7 +120,7 @@ class TodaysStatsViewModelSliceTest : BaseUnitTest() {
             CardsTracker.Type.STATS.label,
             TodaysStatsMenuItemType.VIEW_STATS.label
         )
-        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsInsights(site))
+        assertThat(navigationActions).containsOnly(SiteNavigationAction.OpenStatsByDay(site))
     }
 
 


### PR DESCRIPTION
Fixes #20487

This updates Today's Stats card to have it open "By day" granularity.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Test this with both the `stats_traffic_tab` enabled and disabled cases:
1. Open "My Site → Stats"
2. Change granularity to something different from "Day".
1. Tap on the "Today's Stats" card from My Site.
3. Verify that it opens the Day granularity in Stats.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Opening Stats from other entry points.

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually.

5. What automated tests I added (or what prevented me from doing so)

    - Updated current tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
