### PR TITLE
Display tags chip in subscriptions feed based on tags feed feature flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -137,6 +137,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                         onClearFilterClick = ::clearFilter,
                         isSearchVisible = state.isSearchActionVisible,
                         onSearchClick = viewModel::onSearchActionClicked,
+                        showTagsChip = state.showTagsChip,
                     )
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -52,6 +52,7 @@ import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.config.ReaderTagsFeedFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -79,6 +80,7 @@ class ReaderViewModel @Inject constructor(
     private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil,
     private val readerTopBarMenuHelper: ReaderTopBarMenuHelper,
     private val urlUtilsWrapper: UrlUtilsWrapper,
+    private val readerTagsFeedFeatureConfig: ReaderTagsFeedFeatureConfig,
     // todo: annnmarie removed this private val getFollowedTagsUseCase: GetFollowedTagsUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private var initialized: Boolean = false
@@ -372,6 +374,7 @@ class ReaderViewModel @Inject constructor(
                     selectedItem = selectedItem,
                     filterUiState = filterUiState,
                     onDropdownMenuClick = ::onDropdownMenuClick,
+                    showTagsChip = !readerTagsFeedFeatureConfig.isEnabled(),
                     isSearchActionVisible = isSearchSupported(),
                 )
             )
@@ -523,6 +526,7 @@ class ReaderViewModel @Inject constructor(
         val selectedItem: MenuElementData.Item.Single,
         val filterUiState: FilterUiState? = null,
         val onDropdownMenuClick: () -> Unit,
+        val showTagsChip: Boolean,
         val isSearchActionVisible: Boolean = false,
     ) {
         @Parcelize

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -56,6 +56,7 @@ fun ReaderTopAppBar(
     onClearFilterClick: () -> Unit,
     isSearchVisible: Boolean,
     onSearchClick: () -> Unit = {},
+    showTagsChip: Boolean,
 ) {
     var selectedItem by remember { mutableStateOf(topBarUiState.selectedItem) }
     var isFilterShown by remember { mutableStateOf(topBarUiState.filterUiState != null) }
@@ -120,6 +121,7 @@ fun ReaderTopAppBar(
                             modifier = Modifier
                                 // use padding instead of Spacer for a nicer animation
                                 .padding(start = Margin.Medium.value),
+                            showTagsChip = showTagsChip,
                         )
                     }
                 }
@@ -149,6 +151,7 @@ private fun Filter(
     onFilterClick: (ReaderFilterType) -> Unit,
     onClearFilterClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showTagsChip: Boolean,
 ) {
     ReaderFilterChipGroup(
         modifier = modifier,
@@ -161,6 +164,7 @@ private fun Filter(
         onSelectedItemClick = { filterUiState.selectedItem?.type?.let(onFilterClick) },
         onSelectedItemDismissClick = onClearFilterClick,
         chipHeight = chipHeight,
+        showTagsChip = showTagsChip,
     )
 }
 
@@ -211,6 +215,7 @@ fun ReaderTopAppBarPreview() {
                 menuItems = menuItems,
                 selectedItem = menuItems.first() as MenuElementData.Item.Single,
                 onDropdownMenuClick = {},
+                showTagsChip = true,
             )
         )
     }
@@ -232,6 +237,7 @@ fun ReaderTopAppBarPreview() {
                 onClearFilterClick = {},
                 isSearchVisible = true,
                 onSearchClick = {},
+                showTagsChip = true,
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.MaterialTheme as Material3Theme
 
 private val roundedShape = RoundedCornerShape(100)
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun ReaderFilterChipGroup(
     blogsFilterCount: Int,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -60,6 +60,7 @@ fun ReaderFilterChipGroup(
     showBlogsFilter: Boolean = blogsFilterCount > 0,
     showTagsFilter: Boolean = tagsFilterCount > 0,
     chipHeight: Dp = 36.dp,
+    showTagsChip: Boolean,
 ) {
     Row(
         modifier = modifier,
@@ -97,17 +98,19 @@ fun ReaderFilterChipGroup(
         }
 
         // tags filter chip
-        AnimatedVisibility(
-            modifier = Modifier.clip(roundedShape),
-            visible = isTagChipVisible,
-        ) {
-            ReaderFilterChip(
-                text = tagChipText,
-                onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
-                onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
-                isSelectedItem = isTagSelected,
-                height = chipHeight,
-            )
+        if (showTagsChip) {
+            AnimatedVisibility(
+                modifier = Modifier.clip(roundedShape),
+                visible = isTagChipVisible,
+            ) {
+                ReaderFilterChip(
+                    text = tagChipText,
+                    onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
+                    onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
+                    isSelectedItem = isTagSelected,
+                    height = chipHeight,
+                )
+            }
         }
 
         AnimatedVisibility(visible = isBlogChipVisible && isTagChipVisible) {
@@ -242,6 +245,7 @@ fun ReaderFilterChipGroupPreview() {
             onSelectedItemDismissClick = {
                 selectedItem = null
             },
+            showTagsChip = true,
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -112,7 +112,8 @@ class ReaderViewModelTest : BaseUnitTest() {
             snackbarSequencer,
             jetpackFeatureRemovalOverlayUtil,
             readerTopBarMenuHelper,
-            urlUtilsWrapper
+            urlUtilsWrapper,
+            readerTagsFeedFeatureConfig,
         )
 
         whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))


### PR DESCRIPTION
> [!WARNING]  
> ~Should be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/20596~

Fixes #20594 

-----

## To Test:

- Install JP and sign in.
- Enable remote feature `reader_tags_feed`.
- Open "Reader".
- Select "Subscriptions" feed.
- 🔍 The "Tags" chip should not be displayed..
- Disable remote feature `reader_tags_feed`.
- Restart the app.
- Open "Reader".
- Select "Subscriptions" feed.
- 🔍 The "Tags" chip should be displayed.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing.

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
