### PR TITLE
Refactor Mark all as read in notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.kt
@@ -224,9 +224,13 @@ class Note {
      * Setters
      */
 
-    fun setRead() {
+    fun setRead() = updateReadState(1)
+
+    fun setUnread() = updateReadState(0)
+
+    private fun updateReadState(read: Int) {
         try {
-            mNoteJSON?.putOpt("read", 1)
+            mNoteJSON?.putOpt("read", read)
         } catch (e: JSONException) {
             AppLog.e(AppLog.T.NOTIFS, "Failed to set 'read' property", e)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
@@ -28,7 +28,7 @@ class NotificationsActionsWrapper @Inject constructor(
                 it.id.toLong()
             } catch (ex: Exception) {
                 // id might be empty
-                AppLog.e(AppLog.T.NOTIFS, "Error parsing note id: ${it.id}")
+                AppLog.e(AppLog.T.NOTIFS, "Error parsing note id: ${it.id}", ex)
                 -1L
             }
         }.filter { it != -1L }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
@@ -4,6 +4,7 @@ import dagger.Reusable
 import org.wordpress.android.fluxc.model.notification.NotificationModel
 import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.models.Note
+import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -20,12 +21,14 @@ class NotificationsActionsWrapper @Inject constructor(
                 { continuation.resume(true) })
         }
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun markNoteAsRead(notes: List<Note>): NotificationStore.OnNotificationChanged? {
         val noteIds = notes.map {
             try {
                 it.id.toLong()
             } catch (ex: Exception) {
                 // id might be empty
+                AppLog.e(AppLog.T.NOTIFS, "Error parsing note id: ${it.id}")
                 -1L
             }
         }.filter { it != -1L }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActionsWrapper.kt
@@ -1,13 +1,17 @@
 package org.wordpress.android.ui.notifications.utils
 
 import dagger.Reusable
+import org.wordpress.android.fluxc.model.notification.NotificationModel
+import org.wordpress.android.fluxc.store.NotificationStore
 import org.wordpress.android.models.Note
 import javax.inject.Inject
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 @Reusable
-class NotificationsActionsWrapper @Inject constructor() {
+class NotificationsActionsWrapper @Inject constructor(
+    private val notificationStore: NotificationStore
+) {
     suspend fun downloadNoteAndUpdateDB(noteId: String): Boolean =
         suspendCoroutine { continuation ->
             NotificationsActions.downloadNoteAndUpdateDB(
@@ -16,7 +20,19 @@ class NotificationsActionsWrapper @Inject constructor() {
                 { continuation.resume(true) })
         }
 
-    fun markNoteAsRead(note: Note?) {
-        NotificationsActions.markNoteAsRead(note)
+    suspend fun markNoteAsRead(notes: List<Note>): NotificationStore.OnNotificationChanged? {
+        val noteIds = notes.map {
+            try {
+                it.id.toLong()
+            } catch (ex: Exception) {
+                // id might be empty
+                -1L
+            }
+        }.filter { it != -1L }
+        if (noteIds.isEmpty()) return null
+
+        return notificationStore.markNotificationsRead(
+            NotificationStore.MarkNotificationsReadPayload(noteIds.map { NotificationModel(remoteNoteId = it) })
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
@@ -1,0 +1,12 @@
+package org.wordpress.android.util
+
+import androidx.annotation.StringRes
+import dagger.Reusable
+import org.wordpress.android.WordPress
+import javax.inject.Inject
+
+@Reusable
+class ToastUtilsWrapper @Inject constructor() {
+    fun showToast(@StringRes messageRes: Int) =
+        ToastUtils.showToast(WordPress.getContext(), messageRes)
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/notifications/NotificationsListViewModelTest.kt
@@ -33,6 +33,8 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.actions.ReaderActions
 import org.wordpress.android.ui.reader.actions.ReaderPostActionsWrapper
 import org.wordpress.android.util.EventBusWrapper
+import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.util.ToastUtilsWrapper
 
 private const val REQUEST_BLOG_LISTENER_PARAM_POSITION = 2
 
@@ -76,7 +78,13 @@ class NotificationsListViewModelTest : BaseUnitTest() {
     private lateinit var commentStore: CommentsStore
 
     @Mock
-    private lateinit var  accountStore: AccountStore
+    private lateinit var accountStore: AccountStore
+
+    @Mock
+    private lateinit var toastUtilsWrapper: ToastUtilsWrapper
+
+    @Mock
+    private lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
     @Mock
     private lateinit var action: ActionHandler
@@ -87,9 +95,12 @@ class NotificationsListViewModelTest : BaseUnitTest() {
     fun setup() {
         viewModel = NotificationsListViewModel(
             testDispatcher(),
+            testDispatcher(),
             appPrefsWrapper,
             jetpackFeatureRemovalOverlayUtil,
             gcmMessageHandler,
+            networkUtilsWrapper,
+            toastUtilsWrapper,
             notificationsUtilsWrapper,
             appLogWrapper,
             siteStore,
@@ -104,33 +115,37 @@ class NotificationsListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN marking a note as read THEN the note is marked as read and the notification removed from system bar`() {
+    fun `WHEN marking a note as read THEN the note is marked as read and the notification removed from system bar`() =
+        test {
+            // Given
+            val noteId = "1"
+            val context: Context = mock()
+            val note = mock<Note>()
+            val notes = listOf(note)
+            whenever(note.id).thenReturn(noteId)
+            whenever(note.isUnread).thenReturn(true)
+            whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+
+            // When
+            viewModel.markNoteAsRead(context, notes)
+
+            // Then
+            verify(gcmMessageHandler, times(1)).removeNotificationWithNoteIdFromSystemBar(context, noteId)
+            verify(note, times(1)).setRead()
+            verify(notificationsActionsWrapper).markNoteAsRead(notes)
+            verify(notificationsTableWrapper, times(1)).saveNotes(notes, false)
+            verify(eventBusWrapper, times(1)).post(any())
+        }
+
+    @Test
+    fun `WHEN marking a note as read THEN the read note is saved`() = test {
         // Given
         val noteId = "1"
         val context: Context = mock()
         val note = mock<Note>()
         whenever(note.id).thenReturn(noteId)
         whenever(note.isUnread).thenReturn(true)
-
-        // When
-        viewModel.markNoteAsRead(context, listOf(note))
-
-        // Then
-        verify(gcmMessageHandler, times(1)).removeNotificationWithNoteIdFromSystemBar(context, noteId)
-        verify(notificationsActionsWrapper, times(1)).markNoteAsRead(note)
-        verify(note, times(1)).setRead()
-        verify(notificationsTableWrapper, times(1)).saveNotes(listOf(note), false)
-        verify(eventBusWrapper, times(1)).post(any())
-    }
-
-    @Test
-    fun `WHEN marking a note as read THEN the read note is saved`() {
-        // Given
-        val noteId = "1"
-        val context: Context = mock()
-        val note = mock<Note>()
-        whenever(note.id).thenReturn(noteId)
-        whenever(note.isUnread).thenReturn(true)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
 
         // When
         viewModel.markNoteAsRead(context, listOf(note))
@@ -141,7 +156,7 @@ class NotificationsListViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `WHEN marking all as read THEN only the unread notes are marked as read and saved`() {
+    fun `WHEN marking all as read THEN only the unread notes are marked as read and saved`() = test {
         // Given
         val noteId1 = "1"
         val noteId2 = "2"
@@ -151,19 +166,19 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         whenever(note1.id).thenReturn(noteId1)
         whenever(note1.isUnread).thenReturn(true)
         whenever(note2.isUnread).thenReturn(false)
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
 
         // When
         viewModel.markNoteAsRead(context, listOf(note1, note2))
 
         // Then
         verify(gcmMessageHandler, times(1)).removeNotificationWithNoteIdFromSystemBar(context, noteId1)
-        verify(notificationsActionsWrapper, times(1)).markNoteAsRead(note1)
         verify(note1, times(1)).setRead()
         verify(gcmMessageHandler, times(0)).removeNotificationWithNoteIdFromSystemBar(context, noteId2)
-        verify(notificationsActionsWrapper, times(0)).markNoteAsRead(note2)
         verify(note2, times(0)).setRead()
         verify(notificationsTableWrapper, times(1)).saveNotes(listOf(note1), false)
         verify(eventBusWrapper, times(1)).post(any())
+        verify(notificationsActionsWrapper, times(1)).markNoteAsRead(listOf(note1))
     }
 
     @Test
@@ -230,7 +245,8 @@ class NotificationsListViewModelTest : BaseUnitTest() {
         whenever(note.commentId).thenReturn(commentId)
         whenever(commentStore.likeComment(site, commentId, null, true)).thenReturn(
             CommentsStore.CommentsActionPayload(
-                CommentStore.CommentError(CommentStore.CommentErrorType.GENERIC_ERROR,"error"), null)
+                CommentStore.CommentError(CommentStore.CommentErrorType.GENERIC_ERROR, "error"), null
+            )
         )
 
         // When


### PR DESCRIPTION
Refactor #20066


The previous implementation used a loop to make API requests to mark each note as read, this will be like DDoS if many users are marking their notes read at the same time. The new implementation only uses one API request to mark all notes as read.

-----

## To Test:

1. Sign in the JP app
2. Switch to the notifications tab
3. Create some unread notifications
4. Click the three dots icon at the top-right corner
5. Click Mark all as read
6. The unread dots should be cleared
7. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - Notifications

8. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual

9. What automated tests I added (or what prevented me from doing so)

    - Added some unit tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
