### PR TITLE
Update Jetpack Connection Stats event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionResultActivity.java
@@ -141,7 +141,7 @@ public class JetpackConnectionResultActivity extends LocaleAwareActivity {
         if (mSource == JetpackConnectionSource.STATS) {
             SiteModel site = (SiteModel) getIntent().getSerializableExtra(SITE);
             mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction(SiteUtils.getFetchSitesPayload()));
-            ActivityLauncher.viewBlogStatsAfterJetpackSetup(this, site, StatsLaunchedFrom.JETPACK_CONNECTION);
+            ActivityLauncher.viewBlogStatsAfterJetpackSetup(this, site, StatsLaunchedFrom.QUICK_ACTIONS);
         }
         finish();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsAnalyticsUtils.kt
@@ -40,7 +40,6 @@ enum class StatsLaunchedFrom(val value: String) {
     LINK("link"),
     SHORTCUT("shortcut"),
     ACTIVITY_LOG("activity_log"),
-    JETPACK_CONNECTION("jetpack_connection")
 }
 
 fun AnalyticsTrackerWrapper.trackStatsAccessed(site: SiteModel, tapSource: String) =


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-Android/issues/20398

This PR updates the `StatsLaunchedFrom.JETPACK_CONNECTION` event to `StatsLaunchedFrom.QUICK_ACTIONS`. See discussion on ticket linked above.

-----

## To Test:
1. Follow the testing instructions for `jetpack connection` https://github.com/wordpress-mobile/WordPress-Android/pull/20194.
2. Instead of the `jetpack connection` event, you should see the `quick action` event. 


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

4. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):
- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~