### PR TITLE
Removes multiple calls to the WebSettings.getDefaultUserAgent api

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 24.7
 -----
-
+* [*] [internal] Updates the way the app retrieves the User-Agent request header [https://github.com/wordpress-mobile/WordPress-Android/pull/20603]
 
 24.6
 -----

--- a/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android;
 
+import android.webkit.WebSettings;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -26,12 +28,12 @@ public class UserAgentTest {
 
     @Test
     public void testGetUserAgentAndGetDefaultUserAgent() {
-        String userAgent = WordPress.getUserAgent();
+        String userAgent = AppInitializer.Companion.getUserAgentString();
         assertNotNull("User-Agent must be set", userAgent);
         assertTrue("User-Agent must not be an empty string", userAgent.length() > 0);
         assertTrue("User-Agent must contain app name substring", userAgent.contains(USER_AGENT_APPNAME));
 
-        String defaultUserAgent = WordPress.getDefaultUserAgent();
+        String defaultUserAgent = WebSettings.getDefaultUserAgent(AppInitializer.Companion.getContext());
         assertNotNull("Default User-Agent must be set", defaultUserAgent);
         assertTrue("Default User-Agent must not be an empty string", defaultUserAgent.length() > 0);
         assertFalse("Default User-Agent must not contain app name", defaultUserAgent.contains(USER_AGENT_APPNAME));

--- a/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
@@ -2,8 +2,12 @@ package org.wordpress.android;
 
 import android.webkit.WebSettings;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.wordpress.android.fluxc.network.UserAgent;
+
+import javax.inject.Inject;
 
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
@@ -26,9 +30,16 @@ public class UserAgentTest {
     @Rule(order = 1)
     public InitializationRule initRule = new InitializationRule();
 
+    @Inject UserAgent mUserAgent;
+
+    @Before
+    public void setUp() {
+        hiltRule.inject();
+    }
+
     @Test
     public void testGetUserAgentAndGetDefaultUserAgent() {
-        String userAgent = AppInitializer.Companion.getUserAgentString();
+        String userAgent = mUserAgent.toString();
         assertNotNull("User-Agent must be set", userAgent);
         assertTrue("User-Agent must not be an empty string", userAgent.length() > 0);
         assertTrue("User-Agent must contain app name substring", userAgent.contains(USER_AGENT_APPNAME));

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -365,9 +365,7 @@ class AppInitializer @Inject constructor(
             initAppOpsManager()
         }
 
-        userAgentString = userAgent.toString()
-
-        AppLog.i(T.UTILS, "AppInitializer.userAgentString: $userAgentString")
+        AppLog.i(T.UTILS, "AppInitializer.userAgentString: $userAgent")
 
         initialized = true
     }
@@ -1057,9 +1055,6 @@ class AppInitializer @Inject constructor(
                 RestClient.REST_CLIENT_VERSIONS.V0
             )
         }
-
-        // Note: this variable is used only for testing now (see AppInitializerTest)
-        var userAgentString: String? = null
 
         fun getBitmapCache(): BitmapLruCache {
             if (bitmapCache == null) {

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -22,9 +22,7 @@ import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.SystemClock
 import android.text.TextUtils
-import android.util.AndroidRuntimeException
 import android.util.Log
-import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
@@ -55,6 +53,7 @@ import org.wordpress.android.fluxc.generated.ListActionBuilder
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -124,6 +123,9 @@ class AppInitializer @Inject constructor(
     wellSqlInitializer: WellSqlInitializer,
     private val application: Application
 ) : DefaultLifecycleObserver {
+    @Inject
+    lateinit var userAgent: UserAgent
+
     @Inject
     lateinit var dispatcher: Dispatcher
 
@@ -305,7 +307,7 @@ class AppInitializer @Inject constructor(
                 .installDefaultEventBus()
         }
 
-        RestClientUtils.setUserAgent(userAgent)
+        RestClientUtils.setUserAgent(userAgent.toString())
 
         if (!initialized) {
             zendeskHelper.setupZendesk(
@@ -362,6 +364,10 @@ class AppInitializer @Inject constructor(
         if (!initialized && BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
             initAppOpsManager()
         }
+
+        userAgentString = userAgent.toString()
+
+        AppLog.i(T.UTILS, "AppInitializer.userAgentString: $userAgentString")
 
         initialized = true
     }
@@ -1052,54 +1058,8 @@ class AppInitializer @Inject constructor(
             )
         }
 
-        /**
-         * Device's default User-Agent string.
-         * E.g.:
-         * "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-         * AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile
-         * Safari/537.36"
-         */
-        @Suppress("SwallowedException")
-        val defaultUserAgent: String by lazy {
-            try {
-                WebSettings.getDefaultUserAgent(context)
-            } catch (e: AndroidRuntimeException) {
-                // Catch AndroidRuntimeException that could be raised by the WebView() constructor.
-                // See https://github.com/wordpress-mobile/WordPress-Android/issues/3594
-
-                // initialize with the empty string, it's a rare issue
-                ""
-            } catch (expected: NullPointerException) {
-                // Catch NullPointerException that could be raised by WebSettings.getDefaultUserAgent()
-                // See https://github.com/wordpress-mobile/WordPress-Android/issues/3838
-
-                // initialize with the empty string, it's a rare issue
-                ""
-            } catch (e: IllegalArgumentException) {
-                // Catch IllegalArgumentException that could be raised by WebSettings.getDefaultUserAgent()
-                // See https://github.com/wordpress-mobile/WordPress-Android/issues/9015
-
-                // initialize with the empty string, it's a rare issue
-                ""
-            }
-        }
-
-        /**
-         * User-Agent string when making HTTP connections, for both API traffic and WebViews. Appends
-         * "wp-android/version" to WebView's default User-Agent string for the webservers to get the full feature list
-         * of the browser and serve content accordingly, e.g.:
-         * "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
-         * AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile
-         * Safari/537.36 wp-android/4.7"
-         * Note that app versions prior to 2.7 simply used "wp-android" as the user agent
-         **/
-        val userAgent: String by lazy {
-            if (TextUtils.isEmpty(defaultUserAgent)) {
-                WordPress.USER_AGENT_APPNAME + "/" + PackageUtils.getVersionName(context)
-            } else {
-                (defaultUserAgent + " " + WordPress.USER_AGENT_APPNAME + "/" + PackageUtils.getVersionName(context))
-            }
-        }
+        // Note: this variable is used only for testing now (see AppInitializerTest)
+        var userAgentString: String? = null
 
         fun getBitmapCache(): BitmapLruCache {
             if (bitmapCache == null) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -70,11 +70,5 @@ abstract class WordPress : Application() {
         fun getRestClientUtilsV2() = AppInitializer.restClientUtilsV2
 
         fun getRestClientUtilsV0() = AppInitializer.restClientUtilsV0
-
-        @JvmStatic
-        fun getDefaultUserAgent() = AppInitializer.defaultUserAgent
-
-        @JvmStatic
-        fun getUserAgent() = AppInitializer.userAgent
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.model.encryptedlogging.EncryptedLoggingKey;
 import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.network.rest.wpcom.auth.AppSecrets;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 import dagger.hilt.InstallIn;
@@ -25,6 +27,7 @@ public class AppConfigModule {
         return new AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET);
     }
 
+    @Singleton
     @Provides
     public UserAgent provideUserAgent(@ApplicationContext Context appContext) {
         return new UserAgent(appContext, WordPress.USER_AGENT_APPNAME);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -13,12 +13,14 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.inject.Inject;
 
 /**
  * Basic activity for displaying a WebView.
@@ -34,6 +36,8 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
     private static final int WEBVIEW_CHROMIUM_STATE_THRESHOLD = 300 * 1024; // 300 KB
 
     protected WebView mWebView;
+
+    @Inject UserAgent mUserAgent;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -64,7 +68,7 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
         mWebView = (WebView) findViewById(R.id.webView);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
         // Setting this user agent makes Calypso sites hide any WordPress UIs (e.g. Masterbar, banners, etc.).
-        mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
+        mWebView.getSettings().setUserAgentString(mUserAgent.toString());
         configureWebView();
 
         if (savedInstanceState == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/BlazeFeatureUtils.kt
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.blaze
 
-import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.page.PageModel
 import org.wordpress.android.fluxc.model.page.PageStatus
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailPageSource
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingPageSource
@@ -18,6 +18,7 @@ import org.wordpress.android.util.config.BlazeManageCampaignFeatureConfig
 import javax.inject.Inject
 
 class BlazeFeatureUtils @Inject constructor(
+    private val userAgent: UserAgent,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val appPrefsWrapper: AppPrefsWrapper,
     private val blazeFeatureConfig: BlazeFeatureConfig,
@@ -153,7 +154,7 @@ class BlazeFeatureUtils @Inject constructor(
         )
     }
 
-    fun getUserAgent() = WordPress.getUserAgent()
+    fun getUserAgent() = userAgent.toString()
 
     fun getAuthenticationPostData(authenticationUrl: String,
                                   urlToLoad: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/layoutpicker/LayoutPreviewFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.LayoutPickerPreviewFragmentBinding
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.ui.FullscreenBottomSheetDialogFragment
 import org.wordpress.android.ui.PreviewMode.DESKTOP
 import org.wordpress.android.ui.PreviewMode.MOBILE
@@ -38,6 +39,9 @@ private const val JS_EVALUATION_DELAY = 250L
 private const val JS_READY_CALLBACK_ID = 926L
 
 abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
+    @Inject
+    lateinit var userAgent: UserAgent
+
     @Inject
     lateinit var displayUtilsWrapper: DisplayUtilsWrapper
 
@@ -125,7 +129,7 @@ abstract class LayoutPreviewFragment : FullscreenBottomSheetDialogFragment() {
 
         binding?.previewTypeSelectorButton?.setOnClickListener { viewModel.onPreviewModePressed() }
 
-        binding?.webView?.settings?.userAgentString = WordPress.getUserAgent()
+        binding?.webView?.settings?.userAgentString = userAgent.toString()
         binding?.webView?.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 super.onPageFinished(view, url)

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/ExoPlayerUtils.kt
@@ -19,13 +19,14 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory
 import com.google.android.exoplayer2.util.Util
 import dagger.Reusable
-import org.wordpress.android.WordPress
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.ui.utils.AuthenticationUtils
 import javax.inject.Inject
 
 @Reusable
 @Suppress("DEPRECATION")
 class ExoPlayerUtils @Inject constructor(
+    private val userAgent: UserAgent,
     private val authenticationUtils: AuthenticationUtils,
     private val appContext: Context
 ) {
@@ -33,7 +34,7 @@ class ExoPlayerUtils @Inject constructor(
 
     fun buildHttpDataSourceFactory(url: String): DefaultHttpDataSourceFactory {
         if (httpDataSourceFactory == null) {
-            httpDataSourceFactory = DefaultHttpDataSourceFactory(WordPress.getUserAgent())
+            httpDataSourceFactory = DefaultHttpDataSourceFactory(userAgent.toString())
         }
         httpDataSourceFactory?.defaultRequestProperties?.set(authenticationUtils.getAuthHeaders(url))
         return httpDataSourceFactory as DefaultHttpDataSourceFactory

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -67,6 +67,7 @@ import org.wordpress.android.fluxc.action.MediaAction;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
@@ -152,6 +153,8 @@ public class MediaSettingsActivity extends LocaleAwareActivity
     }
 
     private MediaType mMediaType;
+
+    @Inject UserAgent mUserAgent;
 
     @Inject MediaStore mMediaStore;
     @Inject Dispatcher mDispatcher;
@@ -1031,7 +1034,7 @@ public class MediaSettingsActivity extends LocaleAwareActivity
         }
         request.allowScanningByMediaScanner();
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
-        request.addRequestHeader("User-Agent", WordPress.getUserAgent());
+        request.addRequestHeader("User-Agent", mUserAgent.toString());
 
         mDownloadId = dm.enqueue(request);
         invalidateOptionsMenu();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -54,7 +54,6 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.WordPress.Companion.getContext
-import org.wordpress.android.WordPress.Companion.getUserAgent
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.editor.AztecEditorFragment
@@ -94,6 +93,7 @@ import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.post.PostStatus
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
@@ -322,6 +322,8 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     private var updatingPostArea: FrameLayout? = null
 
     @Inject lateinit var dispatcher: Dispatcher
+
+    @Inject lateinit var userAgent: UserAgent
 
     @Inject lateinit var accountStore: AccountStore
 
@@ -2387,7 +2389,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                             siteModel.password,
                             siteModel.isUsingWpComRestApi,
                             siteModel.webEditor,
-                            getUserAgent(),
+                            userAgent.toString(),
                             isJetpackSsoEnabled
                         )
                     return GutenbergEditorFragment.newInstance(
@@ -2424,7 +2426,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                         editorMediaUploadListener = editorFragment as EditorMediaUploadListener?
 
                         // Set up custom headers for the visual editor's internal WebView
-                        editorFragment?.setCustomHttpHeader("User-Agent", getUserAgent())
+                        editorFragment?.setCustomHttpHeader("User-Agent", userAgent.toString())
                         reattachUploadingMediaForAztec()
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -19,6 +19,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
@@ -38,6 +39,8 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     private int mConnectionId;
     private WebView mWebView;
     private ProgressBar mProgress;
+
+    @Inject UserAgent mUserAgent;
 
     @Inject AccountStore mAccountStore;
 
@@ -106,7 +109,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
-        mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
+        mWebView.getSettings().setUserAgentString(mUserAgent.toString());
 
         return rootView;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderVideoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderVideoViewerActivity.java
@@ -10,9 +10,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.ui.LocaleAwareActivity;
 import org.wordpress.android.util.helpers.WebChromeClientWithVideoPoster;
+
+import javax.inject.Inject;
 
 /**
  * Full screen landscape video player for the reader
@@ -21,6 +23,8 @@ public class ReaderVideoViewerActivity extends LocaleAwareActivity {
     private String mVideoUrl;
     private WebView mWebView;
     private ProgressBar mProgress;
+
+    @Inject UserAgent mUserAgent;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -32,7 +36,7 @@ public class ReaderVideoViewerActivity extends LocaleAwareActivity {
 
         mWebView.setBackgroundColor(Color.TRANSPARENT);
         mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
+        mWebView.getSettings().setUserAgentString(mUserAgent.toString());
 
         mWebView.setWebChromeClient(new WebChromeClientWithVideoPoster(
                 mWebView,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -18,6 +18,7 @@ import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.network.UserAgent;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.WPWebView;
 import org.wordpress.android.util.AppLog;
@@ -77,6 +78,8 @@ public class ReaderWebView extends WPWebView {
     private static boolean mBlogSchemeIsHttps;
 
     private boolean mIsDestroyed;
+
+    @Inject UserAgent mUserAgent;
     @Inject AccountStore mAccountStore;
 
     public ReaderWebView(Context context) {
@@ -103,8 +106,8 @@ public class ReaderWebView extends WPWebView {
 
             mReaderChromeClient = new ReaderWebChromeClient(this);
             this.setWebChromeClient(mReaderChromeClient);
-            this.setWebViewClient(new ReaderWebViewClient(this));
-            this.getSettings().setUserAgentString(WordPress.getUserAgent());
+            this.setWebViewClient(new ReaderWebViewClient(this, mUserAgent));
+            this.getSettings().setUserAgentString(mUserAgent.toString());
 
             // Enable third-party cookies since they are disabled by default;
             // we need third-party cookies to support authenticated images
@@ -261,12 +264,14 @@ public class ReaderWebView extends WPWebView {
 
     private static class ReaderWebViewClient extends WebViewClient {
         private final ReaderWebView mReaderWebView;
+        private final UserAgent mUserAgent;
 
-        ReaderWebViewClient(ReaderWebView readerWebView) {
+        ReaderWebViewClient(ReaderWebView readerWebView, UserAgent userAgent) {
             if (readerWebView == null) {
                 throw new IllegalArgumentException("ReaderWebViewClient requires readerWebView");
             }
             mReaderWebView = readerWebView;
+            mUserAgent = userAgent;
         }
 
 
@@ -309,7 +314,7 @@ public class ReaderWebView extends WPWebView {
                     conn.setRequestProperty("Authorization", "Bearer " + mToken);
                     conn.setReadTimeout(TIMEOUT_MS);
                     conn.setConnectTimeout(TIMEOUT_MS);
-                    conn.setRequestProperty("User-Agent", WordPress.getUserAgent());
+                    conn.setRequestProperty("User-Agent", mUserAgent.toString());
                     conn.setRequestProperty("Connection", "Keep-Alive");
                     return new WebResourceResponse(conn.getContentType(),
                             conn.getContentEncoding(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansViewModel.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.WPWebViewActivity
@@ -23,6 +23,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SiteCreationPlansViewModel @Inject constructor(
+    private val userAgent: UserAgent,
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
     private val networkUtilsWrapper: NetworkUtilsWrapper
@@ -79,7 +80,7 @@ class SiteCreationPlansViewModel @Inject constructor(
             SiteCreationPlansModel(
                 enableJavascript = true,
                 enableDomStorage = true,
-                userAgent = WordPress.getUserAgent(),
+                userAgent = userAgent.toString(),
                 enableChromeClient = true,
                 url = url,
                 addressToLoad = addressToLoad

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/previews/SiteCreationPreviewFragment.kt
@@ -18,10 +18,10 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
-import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.SiteCreationFormScreenBinding
 import org.wordpress.android.databinding.SiteCreationPreviewScreenBinding
 import org.wordpress.android.databinding.SiteCreationPreviewScreenDefaultBinding
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity.Companion.ARG_STATE
 import org.wordpress.android.ui.sitecreation.SiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.SiteCreationState
@@ -39,6 +39,9 @@ private const val SLIDE_IN_ANIMATION_DURATION = 450L
 @AndroidEntryPoint
 class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
     ErrorManagedWebViewClientListener {
+    @Inject
+    lateinit var userAgent: UserAgent
+
     @Inject
     internal lateinit var uiHelpers: UiHelpers
 
@@ -106,7 +109,7 @@ class SiteCreationPreviewFragment : SiteCreationBaseFormFragment(),
         viewModel.preloadPreview.observe(this) { url ->
             url?.let { urlString ->
                 webView.webViewClient = URLFilteredWebViewClient(urlString, this)
-                webView.settings.userAgentString = WordPress.getUserAgent()
+                webView.settings.userAgentString = userAgent.toString()
                 webView.loadUrl(urlString)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtils.kt
@@ -1,15 +1,16 @@
 package org.wordpress.android.ui.sitemonitor
 
-import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
 
 class SiteMonitorUtils @Inject constructor(
+    private val userAgent: UserAgent,
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
-    fun getUserAgent() = WordPress.getUserAgent()
+    fun getUserAgent() = userAgent.toString()
 
     fun getAuthenticationPostData(authenticationUrl: String,
                                   urlToLoad: String,

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitemonitor/SiteMonitorUtilsTest.kt
@@ -8,10 +8,14 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.verify
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 @RunWith(MockitoJUnitRunner::class)
 class SiteMonitorUtilsTest {
+    @Mock
+    lateinit var userAgent: UserAgent
+
     @Mock
     lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
 
@@ -19,7 +23,7 @@ class SiteMonitorUtilsTest {
 
     @Before
     fun setup() {
-        siteMonitorUtils = SiteMonitorUtils(analyticsTrackerWrapper)
+        siteMonitorUtils = SiteMonitorUtils(userAgent, analyticsTrackerWrapper)
     }
 
     @Test


### PR DESCRIPTION
Fixes #12259

## Description
This PR replaces multiple calls to the `WebSettings.getDefaultUserAgent`([which is not recommended](https://issuetracker.google.com/issues/289118199#comment9)) with just one, hoping to prevent the ANR of #12259 and probably reduce the crash count in #20147

The current implementation is making 27 calls to the `WebSettings.getDefaultUserAgent` function during the app startup and more later. One of those was in [the AppInitialiser](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt#L1063) and the rest were calls to [the AppConfigModule](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/modules/AppConfigModule.java#L30) that uses [the FluxC implementation](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/trunk/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt).

Since I wasn't able to reproduce the ANR my plan is to monitor how this fix would affect the occurrences of the issue. If the issue persist I would probably try a more drastic approach of changing the user agent used for the api calls and keep the full user agent using the `WebSettings.getDefaultUserAgent` only for the WebViews.

Internal ref: pcdRpT-5Us-p2#comment-9676

-----

## To Test:
* Since this PR should not change the behaviour of the app but the refactored code affects all network calls a sanity check of the app is recommended. 
* Test Jetpack and WordPress, rest and xmlrpc
* Verify that the `AppInitializer.userAgentString` is [logged correctly](https://github.com/wordpress-mobile/WordPress-Android/blob/fix/12259-userAgent/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt#L368)
-----

## Regression Notes

1. Potential unintended areas of impact

    - All Networking 😅 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Updated an existing test

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)