### PR TITLE
EditPost: fix lateinit property siteModel not initialized error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -411,6 +411,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     @Inject lateinit var editorJetpackSocialViewModel: EditorJetpackSocialViewModel
 
     private lateinit var siteModel: SiteModel
+
     private var siteSettings: SiteSettingsInterface? = null
     private var isJetpackSsoEnabled: Boolean = false
     private var networkErrorOnLastMediaFetchAttempt: Boolean = false
@@ -501,7 +502,6 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
         setContentView(R.layout.new_edit_post_activity)
-
         val callback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 handleBackPressed()
@@ -512,8 +512,11 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
 
         createEditShareMessageActivityResultLauncher()
 
-        // Initialize siteModel based on intent or savedInstanceState
-        initializeSiteModelAndFinishIfNeeded(savedInstanceState)
+        if (!initializeSiteModel(savedInstanceState)) {
+            ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT)
+            finish()
+            return
+        }
 
         isLandingEditor = intent.extras?.getBoolean(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR) ?: false
 
@@ -598,8 +601,8 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         }
     }
 
-    private fun initializeSiteModelAndFinishIfNeeded(savedInstanceState: Bundle?) {
-        // Set siteModel only once
+    private fun initializeSiteModel(savedInstanceState: Bundle?): Boolean {
+        // Initialize siteModel based on intent or savedInstanceState and set it only once
         val tempSiteModel = if (savedInstanceState == null) {
             val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel?
             val siteFromQuickPressBlogId = getSiteModelForExtraQuickPressBlogIdIfRequested(intent.extras)
@@ -607,12 +610,11 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         } else {
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel?
         }
-        tempSiteModel?.let { siteModel = tempSiteModel }?: run {
-            ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT)
-            finish()
-            return
-        }
+        tempSiteModel?.let { siteModel = it }?: return false
+
+        return true
     }
+
     private fun isActionSendOrNewMedia(action: String?): Boolean {
         return action == Intent.ACTION_SEND || action == Intent.ACTION_SEND_MULTIPLE || action == NEW_MEDIA_POST
     }


### PR DESCRIPTION
Fixes #20673 

This PR addresses an issue where the lateinit property siteModel was not being initialized under certain circumstances. The problem occurred when the finish() method did not execute immediately after initialization failure, causing the activity to continue execution despite siteModel being uninitialized.

To resolve this issue, I refactored the initializeSiteModelAndFinishIfNeeded method, now called initializeSiteModel, to return a Boolean indicating whether siteModel was successfully initialized. If siteModel could not be initialized, the method now returns false. In onCreate(), I introduced a check to immediately call finish() if the method returns false

This change ensures that siteModel is properly initialized, and the activity is promptly terminated if initialization fails, thus preventing runtime errors related to lateinit property initialization.

Note: I could not recreate the issue live, but I could by setting onCreate() to immediately finish() and then validating that the next line was still executed.

-----

## To Test:
- Install the app
- Navigate to Post -> Edit post
- Validate the app doesn't crash
-----

## Regression Notes
1. Potential unintended areas of impact
Edit Post does not work

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
