### PR TITLE
Fix the crash that occurs due to titles and categories containing '%'

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1652,7 +1652,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mCategoryPref.setEntries(entries);
         mCategoryPref.setEntryValues(values);
         mCategoryPref.setValue(String.valueOf(mSiteSettings.getDefaultCategory()));
-        mCategoryPref.setSummary(mSiteSettings.getDefaultCategoryForDisplay());
+        mCategoryPref.setSummary(mSiteSettings.getDefaultCategoryForDisplay().replace("%", "%%"));
     }
 
     private void setPostFormats() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -264,7 +264,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
         primarySiteSettingsUiState?.let { state ->
             primarySitePreference.apply {
                 value = (state.primarySite?.siteId ?: "").toString()
-                summary = state.primarySite?.siteName
+                summary = state.primarySite?.siteName?.replace("%", "%%")
                 entries = state.siteNames
                 entryValues = state.siteIds
                 canShowDialog = state.canShowChoosePrimarySiteDialog


### PR DESCRIPTION
Fixes #20582
This fixes the crash that occurs due to titles and categories containing '%'.

#### Steps to reproduce on Account Settings screen
1. Log in.
2. `Open` My Site -> ... More -> Site Settings or `Tap` on site title on My Site
3. Change the site name to something that ends with %, for e.g., "Site Title%".
4. Return to My Site
5. Open "Me → Account Settings"
6. Notice the app crashes

#### Steps to reproduce on Site Settings screen
1. Log in.
2. Open `Categories` under `Writing` from "My Site → ... More → Site Settings"
3. Add a new category that ends with "%".
4. Set the `Default Category` to a category that ends in %
5. Notice, the app crashes

#### Verify
- `Install` this build
- `Rerun` the above two flows
- `Verify` that the app doesn't crash


-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Follow the reproduction steps and verify there is no crash.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

12. What automated tests I added (or what prevented me from doing so)

    - This crash was caused by the Android framework and is not a good case for automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
