### PR TITLE
Fixes: NullPointerException in fillContentEditorFields()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2617,7 +2617,7 @@ public class EditPostActivity extends LocaleAwareActivity implements
         mEditorFragment.setFeaturedImageSupported(mSite.isFeaturedImageSupported());
 
         // Special actions - these only make sense for empty posts that are going to be populated now
-        if (TextUtils.isEmpty(mEditPostRepository.getContent())) {
+        if (mEditPostRepository.hasPost() && TextUtils.isEmpty(mEditPostRepository.getContent())) {
             String action = getIntent().getAction();
             if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
                 setPostContentFromShareAction();


### PR DESCRIPTION
Fixes #20540

After investigating the stacktrace of the above crash, I found the following: 

The crash was indeed introduced by this [PR](https://github.com/wordpress-mobile/WordPress-Android/pull/20301) but this PR is not the root cause of the problem. It only added another place where EditPostActivity.refreshEditorContent() is called. 

This function contains a call to `TextUtils.isEmpty(mEditPostRepository.getContent())`. 

The basic issue that I see here is that EditPostRepository allows access to fields like 
 ```
val content: String
        get() = post!!.content
```

even when `post == null`. 

Accessing properties like id, content, etc., directly assumes that post is not null (post!!). This can lead to NullPointerException if post is null at the time of access. 

I just added the` mEditPostRepository.hasPost()` function so we can avoid this particular crash but maybe we should consider refactoring the EditPostRepository in the future. 

Maybe we could use safe calls (?.) and providing default values or handling null cases explicitly. It depends on the context of EditPostRepository and how it used by its "clients". 

Am I missing something? Was there a specific reason for using the `!!` operator?

@zwarm @AjeshRPai WDYT? 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

I was not able to replicate the crash. Please review the code. 