### PR TITLE
Adds Webview version in Sentry crash logging

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
@@ -7,6 +7,7 @@ import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -50,7 +51,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     override val releaseName: String = BuildConfig.VERSION_NAME
     override val sentryDSN: String = BuildConfig.SENTRY_DSN
 
-    override val applicationContextProvider = MutableStateFlow<Map<String, String>>(emptyMap())
+    override val applicationContextProvider = flowOf(mapOf(WEBVIEW_VERSION to webviewVersionProvider.getVersion()))
 
     override fun crashLoggingEnabled(): Boolean {
         if (buildConfig.isDebug()) {
@@ -65,7 +66,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {
-        return listOf(EXTRA_UUID, WEBVIEW_VERSION)
+        return listOf(EXTRA_UUID)
     }
 
     /**
@@ -84,7 +85,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
         currentExtras: Map<ExtraKnownKey, String>,
         eventLevel: EventLevel
     ): Map<ExtraKnownKey, String> {
-        return currentExtras + appendWebViewVersion() + if (currentExtras[EXTRA_UUID] == null) {
+        return currentExtras + if (currentExtras[EXTRA_UUID] == null) {
             appendEncryptedLogsUuid(eventLevel)
         } else {
             emptyMap()
@@ -104,10 +105,6 @@ class WPCrashLoggingDataProvider @Inject constructor(
             }
         }
         return encryptedLogsUuid
-    }
-
-    private fun appendWebViewVersion(): Map<ExtraKnownKey, String> {
-        return mapOf(WEBVIEW_VERSION to webviewVersionProvider.version)
     }
 
     override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {
@@ -140,7 +137,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
 
     companion object {
         const val EXTRA_UUID = "uuid"
-        const val WEBVIEW_VERSION = "webview_version"
+        const val WEBVIEW_VERSION = "webview.version"
         const val EVENT_BUS_MODULE = "org.greenrobot.eventbus"
         const val EVENT_BUS_EXCEPTION = "EventBusException"
         const val EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR = "Invoking subscriber failed"

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
@@ -33,6 +33,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     private val localeManager: LocaleManagerWrapper,
     private val encryptedLogging: EncryptedLogging,
     private val logFileProvider: LogFileProviderWrapper,
+    private val webviewVersionProvider: WebviewVersionProvider,
     private val buildConfig: BuildConfigWrapper,
     @Named(APPLICATION_SCOPE) private val appScope: CoroutineScope,
     wpPerformanceMonitoringConfig: WPPerformanceMonitoringConfig,
@@ -64,7 +65,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
     }
 
     override fun extraKnownKeys(): List<ExtraKnownKey> {
-        return listOf(EXTRA_UUID)
+        return listOf(EXTRA_UUID, WEBVIEW_VERSION)
     }
 
     /**
@@ -83,7 +84,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
         currentExtras: Map<ExtraKnownKey, String>,
         eventLevel: EventLevel
     ): Map<ExtraKnownKey, String> {
-        return currentExtras + if (currentExtras[EXTRA_UUID] == null) {
+        return currentExtras + appendWebViewVersion() + if (currentExtras[EXTRA_UUID] == null) {
             appendEncryptedLogsUuid(eventLevel)
         } else {
             emptyMap()
@@ -103,6 +104,10 @@ class WPCrashLoggingDataProvider @Inject constructor(
             }
         }
         return encryptedLogsUuid
+    }
+
+    private fun appendWebViewVersion(): Map<ExtraKnownKey, String> {
+        return mapOf(WEBVIEW_VERSION to webviewVersionProvider.version)
     }
 
     override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {
@@ -135,6 +140,7 @@ class WPCrashLoggingDataProvider @Inject constructor(
 
     companion object {
         const val EXTRA_UUID = "uuid"
+        const val WEBVIEW_VERSION = "webview_version"
         const val EVENT_BUS_MODULE = "org.greenrobot.eventbus"
         const val EVENT_BUS_EXCEPTION = "EventBusException"
         const val EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR = "Invoking subscriber failed"

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WebviewVersionProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WebviewVersionProvider.kt
@@ -8,10 +8,8 @@ class WebviewVersionProvider @Inject constructor(private val packageManager: Pac
     private val webviewPackageName = "com.google.android.webview"
     private val unknownVersion = "unknown"
 
-    val version: String by lazy { getWebviewVersion() }
-
     @Suppress("SwallowedException")
-    private fun getWebviewVersion(): String = try {
+    fun getVersion(): String = try {
         packageManager.getPackageInfo(webviewPackageName, 0)?.versionName ?: unknownVersion
     } catch (e: NameNotFoundException) {
         unknownVersion

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WebviewVersionProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WebviewVersionProvider.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.util.crashlogging
+
+import android.content.pm.PackageManager.NameNotFoundException
+import org.wordpress.android.util.publicdata.PackageManagerWrapper
+import javax.inject.Inject
+
+class WebviewVersionProvider @Inject constructor(private val packageManager: PackageManagerWrapper) {
+    private val webviewPackageName = "com.google.android.webview"
+    private val unknownVersion = "unknown"
+
+    val version: String by lazy { getWebviewVersion() }
+
+    @Suppress("SwallowedException")
+    private fun getWebviewVersion(): String = try {
+        packageManager.getPackageInfo(webviewPackageName, 0)?.versionName ?: unknownVersion
+    } catch (e: NameNotFoundException) {
+        unknownVersion
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
@@ -36,7 +36,6 @@ import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Compan
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.io.File
 import java.util.Locale
-import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 @ExperimentalCoroutinesApi
@@ -69,6 +68,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        whenever(webviewVersionProvider.getVersion()).thenReturn(TEST_WEBVIEW_VERSION)
         sut = WPCrashLoggingDataProvider(
             sharedPreferences = sharedPreferences,
             resourceProvider = resourceProvider,
@@ -91,16 +91,6 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     @Test
     fun `should contain encrypted logs key for extra known keys`() {
         assertThat(sut.extraKnownKeys()).contains(EXTRA_UUID)
-    }
-
-    @Test
-    fun `should contain the webview version`() {
-        assertThat(sut.extraKnownKeys()).contains(WEBVIEW_VERSION)
-    }
-
-    @Test
-    fun `should contain two keys (uuid and webview version)`() {
-        assertEquals(sut.extraKnownKeys().size, 2)
     }
 
     @Test
@@ -128,8 +118,14 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `should provide empty application context`() = runTest {
-        assertThat(sut.applicationContextProvider.first()).isEmpty()
+    fun `should provide an application context of size 1`() = runTest {
+        assertThat(sut.applicationContextProvider.first().size).isEqualTo(1)
+    }
+
+    @Test
+    fun `should provide the webview version in the application context1`() = runTest {
+        val expected = mapOf(WEBVIEW_VERSION to TEST_WEBVIEW_VERSION)
+        assertThat(sut.applicationContextProvider.first()).containsAllEntriesOf(expected)
     }
 
     @Test
@@ -156,7 +152,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
 
         verify(logFileProvider).getLogFiles()
         verify(encryptedLogging, never()).encryptAndUploadLogFile(any(), any())
-        assertThat(extras.keys).doesNotContain(EXTRA_UUID)
+        assertThat(extras).isEmpty()
     }
 
     @Test
@@ -213,6 +209,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
         }
 
         const val TEST_UUID = "test uuid"
+        const val TEST_WEBVIEW_VERSION = "123"
         const val SEND_CRASH_SAMPLE_KEY = "send_crash"
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
@@ -123,7 +123,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     }
 
     @Test
-    fun `should provide the webview version in the application context1`() = runTest {
+    fun `should provide the webview version in the application context`() = runTest {
         val expected = mapOf(WEBVIEW_VERSION to TEST_WEBVIEW_VERSION)
         assertThat(sut.applicationContextProvider.first()).containsAllEntriesOf(expected)
     }

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
@@ -32,9 +32,11 @@ import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Compan
 import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Companion.EVENT_BUS_INVOKING_SUBSCRIBER_FAILED_ERROR
 import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Companion.EVENT_BUS_MODULE
 import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Companion.EXTRA_UUID
+import org.wordpress.android.util.crashlogging.WPCrashLoggingDataProvider.Companion.WEBVIEW_VERSION
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.io.File
 import java.util.Locale
+import kotlin.test.assertEquals
 
 @RunWith(MockitoJUnitRunner::class)
 @ExperimentalCoroutinesApi
@@ -59,6 +61,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     private val localeManager: LocaleManagerWrapper = mock()
     private val buildConfig: BuildConfigWrapper = mock()
     private val sharedPreferences: SharedPreferences = mock()
+    private val webviewVersionProvider: WebviewVersionProvider = mock()
 
     private val wpPerformanceMonitoringConfig: WPPerformanceMonitoringConfig = mock {
         on { invoke() } doReturn PerformanceMonitoringConfig.Enabled(1.0)
@@ -73,6 +76,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
             localeManager = localeManager,
             encryptedLogging = encryptedLogging,
             logFileProvider = logFileProvider,
+            webviewVersionProvider = webviewVersionProvider,
             buildConfig = buildConfig,
             appScope = testScope(),
             wpPerformanceMonitoringConfig = wpPerformanceMonitoringConfig,
@@ -87,6 +91,16 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
     @Test
     fun `should contain encrypted logs key for extra known keys`() {
         assertThat(sut.extraKnownKeys()).contains(EXTRA_UUID)
+    }
+
+    @Test
+    fun `should contain the webview version`() {
+        assertThat(sut.extraKnownKeys()).contains(WEBVIEW_VERSION)
+    }
+
+    @Test
+    fun `should contain two keys (uuid and webview version)`() {
+        assertEquals(sut.extraKnownKeys().size, 2)
     }
 
     @Test
@@ -142,7 +156,7 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
 
         verify(logFileProvider).getLogFiles()
         verify(encryptedLogging, never()).encryptAndUploadLogFile(any(), any())
-        assertThat(extras).isEmpty()
+        assertThat(extras.keys).doesNotContain(EXTRA_UUID)
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR adds the Webview version in Sentry crash logging to better monitor issues like https://github.com/wordpress-mobile/WordPress-Android/issues/20147

### Notes
I initially considered adding the version in the extras https://github.com/wordpress-mobile/WordPress-Android/pull/20533/commits/4ba20a721dec802fc7b34a97b77d7d9e7a942e09. This worked ([example](https://a8c.sentry.io/share/issue/8bdde9084d52472ba1082213bf46ea16/)) but additional data are not searchable/filterable making the added data less valuable. I switched to [using a tag](https://docs.sentry.io/platforms/android/enriching-events/tags/) by using the `applicationContextProvider` that [exposes it's data as tags](https://github.com/Automattic/Automattic-Tracks-Android/blob/trunk/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt#L81). Another alternative would be to add a new dedicated field in the [CrashLoggingDataProvider](https://github.com/Automattic/Automattic-Tracks-Android/blob/trunk/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt). Since this might not be valuable for other apps and to keep the enhancement simpler I didn't choose this path.

-----

## To Test:
1. Run a build from this PR
2. Trigger a crash (you could apply [this patch](https://github.com/wordpress-mobile/WordPress-Android/files/14771326/postscrash.patch) and tap on the Posts menu option)
3. Check Sentry and verify that the crash is received containing the `webview.version` tag ([example](https://a8c.sentry.io/share/issue/81be23c9d6434ae28fc7696bc7b2eec3/))

<img width="331" alt="Screenshot 2024-03-27 at 11 51 10 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/304044/f89e9c52-88c2-4725-9fdb-b845b56a1a27">
<img width="851" alt="Screenshot 2024-03-27 at 11 51 17 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/304044/b661f473-4b87-40d7-891b-e31c05a6d87b">


-----

## Regression Notes

1. Potential unintended areas of impact

    - Sentry logging

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

5. What automated tests I added (or what prevented me from doing so)

    - Updated existing test cases

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
