### PR TITLE
Handles fetch media exceptions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -455,15 +455,15 @@ public class WPMediaUtils {
             return MediaUtils.downloadExternalMedia(context, mediaUri);
         } catch (IllegalStateException e) {
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
-            AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri + " See issue #5823", e);
+            AppLog.e(AppLog.T.UTILS, "Can't download the media at: " + mediaUri + " See issue #5823", e);
             return null;
         } catch (IllegalArgumentException e) {
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/20615
-            AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri + ": ", e);
+            AppLog.e(AppLog.T.UTILS, "Can't download the media at: " + mediaUri + ": ", e);
             return null;
         } catch (SecurityException e) {
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/19438
-            AppLog.e(AppLog.T.UTILS, "Can't access the image at: " + mediaUri + ": ", e);
+            AppLog.e(AppLog.T.UTILS, "Can't access the media at: " + mediaUri + ": ", e);
             return null;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -455,9 +455,11 @@ public class WPMediaUtils {
             return MediaUtils.downloadExternalMedia(context, mediaUri);
         } catch (IllegalStateException e) {
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
-            AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri.toString()
-                                     + " See issue #5823", e);
-
+            AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri + " See issue #5823", e);
+            return null;
+        } catch (IllegalArgumentException e) {
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/20615
+            AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri + ": ", e);
             return null;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -461,6 +461,10 @@ public class WPMediaUtils {
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/20615
             AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri + ": ", e);
             return null;
+        } catch (SecurityException e) {
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/19438
+            AppLog.e(AppLog.T.UTILS, "Can't access the image at: " + mediaUri + ": ", e);
+            return null;
         }
     }
 


### PR DESCRIPTION
Fixes #20615, #19438

## Description
This PR adds exception handling for `IllegalArgumentException` (#20615) and `SecurityException` (#19438) similar to the existing handling introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/5826.
Since the return value of the `fetchMedia` function is `@Nullable` communicating the error is left to be done on the call site ([example](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java#L473)).

-----

## To Test:
Since I wasn't able to find specific steps to reproduce the issues which might be device/OS specific (see https://github.com/wordpress-mobile/WordPress-Android/issues/20615#issuecomment-2046875563), a sanity check by uploading a media that is not [in the media store](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java#L448) is recommended. E.g.:
1. Select More > Media in the My Site screen
2. Tap (+) at the top-right
3. Select choose from device
4. Tap the image icon at the top-right
5. Select "Files" or another app
6. Select an image/video
7. **Verify** that it uploads as expected

-----

## Regression Notes

1. Potential unintended areas of impact

    - Media downloading

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

9. What automated tests I added (or what prevented me from doing so)

    - Refactoring the code for testing escapes the scope of this fix

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)