### PR TITLE
Fix #20664 - fix crash in WPAvatarUtils

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/util/WPAvatarUtilsTest.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/WPAvatarUtilsTest.kt
@@ -40,4 +40,15 @@ class WPAvatarUtilsTest {
             )
         )
     }
+
+    @Test
+    fun rewriteAvatarUrlInvalidGravatarUrl() {
+        assertEquals(
+            "",
+            WPAvatarUtils.rewriteAvatarUrl(
+                "https://www.gravatar.com/avatar/?d=404&s=200",
+                200, DefaultAvatarOption.Status404
+            )
+        )
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPAvatarUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPAvatarUtils.java
@@ -47,7 +47,7 @@ public class WPAvatarUtils {
             try {
                 return new AvatarUrl(new URL(imageUrl),
                         new AvatarQueryOptions(avatarSz, defaultImage, null, null)).url().toString();
-            } catch (MalformedURLException e) {
+            } catch (MalformedURLException | IllegalArgumentException e) {
                 return "";
             }
         }


### PR DESCRIPTION
Fixes #20664

-----
## Regression Notes

1. Potential unintended areas of impact

    - This will have the same behavior as before the Gravatar-SDK-Android integration: if the passed Gravatar URL is invalid (no or empty hash), we'll show the default avatar.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - I haven't tested manually

3. What automated tests I added (or what prevented me from doing so)

    - New test added in WPAvatarUtilsTests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

~- [ ] WordPress.com sites and self-hosted Jetpack sites.~
~- [ ] Portrait and landscape orientations.~
~- [ ] Light and dark modes.~
~- [ ] Fonts: Larger, smaller and bold text.~
~- [ ] High contrast.~
~- [ ] Talkback.~
~- [ ] Languages with large words or with letters/accents not frequently used in English.~
~- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
~- [ ] Large and small screen sizes. (Tablet and smaller phones)~
~- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
