### PR TITLE
[Reader Customization] Remote Reading Preferences Feature Flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]
 * [*] Block editor: Fixes an Aztec editor crash occurring on some occasions when the keyboard suggestions are used [https://github.com/wordpress-mobile/WordPress-Android/pull/20518]
 * [*] [Jetpack-only] Change "∞" symbol with "100%" on stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20564]
+* [**] [Jetpack-only] Reader: introduce "reading preferences", an experimental feature that allows users to customize their Reader post content screen with the color, font, and size that they like the most. [https://github.com/wordpress-mobile/WordPress-Android/pull/20567]
 
 24.5
 -----

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ReaderReadingPreferencesFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ReaderReadingPreferencesFeatureConfig.kt
@@ -1,12 +1,18 @@
 package org.wordpress.android.util.config
 
 import org.wordpress.android.BuildConfig
-import org.wordpress.android.annotation.FeatureInDevelopment
+import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
-@FeatureInDevelopment
+private const val READING_PREFERENCES_REMOTE_FIELD = "reading_preferences"
+
+@Feature(READING_PREFERENCES_REMOTE_FIELD, true)
 class ReaderReadingPreferencesFeatureConfig
-@Inject constructor(appConfig: AppConfig) : FeatureConfig(appConfig, BuildConfig.READER_READING_PREFERENCES) {
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    BuildConfig.READER_READING_PREFERENCES,
+    READING_PREFERENCES_REMOTE_FIELD,
+) {
     override fun isEnabled(): Boolean {
         return super.isEnabled() && BuildConfig.IS_JETPACK_APP
     }


### PR DESCRIPTION
Change the `ReaderReadingPreferencesFeatureConfig` to a regular remote feature config, and set it to ON by default.

The remote config name is: `reading_preferences` but we can discuss if there's a better name for it with the whole team and make sure it matches what iOS uses as well.

@osullivanchris this PR is also a good candidate for checking if the Reading Preferences / Reader Customization feature state is in a good state for the v1, since it turns the feature ON, so we want to do any last adjustments / fix bugs before merging this PR to the `release` branch.

-----

## To Test:

To use the Reading Preferences in this build, you can just do the following:
- Open and Log into Jetpack
- Go to Reader
- Open any post details
- Tap the Reading Preferences icon on the top bar/overflow menu
- Change the preferences to your liking
- Verify the color scheme and font configurations apply as expected for v1 in the Post Details screen

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
