### PR TITLE
Fix negative percent issue on Stats for RTL languages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 24.8
 -----
-
+* [*] [Jetpack-only] Fixed percentage numbers direction on Stats for RTL languages [https://github.com/wordpress-mobile/WordPress-Android/pull/20656]
 
 24.7
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtils.kt
@@ -229,7 +229,7 @@ class StatsUtils @Inject constructor(
                 0L -> percentFormatter.format(value = 100)
                 else -> {
                     val percentageValue = difference.toFloat() / previousValue
-                    percentFormatter.format(value = percentageValue, rounding = HALF_UP)
+                    percentFormatter.formatWithJavaLib(value = percentageValue, rounding = HALF_UP)
                 }
             }
             val formattedDifference = mapLongToString(difference, isFormattedNumber)

--- a/WordPress/src/main/java/org/wordpress/android/util/text/PercentFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/text/PercentFormatter.kt
@@ -34,6 +34,25 @@ class PercentFormatter @Inject constructor(
     }
 
     /**
+     * This is similar to format(), except this utilizes java.text.NumberFormat. When the default locale is a RTL
+     * language (e.g., "ar_EG"), the output should be "-83%" but android.icu.text.NumberFormat returns "%83-".
+     * java.text.NumberFormat returns the expected result of "-83%".
+     * @param value the value to be returned formatted
+     * @return the formatted string
+     */
+    fun formatWithJavaLib(
+        value: Float,
+        maxFractionDigits: Int = MAXIMUM_FRACTION_DIGITS,
+        rounding: RoundingMode = RoundingMode.DOWN
+    ): String {
+        val percentFormatter = java.text.NumberFormat.getPercentInstance(localeManagerWrapper.getLocale()).apply {
+            maximumFractionDigits = maxFractionDigits
+            roundingMode = rounding
+        }
+        return percentFormatter.format(value)
+    }
+
+    /**
      * Returns a String with a percent sign (%) using the given Int parameter. The Int value will be returned as the
      * percentage (e.g. if the Int value is 10, the returned String for Locale.US will be "10%"). The returned String
      * uses the default Locale.

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/utils/StatsUtilsTest.kt
@@ -263,7 +263,7 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with positive difference`() {
-        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("300")
+        whenever(percentFormatter.formatWithJavaLib(value = 3.0F, rounding = HALF_UP)).thenReturn("300")
         val previousValue = 5L
         val value = 20L
         val positive = true
@@ -293,7 +293,7 @@ class StatsUtilsTest {
 
     @Test
     fun `build change with negative difference`() {
-        whenever(percentFormatter.format(value = -0.33333334F, rounding = HALF_UP)).thenReturn("-33")
+        whenever(percentFormatter.formatWithJavaLib(value = -0.33333334F, rounding = HALF_UP)).thenReturn("-33")
         val previousValue = 30L
         val value = 20L
         val positive = false
@@ -309,7 +309,7 @@ class StatsUtilsTest {
     @Test
     fun `build change with max negative difference`() {
         val previousValue = 20L
-        whenever(percentFormatter.format(value = -1F, rounding = HALF_UP)).thenReturn("-100")
+        whenever(percentFormatter.formatWithJavaLib(value = -1F, rounding = HALF_UP)).thenReturn("-100")
         val value = 0L
         val positive = false
         val expectedChange = "-20 (-100%)"
@@ -337,8 +337,8 @@ class StatsUtilsTest {
 
     @Test
     fun `when buildChange, should call PercentFormatter`() {
-        whenever(percentFormatter.format(value = 3.0F, rounding = HALF_UP)).thenReturn("3%")
+        whenever(percentFormatter.formatWithJavaLib(value = 3.0F, rounding = HALF_UP)).thenReturn("3%")
         statsUtils.buildChange(5L, 20L, true, isFormattedNumber = true)
-        verify(percentFormatter).format(value = 3.0F, rounding = HALF_UP)
+        verify(percentFormatter).formatWithJavaLib(value = 3.0F, rounding = HALF_UP)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/text/PercentFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/text/PercentFormatterTest.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.util.text
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.util.LocaleManagerWrapper
+import java.math.RoundingMode
+import java.util.Locale
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class PercentFormatterTest : BaseUnitTest() {
+    @Mock
+    private lateinit var localeManagerWrapper: LocaleManagerWrapper
+
+    @Test
+    fun whenRtlLocale_formatWithJavaLibReturnsCorrectDirection() {
+        // Use the locale of Arabic language
+        whenever(localeManagerWrapper.getLocale()).thenReturn(Locale.forLanguageTag("ar_EG"))
+
+        val input = -0.83f
+        val rounding = RoundingMode.HALF_UP
+        val percentFormatter = PercentFormatter(localeManagerWrapper)
+
+        assertEquals("-83%", percentFormatter.formatWithJavaLib(value = input, rounding = rounding))
+    }
+}


### PR DESCRIPTION
Fixes #17447

When the device language is set to **Arabic**, numbers with the percentage were being displayed as "%96-". This was the output of `android.icu.text.NumberFormat` function. I couldn't find any documentation related to this issue, but using `java.text.NumberFormat` resolves it. See the screenshot below:

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/52c635fc-c655-4ac4-9242-adc5a07e2a39" width=560>

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/188d4d52-1fcb-431e-97b3-0e00a9197e78" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/5a3dcea9-8155-4e37-b3d7-5999a7a19ce9" width=320>|

_Ignore the inaccurate chart. I manipulated the code to display the negative percentage._

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Set your device language to Arabic.
2. Open the Jetpack app and head to Stats > Insights, on a site that has less traffic this week than last week.
3. Verify that the negative percentage is displayed correctly.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Other languages.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested in Turkish. The percent is displayed as "(-%96)", as expected.

3. What automated tests I added (or what prevented me from doing so)

    - Added `PercentFormatterTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
