### PR TITLE
[Stats] Add year to date picker for weeks.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
@@ -9,6 +9,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.fluxc.utils.SiteUtils
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.text.DateFormat
 import java.text.ParseException
@@ -30,7 +31,11 @@ private const val YEARS_FORMAT = "MMM"
 private const val REMOVE_YEAR = "([^\\p{Alpha}']|('[\\p{Alpha}]+'))*y+([^\\p{Alpha}']|('[\\p{Alpha}]+'))*"
 
 class StatsDateFormatter
-@Inject constructor(private val localeManagerWrapper: LocaleManagerWrapper, val resourceProvider: ResourceProvider) {
+@Inject constructor(
+    private val localeManagerWrapper: LocaleManagerWrapper,
+    val resourceProvider: ResourceProvider,
+    val statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+) {
     private val inputFormat: SimpleDateFormat
         get() {
             return SimpleDateFormat(STATS_INPUT_FORMAT, localeManagerWrapper.getLocale())
@@ -110,7 +115,7 @@ class StatsDateFormatter
                 val startCalendar = Calendar.getInstance()
                 startCalendar.time = endCalendar.time
                 startCalendar.add(Calendar.DAY_OF_WEEK, -6)
-                return printWeek(startCalendar, endCalendar, true)
+                return printWeek(startCalendar, endCalendar, statsTrafficTabFeatureConfig.isEnabled())
             }
             MONTHS -> outputMonthFormat.format(date)
                 .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatter.kt
@@ -110,7 +110,7 @@ class StatsDateFormatter
                 val startCalendar = Calendar.getInstance()
                 startCalendar.time = endCalendar.time
                 startCalendar.add(Calendar.DAY_OF_WEEK, -6)
-                return printWeek(startCalendar, endCalendar)
+                return printWeek(startCalendar, endCalendar, true)
             }
             MONTHS -> outputMonthFormat.format(date)
                 .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
@@ -78,7 +78,7 @@ class StatsDateFormatterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `prints a week date in string format in granular stats screen`() {
+    fun `prints a week date in the same year in string format with stats traffic tab enabled`() {
         whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
         val unparsedDate = "2018W12W19"
         val result = "Dec 17 - Dec 23, 2018"
@@ -96,7 +96,7 @@ class StatsDateFormatterTest : BaseUnitTest() {
     }
 
     @Test
-    fun `prints a week date in string format in traffic tab`() {
+    fun `prints a week date in two different years in string format with traffic tab enabled`() {
         whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
         val unparsedDate = "2018W12W31"
         val result = "Dec 31, 2018 - Jan 6, 2019"

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsDateFormatterTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.network.utils.StatsGranularity.MONTHS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.YEARS
 import org.wordpress.android.util.LocaleManagerWrapper
+import org.wordpress.android.util.config.StatsTrafficTabFeatureConfig
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Calendar
 import java.util.Locale
@@ -28,13 +29,17 @@ class StatsDateFormatterTest : BaseUnitTest() {
     lateinit var localeManagerWrapper: LocaleManagerWrapper
 
     @Mock
+    lateinit var statsTrafficTabFeatureConfig: StatsTrafficTabFeatureConfig
+
+    @Mock
     lateinit var resourceProvider: ResourceProvider
     private lateinit var statsDateFormatter: StatsDateFormatter
 
     @Before
     fun setUp() {
         whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.US)
-        statsDateFormatter = StatsDateFormatter(localeManagerWrapper, resourceProvider)
+        whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(false)
+        statsDateFormatter = StatsDateFormatter(localeManagerWrapper, resourceProvider, statsTrafficTabFeatureConfig)
     }
 
     @Test
@@ -70,6 +75,42 @@ class StatsDateFormatterTest : BaseUnitTest() {
         val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
 
         assertThat(parsedDate).isEqualTo("Dec 17 - Dec 23")
+    }
+
+    @Test
+    fun `prints a week date in string format in granular stats screen`() {
+        whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
+        val unparsedDate = "2018W12W19"
+        val result = "Dec 17 - Dec 23, 2018"
+        whenever(
+            resourceProvider.getString(
+                R.string.stats_from_to_dates_in_week_label,
+                "Dec 17",
+                "Dec 23, 2018"
+            )
+        ).thenReturn(result)
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
+
+        assertThat(parsedDate).isEqualTo("Dec 17 - Dec 23, 2018")
+    }
+
+    @Test
+    fun `prints a week date in string format in traffic tab`() {
+        whenever(statsTrafficTabFeatureConfig.isEnabled()).thenReturn(true)
+        val unparsedDate = "2018W12W31"
+        val result = "Dec 31, 2018 - Jan 6, 2019"
+        whenever(
+            resourceProvider.getString(
+                R.string.stats_from_to_dates_in_week_label,
+                "Dec 31, 2018",
+                "Jan 6, 2019"
+            )
+        ).thenReturn(result)
+
+        val parsedDate = statsDateFormatter.printGranularDate(unparsedDate, WEEKS)
+
+        assertThat(parsedDate).isEqualTo("Dec 31, 2018 - Jan 6, 2019")
     }
 
     @Test


### PR DESCRIPTION
Fixes #20488

Add year to the week granularity label in datepicker. The screenshot below is on a small screen width.

Note: this affects both the stats that is currently out to everyone and the traffic tab under the week granularity.

![Screenshot_20240403_172130](https://github.com/wordpress-mobile/WordPress-Android/assets/1571223/e3e926d8-8bc0-4d79-b4ff-799965ddb634)

-----

## To Test:

- [ ] Turn on `stats_traffic_tab` feature flag in debug settings.
- [ ] Go to stats and make sure you are on the traffic tab
- [ ] Select the "By Week" granularity.
- [ ] You should see a year on the from/to dates.
- [ ] Turn off `stats_traffic_tab`.
- [ ] Go back into stats and go to the weeks tab.
- [ ] The date picker there should also have the year.

-----

## Regression Notes

1. Potential unintended areas of impact

    This would only affect adding the year to the date picker label on the old stats week granularity.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    n/a

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
