### PR TITLE
[Reader] Fix like button text being cut off in Spanish

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post_new.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post_new.xml
@@ -191,7 +191,7 @@
             android:text="@string/like"
             app:drawableStartCompat="@drawable/ic_like_new_selector"
             app:layout_goneMarginStart="0dp"
-            app:layout_constraintWidth_max="80dp"
+            app:layout_constraintWidth_max="140dp"
             app:layout_constraintStart_toEndOf="@id/comment"
             app:layout_constraintEnd_toStartOf="@id/more_menu"
             app:layout_constraintTop_toBottomOf="@id/reader_card_interactions_bottom_barrier"


### PR DESCRIPTION
Fixes #19689

### Before
<img width="300" alt="Screenshot 2024-03-25 at 2 52 56 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/77ba41eb-41b6-4c02-ad75-56711bf34384">

### After
<img width="300" alt="Screenshot 2024-03-25 at 2 51 58 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/84c272ff-22e6-4263-971c-1b6353ac30ea">


-----

## To Test:

- Install JP and sign in.
- Select Spanish as the app language.
- Open Reader and select any feed that shows "Reblog", "Comment" and "Like" actions under a post (e.g. "Discover" feed).
- 🔍 Verify the "Like" action: the text should be fully visible. Make sure it still works as expected for other languages such as English.
-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader post actions position

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
