### PR TITLE
[Unit Tests] Remove mockito-core dependency

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -471,7 +471,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-core-utils'
     })
     testImplementation "junit:junit:$junitVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$gradle.ext.kotlinVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
@@ -479,7 +478,7 @@ dependencies {
 
     androidTestImplementation project(path:':libs:mocks')
 
-    androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
+    androidTestImplementation "org.mockito:mockito-android:$mockitoAndroidVersion"
     androidTestImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$squareupMockWebServerVersion"
     androidTestImplementation "androidx.test.uiautomator:uiautomator:$androidxTestUiAutomatorVersion"

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/unified/UnrepliedCommentsUtilsTest.kt
@@ -6,8 +6,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.AccountModel

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/BatchModerateCommentsUseCaseTest.kt
@@ -9,7 +9,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.notification.Failure
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
@@ -65,11 +64,11 @@ class BatchModerateCommentsUseCaseTest : BaseUnitTest() {
         )
         whenever(moderateCommentsResourceProvider.bgDispatcher).thenReturn(NoDelayCoroutineDispatcher())
 
-        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
+        whenever(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
             .thenReturn(listOf(approvedComment))
-        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(2)))
+        whenever(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(2)))
             .thenReturn(listOf(pendingComment))
-        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(3)))
+        whenever(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(3)))
             .thenReturn(listOf(trashedComment))
 
         batchModerateCommentsUseCase = BatchModerateCommentsUseCase(moderateCommentsResourceProvider)

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/ModerateCommentsWithUndoUseCaseTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -64,7 +63,7 @@ class ModerateCommentsWithUndoUseCaseTest : BaseUnitTest() {
             localCommentCacheUpdateHandler
         )
 
-        `when`(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
+        whenever(commentStore.getCommentByLocalSiteAndRemoteId(eq(site.id), eq(1)))
             .thenReturn(listOf(approvedComment))
 
         moderateCommentWithUndoUseCase = ModerateCommentWithUndoUseCase(moderateCommentsResourceProvider)

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/usecases/PaginateCommentsUseCaseTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
@@ -64,13 +63,13 @@ class PaginateCommentsUseCaseTest : BaseUnitTest() {
         whenever(paginateCommentsResourceProvider.unrepliedCommentsUtils).thenReturn(unrepliedCommentsUtils)
         whenever(paginateCommentsResourceProvider.networkUtilsWrapper).thenReturn(networkUtilsWrapper)
 
-        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(0), any(), any()))
+        whenever(commentStore.fetchCommentsPage(eq(site), any(), eq(0), any(), any()))
             .thenReturn(testCommentsPayload30)
-        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(30), any(), any()))
+        whenever(commentStore.fetchCommentsPage(eq(site), any(), eq(30), any(), any()))
             .thenReturn(testCommentsPayload60)
-        `when`(commentStore.fetchCommentsPage(eq(site), any(), eq(60), any(), any()))
+        whenever(commentStore.fetchCommentsPage(eq(site), any(), eq(60), any(), any()))
             .thenReturn(testCommentsPayloadLastPage)
-        `when`(commentStore.getCachedComments(eq(site), any(), any()))
+        whenever(commentStore.getCachedComments(eq(site), any(), any()))
             .thenReturn(testCommentsPayload60)
 
         paginateCommentsUseCase = PaginateCommentsUseCase(paginateCommentsResourceProvider)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/backup/download/BackupDownloadViewModelTest.kt
@@ -7,11 +7,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.clearInvocations
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.R

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/restore/RestoreViewModelTest.kt
@@ -7,12 +7,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.anyInt
-import org.mockito.Mockito.clearInvocations
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.Constants
@@ -199,7 +198,7 @@ class RestoreViewModelTest : BaseUnitTest() {
         }
         whenever(restoreStatusUseCase.getRestoreStatus(anyOrNull(), anyOrNull(), anyOrNull()))
             .thenReturn(flowOf(AwaitingCredentials(true)))
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), any()))
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(any(), any()))
             .thenReturn(SERVER_CREDS_MSG_WITH_CLICKABLE_LINK)
 
         startViewModel()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpack/scan/builders/ScanStateListItemsBuilderTest.kt
@@ -4,10 +4,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyArray
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -109,9 +108,9 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
             scanStore,
             percentFormatter
         )
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any?>())).thenReturn("")
-        whenever(resourceProvider.getString(anyInt())).thenReturn(DUMMY_TEXT)
-        whenever(site.name).thenReturn((""))
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(any(), anyVararg())).thenReturn("")
+        whenever(resourceProvider.getString(any())).thenReturn(DUMMY_TEXT)
+        whenever(site.name).thenReturn("")
         whenever(site.siteId).thenReturn(TEST_SITE_ID)
         whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))
     }
@@ -364,7 +363,7 @@ class ScanStateListItemsBuilderTest : BaseUnitTest() {
         test {
             val clickableText = "clickable help text"
             val descriptionWithClickableText = "description with $clickableText"
-            whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any>()))
+            whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(any(), anyVararg()))
                 .thenReturn(descriptionWithClickableText)
             whenever(resourceProvider.getString(R.string.scan_here_to_help)).thenReturn(clickableText)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/GetShowJetpackFullPluginInstallOnboardingUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/GetShowJetpackFullPluginInstallOnboardingUseCaseTest.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.jetpackplugininstall.fullplugin
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSourceTest.kt
@@ -11,9 +11,9 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
-import org.mockito.Mockito.doAnswer
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/BlazeCardViewModelSliceTest.kt
@@ -6,9 +6,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.doReturn
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/RemotePreviewLogicHelperTest.kt
@@ -6,7 +6,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.lenient
+import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -111,7 +111,7 @@ class RemotePreviewLogicHelperTest {
     fun `preview not available for self hosted sites not using WPComRestApi`() {
         // Given
         // next stub not used (made lenient) in case we update future logic.
-        lenient().doReturn(false).whenever(site).isUsingWpComRestApi
+        Mockito.lenient().doReturn(false).whenever(site).isUsingWpComRestApi
 
         // When
         val result = remotePreviewLogicHelper.runPostPreviewLogic(activity, site, post, helperFunctions)
@@ -258,7 +258,7 @@ class RemotePreviewLogicHelperTest {
     fun `preview available for Jetpack sites on a post post without modification`() {
         // Given
         // next stub not used (made lenient) in case we update future logic
-        lenient().doReturn(true).whenever(site).isJetpackConnected
+        Mockito.lenient().doReturn(true).whenever(site).isJetpackConnected
         doReturn(false).whenever(post).isLocallyChanged
 
         // When
@@ -272,7 +272,7 @@ class RemotePreviewLogicHelperTest {
     @Test
     fun `preview available for Jetpack sites on a post without modification`() {
         // Given
-        lenient().doReturn(true).whenever(site).isJetpackConnected
+        Mockito.lenient().doReturn(true).whenever(site).isJetpackConnected
         doReturn(false).whenever(post).isLocallyChanged
 
         // When

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/media/AddLocalMediaToPostUseCaseTest.kt
@@ -6,11 +6,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.inOrder
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
@@ -9,8 +9,8 @@ import android.util.DisplayMetrics
 import com.bumptech.glide.request.target.BaseTarget
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -27,10 +27,10 @@ class AztecImageLoaderTest {
 
     @Before
     fun setUp() {
-        callback = mock(ImageGetter.Callbacks::class.java)
-        imageManager = mock(ImageManager::class.java)
-        imageLoader = AztecImageLoader(mock(Context::class.java), imageManager, mock(Drawable::class.java))
-        bitmap = mock(Bitmap::class.java)
+        callback = mock()
+        imageManager = mock()
+        imageLoader = AztecImageLoader(mock(), imageManager, mock())
+        bitmap = mock()
     }
 
     @Test
@@ -86,7 +86,7 @@ class AztecImageLoaderTest {
             .thenAnswer { invocation ->
                 run {
                     @Suppress("DEPRECATION", "UNCHECKED_CAST")
-                    (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadFailed(mock(Drawable::class.java))
+                    (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadFailed(mock())
                 }
             }
     }
@@ -106,7 +106,7 @@ class AztecImageLoaderTest {
             .thenAnswer { invocation ->
                 run {
                     @Suppress("DEPRECATION", "UNCHECKED_CAST")
-                    (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadStarted(mock(Drawable::class.java))
+                    (invocation.arguments[1] as BaseTarget<Bitmap>).onLoadStarted(mock())
                 }
             }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/services/AztecImageLoaderTest.kt
@@ -2,9 +2,7 @@
 
 package org.wordpress.android.ui.posts.services
 
-import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.util.DisplayMetrics
 import com.bumptech.glide.request.target.BaseTarget
 import org.junit.Before

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsentTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/privacy/banner/domain/ShouldAskPrivacyConsentTest.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.prefs.privacy.banner.domain
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel

--- a/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthViewModelTest.kt
@@ -9,10 +9,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.times
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/discover/ReaderPostCardActionsHandlerTest.kt
@@ -6,15 +6,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyBoolean
-import org.mockito.ArgumentMatchers.anyInt
-import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyArray
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -161,7 +157,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
         actionHandler.initScope(testScope())
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog()).thenReturn(false)
-        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(anyInt(), anyArray<Any?>())).thenReturn(mock())
+        whenever(htmlMessageUtils.getHtmlMessageFromStringFormatResId(any(), anyVararg())).thenReturn(mock())
         whenever(readerBlogTableWrapper.getReaderBlog(any(), any())).thenReturn(mock())
     }
 
@@ -169,7 +165,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `shows dialog when bookmark action is successful and shouldShowDialog returns true`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog())
             .thenReturn(true)
@@ -190,7 +186,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `doesn't shows when dialog bookmark action is successful and shouldShowDialog returns false`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
         whenever(appPrefsWrapper.shouldShowBookmarksSavedLocallyDialog())
             .thenReturn(false)
@@ -211,7 +207,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `shows snackbar on successful bookmark action`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
         val observedValues = startObserving()
@@ -230,7 +226,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Doesn't show snackbar on successful bookmark action when on bookmark(saved) tab`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
         val observedValues = startObserving()
@@ -250,7 +246,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Doesn't show snackbar on successful UNbookmark action`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(false)))
 
         val observedValues = startObserving()
@@ -270,7 +266,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `navigates to bookmark tab on bookmark snackbar action clicked`() = test {
         // Arrange
-        whenever(bookmarkUseCase.toggleBookmark(any(), anyBoolean(), anyString()))
+        whenever(bookmarkUseCase.toggleBookmark(any(), any(), any()))
             .thenReturn(flowOf(Success(true)))
 
         val observedValues = startObserving()
@@ -292,7 +288,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Emit followStatusUpdated after follow status update`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(mock<FollowStatusChanged>()))
         val observedValues = startObserving()
 
@@ -311,7 +307,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Fetch subscriptions after follow status update`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(mock<FollowStatusChanged>()))
 
         // Act
@@ -329,7 +325,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Enable notifications snackbar shown when user follows a post`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(
                 flowOf(FollowStatusChanged(-1, -1, following = true, showEnableNotification = true))
             )
@@ -349,7 +345,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Post notifications are disabled when user unfollows a post`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(
                 flowOf(
                     FollowStatusChanged(
@@ -370,14 +366,14 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
 
         // Assert
-        verify(siteNotificationsUseCase).updateSubscription(anyLong(), eq(SubscriptionAction.DELETE))
-        verify(siteNotificationsUseCase).updateNotificationEnabledForBlogInDb(anyLong(), eq(false))
+        verify(siteNotificationsUseCase).updateSubscription(any(), eq(SubscriptionAction.DELETE))
+        verify(siteNotificationsUseCase).updateNotificationEnabledForBlogInDb(any(), eq(false))
     }
 
     @Test
     fun `Post notifications are enabled when user clicks on enable notifications snackbar action`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(FollowStatusChanged(-1, -1, following = true, showEnableNotification = true)))
         val observedValues = startObserving()
 
@@ -392,14 +388,14 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         observedValues.snackbarMsgs[0].buttonAction.invoke()
 
         // Assert
-        verify(siteNotificationsUseCase).updateSubscription(anyLong(), eq(SubscriptionAction.NEW))
-        verify(siteNotificationsUseCase).updateNotificationEnabledForBlogInDb(anyLong(), eq(true))
+        verify(siteNotificationsUseCase).updateSubscription(any(), eq(SubscriptionAction.NEW))
+        verify(siteNotificationsUseCase).updateNotificationEnabledForBlogInDb(any(), eq(true))
     }
 
     @Test
     fun `Error message is shown when follow action fails with NoNetwork error`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(NoNetwork))
         val observedValues = startObserving()
 
@@ -418,7 +414,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Error message is shown when follow action fails with RequestFailed error`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(RequestFailed))
         val observedValues = startObserving()
 
@@ -437,7 +433,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `given site present in db, when follow action is requested, follow site is triggered`() = test {
         // Arrange
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(FollowSiteState.Success))
 
         // Act
@@ -449,7 +445,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
 
         // Assert
-        verify(followUseCase, times(1)).toggleFollow(any(), anyString())
+        verify(followUseCase, times(1)).toggleFollow(any(), any())
     }
 
     @Test
@@ -459,7 +455,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(null)
         whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
             .thenReturn(FetchSiteState.Success)
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(FollowSiteState.Success))
 
         // Act
@@ -502,7 +498,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(null)
         whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
             .thenReturn(FetchSiteState.Success)
-        whenever(followUseCase.toggleFollow(anyOrNull(), anyString()))
+        whenever(followUseCase.toggleFollow(anyOrNull(), any()))
             .thenReturn(flowOf(FollowSiteState.Success))
 
         // Act
@@ -514,7 +510,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
 
         // Assert
-        verify(followUseCase, times(1)).toggleFollow(any(), anyString())
+        verify(followUseCase, times(1)).toggleFollow(any(), any())
     }
     /** FOLLOW ACTION end **/
 
@@ -522,7 +518,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `ToggleNotifications when user clicks on Notifcations button`() = test {
         // Arrange
-        whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+        whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Success)
         // Act
         actionHandler.onAction(
@@ -533,13 +529,13 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         )
 
         // Assert
-        verify(siteNotificationsUseCase).toggleNotification(anyLong(), anyLong())
+        verify(siteNotificationsUseCase).toggleNotification(any(), any())
     }
 
     @Test
     fun `Show snackbar message when toggleNotification return network error`() = test {
         // Arrange
-        whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+        whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.NoNetwork)
         val observedValues = startObserving()
 
@@ -558,7 +554,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Show snackbar message when toggleNotification returns request error`() = test {
         // Arrange
-        whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+        whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.RequestFailed)
         val observedValues = startObserving()
 
@@ -577,7 +573,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Do not Show snackbar message when toggleNotification returns alreadyRunning error`() = test {
         // Arrange
-        whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+        whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Failed.AlreadyRunning)
         val observedValues = startObserving()
 
@@ -597,7 +593,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     fun `given site present in db, when site notifications action is requested, toggle notifications is triggered`() =
         test {
             // Arrange
-            whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+            whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
                 .thenReturn(SiteNotificationState.Success)
 
             // Act
@@ -619,7 +615,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             .thenReturn(null)
         whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
             .thenReturn(FetchSiteState.Success)
-        whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+        whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
             .thenReturn(SiteNotificationState.Success)
 
         // Act
@@ -664,7 +660,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
                 .thenReturn(null)
             whenever(fetchSiteUseCase.fetchSite(any(), any(), anyOrNull()))
                 .thenReturn(FetchSiteState.Success)
-            whenever(siteNotificationsUseCase.toggleNotification(anyLong(), anyLong()))
+            whenever(siteNotificationsUseCase.toggleNotification(any(), any()))
                 .thenReturn(SiteNotificationState.Success)
 
             // Act
@@ -720,7 +716,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Posts are refreshed when site blocked in local db`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         // Act
@@ -738,7 +734,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when site blocked in local db`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         // Act
@@ -756,7 +752,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when request to block site failes with no network error`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.NoNetwork))
         val observedValues = startObserving()
         // Act
@@ -774,7 +770,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Posts are refreshed when request to block site failes with request failed error`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.RequestFailed))
         val observedValues = startObserving()
         // Act
@@ -792,7 +788,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when request to block site failes with request failed error`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(Failed.RequestFailed))
         val observedValues = startObserving()
         // Act
@@ -810,7 +806,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Undo action is invoked when user clicks on undo action in snackbar`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         actionHandler.onAction(
@@ -822,13 +818,13 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         // Act
         observedValues.snackbarMsgs[0].buttonAction.invoke()
         // Assert
-        verify(undoBlockBlogUseCase).undoBlockBlog(anyOrNull(), anyString())
+        verify(undoBlockBlogUseCase).undoBlockBlog(anyOrNull(), any())
     }
 
     @Test
     fun `Post refreshed when user clicks on undo action in snackbar`() = test {
         // Arrange
-        whenever(blockBlogUseCase.blockBlog(anyLong(), anyLong()))
+        whenever(blockBlogUseCase.blockBlog(any(), any()))
             .thenReturn(flowOf(SiteBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         actionHandler.onAction(
@@ -848,7 +844,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Posts are refreshed when user blocked in local db`() = test {
         // Arrange
-        whenever(blockUserUseCase.blockUser(anyLong(), anyLong()))
+        whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         // Act
@@ -866,7 +862,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when user blocked in local db`() = test {
         // Arrange
-        whenever(blockUserUseCase.blockUser(anyLong(), anyLong()))
+        whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         // Act
@@ -884,7 +880,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Undo action is invoked when user clicks on undo block user action in snackbar`() = test {
         // Arrange
-        whenever(blockUserUseCase.blockUser(anyLong(), anyLong()))
+        whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         actionHandler.onAction(
@@ -902,7 +898,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Post refreshed when user clicks on undo block user action in snackbar`() = test {
         // Arrange
-        whenever(blockUserUseCase.blockUser(anyLong(), anyLong()))
+        whenever(blockUserUseCase.blockUser(any(), any()))
             .thenReturn(flowOf(UserBlockedInLocalDb(mock())))
         val observedValues = startObserving()
         actionHandler.onAction(
@@ -922,7 +918,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Like action is initiated when user clicks on like button`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf())
         // Act
         actionHandler.onAction(
@@ -932,13 +928,13 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             SOURCE
         )
         // Assert
-        verify(likeUseCase).perform(anyOrNull(), anyBoolean(), anyString())
+        verify(likeUseCase).perform(anyOrNull(), any(), any())
     }
 
     @Test
     fun `Like use cases is initiated with like action when the post is not liked by the current user`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf())
         val isLiked = false
         val post = ReaderPost().apply { isLikedByCurrentUser = isLiked }
@@ -950,13 +946,13 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             SOURCE
         )
         // Assert
-        verify(likeUseCase).perform(anyOrNull(), eq(!isLiked), anyString())
+        verify(likeUseCase).perform(anyOrNull(), eq(!isLiked), any())
     }
 
     @Test
     fun `Like use cases is initiated with unlike action when the post is not liked by the current user`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf())
         val isLiked = true
         val post = ReaderPost().apply { isLikedByCurrentUser = isLiked }
@@ -968,13 +964,13 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
             SOURCE
         )
         // Assert
-        verify(likeUseCase).perform(anyOrNull(), eq(!isLiked), anyString())
+        verify(likeUseCase).perform(anyOrNull(), eq(!isLiked), any())
     }
 
     @Test
     fun `Posts are refreshed when user likes a post`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikedInLocalDb))
         val observedValues = startObserving()
         // Act
@@ -991,7 +987,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Posts are refreshed when like action fails with RequestFailed error`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.RequestFailed))
         val observedValues = startObserving()
         // Act
@@ -1008,7 +1004,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when like action fails with no network error`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.NoNetwork))
         val observedValues = startObserving()
         // Act
@@ -1025,7 +1021,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Snackbar shown when like action fails with no RequestFailed error`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Failed.RequestFailed))
         val observedValues = startObserving()
         // Act
@@ -1042,7 +1038,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Nothing happens when like action succeeds`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Success))
         val observedValues = startObserving()
         // Act
@@ -1063,7 +1059,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Nothing happens when like action results in Unchanged state`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.Unchanged))
         val observedValues = startObserving()
         // Act
@@ -1084,7 +1080,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
     @Test
     fun `Nothing happens when like action results in AlreadyRunning`() = test {
         // Arrange
-        whenever(likeUseCase.perform(anyOrNull(), anyBoolean(), anyString()))
+        whenever(likeUseCase.perform(anyOrNull(), any(), any()))
             .thenReturn(flowOf(PostLikeState.AlreadyRunning))
         val observedValues = startObserving()
         // Act
@@ -1224,7 +1220,7 @@ class ReaderPostCardActionsHandlerTest : BaseUnitTest() {
         val observedValues = startObserving()
 
         // Act
-        actionHandler.handleOnItemClicked(mock(), anyString())
+        actionHandler.handleOnItemClicked(mock(), any())
 
         // Assert
         assertThat(observedValues.navigation[0]).isInstanceOf(ShowPostDetail::class.java)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorMapperTest.kt
@@ -6,8 +6,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorWebViewClientTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorWebViewClientTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.sitemonitor
 
 import android.net.Uri
 import android.webkit.WebResourceRequest
-import android.webkit.WebView
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
@@ -12,7 +11,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import android.webkit.WebResourceError
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorWebViewClientTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorWebViewClientTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import android.webkit.WebResourceError
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 
 @ExperimentalCoroutinesApi
@@ -35,24 +35,24 @@ class SiteMonitorWebViewClientTest : BaseUnitTest() {
 
     @Test
     fun `when onPageFinished, then should invoke on web view page loaded`() {
-        webViewClient.onPageFinished(mock(WebView::class.java), "https://example.com")
+        webViewClient.onPageFinished(mock(), "https://example.com")
 
         verify(mockListener).onWebViewPageLoaded("https://example.com", SiteMonitorType.METRICS)
     }
 
     @Test
     fun `when onReceivedError, then should invoke on web view error received`() {
-        val mockRequest = mock(WebResourceRequest::class.java)
+        val mockRequest: WebResourceRequest = mock()
         whenever(mockRequest.isForMainFrame).thenReturn(true)
         val url = "https://some.domain"
         whenever(uri.toString()).thenReturn(url)
         whenever(mockRequest.url).thenReturn(uri)
 
-        webViewClient.onPageStarted(mock(WebView::class.java), url, null)
+        webViewClient.onPageStarted(mock(), url, null)
         webViewClient.onReceivedError(
-            mock(WebView::class.java),
+            mock(),
             mockRequest,
-            mock(WebResourceError::class.java)
+            mock()
         )
 
         verify(mockListener).onWebViewReceivedError(url, SiteMonitorType.METRICS)
@@ -62,7 +62,7 @@ class SiteMonitorWebViewClientTest : BaseUnitTest() {
     fun `when onPageFinished, then should not invoke OnReceivedError`() {
         val url = "https://some.domain"
 
-        webViewClient.onPageFinished(mock(WebView::class.java), url)
+        webViewClient.onPageFinished(mock(), url)
 
         verify(mockListener, never()).onWebViewReceivedError(anyString(), any())
     }

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
@@ -2,11 +2,11 @@ package org.wordpress.android.util.crashlogging
 
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import org.junit.Test
-import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.mock
 import org.wordpress.android.util.config.RemoteConfigWrapper
 
 private const val VALID_SAMPLE_RATE = 0.01

--- a/WordPress/src/test/java/org/wordpress/android/util/image/GlidePopTransitionOptionsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/image/GlidePopTransitionOptionsTest.kt
@@ -8,7 +8,8 @@ import com.bumptech.glide.request.transition.Transition
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
-import org.mockito.Mockito
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 
@@ -35,15 +36,15 @@ class GlidePopTransitionOptionsTest : BaseUnitTest() {
     @Test
     fun testTransition() {
         val glidePopTransition = GlidePopTransition()
-        val drawable: Drawable = Mockito.mock()
-        val viewAdapter: Transition.ViewAdapter = Mockito.mock()
-        val view: View = Mockito.mock()
+        val drawable: Drawable = mock()
+        val viewAdapter: Transition.ViewAdapter = mock()
+        val view: View = mock()
         whenever(viewAdapter.view).thenReturn(view)
-        whenever(view.context).thenReturn(Mockito.mock())
+        whenever(view.context).thenReturn(mock())
 
         val result = glidePopTransition.transition(drawable, viewAdapter)
 
         TestCase.assertTrue(result)
-        Mockito.verify(viewAdapter).setDrawable(drawable)
+        verify(viewAdapter).setDrawable(drawable)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/comments/UnifiedCommentListViewModelTest.kt
@@ -9,7 +9,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -110,9 +109,9 @@ class UnifiedCommentListViewModelTest : BaseUnitTest() {
         localCommentCacheUpdateUseCase = LocalCommentCacheUpdateUseCase()
         localCommentCacheUpdateHandler = LocalCommentCacheUpdateHandler(localCommentCacheUpdateUseCase)
 
-        `when`(commentStore.fetchCommentsPage(any(), any(), eq(0), any(), any()))
+        whenever(commentStore.fetchCommentsPage(any(), any(), eq(0), any(), any()))
             .thenReturn(testCommentsPayload30)
-        `when`(commentStore.fetchCommentsPage(any(), any(), eq(30), any(), any()))
+        whenever(commentStore.fetchCommentsPage(any(), any(), eq(30), any(), any()))
             .thenReturn(testCommentsPayload60)
 
         commentListUiModelHelper = CommentListUiModelHelper(resourceProvider, dateTimeUtilsWrapper, networkUtilsWrapper)

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyArray
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -39,7 +39,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     }
     private val contextProvider: ContextProvider = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(any(), anyArray<Any>()) }.thenReturn("mock_string")
+        on { getString(any(), anyVararg()) }.thenReturn("mock_string")
     }
     private val weeklyRoundupScheduler: WeeklyRoundupScheduler = mock()
     private val notificationsTracker: SystemNotificationsTracker = mock()

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     // test
     assertjVersion = '3.23.1'
     junitVersion = '4.13.2'
-    mockitoAndroidVersion = '5.10.0'
+    mockitoAndroidVersion = '4.5.1'
     mockitoKotlinVersion = '4.1.0'
 
     // android test

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ ext {
     // test
     assertjVersion = '3.23.1'
     junitVersion = '4.13.2'
-    mockitoVersion = '5.10.0'
+    mockitoAndroidVersion = '5.10.0'
     mockitoKotlinVersion = '4.1.0'
 
     // android test


### PR DESCRIPTION
## Issue
We are using both `mockito-core` and `mockito-kotlin` dependencies in our codebase, but the latter transitively depends on the former. We have a issue though that `mockito-kotlin` relies on a different `mockito-core` version than what's declared in the project (which was recently updated to 5.10.0 https://github.com/wordpress-mobile/WordPress-Android/pull/20246).

After that version bump mentioned above, gradle and Android Studio started complaining, on all `@Mock` annotations, that it "Cannot access class 'org.mockit.Answers'." due to missing and conflicting dependencies. Full error message:

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/2e6b693f-dbf1-4176-b391-b6258e6fb928)

## Solution
Because of that conflict, we should be using only `mockito-kotlin`, which introduces the Kotlin-specific functionality while still transitively bringing in the `mockito-core` lib, so we can use it in Java as well.

This PR addresses that by removing `mockito-core` from our dependencies. There are 2 important points to be noted though, see below.

### 1. Mockito 5.X min Java version
[Mockito 5.0.0 changed the minimum JVM target support to Java 11](https://github.com/mockito/mockito/releases/tag/v5.0.0) so, in theory (and as long as I'm not missing anything) it shouldn't really work for us, [since our `jvmTarget` is Java 8](https://github.com/wordpress-mobile/WordPress-Android/blob/345f54d21d835f24ea2619e860c794fd6f3ee842/build.gradle#L177), including test runs.

Our project has been "using" `mockito-core` 5.X for some time now though without running into issues, so my guess is that since most of our tests run in Kotlin, we were actually using stuff from 4.X this whole time, since `mockito-kotlin` is on version 4.1.0. 

I tried updating `mockito-kotlin` to the latest available version (5.2.1) and then I started getting compilation errors regarding inline bytecode using a different version (11) than our project (8), which matches the [notes from Mockito 5.0.0](https://github.com/mockito/mockito/releases/tag/v5.0.0), so I'm keeping 4.1.0 there, which is the latest `mockito-kotlin` 4 version available.

### 2. `mockito-android`
I kept `mockito-android` in our instrumented tests dependencies because otherwise those tests don't run properly. But to keep things consistent I downgraded it to 4.5.1, so it also depends on `mockito-core:4.5.1`, which is the version used by `mockito-kotlin:4.1.0` as well.

-----

## To Test:

Make sure unit tests run successfully for WordPress Vanilla Release and instrumented tests still pass successfully for both Jetpack Vanilla Debug and Wordpress Vanilla Debug, which are the suites that run on our CI currentlly.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Tests breakage

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Ran unit and instrumented tests and check CI passes

3. What automated tests I added (or what prevented me from doing so)

    - Updated any tests that required updating to properly use `mockito-kotlin`
