### PR TITLE
[Reader Customization] Fix snackbar action color

### DIFF
--- a/WordPress/src/main/res/values-night/styles.xml
+++ b/WordPress/src/main/res/values-night/styles.xml
@@ -60,6 +60,7 @@
 
         <item name="toolbarStyle">@style/WordPress.ToolBar</item>
         <item name="appBarLayoutStyle">@style/WordPress.AppBarLayout</item>
+        <item name="snackbarActionColor">?attr/colorSecondaryVariant</item>
         <item name="snackbarStyle">@style/WordPress.Snackbar</item>
         <item name="snackbarButtonStyle">@style/WordPress.SnackbarButton</item>
         <item name="snackbarTextViewStyle">@style/WordPress.SnackbarText</item>
@@ -134,10 +135,6 @@
 
     <style name="DividerHorizontal" tools:ignore="UnusedResources">
         <item name="android:background">?android:attr/listDivider</item>
-    </style>
-
-    <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
-        <item name="android:textColor">?attr/colorSecondaryVariant</item>
     </style>
 
     <!--Post Settings Styles-->

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -42,6 +42,9 @@
     <attr name="readerFollowButtonSelectedTextAlpha" format="float" />
     <attr name="readerFollowButtonSelectedStrokeAlpha" format="reference|float" />
 
+    <!-- Snackbar colors -->
+    <attr name="snackbarActionColor" format="reference|color" />
+
     <!-- SummaryEditTextPreference attributes -->
     <declare-styleable name="SummaryEditTextPreference">
         <attr name="summaryLines" format="integer" />

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="toolbarStyle">@style/WordPress.ToolBar</item>
         <item name="tabStyle">@style/WordPress.TabLayout</item>
         <item name="appBarLayoutStyle">@style/WordPress.AppBarLayout</item>
+        <item name="snackbarActionColor">@color/primary_30</item>
         <item name="snackbarStyle">@style/WordPress.Snackbar</item>
         <item name="snackbarButtonStyle">@style/WordPress.SnackbarButton</item>
         <item name="snackbarTextViewStyle">@style/WordPress.SnackbarText</item>
@@ -142,6 +143,8 @@
         <item name="readerFollowButtonForeground">?attr/colorSurface</item>
         <item name="readerFollowButtonSelectedBackground">@color/transparent</item>
         <item name="readerFollowButtonSelectedForeground">?attr/colorOnSurface</item>
+
+        <item name="snackbarActionColor">?attr/colorSurface</item>
     </style>
 
     <style name="ReaderTheme.Soft" parent="ReaderTheme.Custom">
@@ -433,7 +436,7 @@
     </style>
 
     <style name="WordPress.SnackbarButton" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
-        <item name="android:textColor">@color/primary_30</item>
+        <item name="android:textColor">?attr/snackbarActionColor</item>
     </style>
 
     <style name="WordPress.SnackbarText" parent="@style/Widget.MaterialComponents.Snackbar.TextView">


### PR DESCRIPTION
> [!Warning]
> This should only be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/20560

While working on #20560 I noticed the Snackbar gets stylized with the current theme colors, but the action bar was not using a color that makes sense, so I'm fixing this issue by allowing customization of the snackbar action color, instead of using a hardcoded primary variant color.

@osullivanchris, to keep things simple, for the action color ("Enable" in the case of this specific snackbar) I'm just using the `surfaceColor`, so it matches with the text color inside the Snackbar and we don't have to come up with accent colors. I hope that makes sense.

Here's an example of the issue and fix in the Sepia color scheme:

| Issue | Fix |
|--------|--------|
| ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/aee1f1c7-cb71-4c4b-bf25-3c1b7a42ef00) | ![image](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/5fca6bf3-fc70-4a49-b63d-cc2b0a5f793b) | 

-----

## To Test:

Since the feature is still in development, follow the initial instructions in the "To Test" section of https://github.com/wordpress-mobile/WordPress-Android/pull/20506

- Go to Reader
- Tap any post
- Change the color scheme (test all if possible)
- For each one:
  - Tap the Subscribe button (you might need to unsubscribe first)
  - **Verify** the action color matches the snackbar text color (except for "Default" which uses a color based on the app's primary color).

-----

## Regression Notes

1. Potential unintended areas of impact

    - Snackbar color getting wrong in other parts of the app
   
2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A, UI/style changes only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [x] Light and dark modes.
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
