### PR TITLE
QR Code Scanning: Prevent illegalStateException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
@@ -54,7 +54,7 @@ class BarcodeScanningFragment : Fragment() {
                         },
                         onScannedResult = { codeScannerStatus ->
                             viewLifecycleOwner.lifecycleScope.launch {
-                                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                                     codeScannerStatus.collect { status ->
                                         setResultAndPopStack(status)
                                     }
@@ -90,8 +90,10 @@ class BarcodeScanningFragment : Fragment() {
     }
 
     private fun setResultAndPopStack(status: CodeScannerStatus) {
-        setFragmentResult(KEY_BARCODE_SCANNING_REQUEST, bundleOf(KEY_BARCODE_SCANNING_SCAN_STATUS to status))
-        requireActivity().supportFragmentManager.popBackStackImmediate()
+        if (isAdded) {
+            setFragmentResult(KEY_BARCODE_SCANNING_REQUEST, bundleOf(KEY_BARCODE_SCANNING_SCAN_STATUS to status))
+            requireActivity().supportFragmentManager.popBackStackImmediate()
+        }
     }
 
     companion object {


### PR DESCRIPTION
Fixes #20643 

This PR addresses an issue where the app may encounter an `IllegalStateException` when attempting to set a fragment result after its lifecycle has reached the STOPPED state or beyond. To prevent this potential issue the following changes have been made:

Changed the lifecycle state in the observeCameraPermissionState from Lifecycle.State.CREATED to Lifecycle.State.STARTED. This ensures that the code block is executed only when the fragment is at least in the STARTED state, eliminating potential IllegalStateExceptions.

Introduced a check for isAdded in the setFragmentResultAndPopStack method. The isAdded property returns true if the fragment is currently added to its activity, providing a way to ensure that the fragment is still attached to its activity before executing UI-related code.

I was unable to recreate this crash, but according to the logs it happens when the app is backgrounded while the scanner is opened for QR Code login.  

-----

## To Test:
Pre-req
- Remove all versions of Jetpack from your device

[JP] Scan Login Code 
Step.1:
- Install the Jetpack app from this PR
- Log in to the Jetpack app with a WP.com account (note that you need to use a non A8C account and a non 2FA enabled account).
- Navigate to the Me screen (click on bottom Me navigation tab).
(STOP)

Step.2:
- Head over to your desktop and open a web browser (note that using an incognito tab works best).
- Browse to wordpress.com (note that if you are logged-in, log-out first).
- Tap the Log In link (top-right).
- Tap the Login via the mobile app link in the list of options below the main Continue button (bottom-middle).
- Verify you are on the Login via the mobile app view and Use QR Code to login is shown, along with a QR code for you to scan.

(STOP)
Step.3:
- Head back to your mobile.
- Tap the Scan Login Code item on the Me screen you are currently at.
- Accept the use camera permissions
- Scan the QR code on the web browser.
- Follow the remaining prompts on your mobile to log in to WordPress on your web browser (desktop), verify that you have successfully logged-in and are able to use WordPress as expected.

[JP] Super Fast Media Upload
- Verify that scanning the super fast media upload qr code works as expected. You do not have to run the entire flow, just scan the barcode to launch the app.

-----
## Regression Notes
1. Potential unintended areas of impact
- Bar scanner no longer works

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manul testing

3. What automated tests I added (or what prevented me from doing so)
N/A
-----

## PR Submission Checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
