### PR TITLE
EditPost: Fix NullPointerException in overriding methods

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -903,8 +903,8 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     // SiteSettingsListener
-    override fun onSaveError(error: Exception) { /* No Op */ }
-    override fun onFetchError(error: Exception) { /* No Op */ }
+    override fun onSaveError(error: Exception?) { /* No Op */ }
+    override fun onFetchError(error: Exception?) { /* No Op */ }
     override fun onSettingsUpdated() {
         // Let's hold the value in local variable as listener is too noisy
         val isJetpackSsoEnabled = siteModel.isJetpackConnected && siteSettings?.isJetpackSsoEnabled == true
@@ -919,7 +919,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     override fun onSettingsSaved() { /* No Op */ }
-    override fun onCredentialsValidated(error: Exception) { /* No Op */ }
+    override fun onCredentialsValidated(error: Exception?) { /* No Op */ }
     private fun setupViewPager() {
         // Set up the ViewPager with the sections adapter.
         viewPager = findViewById(R.id.pager)


### PR DESCRIPTION
Fixes #20663 

This PR addresses a NullPointerException that occurred in a Kotlin class when overriding a method from a Java interface. The issue was caused by the Kotlin class expecting a non-null parameter for the method, while the Java interface allowed the parameter to be nullable.

To resolve this issue, the method signature in the Kotlin `EditPostActivity` has been updated to accept a nullable Exception parameter. This change allows the Kotlin class to handle cases where the Java implementation passes a null Exception reference without throwing a NullPointerException.

Note: I was unable to recreate this crash

FYI: @oguzkocer - We are targeting release/24.7 with this fix. I'll post in #app-infrastructure after it's been reviewed

-----

### Test
- Download the app from this PR
- Create and edit a post to ensure it functions correctly.

-----

## Regression Notes

1. Potential unintended areas of impact
The NPE is still present

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Relied on existing unit tests

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A

