### PR TITLE
Quick Start: Fix IllegalStateException  

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -302,7 +302,7 @@ class QuickStartRepository
 
     fun clearMenuStep() {
         if (_quickStartMenuStep.value != null) {
-            _quickStartMenuStep.value = null
+            _quickStartMenuStep.postValue(null)
         }
     }
 


### PR DESCRIPTION
Fixes #20653 

This PR addresses the potential for an IllegalStateException that can occur when updating from a background thread in the clearMenuStep(). The issue was due to invoking setValue() on _quickStartMenuStep directly, which throws an illegalStateException when called from the mainthread.

To resolve this issue, the clearMenuStep() function has been updated to use postValue() instead of setValue(). This ensures that the update to _quickStartMenuStep happens asynchronously on the main thread, preventing threading issues and IllegalStateExceptions.

-----

## To Test:

I was unable to recreate the crash, so the test validates all still works correctly.

- Install the app from this PR
- Logout of the app and log in again
- When prompted, select the "Show me around" option
- Navigate through the quick start tasks
- Verify you don't experience a crash

-----

## Regression Notes

1. Potential unintended areas of impact
Quick start tutorial doesn't work as normal

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests and unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
