### PR TITLE
[Reader Customization] Update preview, adding link to feedback survey

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -149,6 +149,7 @@ android {
         buildConfigField "boolean", "STATS_TRAFFIC_TAB", "false"
         buildConfigField "boolean", "READER_DISCOVER_NEW_ENDPOINT", "false"
         buildConfigField "boolean", "READER_READING_PREFERENCES", "false"
+        buildConfigField "boolean", "READER_READING_PREFERENCES_FEEDBACK", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -46,6 +46,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
         setContent {
             AppTheme {
                 val readerPreferences by viewModel.currentReadingPreferences.collectAsState()
+                val isFeedbackEnabled by viewModel.isFeedbackEnabled.collectAsState()
                 ReadingPreferencesScreen(
                     currentReadingPreferences = readerPreferences,
                     onCloseClick = viewModel::saveReadingPreferencesAndClose,
@@ -53,7 +54,8 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
                     onThemeClick = viewModel::onThemeClick,
                     onFontFamilyClick = viewModel::onFontFamilyClick,
                     onFontSizeClick = viewModel::onFontSizeClick,
-                    onBackgroundColorUpdate = { dialog?.window?.setWindowStatusBarColor(it) }
+                    onBackgroundColorUpdate = { dialog?.window?.setWindowStatusBarColor(it) },
+                    isFeedbackEnabled = isFeedbackEnabled,
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -48,6 +48,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
                 ReadingPreferencesScreen(
                     currentReadingPreferences = readerPreferences,
                     onCloseClick = viewModel::saveReadingPreferencesAndClose,
+                    onSendFeedbackClick = viewModel::onSendFeedbackClick,
                     onThemeClick = viewModel::onThemeClick,
                     onFontFamilyClick = viewModel::onFontFamilyClick,
                     onFontSizeClick = viewModel::onFontSizeClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.R
+import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
@@ -74,6 +75,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
             when (it) {
                 is ActionEvent.UpdateStatusBarColor -> handleUpdateStatusBarColor(it.theme)
                 is ActionEvent.Close -> handleClose(it.isDirty)
+                is ActionEvent.OpenWebView -> handleOpenWebView(it.url)
             }
         }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
@@ -87,6 +89,12 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
         val context = requireContext()
         val themeValues = ReaderReadingPreferences.ThemeValues.from(context, theme)
         dialog?.window?.setWindowStatusBarColor(themeValues.intBackgroundColor)
+    }
+
+    private fun handleOpenWebView(url: String) {
+        context?.let { context ->
+            WPWebViewActivity.openURL(context, url)
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.viewmodels
 
+import android.util.Log
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -56,6 +57,10 @@ class ReaderReadingPreferencesViewModel @Inject constructor(
                 _actionEvents.emit(ActionEvent.Close(isDirty = false))
             }
         }
+    }
+
+    fun onSendFeedbackClick() {
+        // TODO
     }
 
     sealed interface ActionEvent {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader.viewmodels
 
-import android.util.Log
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -60,11 +60,18 @@ class ReaderReadingPreferencesViewModel @Inject constructor(
     }
 
     fun onSendFeedbackClick() {
-        // TODO
+        launch {
+            _actionEvents.emit(ActionEvent.OpenWebView(FEEDBACK_URL))
+        }
     }
 
     sealed interface ActionEvent {
         data class Close(val isDirty: Boolean) : ActionEvent
         data class UpdateStatusBarColor(val theme: ReaderReadingPreferences.Theme) : ActionEvent
+        data class OpenWebView(val url: String) : ActionEvent
+    }
+
+    companion object {
+        private const val FEEDBACK_URL = "https://automattic.survey.fm/reader-customization-survey"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.usecases.ReaderGetReadingPreferencesSyncUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSaveReadingPreferencesUseCase
+import org.wordpress.android.util.config.ReaderReadingPreferencesFeedbackFeatureConfig
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -19,17 +20,22 @@ import javax.inject.Named
 class ReaderReadingPreferencesViewModel @Inject constructor(
     getReadingPreferences: ReaderGetReadingPreferencesSyncUseCase,
     private val saveReadingPreferences: ReaderSaveReadingPreferencesUseCase,
+    private val readerReadingPreferencesFeedbackFeatureConfig: ReaderReadingPreferencesFeedbackFeatureConfig,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
 ) : ScopedViewModel(bgDispatcher) {
     private val originalReadingPreferences = getReadingPreferences()
     private val _currentReadingPreferences = MutableStateFlow(originalReadingPreferences)
     val currentReadingPreferences: StateFlow<ReaderReadingPreferences> = _currentReadingPreferences
 
+    private val _isFeedbackEnabled = MutableStateFlow(false)
+    val isFeedbackEnabled: StateFlow<Boolean> = _isFeedbackEnabled
+
     private val _actionEvents = MutableSharedFlow<ActionEvent>()
     val actionEvents: SharedFlow<ActionEvent> = _actionEvents
 
     fun init() {
         launch {
+            _isFeedbackEnabled.emit(readerReadingPreferencesFeedbackFeatureConfig.isEnabled())
             _actionEvents.emit(ActionEvent.UpdateStatusBarColor(originalReadingPreferences.theme))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -32,10 +33,14 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
@@ -65,6 +70,7 @@ fun ReadingPreferencesScreen(
     val backgroundColor by animateColorAsState(Color(themeValues.intBackgroundColor), label = "backgroundColor")
     val baseTextColor by animateColorAsState(Color(themeValues.intBaseTextColor), label = "baseTextColor")
     val textColor by animateColorAsState(Color(themeValues.intTextColor), label = "textColor")
+    val linkColor by animateColorAsState(Color(themeValues.intLinkColor), label = "linkColor")
 
     SideEffect {
         // update background color based on value animation and notify the parent
@@ -111,6 +117,15 @@ fun ReadingPreferencesScreen(
                 style = getTitleTextStyle(fontFamily, fontSizeMultiplier, baseTextColor),
             )
 
+            // Content
+            ReadingPreferencesPreviewContent(
+                onSendFeedbackClick = { /*TODO*/ },
+                fontFamily = fontFamily,
+                fontSize = fontSize,
+                textColor = textColor,
+                linkColor = linkColor,
+            )
+
             // Tags
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
@@ -128,18 +143,6 @@ fun ReadingPreferencesScreen(
                         )
                     }
             }
-
-            // Content
-            Text(
-                text = stringResource(R.string.reader_preferences_screen_preview_text),
-                style = TextStyle(
-                    fontFamily = fontFamily,
-                    fontSize = fontSize,
-                    fontWeight = FontWeight.Normal,
-                    color = textColor,
-                    lineHeight = fontSize * TEXT_LINE_HEIGHT_MULTIPLIER,
-                ),
-            )
         }
 
         // Preferences section
@@ -211,6 +214,60 @@ fun ReadingPreferencesScreen(
             )
         }
     }
+}
+
+@Composable
+private fun ReadingPreferencesPreviewContent(
+    onSendFeedbackClick: () -> Unit,
+    fontFamily: FontFamily,
+    fontSize: TextUnit,
+    textColor: Color,
+    linkColor: Color,
+) {
+    val feedbackString = stringResource(R.string.reader_preferences_screen_preview_text_feedback)
+    val contentString = stringResource(R.string.reader_preferences_screen_preview_text, feedbackString)
+    val annotatedString = buildAnnotatedString {
+        append(contentString)
+
+        val startIndex = contentString.indexOf(feedbackString)
+        val endIndex = startIndex + feedbackString.length
+
+        addStyle(
+            style = SpanStyle(
+                color = linkColor,
+                textDecoration = TextDecoration.Underline,
+            ),
+            start = startIndex,
+            end = endIndex,
+        )
+
+        addStringAnnotation(
+            tag = "url",
+            annotation = "feedback",
+            start = startIndex,
+            end = endIndex,
+        )
+    }
+
+    ClickableText(
+        text = annotatedString,
+        style = TextStyle(
+            fontFamily = fontFamily,
+            fontSize = fontSize,
+            fontWeight = FontWeight.Normal,
+            color = textColor,
+            lineHeight = fontSize * TEXT_LINE_HEIGHT_MULTIPLIER,
+        ),
+        onClick = { offset ->
+            annotatedString.getStringAnnotations(tag = "url", start = offset, end = offset)
+                .firstOrNull()
+                ?.let { annotation ->
+                    if (annotation.item == "feedback") {
+                        onSendFeedbackClick()
+                    }
+                }
+        },
+    )
 }
 
 private fun getTitleTextStyle(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -119,11 +119,22 @@ fun ReadingPreferencesScreen(
             )
 
             // Content
-            ReadingPreferencesPreviewContent(
-                onSendFeedbackClick = onSendFeedbackClick,
+            val contentStyle = TextStyle(
                 fontFamily = fontFamily,
                 fontSize = fontSize,
-                textColor = textColor,
+                fontWeight = FontWeight.Normal,
+                color = textColor,
+                lineHeight = fontSize * TEXT_LINE_HEIGHT_MULTIPLIER,
+            )
+
+            Text(
+                text = stringResource(R.string.reader_preferences_screen_preview_text),
+                style = contentStyle,
+            )
+
+            ReadingPreferencesPreviewFeedback(
+                onSendFeedbackClick = onSendFeedbackClick,
+                textStyle = contentStyle,
                 linkColor = linkColor,
             )
 
@@ -218,20 +229,18 @@ fun ReadingPreferencesScreen(
 }
 
 @Composable
-private fun ReadingPreferencesPreviewContent(
+private fun ReadingPreferencesPreviewFeedback(
     onSendFeedbackClick: () -> Unit,
-    fontFamily: FontFamily,
-    fontSize: TextUnit,
-    textColor: Color,
+    textStyle: TextStyle,
     linkColor: Color,
 ) {
-    val feedbackString = stringResource(R.string.reader_preferences_screen_preview_text_feedback)
-    val contentString = stringResource(R.string.reader_preferences_screen_preview_text, feedbackString)
+    val linkString = stringResource(R.string.reader_preferences_screen_preview_text_feedback_link)
+    val feedbackString = stringResource(R.string.reader_preferences_screen_preview_text_feedback, linkString)
     val annotatedString = buildAnnotatedString {
-        append(contentString)
+        append(feedbackString)
 
-        val startIndex = contentString.indexOf(feedbackString)
-        val endIndex = startIndex + feedbackString.length
+        val startIndex = feedbackString.indexOf(linkString)
+        val endIndex = startIndex + linkString.length
 
         addStyle(
             style = SpanStyle(
@@ -252,13 +261,7 @@ private fun ReadingPreferencesPreviewContent(
 
     ClickableText(
         text = annotatedString,
-        style = TextStyle(
-            fontFamily = fontFamily,
-            fontSize = fontSize,
-            fontWeight = FontWeight.Normal,
-            color = textColor,
-            lineHeight = fontSize * TEXT_LINE_HEIGHT_MULTIPLIER,
-        ),
+        style = textStyle,
         onClick = { offset ->
             annotatedString.getStringAnnotations(tag = "url", start = offset, end = offset)
                 .firstOrNull()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -64,6 +64,7 @@ fun ReadingPreferencesScreen(
     onFontFamilyClick: (ReaderReadingPreferences.FontFamily) -> Unit,
     onFontSizeClick: (ReaderReadingPreferences.FontSize) -> Unit,
     onBackgroundColorUpdate: (Int) -> Unit,
+    isFeedbackEnabled: Boolean,
     isHapticsFeedbackEnabled: Boolean = true,
 ) {
     val themeValues = ReaderReadingPreferences.ThemeValues.from(LocalContext.current, currentReadingPreferences.theme)
@@ -131,11 +132,13 @@ fun ReadingPreferencesScreen(
                 style = contentStyle,
             )
 
-            ReadingPreferencesPreviewFeedback(
-                onSendFeedbackClick = onSendFeedbackClick,
-                textStyle = contentStyle,
-                linkColor = linkColor,
-            )
+            if (isFeedbackEnabled) {
+                ReadingPreferencesPreviewFeedback(
+                    onSendFeedbackClick = onSendFeedbackClick,
+                    textStyle = contentStyle,
+                    linkColor = linkColor,
+                )
+            }
 
             // Tags
             FlowRow(
@@ -302,6 +305,7 @@ private fun ReadingPreferencesScreenPreview() {
             onThemeClick = { readingPreferences = readingPreferences.copy(theme = it) },
             onFontFamilyClick = { readingPreferences = readingPreferences.copy(fontFamily = it) },
             onFontSizeClick = { readingPreferences = readingPreferences.copy(fontSize = it) },
+            isFeedbackEnabled = true,
             onBackgroundColorUpdate = {},
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -60,6 +60,7 @@ private const val TEXT_LINE_HEIGHT_MULTIPLIER = 1.6f
 fun ReadingPreferencesScreen(
     currentReadingPreferences: ReaderReadingPreferences,
     onCloseClick: () -> Unit,
+    onSendFeedbackClick: () -> Unit,
     onThemeClick: (ReaderReadingPreferences.Theme) -> Unit,
     onFontFamilyClick: (ReaderReadingPreferences.FontFamily) -> Unit,
     onFontSizeClick: (ReaderReadingPreferences.FontSize) -> Unit,
@@ -119,7 +120,7 @@ fun ReadingPreferencesScreen(
 
             // Content
             ReadingPreferencesPreviewContent(
-                onSendFeedbackClick = { /*TODO*/ },
+                onSendFeedbackClick = onSendFeedbackClick,
                 fontFamily = fontFamily,
                 fontSize = fontSize,
                 textColor = textColor,
@@ -295,6 +296,7 @@ private fun ReadingPreferencesScreenPreview() {
         ReadingPreferencesScreen(
             currentReadingPreferences = readingPreferences,
             onCloseClick = {},
+            onSendFeedbackClick = {},
             onThemeClick = { readingPreferences = readingPreferences.copy(theme = it) },
             onFontFamilyClick = { readingPreferences = readingPreferences.copy(fontFamily = it) },
             onFontSizeClick = { readingPreferences = readingPreferences.copy(fontSize = it) },

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ReaderReadingPreferencesFeedbackFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ReaderReadingPreferencesFeedbackFeatureConfig.kt
@@ -1,0 +1,21 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val READING_PREFERENCES_FEEDBACK_REMOTE_FIELD = "reading_preferences_feedback"
+@Feature(
+    READING_PREFERENCES_FEEDBACK_REMOTE_FIELD,
+    true,
+)
+class ReaderReadingPreferencesFeedbackFeatureConfig
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.READER_READING_PREFERENCES_FEEDBACK,
+    READING_PREFERENCES_FEEDBACK_REMOTE_FIELD,
+) {
+    override fun isEnabled(): Boolean {
+        return super.isEnabled() && BuildConfig.IS_JETPACK_APP
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1699,9 +1699,11 @@
 
     <string name="reader_preferences_screen_preview_title">Reading Preferences</string>
     <string name="reader_preferences_screen_preview_tags" translatable="false">reading,colors,fonts</string>
-    <!-- translators: %s is replaced with the string at reader_preferences_screen_preview_text_feedback, so please translate both in a way that the full final sentence make sense -->
-    <string name="reader_preferences_screen_preview_text">Choose the right colors, fonts and sizes for you. Preview the changes here, and tap ‘Done’ when you’re ready to read.\n\nThis is a new feature still in development. To help us improve it %s.</string>
-    <string name="reader_preferences_screen_preview_text_feedback">send your feedback</string>
+    <string name="reader_preferences_screen_preview_text">Choose your colors, fonts and sizes. Preview your selection here, and read posts with your styles once you’re done.</string>
+
+    <!-- translators: %s is replaced with the string in reader_preferences_screen_preview_text_feedback_link, so please translate both in a way that the full final sentence make sense -->
+    <string name="reader_preferences_screen_preview_text_feedback">This is a new feature still in development. To help us improve it %s.</string>
+    <string name="reader_preferences_screen_preview_text_feedback_link">send your feedback</string>
 
     <string name="reader_preferences_theme_system">Default</string>
     <string name="reader_preferences_theme_soft">Soft</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1697,9 +1697,12 @@
     <string name="reader_filter_chip_tag_one">1 Tag</string>
     <string name="reader_filter_chip_tag_other">%d Tags</string>
 
-    <string name="reader_preferences_screen_preview_title" translatable="false">The quick brown fox jumps over the lazy dog</string>
-    <string name="reader_preferences_screen_preview_tags" translatable="false">dogs,fox,design,writing</string>
-    <string name="reader_preferences_screen_preview_text" translatable="false">Once upon a time, in a quaint little village nestled between rolling hills and lush greenery, there lived a quick brown fox named Jasper.</string>
+    <string name="reader_preferences_screen_preview_title">Reading Preferences</string>
+    <string name="reader_preferences_screen_preview_tags" translatable="false">reading,colors,fonts</string>
+    <!-- translators: %s is replaced with the string at reader_preferences_screen_preview_text_feedback, so please translate both in a way that the full final sentence make sense -->
+    <string name="reader_preferences_screen_preview_text">Choose the right colors, fonts and sizes for you. Preview the changes here, and tap ‘Done’ when you’re ready to read.\n\nThis is a new feature still in development. To help us improve it %s.</string>
+    <string name="reader_preferences_screen_preview_text_feedback">send your feedback</string>
+    <string name="reader_preferences_screen_feedback_url" translatable="false">https://automattic.survey.fm/reader-customization-survey</string>
 
     <string name="reader_preferences_theme_system">Default</string>
     <string name="reader_preferences_theme_soft">Soft</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1702,7 +1702,6 @@
     <!-- translators: %s is replaced with the string at reader_preferences_screen_preview_text_feedback, so please translate both in a way that the full final sentence make sense -->
     <string name="reader_preferences_screen_preview_text">Choose the right colors, fonts and sizes for you. Preview the changes here, and tap ‘Done’ when you’re ready to read.\n\nThis is a new feature still in development. To help us improve it %s.</string>
     <string name="reader_preferences_screen_preview_text_feedback">send your feedback</string>
-    <string name="reader_preferences_screen_feedback_url" translatable="false">https://automattic.survey.fm/reader-customization-survey</string>
 
     <string name="reader_preferences_theme_system">Default</string>
     <string name="reader_preferences_theme_soft">Soft</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.usecases.ReaderGetReadingPreferencesSyncUseCase
 import org.wordpress.android.ui.reader.usecases.ReaderSaveReadingPreferencesUseCase
 import org.wordpress.android.ui.reader.viewmodels.ReaderReadingPreferencesViewModel.ActionEvent
+import org.wordpress.android.util.config.ReaderReadingPreferencesFeedbackFeatureConfig
 
 @ExperimentalCoroutinesApi
 class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
@@ -27,6 +28,9 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var saveReadingPreferences: ReaderSaveReadingPreferencesUseCase
+
+    @Mock
+    lateinit var readerReadingPreferencesFeedbackFeatureConfig: ReaderReadingPreferencesFeedbackFeatureConfig
 
     private val viewModelDispatcher = UnconfinedTestDispatcher(testDispatcher().scheduler)
     private lateinit var viewModel: ReaderReadingPreferencesViewModel
@@ -40,6 +44,7 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
         viewModel = ReaderReadingPreferencesViewModel(
             getReadingPreferences,
             saveReadingPreferences,
+            readerReadingPreferencesFeedbackFeatureConfig,
             viewModelDispatcher,
         )
 
@@ -162,6 +167,32 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
         // Then
         val openWebViewEvent = collectedEvents.last() as ActionEvent.OpenWebView
         assertThat(openWebViewEvent.url).isEqualTo(EXPECTED_FEEDBACK_URL)
+    }
+
+    @Test
+    fun `when readerReadingPreferencesFeedbackFeatureConfig is true then isFeedbackEnabled emits true`() = test {
+        // Given
+        whenever(readerReadingPreferencesFeedbackFeatureConfig.isEnabled()).thenReturn(true)
+
+        // When
+        viewModel.init()
+
+        // Then
+        val isFeedbackEnabled = viewModel.isFeedbackEnabled.first()
+        assertThat(isFeedbackEnabled).isTrue()
+    }
+
+    @Test
+    fun `when readerReadingPreferencesFeedbackFeatureConfig is false then isFeedbackEnabled emits false`() = test {
+        // Given
+        whenever(readerReadingPreferencesFeedbackFeatureConfig.isEnabled()).thenReturn(false)
+
+        // When
+        viewModel.init()
+
+        // Then
+        val isFeedbackEnabled = viewModel.isFeedbackEnabled.first()
+        assertThat(isFeedbackEnabled).isFalse()
     }
 
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
@@ -154,7 +154,18 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
         verify(saveReadingPreferences).invoke(argThat { theme == newTheme })
     }
 
+    @Test
+    fun `when onSendFeedbackClick is called then it emits OpenWebView action event`() = test {
+        // When
+        viewModel.onSendFeedbackClick()
+
+        // Then
+        val openWebViewEvent = collectedEvents.last() as ActionEvent.OpenWebView
+        assertThat(openWebViewEvent.url).isEqualTo(EXPECTED_FEEDBACK_URL)
+    }
+
     companion object {
         private val DEFAULT_READING_PREFERENCES = ReaderReadingPreferences()
+        private const val EXPECTED_FEEDBACK_URL = "https://automattic.survey.fm/reader-customization-survey"
     }
 }


### PR DESCRIPTION
> [!Warning]
> This should only be merged after #20558

Update the Reading Preferences screen preview to talk about the feature and have a link to a feedback survey, so we get direct feedback from the users.

 The `send your feedback` link opens the Crowdsignal survey in a WebView. _Note that the survey is still WIP and, ideally, it should not be answered while testing the app._

This PR also introduces a remote `FeatureConfig` so we can disable the preview part that talks about the feature being in development and presents the survey link, so we can remotely disable it if needed. It is on by default.

Remote feature flag name: `reading_preferences_feedback`

-----

## To Test:

Since the feature is still in development, follow the initial instructions in the "To Test" section of https://github.com/wordpress-mobile/WordPress-Android/pull/20506

- Open Reader
- Tap any post
- Open the Reading Preferences screen
- **Verify** the preview text is updated
- Tap "send your feedback"
- **Verify** a WebView is opened in a CrowdSignal survey

_Please don't answer the survey with fake answers. We might want to create another internal survey to be used in debug builds._

To test the feature config being disabled:
- Go to Debug Settings
- Find and disable `reading_preferences_feedback`
- Go to the Reader
- Tap any post
- Open the Reading Preferences Screen
- **Verify** the "new feature" section is not shown in the preview anymore


-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Unit tests in the ViewModel.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
