### PR TITLE
Fixes: bug in postLocalChangesAlreadyRemoteAutoSaved()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -51,6 +51,7 @@ import org.wordpress.android.util.UploadWorkerKt;
 import org.wordpress.android.util.WPMediaUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -657,9 +658,17 @@ public class UploadUtils {
     }
 
     public static boolean postLocalChangesAlreadyRemoteAutoSaved(PostImmutableModel post) {
-        return !TextUtils.isEmpty(post.getAutoSaveModified())
-               && DateTimeUtils.dateFromIso8601(post.getDateLocallyChanged())
-                               .before(DateTimeUtils.dateFromIso8601(post.getAutoSaveModified()));
+        // Check if the autoSaveModified field is not empty.
+        boolean isAutoSaveModifiedNotEmpty = !TextUtils.isEmpty(post.getAutoSaveModified());
+
+        // Parse dates from ISO8601 format.
+        Date dateLocallyChanged = DateTimeUtils.dateFromIso8601(post.getDateLocallyChanged());
+        Date autoSaveModified = DateTimeUtils.dateFromIso8601(post.getAutoSaveModified());
+
+        // Check if dateLocallyChanged is not after autoSaveModified (it is before or the same).
+        boolean isDateLocallyChangedNotAfter = !dateLocallyChanged.after(autoSaveModified);
+
+        return isAutoSaveModifiedNotEmpty && isDateLocallyChangedNotAfter;
     }
 
     public static int cancelPendingAutoUpload(PostModel post, Dispatcher dispatcher) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -661,6 +661,11 @@ public class UploadUtils {
         // Check if the autoSaveModified field is not empty.
         boolean isAutoSaveModifiedNotEmpty = !TextUtils.isEmpty(post.getAutoSaveModified());
 
+        // If autoSaveModified is null, return false immediately.
+        if (!isAutoSaveModifiedNotEmpty) {
+            return false;
+        }
+
         // Parse dates from ISO8601 format.
         Date dateLocallyChanged = DateTimeUtils.dateFromIso8601(post.getDateLocallyChanged());
         Date autoSaveModified = DateTimeUtils.dateFromIso8601(post.getAutoSaveModified());


### PR DESCRIPTION
Fixes #20166

This PR aims to resolve an unusual bug detailed in this [GitHub issue comment](https://github.com/wordpress-mobile/WordPress-Android/issues/20166#issuecomment-2049292031).

The issue occurs under specific conditions when uploading an autosave: the mAutoSaveModified and mDateLocallyChanged fields in the PostModel are updated sequentially within milliseconds of each other.

When invoking postLocalChangesAlreadyRemoteAutoSaved() to determine whether to upload an autosave after the app restarts, these two values are compared. However, the comparison only considers the second components of the timestamps, disregarding the milliseconds. This truncation can cause the two values to appear identical, leading to the erroneous reupload of the autosave.

There's a risk that the user may have already restored the autosave from the web by this time. Reuploading the same autosave under these circumstances can result in inconsistent states, as demonstrated in this [video recording](https://drive.google.com/file/d/1Ne3lYtzLyPyAfglD_GoZdi-4GLUG_Sac/view?usp=drivesdk).

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->


Here's a corrected and slightly refined version of the instructions for a clearer and more formal presentation:

1. Build and install the app on your device.
2. Open a post within the app and make some edits.
3. Press the "back" button without publishing the updated content.
4. Force close the app.
5. Access the web application through your browser and locate the edited post. Refresh the page if necessary and verify that the message "There is an autosave of this post that is more recent than the version below." is displayed at the top left corner.
6. Click on the message to view the autosave.
7. Select "Restore this Autosave."
8. Reopen the app on your mobile device.
9. Confirm that the post is listed with the "Version conflict" label.
10. Tap on the post, then in the conflict resolution dialog, choose "Discard local."
11. Ensure that the conflict is resolved and the "Version conflict" label is no longer visible.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

12. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

13. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
