### PR TITLE
Prevents the app from crashing when there is no space left to persist the logfiles

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -114,6 +114,7 @@ import org.wordpress.android.widgets.AppRatingDialog
 import org.wordpress.android.workers.WordPressWorkersFactory
 import java.io.File
 import java.io.IOException
+import java.lang.Exception
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
@@ -404,9 +405,15 @@ class AppInitializer @Inject constructor(
         WorkManager.initialize(application, configBuilder.build())
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun enableLogRecording() {
         AppLog.enableRecording(true)
-        AppLog.enableLogFilePersistence(application.baseContext, MAX_LOG_COUNT)
+        try {
+            AppLog.enableLogFilePersistence(application.baseContext, MAX_LOG_COUNT)
+        } catch (e: Exception) {
+            AppLog.enableRecording(false)
+            AppLog.e(T.UTILS, "Error enabling log file persistence", e)
+        }
         AppLog.addListener { tag, logLevel, message ->
             val sb = StringBuffer()
             sb.append(logLevel.toString())


### PR DESCRIPTION
Fixes #20538

## Description
This fix adds error handling for the exceptions thrown (`FileNotFoundException `, a `RuntimeException` or an `ErrnoException`) when the app initialises log recording and there is no space left
```
    at org.wordpress.android.util.AppLog.enableLogFilePersistence(AppLog.java:111)
    at org.wordpress.android.AppInitializer.enableLogRecording(AppInitializer.kt:426)
    at org.wordpress.android.AppInitializer.init(AppInitializer.kt:302)
```
When the log files cannot be created the app keeps operating normally (considering the low space) and does not crash.

-----

## To Test:
1. Verify that the app starts normally
2. Go to Me > Help > Logs and verify that the logs exist
3. Apply the [error.patch](https://github.com/wordpress-mobile/WordPress-Android/files/14918699/error.patch) and start the app
4. Verify that `Error enabling log file persistence` is logged
5. Verify that the app works as expected
6. Go to Me > Help > Logs and verify that the logs are empty

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

8. What automated tests I added (or what prevented me from doing so)

    - Mocking this part of the app for testing isn't easy without refactoring escaping the small scope of the fix

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
