### PR TITLE
Prevents ANR when fetching reader post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -291,8 +291,10 @@ public class ReaderPostActions {
             @Override
             public void onResponse(JSONObject jsonObject) {
                 ReaderPost post = ReaderPost.fromJson(jsonObject);
-                ReaderPostTable.addPost(post);
-                handlePostLikes(post, jsonObject);
+                new Thread(() -> {
+                    ReaderPostTable.addPost(post);
+                    handlePostLikes(post, jsonObject);
+                }).start();
                 if (requestListener != null) {
                     requestListener.onSuccess(post.getBlogUrl());
                 }


### PR DESCRIPTION
Fixes #20641

## Description
This PR prevents an ANR when fetching post by moving the DB operation to the background

-----

## To Test:
I was not able to reproduce this ANR thus I'd recommend a sanity of the functionality:
1. In the MySite screen select More>Comments
2. Tap on a comment
3. **Verify** that it load correctly and the like status loads correctly

-----

## Regression Notes

1. Potential unintended areas of impact

    - Reader post comment

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - The specific code is hard to test without major refactoring

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
