### PR TITLE
[Reader Customization] Add Experimental badge

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -16,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -101,24 +99,10 @@ fun ReadingPreferencesScreen(
             backgroundColor = backgroundColor,
             contentColor = baseTextColor,
             actions = {
-                Box(
-                    modifier = Modifier
-                        .background(baseTextColor, shape = CircleShape)
-                        .padding(
-                            vertical = Margin.Medium.value,
-                            horizontal = Margin.Large.value,
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "Experimental",
-                        style = TextStyle(
-                            color = backgroundColor,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Medium,
-                        ),
-                    )
-                }
+                ExperimentalBadge(
+                    contentColor = textColor,
+                    modifier = Modifier.padding(end = Margin.Large.value),
+                )
             }
         )
 
@@ -252,6 +236,22 @@ fun ReadingPreferencesScreen(
             )
         }
     }
+}
+
+@Composable
+private fun ExperimentalBadge(
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = stringResource(R.string.experimental_badge),
+        modifier = modifier,
+        style = TextStyle(
+            color = contentColor.copy(alpha = 0.6f),
+            fontWeight = FontWeight.Medium,
+            fontFamily = FontFamily.Monospace,
+        ),
+    )
 }
 
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
@@ -98,6 +100,26 @@ fun ReadingPreferencesScreen(
             onNavigationIconClick = onCloseClick,
             backgroundColor = backgroundColor,
             contentColor = baseTextColor,
+            actions = {
+                Box(
+                    modifier = Modifier
+                        .background(baseTextColor, shape = CircleShape)
+                        .padding(
+                            vertical = Margin.Medium.value,
+                            horizontal = Margin.Large.value,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Experimental",
+                        style = TextStyle(
+                            color = backgroundColor,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                    )
+                }
+            }
         )
 
         // Preview section

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -101,6 +101,7 @@ fun ReadingPreferencesScreen(
             actions = {
                 ExperimentalBadge(
                     contentColor = textColor,
+                    fontFamily = fontFamily,
                     modifier = Modifier.padding(end = Margin.Large.value),
                 )
             }
@@ -241,6 +242,7 @@ fun ReadingPreferencesScreen(
 @Composable
 private fun ExperimentalBadge(
     contentColor: Color,
+    fontFamily: FontFamily,
     modifier: Modifier = Modifier,
 ) {
     Text(
@@ -249,7 +251,7 @@ private fun ExperimentalBadge(
         style = TextStyle(
             color = contentColor.copy(alpha = 0.6f),
             fontWeight = FontWeight.Medium,
-            fontFamily = FontFamily.Monospace,
+            fontFamily = fontFamily,
         ),
     )
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
     <string name="me">Me</string>
     <string name="everyone">Everyone</string>
 
-    <string name="experimental_badge">[Experimental]</string>
+    <string name="experimental_badge">&lt;Experimental&gt;</string>
 
     <!-- CAB -->
     <string name="cab_selected">%d selected</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
     <string name="me">Me</string>
     <string name="everyone">Everyone</string>
 
+    <string name="experimental_badge">[Experimental]</string>
+
     <!-- CAB -->
     <string name="cab_selected">%d selected</string>
 


### PR DESCRIPTION
Add an experimental text on the top right of the Reading Preferences screen.

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/7837d0e2-4700-4145-a796-d6718ea18f0a

-----

## To Test:

- Open Jetpack
- Enable `ReaderReadingPreferencesFeatureConfig` in `Debug Menu > Features in Development`
- Go to Reader
- Tap any post
- Open the Reading Preferences
- **Verify** the `<Experimental>` text is shown in the top bar
- Change color schemes and fonts
- **Verify** the font and color of the badge changes accordingly
- Change Font Sizes
- **Verify** the font size of the badge text does NOT change

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A, UI only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
