### PR TITLE
Post conflict resolution for self-hosted site companion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.117.0'
     wordPressAztecVersion = 'v2.1.1'
-    wordPressFluxCVersion = '2990-d59458c31b8c633f18205016dd8f5fb538462636'
+    wordPressFluxCVersion = 'trunk-b5daa1e612ae7ce5a248c5975f90b0e0093378b1'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.117.0'
     wordPressAztecVersion = 'v2.1.1'
-    wordPressFluxCVersion = '2.76.0'
+    wordPressFluxCVersion = '2990-d59458c31b8c633f18205016dd8f5fb538462636'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
This PR is the companion app for FluxC Post conflict resolution for self-hosted sites.
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2990


Merge Instructions
- Ensure FluxC PR has been merged to trunk
- Update this PR with the CI Publish hash from the FluxC Merge into trunk
- Remove the Not Ready for Merge label
- Merge as normal
-----

## To Test:

Follow the instructions in the FLuxC https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2990 

-----

## Regression Notes

1. Potential unintended areas of impact
The XMLRPC sites don't address conflicts in posts

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and existing unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
