### PR TITLE
Fix failing unit tests in post list item UI state helper test

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/posts/PostListItemUiStateHelper.kt
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.utils.UiString.UiStringRes
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.POSTS
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.HtmlUtils
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState
@@ -76,6 +77,7 @@ class PostListItemUiStateHelper @Inject constructor(
     private val labelColorUseCase: PostPageListLabelColorUseCase,
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
     private val blazeFeatureUtils: BlazeFeatureUtils,
+    private val buildConfigWrapper: BuildConfigWrapper
 ) {
     @Suppress("LongParameterList", "LongMethod")
     fun createPostListItemUiState(
@@ -438,7 +440,7 @@ class PostListItemUiStateHelper @Inject constructor(
 
         if (canShowViewButton) {
             buttonTypes.addViewOrPreviewAction(isLocalDraft || isLocallyChanged)
-            if (BuildConfig.IS_JETPACK_APP) {
+            if (buildConfigWrapper.isJetpackApp) {
                 buttonTypes.addReadAction(isLocalDraft || isLocallyChanged)
             }
         }


### PR DESCRIPTION
Description
-----
This pull request addresses the failing unit tests within `PostListItemUiStateHelperTest` that pertain to the "READ" more option in the post list specifically designed for Jetpack. See #20476 for specifics on the read action.
- A minor modification has been implemented in `PostListItemUiStateHelper` to use `BuildConfigWrapper` instead of `BuildConfig`, to support its testability.
- Additional tests were added specifically for Jetpack

## To Test:

- Download the branch
- Run the `PostListItemUiStateHelperTest` test locally

-----

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added unit tests when the app is Jetpack

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
