### PR TITLE
Fix for auto-scrolling issues on stats screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/BaseListUseCase.kt
@@ -77,9 +77,6 @@ class BaseListUseCase(
     private val mutableListSelected = SingleLiveEvent<Unit?>()
     val listSelected: LiveData<Unit?> = mutableListSelected
 
-    private val mutableScrollTo = MutableLiveData<Event<StatsType>>()
-    val scrollTo: LiveData<Event<StatsType>> = mutableScrollTo
-
     suspend fun loadData() {
         loadData(refresh = false, forced = false)
     }
@@ -123,9 +120,6 @@ class BaseListUseCase(
                                 block.fetch(refresh, forced)
                             }
                         }
-                }
-                if (!refresh) {
-                    mutableScrollTo.postValue(Event(visibleTypes.last()))
                 }
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -284,6 +284,8 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
                 selectedTrafficGranularityManager.getSelectedTrafficGranularity()
             )
             dateSelector.granularitySpinner.setSelection(selectedGranularityItemPos)
+
+            recyclerView.scrollToPosition(0)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -348,15 +348,10 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             adapter = recyclerView.adapter as StatsBlockAdapter
         }
 
-        val layoutManager = recyclerView.layoutManager
-        val recyclerViewState = layoutManager?.onSaveInstanceState()
         adapter.update(statsState)
-        recyclerView.scrollToPosition(0)
 
         errorView.statsErrorView.isGone = true
         emptyView.statsEmptyView.isGone = true
         recyclerView.isVisible = true
-
-        layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -15,7 +15,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
@@ -243,7 +242,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             viewModel.uiModel.removeObservers(viewLifecycleOwner)
             viewModel.navigationTarget.removeObservers(viewLifecycleOwner)
             viewModel.listSelected.removeObservers(viewLifecycleOwner)
-            viewModel.scrollToNewCard.removeObservers(viewLifecycleOwner)
         }
 
         viewModel.uiSourceAdded.observe(viewLifecycleOwner) {
@@ -297,16 +295,6 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         viewModel.navigationTarget.observeEvent(viewLifecycleOwner) { target -> navigator.navigate(activity, target) }
 
         viewModel.listSelected.observe(viewLifecycleOwner) { viewModel.onListSelected() }
-
-        viewModel.scrollToNewCard.observeEvent(viewLifecycleOwner) {
-            (recyclerView.adapter as? StatsBlockAdapter)?.let { adapter ->
-                adapter.registerAdapterDataObserver(object : AdapterDataObserver() {
-                    override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                        layoutManager?.smoothScrollToPosition(recyclerView, null, adapter.itemCount)
-                    }
-                })
-            }
-        }
     }
 
     private fun StatsListFragmentBinding.showUiModel(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.delay
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
-import org.wordpress.android.fluxc.store.StatsStore
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.stats.refresh.DAY_STATS_USE_CASE
 import org.wordpress.android.ui.stats.refresh.INSIGHTS_USE_CASE
@@ -102,8 +101,6 @@ abstract class StatsListViewModel(
 
     val scrollTo = newsCardHandler?.scrollTo
 
-    lateinit var scrollToNewCard: LiveData<Event<StatsStore.StatsType>>
-
     override fun onCleared() {
         statsUseCase.onCleared()
         super.onCleared()
@@ -174,7 +171,6 @@ abstract class StatsListViewModel(
         uiModel = statsUseCase.data.throttle(viewModelScope, distinct = true)
         listSelected = statsUseCase.listSelected
         navigationTarget = mergeNotNull(statsUseCase.navigationTarget, mutableNavigationTarget)
-        scrollToNewCard = statsUseCase.scrollTo
         mutableUiSourceAdded.call()
     }
 


### PR DESCRIPTION
Fixes #20523 

This fixes auto-scrolling issues on the stats screen. 

Changes made:
- Expanding items on the card will no longer cause auto-scrolling to the top.
- Changing the granularity spinner will trigger auto-scrolling to the top.
- Changing the selected date will not cause auto-scrolling to the top.
- Adding new cards to the INSIGHTS tab won't cause auto-scrolling to the new card.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Test this with both `stats_traffic_enabled` is off and on cases.
1. Log in.
2. Open "My Site → Stats".
3. Test the changes listed above.

-----

## Regression Notes

1. Potential unintended areas of impact

    - There may be some issues related to updating cards.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually.

3. What automated tests I added (or what prevented me from doing so)

    - The behavior changes are minor and not suitable for UI tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
