### PR TITLE
Integrate gutenberg-mobile release v1.116.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.6.0'
-    gutenbergMobileVersion = 'v1.116.0-alpha2'
+    gutenbergMobileVersion = '6773-aa057730ebeb4a5ee15754a9507d5acfb829959f'
     wordPressAztecVersion = 'v2.1.1'
     wordPressFluxCVersion = '2.72.0'
     wordPressLoginVersion = '1.14.1'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '3.6.0'
-    gutenbergMobileVersion = '6773-aa057730ebeb4a5ee15754a9507d5acfb829959f'
+    gutenbergMobileVersion = 'v1.116.0'
     wordPressAztecVersion = 'v2.1.1'
     wordPressFluxCVersion = '2.72.0'
     wordPressLoginVersion = '1.14.1'


### PR DESCRIPTION
## Description
This PR incorporates the 1.116.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6773

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.