### PR TITLE
Fix scrolling issue occurs when opening granular tabs on stats screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -338,10 +338,14 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
             adapter = recyclerView.adapter as StatsBlockAdapter
         }
 
+        val layoutManager = recyclerView.layoutManager
+        val recyclerViewState = layoutManager?.onSaveInstanceState()
         adapter.update(statsState)
 
         errorView.statsErrorView.isGone = true
         emptyView.statsEmptyView.isGone = true
         recyclerView.isVisible = true
+
+        layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }


### PR DESCRIPTION
This fixes the scrolling issue that occurs when opening granular tabs on the stats screen. The issue was introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/20546.

**Issue video:**

[scroll-issue.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/b7580c7e-1ade-4fac-b421-0627904f26f2)

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Open "My Site → Stats".
3. Switch to tabs other than INSIGHTS.
4. Verify that the scrolling position is at the top.
5. Navigate back and repeat 2-3 a couple of times.
6. Repeat 4.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - The behavior changes are minor and not suitable for UI tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
