### PR TITLE
[Reader Customization] Add [internal] tag to the release note item

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]
 * [*] Block editor: Fixes an Aztec editor crash occurring on some occasions when the keyboard suggestions are used [https://github.com/wordpress-mobile/WordPress-Android/pull/20518]
 * [*] [Jetpack-only] Change "∞" symbol with "100%" on stats [https://github.com/wordpress-mobile/WordPress-Android/pull/20564]
-* [**] [Jetpack-only] Reader: introduce "reading preferences", an experimental feature that allows users to customize their Reader post content screen with the color, font, and size that they like the most. [https://github.com/wordpress-mobile/WordPress-Android/pull/20567]
+* [**] [internal][Jetpack-only] Reader: introduce "reading preferences", an experimental feature that allows users to customize their Reader post content screen with the color, font, and size that they like the most. [https://github.com/wordpress-mobile/WordPress-Android/pull/20567]
 
 24.5
 -----


### PR DESCRIPTION
Add an [internal] tag to the Release Notes file entry for Reader Customization, since we won't need it to be shown in the Play Store notes for now, as discussed here: p1712614130772109/1712583344.843729-slack-CC7L49W13.