### PR TITLE
Fix empty bar chart issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -90,7 +90,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
         val dataSet = if (hasData) {
             buildDataSet(context, mappedEntries)
         } else {
-            BarDataSet(emptyList(), "Empty")
+            buildEmptyDataSet(cutEntries.size)
         }
         item.onBarChartDrawn?.invoke(dataSet.entryCount)
         val dataSets = mutableListOf<IBarDataSet>()
@@ -206,6 +206,11 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
             high2.dataIndex = index
             highlightValues(arrayOf(high2, high))
         }
+    }
+
+    private fun buildEmptyDataSet(count: Int): BarDataSet {
+        val emptyValues = (0 until count).map { index -> BarEntry(index.toFloat(), 0f, "empty") }
+        return BarDataSet(emptyValues, "Empty").apply { setDrawValues(false) }
     }
 
     private fun buildDataSet(context: Context, cut: List<BarEntry>): BarDataSet {


### PR DESCRIPTION
This fixes an issue that is introduced with https://github.com/wordpress-mobile/WordPress-Android/pull/20605.
Some cards were stuck in the loading state, and the date picker was disabled.

I added values with `0f` to the chart data to fix the issue.

|before|after|
|-|-|
|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/cdcc58a2-ce1b-4b58-9e28-3a56a81376f5" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/e2262755-f186-4211-9cb6-6eecb15e4195" width=320>|
-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Select a site with empty stats. (You can create a fresh one)
3. Open the DAYS tab from "My Site → Stats"

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

6. What automated tests I added (or what prevented me from doing so)

    - This reverts some part of previous PR.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
