### PR TITLE
Stats: Add singular strings to weekly roundup notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifier.kt
@@ -90,34 +90,56 @@ class WeeklyRoundupNotifier @Inject constructor(
     }
 
     private fun buildContentText(data: WeeklyRoundupData) = when {
-        data.likes <= 0 && data.comments <= 0 -> {
-            resourceProvider.getString(
-                R.string.weekly_roundup_notification_text_views_only,
-                statsUtils.toFormattedString(data.views)
-            )
-        }
-        data.likes > 0 && data.comments <= 0 -> {
-            resourceProvider.getString(
-                R.string.weekly_roundup_notification_text_views_and_likes,
-                statsUtils.toFormattedString(data.views),
-                statsUtils.toFormattedString(data.likes)
-            )
-        }
-        data.likes <= 0 && data.comments > 0 -> {
-            resourceProvider.getString(
-                R.string.weekly_roundup_notification_text_views_and_comments,
-                statsUtils.toFormattedString(data.views),
-                statsUtils.toFormattedString(data.comments)
-            )
-        }
-        else -> {
-            resourceProvider.getString(
-                R.string.weekly_roundup_notification_text_all,
-                statsUtils.toFormattedString(data.views),
-                statsUtils.toFormattedString(data.likes),
-                statsUtils.toFormattedString(data.comments)
-            )
-        }
+        data.likes <= 0 && data.comments <= 0 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_only,
+            statsUtils.toFormattedString(data.views)
+        )
+
+        data.likes.toInt() == 1 && data.comments <= 0 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_and_like,
+            statsUtils.toFormattedString(data.views)
+        )
+
+        data.likes > 0 && data.comments <= 0 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_and_likes,
+            statsUtils.toFormattedString(data.views),
+            statsUtils.toFormattedString(data.likes)
+        )
+
+        data.likes <= 0 && data.comments.toInt() == 1 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_and_comment,
+            statsUtils.toFormattedString(data.views)
+        )
+
+        data.likes <= 0 && data.comments > 0 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_and_comments,
+            statsUtils.toFormattedString(data.views),
+            statsUtils.toFormattedString(data.comments)
+        )
+
+        data.likes.toInt() == 1 && data.comments.toInt() == 1 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_like_comment,
+            statsUtils.toFormattedString(data.views)
+        )
+
+        data.likes.toInt() == 1 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_like_comments,
+            statsUtils.toFormattedString(data.views),
+            statsUtils.toFormattedString(data.comments)
+        )
+
+        data.comments.toInt() == 1 -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_views_likes_comment,
+            statsUtils.toFormattedString(data.views),
+            statsUtils.toFormattedString(data.likes)
+        )
+
+        else -> resourceProvider.getString(
+            R.string.weekly_roundup_notification_text_all,
+            statsUtils.toFormattedString(data.views),
+            statsUtils.toFormattedString(data.likes),
+            statsUtils.toFormattedString(data.comments)
+        )
     }
 
     companion object {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4198,9 +4198,14 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="weekly_roundup">Weekly Roundup</string>
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text_all">Last week you had %1$s views, %2$s likes, and %3$s comments.</string>
+    <string name="weekly_roundup_notification_text_views_like_comments">Last week you had %1$s views, 1 like, and %3$s comments.</string>
+    <string name="weekly_roundup_notification_text_views_likes_comment">Last week you had %1$s views, %2$s likes, and 1 comment.</string>
+    <string name="weekly_roundup_notification_text_views_like_comment">Last week you had %1$s views, 1 like, and 1 comment.</string>
     <string name="weekly_roundup_notification_text_views_only">Last week you had %1$s views.</string>
     <string name="weekly_roundup_notification_text_views_and_likes">Last week you had %1$s views and %2$s likes</string>
+    <string name="weekly_roundup_notification_text_views_and_like">Last week you had %1$s views and 1 like</string>
     <string name="weekly_roundup_notification_text_views_and_comments">Last week you had %1$s views and %2$s comments</string>
+    <string name="weekly_roundup_notification_text_views_and_comment">Last week you had %1$s views and 1 comment</string>
 
     <!-- About -->
     <string name="about_blog">Blog</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4198,7 +4198,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="weekly_roundup">Weekly Roundup</string>
     <string name="weekly_roundup_notification_title">Weekly Roundup: %s</string>
     <string name="weekly_roundup_notification_text_all">Last week you had %1$s views, %2$s likes, and %3$s comments.</string>
-    <string name="weekly_roundup_notification_text_views_like_comments">Last week you had %1$s views, 1 like, and %3$s comments.</string>
+    <string name="weekly_roundup_notification_text_views_like_comments">Last week you had %1$s views, 1 like, and %2$s comments.</string>
     <string name="weekly_roundup_notification_text_views_likes_comment">Last week you had %1$s views, %2$s likes, and 1 comment.</string>
     <string name="weekly_roundup_notification_text_views_like_comment">Last week you had %1$s views, 1 like, and 1 comment.</string>
     <string name="weekly_roundup_notification_text_views_only">Last week you had %1$s views.</string>

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -39,7 +40,20 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     }
     private val contextProvider: ContextProvider = mock()
     private val resourceProvider: ResourceProvider = mock {
-        on { getString(any(), anyVararg()) }.thenReturn("mock_string")
+        on { getString(eq(R.string.weekly_roundup_notification_title), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_title")
+        on { getString(eq(R.string.weekly_roundup_notification_text_views_only), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_views_only")
+        on { getString(eq(R.string.weekly_roundup_notification_text_views_and_comments), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_views_and_comments")
+        on { getString(eq(R.string.weekly_roundup_notification_text_views_and_likes), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_views_and_likes")
+        on { getString(eq(R.string.weekly_roundup_notification_text_all), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_all")
+        on { getString(eq(R.string.weekly_roundup_notification_text_views_likes_comment), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_views_likes_comment")
+        on { getString(eq(R.string.weekly_roundup_notification_text_views_like_comments), anyVararg()) }
+            .thenReturn("weekly_roundup_notification_text_views_like_comments")
     }
     private val weeklyRoundupScheduler: WeeklyRoundupScheduler = mock()
     private val notificationsTracker: SystemNotificationsTracker = mock()
@@ -157,7 +171,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
         val mockSites = buildMockSites()
         val data1 = buildMockData(mockSites[0], views = 10, comments = 0, likes = 0)
         val data2 = buildMockData(mockSites[1], views = 9, comments = 8, likes = 8)
-        val data3 = buildMockData(mockSites[2], views = 10, comments = 1, likes = 1)
+        val data3 = buildMockData(mockSites[2], views = 10, comments = 2, likes = 2)
         val unsortedData = listOf(data1, data2, data3)
         val sortedData = listOf(data1, data3, data2)
 
@@ -192,7 +206,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
     @Test
     fun `buildNotifications should not include likes with 0 count`() = test {
         val mockSites = buildMockSites()
-        val data = buildMockData(mockSites[2], views = 10, comments = 1, likes = 0)
+        val data = buildMockData(mockSites[2], views = 10, comments = 2, likes = 0)
 
         whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
         whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
@@ -242,6 +256,44 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
                 R.string.weekly_roundup_notification_text_all,
                 statsUtils.toFormattedString(data!!.views),
                 statsUtils.toFormattedString(data.likes),
+                statsUtils.toFormattedString(data.comments)
+            )
+        )
+    }
+
+    @Test
+    fun `buildNotifications should include singular comment string if the comment is one`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[1], views = 9, comments = 1, likes = 8)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentText).isEqualTo(
+            resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_views_likes_comment,
+                statsUtils.toFormattedString(data!!.views),
+                statsUtils.toFormattedString(data.likes),
+            )
+        )
+    }
+
+    @Test
+    fun `buildNotifications should include singular like string if the comment is one`() = test {
+        val mockSites = buildMockSites()
+        val data = buildMockData(mockSites[1], views = 9, comments = 8, likes = 1)
+
+        whenever(siteStore.sitesAccessedViaWPComRest).thenReturn(mockSites)
+        whenever(weeklyRoundupRepository.fetchWeeklyRoundupData(any())).then { data }
+
+        val list = weeklyRoundupNotifier.buildNotifications()
+
+        assertThat(list.first().contentText).isEqualTo(
+            resourceProvider.getString(
+                R.string.weekly_roundup_notification_text_views_like_comments,
+                statsUtils.toFormattedString(data!!.views),
                 statsUtils.toFormattedString(data.comments)
             )
         )

--- a/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupNotifierTest.kt
@@ -181,7 +181,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
 
         val list = weeklyRoundupNotifier.buildNotifications()
 
-        assertThat(list.first().contentTitle).isEqualTo(
+        assertThat(list.first().contentText).isEqualTo(
             resourceProvider.getString(
                 R.string.weekly_roundup_notification_text_views_only,
                 statsUtils.toFormattedString(data!!.views)
@@ -199,7 +199,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
 
         val list = weeklyRoundupNotifier.buildNotifications()
 
-        assertThat(list.first().contentTitle).isEqualTo(
+        assertThat(list.first().contentText).isEqualTo(
             resourceProvider.getString(
                 R.string.weekly_roundup_notification_text_views_and_comments,
                 statsUtils.toFormattedString(data!!.views),
@@ -218,7 +218,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
 
         val list = weeklyRoundupNotifier.buildNotifications()
 
-        assertThat(list.first().contentTitle).isEqualTo(
+        assertThat(list.first().contentText).isEqualTo(
             resourceProvider.getString(
                 R.string.weekly_roundup_notification_text_views_and_likes,
                 statsUtils.toFormattedString(data!!.views),
@@ -237,7 +237,7 @@ class WeeklyRoundupNotifierTest : BaseUnitTest() {
 
         val list = weeklyRoundupNotifier.buildNotifications()
 
-        assertThat(list.first().contentTitle).isEqualTo(
+        assertThat(list.first().contentText).isEqualTo(
             resourceProvider.getString(
                 R.string.weekly_roundup_notification_text_all,
                 statsUtils.toFormattedString(data!!.views),


### PR DESCRIPTION
Fixes #17824
This fixes using the plural form of "view" and "comment" for singular values on Weekly roundup notifications.

Additionally, this fixes false positive test cases for 
- `buildNotifications should not include likes and comments with 0 count`
- `buildNotifications should not include likes with 0 count`
- `buildNotifications should not include comments with 0 count`
- `buildNotifications should include views, likes, and comments greater than zero`
in `WeeklyRoundupNotifierTest`. Before, it was always checking `"mock_string" == "mock_string`", which was always true.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Ensure one of your top 5 sites has 1 like/comment.
3. Ensure notification permission is allowed.
4. Open Me → Debug settings.
5. Tap the menu button at the top right.
6. Tap "Force show Weekly Roundup notification" button.
7. Wait for a while, ~30 seconds.
8. Tap the Weekly Roundup notification received.
9. Verify that the notification text contains "1 comment" instead of "1 comments" and/or "1 like" instead of "1 likes".

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

4. What automated tests I added (or what prevented me from doing so)

    - Updated `WeeklyRoundupNotifierTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
