### PR TITLE
Handles site successfully fetched but has not been found in the local db

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SiteP
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewLoadingShimmerState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewWebErrorUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SiteNotCreatedErrorUiState
+import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SiteNotFoundInDbUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.UrlData
 import org.wordpress.android.ui.sitecreation.services.FetchWpComSiteUseCase
 import org.wordpress.android.ui.sitecreation.usecases.isWordPressComSubDomain
@@ -138,7 +139,7 @@ class SitePreviewViewModel @Inject constructor(
         return if (!onSiteFetched.isError) {
             val site = siteStore.getSiteBySiteId(remoteSiteId)
             if (site == null) {
-                updateUiState(SiteNotCreatedErrorUiState)
+                updateUiState(SiteNotFoundInDbUiState)
             }
             site
         } else {
@@ -224,6 +225,14 @@ class SitePreviewViewModel @Inject constructor(
             subtitle = UiStringRes(R.string.site_creation_error_generic_title),
             caption = UiStringRes(R.string.site_creation_error_generic_subtitle),
             errorTitle = UiStringRes(R.string.error),
+        )
+
+        data object SiteNotFoundInDbUiState : SitePreviewUiState(
+            urlData = UrlData("", "", 0 to 0, 0 to 0),
+            webViewVisibility = false,
+            webViewErrorVisibility = true,
+            subtitle = UiStringRes(R.string.site_creation_error_generic_title),
+            caption = UiStringRes(R.string.site_creation_error_generic_subtitle),
         )
 
         data class SitePreviewLoadingShimmerState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -139,7 +139,9 @@ class SitePreviewViewModel @Inject constructor(
         return if (!onSiteFetched.isError) {
             val site = siteStore.getSiteBySiteId(remoteSiteId)
             if (site == null) {
-                updateUiState(SiteNotFoundInDbUiState)
+                withContext(mainDispatcher) {
+                    updateUiState(SiteNotFoundInDbUiState)
+                }
             }
             site
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModel.kt
@@ -136,9 +136,11 @@ class SitePreviewViewModel @Inject constructor(
     private suspend fun fetchNewlyCreatedSiteModel(remoteSiteId: Long): SiteModel? {
         val onSiteFetched = fetchWpComSiteUseCase.fetchSiteWithRetry(remoteSiteId)
         return if (!onSiteFetched.isError) {
-            return requireNotNull(siteStore.getSiteBySiteId(remoteSiteId)) {
-                "Site successfully fetched but has not been found in the local db."
+            val site = siteStore.getSiteBySiteId(remoteSiteId)
+            if (site == null) {
+                updateUiState(SiteNotCreatedErrorUiState)
             }
+            site
         } else {
             null
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SiteP
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewContentUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SitePreviewWebErrorUiState
 import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SiteNotCreatedErrorUiState
+import org.wordpress.android.ui.sitecreation.previews.SitePreviewViewModel.SitePreviewUiState.SiteNotFoundInDbUiState
 import org.wordpress.android.ui.sitecreation.progress.LOADING_STATE_TEXT_ANIMATION_DELAY
 import org.wordpress.android.ui.sitecreation.services.FetchWpComSiteUseCase
 import org.wordpress.android.util.UrlUtilsWrapper
@@ -104,7 +105,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
     fun `on start if retrying to fetch the site succeeds but retrieving from fb fails show error`() = testWith(FETCH_SUCCESS) {
         whenever(siteStore.getSiteBySiteId(SITE_REMOTE_ID)).thenReturn(null)
         startViewModel(SITE_CREATION_STATE.copy(result = RESULT_NOT_IN_LOCAL_DB))
-        assertThat(viewModel.uiState.value).isInstanceOf(SiteNotCreatedErrorUiState::class.java)
+        assertThat(viewModel.uiState.value).isInstanceOf(SiteNotFoundInDbUiState::class.java)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -102,7 +102,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `on start if retrying to fetch the site succeeds but retrieving from fb fails show error`() = testWith(FETCH_SUCCESS) {
+    fun `on start if site is created but cannot be retrieved from fb fails show error`() = testWith(FETCH_SUCCESS) {
         whenever(siteStore.getSiteBySiteId(SITE_REMOTE_ID)).thenReturn(null)
         startViewModel(SITE_CREATION_STATE.copy(result = RESULT_NOT_IN_LOCAL_DB))
         assertThat(viewModel.uiState.value).isInstanceOf(SiteNotFoundInDbUiState::class.java)

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -101,6 +101,13 @@ class SitePreviewViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `on start if retrying to fetch the site succeeds but retrieving from fb fails show error`() = testWith(FETCH_SUCCESS) {
+        whenever(siteStore.getSiteBySiteId(SITE_REMOTE_ID)).thenReturn(null)
+        startViewModel(SITE_CREATION_STATE.copy(result = RESULT_NOT_IN_LOCAL_DB))
+        assertThat(viewModel.uiState.value).isInstanceOf(SiteNotCreatedErrorUiState::class.java)
+    }
+
+    @Test
     fun `on start does not show preview when fetching fails`() = testWith(FETCH_ERROR) {
         startViewModel()
         verify(siteStore, never()).getSiteBySiteId(SITE_REMOTE_ID)


### PR DESCRIPTION
Fixes #20530

**Depends on:** https://github.com/wordpress-mobile/WordPress-Android/pull/20571

## Description
This PR adds a new error UI state to gracefully handle an unexpected error in the site creation preview screen were the site successfully fetched but has not been found in the local db.

-----

## To Test:
Since I was not able to reproduce the error in real conditions I added a test and faked the state with an [error.patch](https://github.com/wordpress-mobile/WordPress-Android/files/14838068/error.patch)


1. Start the site creation (e.g. Site Picker and ➕)
2. Proceed to the end (e.g. with a free wordpress.com domain and plan) and expect a success state
3. Apply the patch above
4. Start the site creation
5. Proceed to the end and expect the new error state

|New Error|Success|
|---|---|
|![error](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/93cfbc6d-65aa-44e2-b636-4605a1827560)|![Screenshot_20240402_160522](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/5c744760-76b1-4a6a-a12d-e0fd966b8eaa)|

-----

## Regression Notes

1. Potential unintended areas of impact

    - Site creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Added a new test case

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
