### PR TITLE
Prevents the app from crashing when the MediaDeleteService fails to resume

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1149,7 +1149,13 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
                 intent.putExtra(MediaDeleteService.MEDIA_LIST_KEY, mediaToDelete);
                 doBindDeleteService(intent);
             }
-            startService(intent);
+            try {
+                startService(intent);
+            } catch (IllegalStateException e) {
+                // This can happen if the app still appears to be running in the background
+                // see: https://github.com/wordpress-mobile/WordPress-Android/issues/18638
+                AppLog.e(AppLog.T.MEDIA, "Unable to start MediaDeleteService: " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #18638

# Description
This PR catches and logs the IllegalStateException/[BackgroundServiceStartNotAllowedException](https://developer.android.com/reference/android/app/BackgroundServiceStartNotAllowedException) thrown when the `MediaBrowserActivity` is resumed but the service fails to start because the app still appears to be in the background.

-----

## To Test:
I was not able to reproduce this crash thus I'd recommend a sanity of the functionality:
1. On the My Site Screen tap More > Media
2. Select a media
3. On the detail screen tap the trash icon at the top right and confirm
4. **Verify** that the app does not crash and the media is deleted

-----

## Regression Notes

1. Potential unintended areas of impact

    - Media delete functionality

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

7. What automated tests I added (or what prevented me from doing so)

    - The specific code is hard to test without major refactoring

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
