### PR TITLE
Fix null `siteModel` crash on the posts list screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -513,7 +513,7 @@ class PostUploadNotifier {
                 mContext,
                 (int) notificationId,
                 notificationIntent,
-                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
 
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);


### PR DESCRIPTION
Fixes #20534 

This aims to address a crash that started 5 years ago and was previously attempted to be fixed (with https://github.com/wordpress-mobile/WordPress-Android/pull/13171). 

I couldn't reproduce the crash, but I'm implementing the suggestion made in https://github.com/wordpress-mobile/WordPress-Android/pull/13171#issuecomment-712938324. 

Using `PendingIntent.FLAG_ONE_SHOT` and `PendingIntent.FLAG_UPDATE_CURRENT` together may not work properly, so I believe this change will resolve the crash.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

I don't know how to reproduce this issue but you can test starting posts list from the notification.

1. Ensure notification permission is allowed.
2. Add a video to a post.
3. Publish and put the app into the background just after publishing the post.
4. Verify that you received a "post published" notification and that it opens the posts list.

<details>
  <summary>test notification video</summary>
 
https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/176a97ef-f14f-4c29-84d2-549b48fae486
</details>

-----

## Regression Notes

1. Potential unintended areas of impact

    - "post published" notification

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually.

3. What automated tests I added (or what prevented me from doing so)

    - Since I couldn't reproduce the crash, adding automated tests is not proper.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
