### PR TITLE
Change "∞" symbol with "100%" on stats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,10 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
-24.7
------
-* [*] [Jetpack-only] Change "∞" symbol with "100%" on stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20564]
-
 24.6
 -----
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]
 * [*] Block editor: Fixes an Aztec editor crash occurring on some occasions when the keyboard suggestions are used [https://github.com/wordpress-mobile/WordPress-Android/pull/20518]
+* [*] [Jetpack-only] Change "∞" symbol with "100%" on stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20564]
 
 24.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+24.7
+-----
+* [*] [Jetpack-only] Change "∞" symbol with "100%" on stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20564]
+
 24.6
 -----
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -226,7 +226,7 @@ class StatsUtils @Inject constructor(
             val difference = value - previousValue
             val percentage = when (previousValue) {
                 value -> "0"
-                0L -> "∞"
+                0L -> percentFormatter.format(value = 100)
                 else -> {
                     val percentageValue = difference.toFloat() / previousValue
                     percentFormatter.format(value = percentageValue, rounding = HALF_UP)

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -278,12 +278,12 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with infinite positive difference`() {
-        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("∞")
+        whenever(percentFormatter.format(100)).thenReturn("100")
         val previousValue = 0L
         val value = 20L
         val positive = true
-        val expectedChange = "+20 (∞%)"
-        whenever(resourceProvider.getString(eq(R.string.stats_traffic_increase), eq("20"), eq("∞")))
+        val expectedChange = "+20 (100%)"
+        whenever(resourceProvider.getString(eq(R.string.stats_traffic_increase), eq("20"), eq("100")))
             .thenReturn(expectedChange)
 
         val change = statsUtils.buildChange(previousValue, value, positive, isFormattedNumber = true)


### PR DESCRIPTION
Fixes #17314 

This changes "∞" symbol with "100%" on stats. The issue description states removing "∞" symbol but this PR changes it to "%100" and matches this behavior with the web. 

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/08158f05-6293-49a5-b1f5-25b144cd3aba" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/7963d63e-f8ba-4ea5-abd8-35d330289b37" width=320>|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/6acc7541-a25f-4db7-b9fd-f2c121092120" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/54db1ef3-3c9d-46ba-ac34-340de71a2d77" width=320>|

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Open "My Site → Stats"
3. Select the INSIGHTS tab. 
4. Select a date that has 0 views for the previous date on Views & Visitors card.
5. Verify that the data shows "%100" instead of "∞".
6. Repeat the same test for total cards.
7. Repeat the same test for the Overview card on granular tabs.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated `StatsUtilsTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
