### PR TITLE
Fixes LongMethod detekt issue in AppInitializer.init method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -367,10 +367,7 @@ class AppInitializer @Inject constructor(
 
         exPlat.forceRefresh()
 
-        if (buildConfig.isDebugSettingsEnabled()) {
-            debugCookieManager = DebugCookieManager(application, cookieManager, buildConfig)
-            debugCookieManager.sync()
-        }
+        initDebugCookieManager()
 
         if (!initialized && BuildConfig.DEBUG && Build.VERSION.SDK_INT >= VERSION_CODES.R) {
             initAppOpsManager()
@@ -379,6 +376,13 @@ class AppInitializer @Inject constructor(
         AppLog.i(T.UTILS, "AppInitializer.userAgentString: $userAgent")
 
         initialized = true
+    }
+
+    private fun initDebugCookieManager() {
+        if (buildConfig.isDebugSettingsEnabled()) {
+            debugCookieManager = DebugCookieManager(application, cookieManager, buildConfig)
+            debugCookieManager.sync()
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes `LongMethod` Detekt issue in `AppInitializer.init` method introduced by merging https://github.com/wordpress-mobile/WordPress-Android/pull/20603 and https://github.com/wordpress-mobile/WordPress-Android/pull/20620 that both extended the method without merging from `trunk`.

-----

## To Test:
Verify that all CI tests are 🟢 

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
