### PR TITLE
Sets an uninitialised flow step as unspecified before dismissing the screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewViewModel.kt
@@ -129,6 +129,9 @@ class BlazePromoteWebViewViewModel @Inject constructor(
     }
 
     private fun onHeaderCancelActionClick() {
+        if (::blazeFlowStep.isInitialized.not()) {
+            blazeFlowStep = BlazeFlowStep.UNSPECIFIED
+        }
         blazeFeatureUtils.trackFlowCanceled(blazeFlowSource, blazeFlowStep)
         postActionEvent(BlazeActionEvent.FinishActivity)
     }
@@ -258,6 +261,10 @@ class BlazePromoteWebViewViewModel @Inject constructor(
     fun handleOnBackPressed() {
         val nonDismissibleStep = nonDismissableHashConfig.getValue<String>()
         val completedStep = completedStepHashConfig.getValue<String>()
+
+        if (::blazeFlowStep.isInitialized.not()) {
+            blazeFlowStep = BlazeFlowStep.UNSPECIFIED
+        }
 
         if (blazeFlowStep.label == nonDismissibleStep) return
 


### PR DESCRIPTION
Fixes #20555, #20556

## Description
Sets an uninitialised flow step as unspecified before dismissing the screen to prevent a crash on back press (`handleOnBackPressed`) or cancel (`onHeaderCancelActionClick`) (see stack traces in the linked issues).

-----

## To Test:
I was not able to reproduce the crash and I'd recommend a sanity check of the flows.

1. In the MySite screen tap `Create campaign` on the `Blaze campaign` card.
2. Tap the `Cancel` button at the top right
3. *Verify* that the app does not crash
4. Start a campaign again (see 1)
5. Press the back button or swipe back 
6. *Verify* that the app does not crash

-----

## Regression Notes

1. Potential unintended areas of impact

    - Blaze

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

7. What automated tests I added (or what prevented me from doing so)

    - Relied on existing tests of the fucntionality

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
