### PR TITLE
feat: assign "debug" release, when app is not in `release` variant

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProvider.kt
@@ -5,6 +5,7 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -48,7 +49,11 @@ class WPCrashLoggingDataProvider @Inject constructor(
     override val enableCrashLoggingLogs: Boolean = false
     override val locale: Locale
         get() = localeManager.getLocale()
-    override val releaseName: String = BuildConfig.VERSION_NAME
+    override val releaseName: ReleaseName = if (buildConfig.isDebug()) {
+        ReleaseName.SetByApplication("debug")
+    } else {
+        ReleaseName.SetByTracksLibrary
+    }
     override val sentryDSN: String = BuildConfig.SENTRY_DSN
 
     override val applicationContextProvider = flowOf(mapOf(WEBVIEW_VERSION to webviewVersionProvider.getVersion()))

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPCrashLoggingDataProviderTest.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.util.crashlogging
 import android.content.SharedPreferences
 import com.automattic.android.tracks.crashlogging.EventLevel.DEBUG
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -199,6 +200,22 @@ class WPCrashLoggingDataProviderTest : BaseUnitTest() {
         reinitialize()
 
         assertThat(sut.crashLoggingEnabled()).isTrue
+    }
+
+    @Test
+    fun `should assign debug release in debug`() {
+        whenever(buildConfig.isDebug()).thenReturn(true)
+        reinitialize()
+
+        assertThat(sut.releaseName).isEqualTo(ReleaseName.SetByApplication("debug"))
+    }
+
+    @Test
+    fun `should delegate release name creation to tracks in release`() {
+        whenever(buildConfig.isDebug()).thenReturn(false)
+        reinitialize()
+
+        assertThat(sut.releaseName).isEqualTo(ReleaseName.SetByTracksLibrary)
     }
 
     companion object {

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     // libs
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
-    automatticTracksVersion = '3.6.0'
+    automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.116.0-alpha2'
     wordPressAztecVersion = 'v2.1.1'
     wordPressFluxCVersion = '2.72.0'


### PR DESCRIPTION
### Description
This PR bumps Tracks to `4.0.2`. The major change here is that we delegate creating a release name to Tracks library (Sentry internally), instead of providing value from our build config. 

This will address a problem of matching a release with the same name from different projects in the same Sentry organization.

Additionally, in debug/PR builds, we'll assign a `debug` release. This way, we'll clean up Sentry dashboard, as currently we have dozens of "pr-0000-00000" releases.

<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->


-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Screen from a test issue on release build type:

![Screenshot 2024-03-27 at 19 47 23](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/0b8c02f2-76fb-4b58-b956-5547907d001f)

and on debug build type:

![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5845095/3a84d769-b90b-4349-b1db-44dff77e00a8)


-----

## Regression Notes

1. Potential unintended areas of impact

    - Assigning incorrect release name to an issue

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Test Sentry issues, see above

3. What automated tests I added (or what prevented me from doing so)

    - Unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
