### PR TITLE
Fix an issue of IndexOutOfBoundsException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.kt
@@ -22,7 +22,7 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
     RecyclerView.Adapter<NoteViewHolder>() {
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
     private var reloadLocalNotesJob: Job? = null
-    val filteredNotes = ArrayList<Note>()
+    var filteredNotes = ArrayList<Note>()
     var onNoteClicked = { _: String -> }
     var onNotesLoaded = { _: Int -> }
     var onScrolledToBottom = { _: Long -> }
@@ -49,9 +49,8 @@ class NotesAdapter(context: Context, private val inlineActionEvents: MutableShar
     @SuppressLint("NotifyDataSetChanged")
     fun addAll(notes: List<Note>) = coroutineScope.launch {
         val newNotes = buildFilteredNotesList(notes, currentFilter)
-        filteredNotes.clear()
-        filteredNotes.addAll(newNotes)
         withContext(Dispatchers.Main) {
+            filteredNotes = newNotes
             notifyDataSetChanged()
             onNotesLoaded(newNotes.size)
         }


### PR DESCRIPTION
Fixes #20601

It is a crash issue that I cannot reproduce, and I found [an article](https://nhancv.medium.com/android-fix-java-lang-indexoutofboundsexception-inconsistency-detected-invalid-item-70e9b3b489a2) mentioned the root cause, so I want to give it a try.

-----

## To Test:

1. Sign in JP app
2. Go to the Notifications tab
3. Smoke test the tab to ensure I don't break anything in this PR.
4. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

6. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
