### PR TITLE
[Reader Tags Feed] Show tags chip in tags feed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -208,7 +208,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     public boolean isFilterable() {
-        return this.isFollowedSites() || this.isA8C() || this.isP2();
+        return this.isFollowedSites() || this.isA8C() || this.isP2() || this.isTags();
     }
 
     public boolean isListTopic() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -137,7 +137,6 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                         onClearFilterClick = ::clearFilter,
                         isSearchVisible = state.isSearchActionVisible,
                         onSearchClick = viewModel::onSearchActionClicked,
-                        showTagsChip = state.showTagsChip,
                     )
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.Organization
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil
 import org.wordpress.android.ui.jetpackoverlay.JetpackOverlayConnectedFeature.READER
@@ -52,6 +51,7 @@ import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UrlUtilsWrapper
+import org.wordpress.android.util.config.ReaderTagsFeedFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -79,6 +79,7 @@ class ReaderViewModel @Inject constructor(
     private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil,
     private val readerTopBarMenuHelper: ReaderTopBarMenuHelper,
     private val urlUtilsWrapper: UrlUtilsWrapper,
+    private val readerTagsFeedFeatureConfig: ReaderTagsFeedFeatureConfig,
     // todo: annnmarie removed this private val getFollowedTagsUseCase: GetFollowedTagsUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private var initialized: Boolean = false
@@ -511,11 +512,14 @@ class ReaderViewModel @Inject constructor(
     }
 
     private fun shouldShowBlogsFilter(readerTag: ReaderTag): Boolean {
-        return readerTag.isFilterable
+        return readerTag.isFilterable && readerTag.isFollowedSites
     }
 
     private fun shouldShowTagsFilter(readerTag: ReaderTag): Boolean {
-        return readerTag.isFilterable && readerTag.organization == Organization.NO_ORGANIZATION
+        val showForFollowedSites = readerTag.isFollowedSites && !readerTagsFeedFeatureConfig.isEnabled()
+        val showForTags = readerTag.isTags
+
+        return readerTag.isFilterable && (showForFollowedSites || showForTags)
     }
 
     data class TopBarUiState(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -52,7 +52,6 @@ import org.wordpress.android.util.JetpackBrandingUtils
 import org.wordpress.android.util.QuickStartUtils
 import org.wordpress.android.util.SnackbarSequencer
 import org.wordpress.android.util.UrlUtilsWrapper
-import org.wordpress.android.util.config.ReaderTagsFeedFeatureConfig
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -80,7 +79,6 @@ class ReaderViewModel @Inject constructor(
     private val jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil,
     private val readerTopBarMenuHelper: ReaderTopBarMenuHelper,
     private val urlUtilsWrapper: UrlUtilsWrapper,
-    private val readerTagsFeedFeatureConfig: ReaderTagsFeedFeatureConfig,
     // todo: annnmarie removed this private val getFollowedTagsUseCase: GetFollowedTagsUseCase
 ) : ScopedViewModel(mainDispatcher) {
     private var initialized: Boolean = false
@@ -374,7 +372,6 @@ class ReaderViewModel @Inject constructor(
                     selectedItem = selectedItem,
                     filterUiState = filterUiState,
                     onDropdownMenuClick = ::onDropdownMenuClick,
-                    showTagsChip = !readerTagsFeedFeatureConfig.isEnabled(),
                     isSearchActionVisible = isSearchSupported(),
                 )
             )
@@ -526,7 +523,6 @@ class ReaderViewModel @Inject constructor(
         val selectedItem: MenuElementData.Item.Single,
         val filterUiState: FilterUiState? = null,
         val onDropdownMenuClick: () -> Unit,
-        val showTagsChip: Boolean,
         val isSearchActionVisible: Boolean = false,
     ) {
         @Parcelize

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -56,7 +56,6 @@ fun ReaderTopAppBar(
     onClearFilterClick: () -> Unit,
     isSearchVisible: Boolean,
     onSearchClick: () -> Unit = {},
-    showTagsChip: Boolean,
 ) {
     var selectedItem by remember { mutableStateOf(topBarUiState.selectedItem) }
     var isFilterShown by remember { mutableStateOf(topBarUiState.filterUiState != null) }
@@ -121,7 +120,6 @@ fun ReaderTopAppBar(
                             modifier = Modifier
                                 // use padding instead of Spacer for a nicer animation
                                 .padding(start = Margin.Medium.value),
-                            showTagsChip = showTagsChip,
                         )
                     }
                 }
@@ -151,7 +149,6 @@ private fun Filter(
     onFilterClick: (ReaderFilterType) -> Unit,
     onClearFilterClick: () -> Unit,
     modifier: Modifier = Modifier,
-    showTagsChip: Boolean,
 ) {
     ReaderFilterChipGroup(
         modifier = modifier,
@@ -164,7 +161,6 @@ private fun Filter(
         onSelectedItemClick = { filterUiState.selectedItem?.type?.let(onFilterClick) },
         onSelectedItemDismissClick = onClearFilterClick,
         chipHeight = chipHeight,
-        showTagsChip = showTagsChip,
     )
 }
 
@@ -215,7 +211,6 @@ fun ReaderTopAppBarPreview() {
                 menuItems = menuItems,
                 selectedItem = menuItems.first() as MenuElementData.Item.Single,
                 onDropdownMenuClick = {},
-                showTagsChip = true,
             )
         )
     }
@@ -237,7 +232,6 @@ fun ReaderTopAppBarPreview() {
                 onClearFilterClick = {},
                 isSearchVisible = true,
                 onSearchClick = {},
-                showTagsChip = true,
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -48,7 +48,6 @@ import androidx.compose.material3.MaterialTheme as Material3Theme
 
 private val roundedShape = RoundedCornerShape(100)
 
-@Suppress("CyclomaticComplexMethod")
 @Composable
 fun ReaderFilterChipGroup(
     blogsFilterCount: Int,
@@ -61,7 +60,6 @@ fun ReaderFilterChipGroup(
     showBlogsFilter: Boolean = blogsFilterCount > 0,
     showTagsFilter: Boolean = tagsFilterCount > 0,
     chipHeight: Dp = 36.dp,
-    showTagsChip: Boolean,
 ) {
     Row(
         modifier = modifier,
@@ -99,19 +97,17 @@ fun ReaderFilterChipGroup(
         }
 
         // tags filter chip
-        if (showTagsChip) {
-            AnimatedVisibility(
-                modifier = Modifier.clip(roundedShape),
-                visible = isTagChipVisible,
-            ) {
-                ReaderFilterChip(
-                    text = tagChipText,
-                    onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
-                    onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
-                    isSelectedItem = isTagSelected,
-                    height = chipHeight,
-                )
-            }
+        AnimatedVisibility(
+            modifier = Modifier.clip(roundedShape),
+            visible = isTagChipVisible,
+        ) {
+            ReaderFilterChip(
+                text = tagChipText,
+                onClick = if (isTagSelected) onSelectedItemClick else ({ onFilterClick(ReaderFilterType.TAG) }),
+                onDismissClick = if (isTagSelected) onSelectedItemDismissClick else null,
+                isSelectedItem = isTagSelected,
+                height = chipHeight,
+            )
         }
 
         AnimatedVisibility(visible = isBlogChipVisible && isTagChipVisible) {
@@ -246,7 +242,6 @@ fun ReaderFilterChipGroupPreview() {
             onSelectedItemDismissClick = {
                 selectedItem = null
             },
-            showTagsChip = true,
         )
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -112,8 +112,7 @@ class ReaderViewModelTest : BaseUnitTest() {
             snackbarSequencer,
             jetpackFeatureRemovalOverlayUtil,
             readerTopBarMenuHelper,
-            urlUtilsWrapper,
-            readerTagsFeedFeatureConfig,
+            urlUtilsWrapper
         )
 
         whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -31,10 +31,10 @@ import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.quickstart.QuickStartEvent
 import org.wordpress.android.ui.quickstart.QuickStartType
-import org.wordpress.android.ui.reader.utils.ReaderTopBarMenuHelper
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.usecases.LoadReaderItemsUseCase
 import org.wordpress.android.ui.reader.utils.DateProvider
+import org.wordpress.android.ui.reader.utils.ReaderTopBarMenuHelper
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.QuickStartReaderPrompt
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel.ReaderUiState.ContentUiState
@@ -86,10 +86,8 @@ class ReaderViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var jetpackFeatureRemovalOverlayUtil: JetpackFeatureRemovalOverlayUtil
 
-    private val readerTagsFeedFeatureConfig: ReaderTagsFeedFeatureConfig = mock()
-
-    private val readerTopBarMenuHelper: ReaderTopBarMenuHelper = ReaderTopBarMenuHelper(readerTagsFeedFeatureConfig)
-
+    @Mock
+    lateinit var readerTagsFeedFeatureConfig: ReaderTagsFeedFeatureConfig
 
     private val emptyReaderTagList = ReaderTagList()
     private val nonEmptyReaderTagList = createNonMockedNonEmptyReaderTagList()
@@ -111,8 +109,9 @@ class ReaderViewModelTest : BaseUnitTest() {
             jetpackBrandingUtils,
             snackbarSequencer,
             jetpackFeatureRemovalOverlayUtil,
-            readerTopBarMenuHelper,
-            urlUtilsWrapper
+            ReaderTopBarMenuHelper(readerTagsFeedFeatureConfig),
+            urlUtilsWrapper,
+            readerTagsFeedFeatureConfig,
         )
 
         whenever(dateProvider.getCurrentDate()).thenReturn(Date(DUMMY_CURRENT_TIME))


### PR DESCRIPTION
Fixes #20597 

This PR reverts the changes in https://github.com/wordpress-mobile/WordPress-Android/pull/20600 in favor of leveraging the already existing mechanism to show or hide the top bar filters based on the currently selected feed/"tag".

-----

## To Test:

- Install JP and sign in.
- Enable remote feature `reader_tags_feed`.
- Open "Reader".
- Select "Subscriptions" feed.
- 🔍 The "Tags" chip should not be displayed.
- Select "Tags" feed.
- 🔍 The "Tags" chip should be displayed.
- Disable remote feature `reader_tags_feed`.
- Restart the app.
- Open "Reader".
- Select "Subscriptions" feed.
- 🔍 The "Tags" chip should be displayed.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A - The tests are outdated from previous projects, they should be tackled separately in a bigger PR

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
