### PR TITLE
Fix NullPointerException calling sendToJSPostSaveEvent

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -220,7 +220,12 @@ public class GutenbergContainerFragment extends Fragment {
     }
 
     public void sendToJSPostSaveEvent() {
-        mWPAndroidGlueCode.sendToJSPostSaveEvent();
+        // Check that the activity isn't null, there is a possibilty it can cause the following crash
+        // https://github.com/wordpress-mobile/WordPress-Android/issues/20665
+        final Activity activity = getActivity();
+        if (activity != null) {
+            mWPAndroidGlueCode.sendToJSPostSaveEvent();
+        }
     }
 
     /**

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergContainerFragment.java
@@ -220,7 +220,7 @@ public class GutenbergContainerFragment extends Fragment {
     }
 
     public void sendToJSPostSaveEvent() {
-        // Check that the activity isn't null, there is a possibilty it can cause the following crash
+        // Check that the activity isn't null, there is a possibility it can cause the following crash
         // https://github.com/wordpress-mobile/WordPress-Android/issues/20665
         final Activity activity = getActivity();
         if (activity != null) {


### PR DESCRIPTION
Fixes #20665 

This PR introduces a null check for the activity. This change is made to prevent potential NullPointerExceptions that could occur if the activity is not available at the time of call. 

We were unable to recreate this crash. See discussion p1713455342282519-slack-C012H19SZQ8 for the reasoning behind the solution implemented.

-----
## To Test:
- Install the JP app from this PR
- Login
- Navigate to Posts
- Edit a post or create a new post
- Add images
- Set a featured image
- Update or publish the post
- Verify the app doesn't crash
-----

## Regression Notes

1. Potential unintended areas of impact
Edit/create post crashes

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
