### PR TITLE
Upgrade ucrop library to 2.2.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ ext {
     squareupKotlinPoetVersion = '1.16.0'
     squareupOkioVersion = '3.6.0'
     squareupRetrofitVersion = '2.9.0'
-    uCropVersion = '2.2.8'
+    uCropVersion = '2.2.9'
     zendeskVersion = '5.1.2'
 
     // react native


### PR DESCRIPTION
Fixes #20570

This updates ucrop library and potentially fixes `java.lang.SecurityException` on the crop library.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Add a new blog post.
2. Add a new image block.
3. Choose an image and wait for it to be uploaded within the image block.
4. Click on the media options of this image (top right) and then click edit.
5. Crop the image and click the done menu option (top right).
6. Verify the image is updated accordingly.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Cropping image

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually

3. What automated tests I added (or what prevented me from doing so)

    - No test added since this is only a third party lib update.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
