### PR TITLE
Fix UninitializedPropertyAccessException in EditorJetpackSocialViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorJetpackSocialViewModel.kt
@@ -187,7 +187,8 @@ class EditorJetpackSocialViewModel @Inject constructor(
         }
     }
 
-    private fun shouldShowJetpackSocial() = !editPostRepository.isPage
+    private fun shouldShowJetpackSocial() = ::editPostRepository.isInitialized
+            && !editPostRepository.isPage
             && siteModel.supportsPublicize()
             && currentPost?.status != PostStatus.PRIVATE.toString()
 


### PR DESCRIPTION
Fixes #20662 

Even though I couldn't reproduce the crash, the root cause seem to be a race condition that makes the method `EditorJetpackSocialViewModel#shouldShowJetpackSocial` be called before `editPostRepository` is initialized. As a quick fix to avoid crashing, I'm checking if the variable was initialized before using it.

-----

## To Test:

- Install JP and sign in.
- Select a site that has at least one social network connected.
- Tap "+" FAB in "My Site" screen.
- 🔍  Tap "Blog post" option: the app should not crash.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
