### PR TITLE
Initialises DebugCookieManager only when the debug settings are enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -93,6 +93,7 @@ import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.AppLog.T.MAIN
 import org.wordpress.android.util.AppThemeUtils
 import org.wordpress.android.util.BitmapLruCache
+import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.DateTimeUtils
 import org.wordpress.android.util.EncryptedLogging
 import org.wordpress.android.util.FluxCUtils
@@ -115,6 +116,7 @@ import org.wordpress.android.workers.WordPressWorkersFactory
 import java.io.File
 import java.io.IOException
 import java.lang.Exception
+import java.net.CookieManager
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
@@ -186,7 +188,12 @@ class AppInitializer @Inject constructor(
     lateinit var gcmRegistrationScheduler: GCMRegistrationScheduler
 
     @Inject
-    lateinit var debugCookieManager: DebugCookieManager
+    lateinit var cookieManager: CookieManager
+
+    @Inject
+    lateinit var buildConfig: BuildConfigWrapper
+
+    private lateinit var debugCookieManager: DebugCookieManager
 
     @Inject
     @Named(APPLICATION_SCOPE)
@@ -358,7 +365,10 @@ class AppInitializer @Inject constructor(
 
         exPlat.forceRefresh()
 
-        debugCookieManager.sync()
+        if (buildConfig.isDebugSettingsEnabled()) {
+            debugCookieManager = DebugCookieManager(application, cookieManager, buildConfig)
+            debugCookieManager.sync()
+        }
 
         if (!initialized && BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
             initAppOpsManager()


### PR DESCRIPTION
Fixes #20619

## Description
The linked crash occurs in the initialisation of the `DebugCookieManager` when there is no `WebView` installed.
```
AndroidRuntimeException: android.util.AndroidRuntimeException: android.webkit.WebViewFactory$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed
    at org.wordpress.android.ui.debug.cookies.DebugCookieManager.<init>(DebugCookieManager.kt:40)
    android.webkit.CookieManager.getInstance(),
```
Given that the `DebugCookieManager` [is used only for debugging](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/debug/cookies/DebugCookieManager.kt#L47) when the `ENABLE_DEBUG_SETTINGS` flag is `true` we can prevent the crash in production by conditionally initialising the object only when it is needed ([and not always via injection](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt#L189)).

-----

## To Test:
- *Verify* that the app starts normally
- *Verify* the the cookie manager functionality works as expected (see https://github.com/wordpress-mobile/WordPress-Android/pull/15153)

-----

## Regression Notes

1. Potential unintended areas of impact

    - Debug cookies

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Refactoring the code for testing escapes the scope of this fix

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
