### PR TITLE
[Reader Customization] Allow dragging to close Preferences bottom sheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader
 
 import android.app.Dialog
 import android.content.DialogInterface
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,6 +15,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -81,7 +83,27 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         super.onCreateDialog(savedInstanceState).apply {
-            (this as? BottomSheetDialog)?.fillScreen()
+            (this as? BottomSheetDialog)?.apply {
+                fillScreen(isDraggable = true)
+
+                behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+                    private var isStatusBarTransparent = false
+                    override fun onStateChanged(bottomSheet: View, newState: Int) {
+                        if (newState == BottomSheetBehavior.STATE_EXPANDED && isStatusBarTransparent) {
+                            isStatusBarTransparent = false
+                            val currentTheme = viewModel.currentReadingPreferences.value.theme
+                            handleUpdateStatusBarColor(currentTheme)
+                        } else if (newState != BottomSheetBehavior.STATE_EXPANDED && !isStatusBarTransparent) {
+                            isStatusBarTransparent = true
+                            dialog?.window?.setWindowStatusBarColor(Color.TRANSPARENT)
+                        }
+                    }
+
+                    override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                        // no-op
+                    }
+                })
+            }
 
             (this as ComponentDialog).onBackPressedDispatcher.addCallback(this@ReaderReadingPreferencesDialogFragment) {
                 viewModel.saveReadingPreferencesAndClose()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -63,7 +63,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
                 val isFeedbackEnabled by viewModel.isFeedbackEnabled.collectAsState()
                 ReadingPreferencesScreen(
                     currentReadingPreferences = readerPreferences,
-                    onCloseClick = viewModel::saveReadingPreferencesAndClose,
+                    onCloseClick = viewModel::onExitActionClick,
                     onSendFeedbackClick = viewModel::onSendFeedbackClick,
                     onThemeClick = viewModel::onThemeClick,
                     onFontFamilyClick = viewModel::onFontFamilyClick,
@@ -99,7 +99,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
                         }
 
                         if (newState == BottomSheetBehavior.STATE_HIDDEN) {
-                            viewModel.saveReadingPreferences()
+                            viewModel.onBottomSheetHidden()
                         }
                     }
 
@@ -110,7 +110,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
             }
 
             (this as ComponentDialog).onBackPressedDispatcher.addCallback(this@ReaderReadingPreferencesDialogFragment) {
-                viewModel.saveReadingPreferencesAndClose()
+                viewModel.onExitActionClick()
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -97,6 +97,10 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
                             isStatusBarTransparent = true
                             dialog?.window?.setWindowStatusBarColor(Color.TRANSPARENT)
                         }
+
+                        if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+                            viewModel.saveReadingPreferences()
+                        }
                     }
 
                     override fun onSlide(bottomSheet: View, slideOffset: Float) {
@@ -111,23 +115,19 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
         }
 
     override fun onDismiss(dialog: DialogInterface) {
-        super.onDismiss(dialog)
         viewModel.onScreenClosed()
+        super.onDismiss(dialog)
     }
 
     private fun observeActionEvents() {
         viewModel.actionEvents.onEach {
             when (it) {
+                is ActionEvent.Close -> dismiss()
+                is ActionEvent.UpdatePostDetails -> postDetailViewModel.onReadingPreferencesThemeChanged()
                 is ActionEvent.UpdateStatusBarColor -> handleUpdateStatusBarColor(it.theme)
-                is ActionEvent.Close -> handleClose(it.isDirty)
                 is ActionEvent.OpenWebView -> handleOpenWebView(it.url)
             }
         }.launchIn(viewLifecycleOwner.lifecycleScope)
-    }
-
-    private fun handleClose(isDirty: Boolean) {
-        if (isDirty) postDetailViewModel.onReadingPreferencesThemeChanged()
-        dismiss()
     }
 
     private fun handleUpdateStatusBarColor(theme: ReaderReadingPreferences.Theme) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -107,9 +107,7 @@ class ReaderReadingPreferencesViewModel @Inject constructor(
         }
     }
 
-    private fun isDirty(): Boolean {
-        return currentReadingPreferences.value != originalReadingPreferences
-    }
+    private fun isDirty(): Boolean = currentReadingPreferences.value != originalReadingPreferences
 
     sealed interface ActionEvent {
         data object Close : ActionEvent

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModel.kt
@@ -48,7 +48,7 @@ class ReaderReadingPreferencesViewModel @Inject constructor(
 
     fun onScreenClosed() {
         if (isDirty()) {
-            // let's assume it already saved the preferences
+            // here we assume the code for saving preferences has been called before reaching this point
             launch {
                 _actionEvents.emit(ActionEvent.UpdatePostDetails)
             }
@@ -71,14 +71,22 @@ class ReaderReadingPreferencesViewModel @Inject constructor(
         readingPreferencesTracker.trackItemTapped(fontSize)
     }
 
-    fun saveReadingPreferencesAndClose() {
+    /**
+     * An exit action has been triggered by the user. This means that we need to save the current preferences and emit
+     * the close event, so the dialog is dismissed.
+     */
+    fun onExitActionClick() {
         launch {
             saveReadingPreferencesInternal()
             _actionEvents.emit(ActionEvent.Close)
         }
     }
 
-    fun saveReadingPreferences() {
+    /**
+     * The bottom sheet has been hidden by the user, which means the dismiss process is already on its way. All we need
+     * to do is save the current preferences.
+     */
+    fun onBottomSheetHidden() {
         launch {
             saveReadingPreferencesInternal()
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
@@ -88,7 +90,9 @@ fun ReadingPreferencesScreen(
     val haptics = LocalHapticFeedback.current.takeIf { isHapticsFeedbackEnabled }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(rememberNestedScrollInteropConnection()),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1371,6 +1371,7 @@
     </style>
 
     <style name="ReaderReadingPreferencesDialogFragment" parent="WordPress.NoActionBar">
+        <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowAnimationStyle">

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderReadingPreferencesViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
@@ -127,41 +128,87 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `when saveReadingPreferencesAndClose is called then it emits Close action event`() = test {
+    fun `when onExitActionClick is called then it emits Close action event`() = test {
         // When
-        viewModel.saveReadingPreferencesAndClose()
+        viewModel.onExitActionClick()
 
         // Then
-        val closeEvent = collectedEvents.last() as ActionEvent.Close
-        assertThat(closeEvent.isDirty).isFalse()
+        val closeEvent = collectedEvents.last()
+        assertThat(closeEvent).isEqualTo(ActionEvent.Close)
     }
 
     @Test
-    fun `when saveReadingPreferencesAndClose is called with updated preferences then it emit Close action event`() =
+    fun `when onExitActionClick is called with original preferences then it doesn't save them`() =
         test {
-            // Given
-            val newTheme = ReaderReadingPreferences.Theme.SEPIA
-            viewModel.onThemeClick(newTheme)
-
             // When
-            viewModel.saveReadingPreferencesAndClose()
+            viewModel.onExitActionClick()
 
             // Then
-            val closeEvent = collectedEvents.last() as ActionEvent.Close
-            assertThat(closeEvent.isDirty).isTrue()
+            verifyNoInteractions(saveReadingPreferences)
         }
 
     @Test
-    fun `when saveReadingPreferencesAndClose is called with updated preferences then it saves them`() = test {
+    fun `when onExitActionClick is called with updated preferences then it saves them`() = test {
         // Given
         val newTheme = ReaderReadingPreferences.Theme.SOFT
         viewModel.onThemeClick(newTheme)
 
         // When
-        viewModel.saveReadingPreferencesAndClose()
+        viewModel.onExitActionClick()
 
         // Then
         verify(saveReadingPreferences).invoke(argThat { theme == newTheme })
+    }
+
+    @Test
+    fun `when onBottomSheetHidden is called with original preferences then it doesn't save them`() =
+        test {
+            // When
+            viewModel.onBottomSheetHidden()
+
+            // Then
+            verifyNoInteractions(saveReadingPreferences)
+        }
+
+    @Test
+    fun `when onBottomSheetHidden is called with updated preferences then it saves them`() = test {
+        // Given
+        val newTheme = ReaderReadingPreferences.Theme.SOFT
+        viewModel.onThemeClick(newTheme)
+
+        // When
+        viewModel.onBottomSheetHidden()
+
+        // Then
+        verify(saveReadingPreferences).invoke(argThat { theme == newTheme })
+    }
+
+    @Test
+    fun `when onScreenClosed is called with original preferences then it doesn't emit UpdatePostDetail`() = test {
+        // Given
+        viewModel.onExitActionClick()
+
+        // When
+        viewModel.onScreenClosed()
+
+        // Then
+        val updateEvent = collectedEvents.last()
+        assertThat(updateEvent).isNotEqualTo(ActionEvent.UpdatePostDetails)
+    }
+
+    @Test
+    fun `when onScreenClosed is called with updated preferences then it emits UpdatePostDetail`() = test {
+        // Given
+        val newTheme = ReaderReadingPreferences.Theme.SOFT
+        viewModel.onThemeClick(newTheme)
+        viewModel.onExitActionClick()
+
+        // When
+        viewModel.onScreenClosed()
+
+        // Then
+        val updateEvent = collectedEvents.last()
+        assertThat(updateEvent).isEqualTo(ActionEvent.UpdatePostDetails)
     }
 
     @Test
@@ -270,7 +317,7 @@ class ReaderReadingPreferencesViewModelTest : BaseUnitTest() {
         viewModel.onThemeClick(newTheme)
 
         // When
-        viewModel.saveReadingPreferencesAndClose()
+        viewModel.onExitActionClick()
 
         // Then
         verify(readingPreferencesTracker).trackSaved(argThat { theme == newTheme })


### PR DESCRIPTION
Improvement suggested by @notandyvee here: pcdRpT-6gD-p2#comment-9800

Allow dragging to hide and close the Reading Preferences bottom sheet, saving the latest user selection. 

The main caveat is that dragging down conflicts with preview content scroll when the font is too large and/or the screen size is too small, which has the potential to be more annoying than dragging being disabled, so it would be great to have feedback from the Reviewers here and maybe merging this change and keeping an eye out for user complaints/reviews.

If anyone knows if there's some sort of way of providing some "scroll preference order" to the gesture system so it first scrolls the content and only scrolls the sheet when content is at the top, that would be ideal, but I couldn't find something like that. 😞 

-----

## To Test:

1. Open the Reader
2. Open any post
3. Go to Reading Preferences
4. Change some preferences
5. Drag down to close the Preferences sheet

Make sure to also test using large font sizes and trying to drag the preview content. 

Note: It's possible to drag the content consistently if the user starts by dragging the finger UP before trying to drag it down.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Not saving properly the Reading Preferences
    - Not sending the correct analytics events

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing
    - Unit Testing

8. What automated tests I added (or what prevented me from doing so)

    - Unit tests for the new scenarios

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):
N/A

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)