### PR TITLE
Fixes: NullPointerException in SiteCreationActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationActivity.kt
@@ -118,7 +118,7 @@ class SiteCreationActivity : LocaleAwareActivity(),
         mainViewModel.preloadThumbnails(this)
 
         observeVMState()
-        observeOverlayEvents(savedInstanceState)
+        observeOverlayEvents()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -169,20 +169,13 @@ class SiteCreationActivity : LocaleAwareActivity(),
         previewViewModel.onOkButtonClicked.observe(this, mainViewModel::onWizardFinished)
     }
 
-    private fun observeOverlayEvents(savedInstanceState: Bundle?) {
+    private fun observeOverlayEvents() {
         if(BuildConfig.IS_JETPACK_APP)
             return
 
-        val fragment =  if (savedInstanceState == null) {
-            JetpackFeatureFullScreenOverlayFragment
-                .newInstance(
-                    isSiteCreationOverlay = true,
-                    siteCreationSource = getSiteCreationSource()
-                )
-        }else {
-            supportFragmentManager.findFragmentByTag(JetpackFeatureFullScreenOverlayFragment.TAG)
-                    as JetpackFeatureFullScreenOverlayFragment
-        }
+        val fragment = supportFragmentManager.findFragmentByTag(JetpackFeatureFullScreenOverlayFragment.TAG)
+                    as? JetpackFeatureFullScreenOverlayFragment ?: JetpackFeatureFullScreenOverlayFragment
+                        .newInstance(isSiteCreationOverlay = true, siteCreationSource = getSiteCreationSource())
 
         jetpackFullScreenViewModel.action.observe(this) { action ->
             if (mainViewModel.siteCreationDisabled) finish()


### PR DESCRIPTION
Fixes #20647 

-----

This PR tries to fix sentry crash reported [here](https://a8c.sentry.io/issues/5152595060/?project=1438088&referrer=github_integration).  

The issue is in these lines: 

```
supportFragmentManager.findFragmentByTag(JetpackFeatureFullScreenOverlayFragment.TAG)
                    as JetpackFeatureFullScreenOverlayFragment
```

findFragmentByTag() may return a null value and if we then try to cast null to JetpackFeatureFullScreenOverlayFragment, a NullPointerException is thrown. 

I was not able to replicate the crash on my device but it seems that the approach of using `savedInstanceState == null` check does not work for all cases. 

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Install the **WordPress** apk from this PR. 
2. Log in and try to create a new site. 
3. When the overlay that promotes Jetpack app appears, rotate your device multiple times and check that no crash occurs. 

-----

## Regression Notes

1. Potential unintended areas of impact

    - JetpackFeatureFullScreenOverlayFragment is not shown

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
