### PR TITLE
Fix Crash in post related to sync publishing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher
@@ -34,6 +35,7 @@ import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.config.SyncPublishingFeatureConfig
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
@@ -51,7 +53,8 @@ class StorePostViewModel
     private val savePostToDbUseCase: SavePostToDbUseCase,
     private val networkUtils: NetworkUtilsWrapper,
     private val dispatcher: Dispatcher,
-    private val postFreshnessChecker: IPostFreshnessChecker
+    private val postFreshnessChecker: IPostFreshnessChecker,
+    private val syncPublishingFeatureConfig: SyncPublishingFeatureConfig
 ) : ScopedViewModel(uiCoroutineDispatcher), DialogVisibilityProvider {
     private var debounceCounter = 0
     private var saveJob: Job? = null
@@ -226,6 +229,11 @@ class StorePostViewModel
     @Subscribe
     fun onPostChanged(event: OnPostChanged) {
         hideSavingProgressDialog()
+        handlePostRefreshedIfNeeded(event)
+    }
+
+    private fun handlePostRefreshedIfNeeded(event: OnPostChanged) {
+        if (syncPublishingFeatureConfig.isEnabled().not()) return
 
         // Refresh post content if needed
         (event.causeOfChange as? CauseOfOnPostChanged.UpdatePost)?.let { updatePost ->
@@ -238,7 +246,6 @@ class StorePostViewModel
             }
         }
     }
-
     sealed class UpdateResult {
         object Error : UpdateResult()
         data class Success(val postTitleOrContentChanged: Boolean) : UpdateResult()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts.editor
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineDispatcher

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/StorePostViewModelTest.kt
@@ -32,6 +32,7 @@ import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor
 import org.wordpress.android.ui.posts.editor.StorePostViewModel.UpdateFromEditor.PostFields
 import org.wordpress.android.ui.uploads.UploadServiceFacade
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.config.SyncPublishingFeatureConfig
 import org.wordpress.android.viewmodel.Event
 
 @ExperimentalCoroutinesApi
@@ -63,6 +64,9 @@ class StorePostViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var postFreshnessChecker: IPostFreshnessChecker
 
+    @Mock
+    lateinit var syncPublishingFeatureConfig: SyncPublishingFeatureConfig
+
     private lateinit var viewModel: StorePostViewModel
     private val title = "title"
     private val updatedTitle = "updatedTitle"
@@ -84,7 +88,8 @@ class StorePostViewModelTest : BaseUnitTest() {
             savePostToDbUseCase,
             networkUtils,
             dispatcher,
-            postFreshnessChecker
+            postFreshnessChecker,
+            syncPublishingFeatureConfig
         )
         postModel.setId(postId)
         postModel.setTitle(title)


### PR DESCRIPTION
Fixes #20540 

This PR addresses a crash related to sync publishing.

I am unable to reproduce the crash; however I am able to prevent the code from running while the sync feature is in development. The front part of this code will refresh the post if it's outdated and the tail end (where the crash is happening) should match the request. Right now the fetching part is wrapped with a feature flag, but the end part isn’t wrapped. As such, each time content is added to a post, this method is executing and in some circumstances is causing a crash. 

The team will address the underlying issue outside of this PR

-----

## To Test:
- Install the version of the app from this PR
- ✅ Validate that you can create and modify a post without any crashes

-----

## Regression Notes

1. Potential unintended areas of impact
Post crash

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
