### PR TITLE
Update empty Stats display to match iOS

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -168,10 +168,8 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
                 android.R.color.transparent
             )
         )
-        dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = false
-        dataSet.highLightAlpha = 255
         return dataSet
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -162,7 +162,7 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         dataSet.setGradientColor(
             ContextCompat.getColor(
                 context,
-                R.color.primary_5
+                android.R.color.transparent
             ), ContextCompat.getColor(
                 context,
                 android.R.color.transparent

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/traffic/TrafficBarChartViewHolder.kt
@@ -80,7 +80,7 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val dataSet = if (hasData(item.entries)) {
             buildDataSet(chart.context, mappedEntries)
         } else {
-            buildEmptyDataSet(chart.context, cutEntries.size)
+            BarDataSet(emptyList(), "Empty")
         }
         item.onBarChartDrawn?.invoke(dataSet.entryCount)
 
@@ -154,23 +154,6 @@ class TrafficBarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             valueFormatter = BarChartLabelFormatter(item.entries)
             textColor = ContextCompat.getColor(chart.context, R.color.neutral_30)
         }
-    }
-
-    private fun buildEmptyDataSet(context: Context, count: Int): BarDataSet {
-        val emptyValues = (0 until count).map { index -> BarEntry(index.toFloat(), 1f, "empty") }
-        val dataSet = BarDataSet(emptyValues, "Empty")
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                android.R.color.transparent
-            ), ContextCompat.getColor(
-                context,
-                android.R.color.transparent
-            )
-        )
-        dataSet.setDrawValues(false)
-        dataSet.isHighlightEnabled = false
-        return dataSet
     }
 
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -90,7 +90,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
         } else {
-            buildEmptyDataSet(context, cutEntries.size)
+            buildEmptyDataSet(cutEntries.size)
         }
         item.onBarChartDrawn?.invoke(dataSet.entryCount)
         val dataSets = mutableListOf<IBarDataSet>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -90,7 +90,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
         } else {
-            buildEmptyDataSet(cutEntries.size)
+            buildEmptyDataSet(context, cutEntries.size)
         }
         item.onBarChartDrawn?.invoke(dataSet.entryCount)
         val dataSets = mutableListOf<IBarDataSet>()
@@ -208,9 +208,18 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         }
     }
 
-    private fun buildEmptyDataSet(count: Int): BarDataSet {
+    private fun buildEmptyDataSet(context: Context, count: Int): BarDataSet {
         val emptyValues = (0 until count).map { index -> BarEntry(index.toFloat(), 1f, "empty") }
         val dataSet = BarDataSet(emptyValues, "Empty")
+        dataSet.setGradientColor(
+            ContextCompat.getColor(
+                context,
+                AndroidR.color.transparent
+            ), ContextCompat.getColor(
+                context,
+                AndroidR.color.transparent
+            )
+        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = false

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -90,7 +90,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
         } else {
-            buildEmptyDataSet(context, cutEntries.size)
+            BarDataSet(emptyList(), "Empty")
         }
         item.onBarChartDrawn?.invoke(dataSet.entryCount)
         val dataSets = mutableListOf<IBarDataSet>()
@@ -206,25 +206,6 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             high2.dataIndex = index
             highlightValues(arrayOf(high2, high))
         }
-    }
-
-    private fun buildEmptyDataSet(context: Context, count: Int): BarDataSet {
-        val emptyValues = (0 until count).map { index -> BarEntry(index.toFloat(), 1f, "empty") }
-        val dataSet = BarDataSet(emptyValues, "Empty")
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                AndroidR.color.transparent
-            ), ContextCompat.getColor(
-                context,
-                AndroidR.color.transparent
-            )
-        )
-        dataSet.formLineWidth = 0f
-        dataSet.setDrawValues(false)
-        dataSet.isHighlightEnabled = false
-        dataSet.highLightAlpha = 255
-        return dataSet
     }
 
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -208,18 +208,9 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         }
     }
 
-    private fun buildEmptyDataSet(context: Context, count: Int): BarDataSet {
+    private fun buildEmptyDataSet(count: Int): BarDataSet {
         val emptyValues = (0 until count).map { index -> BarEntry(index.toFloat(), 1f, "empty") }
         val dataSet = BarDataSet(emptyValues, "Empty")
-        dataSet.setGradientColor(
-            ContextCompat.getColor(
-                context,
-                R.color.primary_5
-            ), ContextCompat.getColor(
-                context,
-                AndroidR.color.transparent
-            )
-        )
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = false


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20423

This PR updates the bar chart display to transparent when there is no data, since `BarDataSet` from the charting library displays empty bars with color by default.


| Before | After |
|--------|-------|
|     <img width="287" alt="Screenshot 2024-04-06 at 1 35 28 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/05e12972-f258-4fbd-93a1-25c178a97128">   |    <img width="286" alt="Screenshot 2024-04-06 at 1 34 57 AM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/aed1b7c6-50f6-475b-a511-a0569ca21407">   |
-----

## To Test:
1. With the `stats_traffic_tab` feature flag off, navigate to a site that has no data for any of the time granularities.
2. Ensure that you don't see the green colored bars signifying empty data.
3. Repeat with the feature flag on. 



<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

5. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)