### PR TITLE
[Reader Customization] Customize Subscribe button

### DIFF
--- a/WordPress/src/main/res/color/reader_follow_button_selected_stroke_color.xml
+++ b/WordPress/src/main/res/color/reader_follow_button_selected_stroke_color.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="?attr/readerFollowButtonSelectedStrokeAlpha" android:color="?attr/readerFollowButtonSelectedForeground" />
+</selector>

--- a/WordPress/src/main/res/color/reader_follow_button_text_color_selector.xml
+++ b/WordPress/src/main/res/color/reader_follow_button_text_color_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/reader_following_button_text_color" android:state_selected="true" />
-    <item android:color="@color/reader_follow_button_text_color" />
+    <item android:alpha="?attr/readerFollowButtonSelectedTextAlpha" android:color="?attr/readerFollowButtonSelectedForeground" android:state_selected="true" />
+    <item android:color="?attr/readerFollowButtonForeground" />
 </selector>

--- a/WordPress/src/main/res/drawable/reader_follow_button_shape.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button_shape.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="5dp" />
-    <solid android:color="@color/reader_follow_button" />
+    <solid android:color="?attr/readerFollowButtonBackground" />
 </shape>

--- a/WordPress/src/main/res/drawable/reader_following_button_shape.xml
+++ b/WordPress/src/main/res/drawable/reader_following_button_shape.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <corners android:radius="5dp" />
-    <solid android:color="@color/transparent" />
+    <solid android:color="?attr/readerFollowButtonSelectedBackground" />
     <stroke
         android:width="1dp"
-        android:color="@color/reader_following_button_stroke" />
+        android:color="@color/reader_follow_button_selected_stroke_color" />
 </shape>

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -100,10 +100,9 @@
     <!-- Reader Improvements -->
     <color name="reader_you_might_like_background">#1FFFFFFF</color>
     <color name="reader_improvements_recommended_section_text">#99FFFFFF</color>
-    <color name="reader_following_button_stroke">#40FFFFFF</color>
     <color name="reader_follow_button">@color/white</color>
-    <color name="reader_follow_button_text_color">@color/black</color>
-    <color name="reader_following_button_text_color">#99FFFFFF</color>
+    <color name="reader_follow_button_foreground">@color/black</color>
+    <color name="reader_following_button_foreground">@color/white</color>
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_dark</color>
     <color name="reader_blog_section_avatar_internal_border">@color/white_translucent_20</color>
     <color name="reader_post_body_link">@color/blue_30</color>

--- a/WordPress/src/main/res/values-night/dimens.xml
+++ b/WordPress/src/main/res/values-night/dimens.xml
@@ -14,4 +14,7 @@
     <item name="dashboard_card_pages_status_background_alpha" format="float" type="dimen">
         @dimen/disabled_alpha
     </item>
+
+    <!-- Reader Follow Button -->
+    <dimen name="reader_follow_button_stroke_alpha" format="float">0.25</dimen>
 </resources>

--- a/WordPress/src/main/res/values-night/dimens.xml
+++ b/WordPress/src/main/res/values-night/dimens.xml
@@ -16,5 +16,5 @@
     </item>
 
     <!-- Reader Follow Button -->
-    <dimen name="reader_follow_button_stroke_alpha" format="float">0.25</dimen>
+    <dimen name="reader_follow_button_stroke_alpha" format="float">@dimen/reader_follow_button_stroke_alpha_dark</dimen>
 </resources>

--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -93,6 +93,14 @@
         <item name="materialCalendarStyle">@style/WordPress.MaterialCalendarStyle</item>
         <item name="materialCalendarFullscreenTheme">@style/WordPress.MaterialCalendarFullscreenTheme</item>
         <item name="materialCalendarTheme">@style/WordPress.MaterialCalendarTheme</item>
+
+        <!-- Reader Subscribe Button -->
+        <item name="readerFollowButtonBackground">@color/reader_follow_button</item>
+        <item name="readerFollowButtonForeground">@color/reader_follow_button_foreground</item>
+        <item name="readerFollowButtonSelectedBackground">@color/transparent</item>
+        <item name="readerFollowButtonSelectedForeground">@color/reader_following_button_foreground</item>
+        <item name="readerFollowButtonSelectedTextAlpha">@dimen/reader_follow_button_text_alpha</item>
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha</item>
     </style>
 
     <style name="WordPress.ActionMode" parent="@style/Widget.AppCompat.ActionMode">

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -34,7 +34,7 @@
     <attr name="categoriesButtonBackgroundSelected" format="reference|color" />
     <attr name="mlpDividerColor" format="reference|color" />
 
-    <!-- Reader colors -->
+    <!-- Reader attributes -->
     <attr name="readerFollowButtonBackground" format="reference|color" />
     <attr name="readerFollowButtonForeground" format="reference|color" />
     <attr name="readerFollowButtonSelectedBackground" format="reference|color" />

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -34,6 +34,14 @@
     <attr name="categoriesButtonBackgroundSelected" format="reference|color" />
     <attr name="mlpDividerColor" format="reference|color" />
 
+    <!-- Reader colors -->
+    <attr name="readerFollowButtonBackground" format="reference|color" />
+    <attr name="readerFollowButtonForeground" format="reference|color" />
+    <attr name="readerFollowButtonSelectedBackground" format="reference|color" />
+    <attr name="readerFollowButtonSelectedForeground" format="reference|color" />
+    <attr name="readerFollowButtonSelectedTextAlpha" format="float" />
+    <attr name="readerFollowButtonSelectedStrokeAlpha" format="reference|float" />
+
     <!-- SummaryEditTextPreference attributes -->
     <declare-styleable name="SummaryEditTextPreference">
         <attr name="summaryLines" format="integer" />

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -103,10 +103,9 @@
     <color name="reader_improvements_follow_button_following_state">#F4F4F4</color>
     <color name="reader_improvements_recommended_section_text">#99000000</color>
     <color name="reader_you_might_like_background">@color/neutral_0</color>
-    <color name="reader_following_button_stroke">#1F000000</color>
     <color name="reader_follow_button">@color/black</color>
-    <color name="reader_follow_button_text_color">@color/white</color>
-    <color name="reader_following_button_text_color">#99000000</color>
+    <color name="reader_follow_button_foreground">@color/white</color>
+    <color name="reader_following_button_foreground">@color/black</color>
     <color name="reader_follow_button_ripple">@color/reader_follow_button_ripple_selector_light</color>
     <color name="reader_blog_section_avatar_internal_border">@color/black_translucent_20</color>
     <color name="reader_post_body_link">@color/blue_50</color>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -770,4 +770,7 @@
     <dimen name="post_list_more_button_extra_padding">24dp</dimen>
     <dimen name="navbar_me_icon_padding">4dp</dimen>
 
+    <!-- Reader Follow Button -->
+    <dimen name="reader_follow_button_stroke_alpha" format="float">0.12</dimen>
+    <dimen name="reader_follow_button_text_alpha" format="float">0.6</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -771,6 +771,9 @@
     <dimen name="navbar_me_icon_padding">4dp</dimen>
 
     <!-- Reader Follow Button -->
-    <dimen name="reader_follow_button_stroke_alpha" format="float">0.12</dimen>
+    <dimen name="reader_follow_button_stroke_alpha_light" format="float">0.12</dimen>
+    <dimen name="reader_follow_button_stroke_alpha_dark" format="float">0.25</dimen>
+
+    <dimen name="reader_follow_button_stroke_alpha" format="float">@dimen/reader_follow_button_stroke_alpha_light</dimen>
     <dimen name="reader_follow_button_text_alpha" format="float">0.6</dimen>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -132,58 +132,58 @@
         <item name="android:dropDownListViewStyle">@style/ReaderDetailsPopupTheme.Dropdown</item>
     </style>
 
-    <style name="ReaderTheme.Soft" parent="ReaderTheme.System">
+    <style name="ReaderTheme.Custom" parent="ReaderTheme.System">
+        <item name="android:colorBackground">?attr/colorSurface</item>
+        <item name="colorOnBackground">?attr/colorOnSurface</item>
+        <item name="android:textColorPrimary">?attr/colorOnSurface</item>
+        <item name="android:textColorSecondary">?attr/colorOnSurface</item>
+
+        <item name="readerFollowButtonBackground">?attr/colorOnSurface</item>
+        <item name="readerFollowButtonForeground">?attr/colorSurface</item>
+        <item name="readerFollowButtonSelectedBackground">@color/transparent</item>
+        <item name="readerFollowButtonSelectedForeground">?attr/colorOnSurface</item>
+    </style>
+
+    <style name="ReaderTheme.Soft" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_soft_background</item>
         <item name="colorOnSurface">@color/reader_theme_soft_text</item>
-        <item name="android:colorBackground">@color/reader_theme_soft_background</item>
-        <item name="colorOnBackground">@color/reader_theme_soft_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_soft_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_soft_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_light</item>
     </style>
 
-    <style name="ReaderTheme.Sepia" parent="ReaderTheme.System">
+    <style name="ReaderTheme.Sepia" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_sepia_background</item>
         <item name="colorOnSurface">@color/reader_theme_sepia_text</item>
-        <item name="android:colorBackground">@color/reader_theme_sepia_background</item>
-        <item name="colorOnBackground">@color/reader_theme_sepia_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_sepia_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_sepia_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_light</item>
     </style>
 
-    <style name="ReaderTheme.Evening" parent="ReaderTheme.System">
+    <style name="ReaderTheme.Evening" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_evening_background</item>
         <item name="colorOnSurface">@color/reader_theme_evening_text</item>
-        <item name="android:colorBackground">@color/reader_theme_evening_background</item>
-        <item name="colorOnBackground">@color/reader_theme_evening_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_evening_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_evening_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_dark</item>
     </style>
 
-    <style name="ReaderTheme.OLED" parent="ReaderTheme.System">
+    <style name="ReaderTheme.OLED" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_oled_background</item>
         <item name="colorOnSurface">@color/reader_theme_oled_text</item>
-        <item name="android:colorBackground">@color/reader_theme_oled_background</item>
-        <item name="colorOnBackground">@color/reader_theme_oled_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_oled_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_oled_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_dark</item>
     </style>
 
-    <style name="ReaderTheme.h4x0r" parent="ReaderTheme.System">
+    <style name="ReaderTheme.h4x0r" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_h4x0r_background</item>
         <item name="colorOnSurface">@color/reader_theme_h4x0r_text</item>
-        <item name="android:colorBackground">@color/reader_theme_h4x0r_background</item>
-        <item name="colorOnBackground">@color/reader_theme_h4x0r_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_h4x0r_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_h4x0r_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_dark</item>
     </style>
 
-    <style name="ReaderTheme.Candy" parent="ReaderTheme.System">
+    <style name="ReaderTheme.Candy" parent="ReaderTheme.Custom">
         <item name="colorSurface">@color/reader_theme_candy_background</item>
         <item name="colorOnSurface">@color/reader_theme_candy_text</item>
-        <item name="android:colorBackground">@color/reader_theme_candy_background</item>
-        <item name="colorOnBackground">@color/reader_theme_candy_text</item>
-        <item name="android:textColorPrimary">@color/reader_theme_candy_text</item>
-        <item name="android:textColorSecondary">@color/reader_theme_candy_text</item>
+
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha_light</item>
     </style>
 
     <style name="WordPress.MaterialCalendarFullscreenTheme" parent="ThemeOverlay.MaterialComponents.MaterialCalendar.Fullscreen">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -107,6 +107,14 @@
         <item name="materialCalendarStyle">@style/Widget.MaterialComponents.MaterialCalendar</item>
         <item name="materialCalendarFullscreenTheme">@style/WordPress.MaterialCalendarFullscreenTheme</item>
         <item name="materialCalendarTheme">@style/WordPress.MaterialCalendarTheme</item>
+
+        <!-- Reader Subscribe Button -->
+        <item name="readerFollowButtonBackground">@color/reader_follow_button</item>
+        <item name="readerFollowButtonForeground">@color/reader_follow_button_foreground</item>
+        <item name="readerFollowButtonSelectedBackground">@color/transparent</item>
+        <item name="readerFollowButtonSelectedForeground">@color/reader_following_button_foreground</item>
+        <item name="readerFollowButtonSelectedTextAlpha">@dimen/reader_follow_button_text_alpha</item>
+        <item name="readerFollowButtonSelectedStrokeAlpha">@dimen/reader_follow_button_stroke_alpha</item>
     </style>
 
     <style name="ReaderDetailsPopupTheme.Popup" parent="Widget.MaterialComponents.PopupMenu.ListPopupWindow">


### PR DESCRIPTION
> [!Warning]
> This should only be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/20506

Apply Reading Preferences color scheme to Subscribe/Subscribed button inside the Reader Details.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/45dde430-4ed7-4438-a189-2d81f670597c

-----

## To Test:

Since the feature is still in development, follow the initial instructions in the "To Test" section of https://github.com/wordpress-mobile/WordPress-Android/pull/20506

- Go to Reader
- Tap any post
- Tap the "Reading Preferences" top bar option
- Change the color scheme (test all if possible)
- **Verify** the Subscribe/Subscribed button colors match the selected color scheme

-----

## Regression Notes

1. Potential unintended areas of impact

    - Wrong color of Subscribe Button in other parts of the app or Default theme

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [x] Light and dark modes.
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
