### PR TITLE
Replace tab with a popup window in notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -205,6 +205,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     private fun NotificationsListFragmentBinding.setSelectedTab(position: Int) {
         lastTabPosition = position
+        binding?.viewPager?.currentItem = position
     }
 
     private fun NotificationsListFragmentBinding.setNotificationPermissionWarning() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -104,6 +104,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             (requireActivity() as AppCompatActivity).setSupportActionBar(toolbarMain)
 
             viewPager.adapter = NotificationsFragmentAdapter(this@NotificationsListFragment)
+            viewPager.isUserInputEnabled = false
             viewPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -24,9 +24,6 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.MarginPageTransformer
 import com.google.android.material.appbar.AppBarLayout.LayoutParams
-import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
-import com.google.android.material.tabs.TabLayout.Tab
-import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.wordpress.android.R
@@ -35,6 +32,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.NOTIFICATIONS_SELECTED_F
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATIONS_MARK_ALL_READ_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_MENU_TAPPED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.NOTIFICATION_TAPPED_SEGMENTED_CONTROL
+import org.wordpress.android.databinding.NotificationFilterPopupBinding
 import org.wordpress.android.databinding.NotificationsListFragmentBinding
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.JetpackPoweredScreen
@@ -102,27 +100,10 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         super.onViewCreated(view, savedInstanceState)
         setHasOptionsMenu(true)
         binding = NotificationsListFragmentBinding.bind(view).apply {
-            toolbarMain.setTitle(R.string.notifications_screen_title)
+            toolbarTitle.setOnClickListener { showFilterPopup(toolbarTitle) }
             (requireActivity() as AppCompatActivity).setSupportActionBar(toolbarMain)
 
-            tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
-                override fun onTabSelected(tab: Tab) {
-                    val tabPosition = TabPosition.values().getOrNull(tab.position) ?: All
-                    AnalyticsTracker.track(
-                        NOTIFICATION_TAPPED_SEGMENTED_CONTROL, hashMapOf(
-                            NOTIFICATIONS_SELECTED_FILTER to tabPosition.filter.toString()
-                        )
-                    )
-                    lastTabPosition = tab.position
-                }
-
-                override fun onTabUnselected(tab: Tab) = Unit
-                override fun onTabReselected(tab: Tab) = Unit
-            })
             viewPager.adapter = NotificationsFragmentAdapter(this@NotificationsListFragment)
-            TabLayoutMediator(tabLayout, viewPager) { tab, position ->
-                tab.text = TabPosition.values().getOrNull(position)?.let { getString(it.titleRes) } ?: ""
-            }.attach()
             viewPager.setPageTransformer(
                 MarginPageTransformer(resources.getDimensionPixelSize(R.dimen.margin_extra_large))
             )
@@ -153,6 +134,32 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         }
     }
 
+    private fun showFilterPopup(anchorView: View) {
+        val popupWindow = PopupWindow(requireContext(), null, R.style.WordPress)
+        popupWindow.isOutsideTouchable = true
+        popupWindow.elevation = resources.getDimension(R.dimen.popup_over_toolbar_elevation)
+        popupWindow.contentView = NotificationFilterPopupBinding.inflate(LayoutInflater.from(requireContext()))
+            .apply {
+                textFilterAll.setOnClickListener(getFilterClickListener(TabPosition.All, popupWindow))
+                textFilterUnread.setOnClickListener(getFilterClickListener(TabPosition.Unread, popupWindow))
+                textFilterComments.setOnClickListener(getFilterClickListener(TabPosition.Comment, popupWindow))
+                textFilterFollows.setOnClickListener(getFilterClickListener(TabPosition.Follow, popupWindow))
+                textFilterLikes.setOnClickListener(getFilterClickListener(TabPosition.Like, popupWindow))
+            }.root
+        popupWindow.showAsDropDown(anchorView)
+    }
+
+    private fun getFilterClickListener(filter: TabPosition, popupWindow: PopupWindow) = View.OnClickListener {
+        AnalyticsTracker.track(
+            NOTIFICATION_TAPPED_SEGMENTED_CONTROL, hashMapOf(
+                NOTIFICATIONS_SELECTED_FILTER to filter.toString()
+            )
+        )
+        lastTabPosition = filter.ordinal
+        binding?.viewPager?.currentItem = filter.ordinal
+        popupWindow.dismiss()
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
@@ -165,11 +172,9 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
             if (!accountStore.hasAccessToken()) {
                 showConnectJetpackView()
                 connectJetpack.visibility = View.VISIBLE
-                tabLayout.visibility = View.GONE
                 viewPager.visibility = View.GONE
             } else {
                 connectJetpack.visibility = View.GONE
-                tabLayout.visibility = View.VISIBLE
                 viewPager.visibility = View.VISIBLE
                 fetchRemoteNotes()
             }
@@ -200,7 +205,6 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
 
     private fun NotificationsListFragmentBinding.setSelectedTab(position: Int) {
         lastTabPosition = position
-        tabLayout.getTabAt(lastTabPosition)?.select()
     }
 
     private fun NotificationsListFragmentBinding.setNotificationPermissionWarning() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -157,6 +157,11 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
         )
         lastTabPosition = filter.ordinal
         binding?.viewPager?.currentItem = filter.ordinal
+        binding?.toolbarTitle?.text = if (filter == All) {
+            getString(R.string.notifications_screen_spinner_title)
+        } else {
+            getString(filter.titleRes)
+        }
         popupWindow.dismiss()
     }
 
@@ -206,6 +211,13 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
     private fun NotificationsListFragmentBinding.setSelectedTab(position: Int) {
         lastTabPosition = position
         binding?.viewPager?.currentItem = position
+        TabPosition.entries.getOrNull(position)?.let {
+            toolbarTitle.text = if (it == All) {
+                getString(R.string.notifications_screen_spinner_title)
+            } else {
+                getString(it.titleRes)
+            }
+        }
     }
 
     private fun NotificationsListFragmentBinding.setNotificationPermissionWarning() {

--- a/WordPress/src/main/res/drawable/chevron_right_small.xml
+++ b/WordPress/src/main/res/drawable/chevron_right_small.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15.96,10.862L11.971,14.281L7.983,10.862L8.96,9.723L11.971,12.305L14.983,9.723L15.96,10.862Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/WordPress/src/main/res/layout/notification_filter_popup.xml
+++ b/WordPress/src/main/res/layout/notification_filter_popup.xml
@@ -7,7 +7,7 @@
     app:cardCornerRadius="@dimen/notifications_popup_radius">
 
     <LinearLayout
-        android:layout_width="200dp"
+        android:layout_width="@dimen/notifications_filter_popup_width"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
@@ -25,7 +25,7 @@
             android:id="@+id/divider"
             android:layout_width="match_parent"
             android:layout_height="1px"
-            android:layout_marginVertical="8dp"
+            android:layout_marginVertical="@dimen/margin_medium"
             android:background="@color/grey_300"
             app:layout_constraintTop_toBottomOf="@+id/text_mark_all_as_read" />
 

--- a/WordPress/src/main/res/layout/notification_filter_popup.xml
+++ b/WordPress/src/main/res/layout/notification_filter_popup.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:cardBackgroundColor="?colorSurface"
+    app:cardCornerRadius="@dimen/notifications_popup_radius">
+
+    <LinearLayout
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/text_filter_all"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_tab_title_all"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1px"
+            android:layout_marginVertical="8dp"
+            android:background="@color/grey_300"
+            app:layout_constraintTop_toBottomOf="@+id/text_mark_all_as_read" />
+
+        <TextView
+            android:id="@+id/text_filter_unread"
+            android:layout_width="match_parent"
+            android:background="?attr/selectableItemBackground"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_tab_title_unread_notifications"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large" />
+
+        <TextView
+            android:id="@+id/text_filter_comments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_tab_title_comments"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large" />
+
+        <TextView
+            android:id="@+id/text_filter_follows"
+            android:layout_width="match_parent"
+            android:background="?attr/selectableItemBackground"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_tab_title_follows"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large" />
+
+        <TextView
+            android:id="@+id/text_filter_likes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:padding="@dimen/notifications_item_action_padding"
+            android:text="@string/notifications_tab_title_likes"
+            android:textColor="?wpColorOnSurfaceHigh"
+            android:textSize="@dimen/text_sz_large" />
+    </LinearLayout>
+</androidx.cardview.widget.CardView>
+

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -26,16 +26,19 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/toolbar_height"
             app:layout_scrollFlags="scroll|enterAlways"
-            app:theme="@style/WordPress.ActionBar" />
+            app:theme="@style/WordPress.ActionBar">
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tab_layout"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:visibility="visible"
-            app:layout_scrollFlags="scroll|enterAlways"
-            app:tabGravity="fill"
-            app:tabMode="scrollable" />
+            <TextView
+                android:id="@+id/toolbar_title"
+                style="@android:style/TextAppearance.Material.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                android:text="@string/notifications_screen_title"
+                android:textColor="?attr/colorOnSurface"
+                app:drawableEndCompat="@drawable/chevron_right_small"
+                app:drawableTint="?attr/colorOnSurface" />
+        </com.google.android.material.appbar.MaterialToolbar>
 
         <LinearLayout
             android:id="@+id/notification_permission_warning"

--- a/WordPress/src/main/res/layout/notifications_list_fragment.xml
+++ b/WordPress/src/main/res/layout/notifications_list_fragment.xml
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
-                android:text="@string/notifications_screen_title"
+                android:text="@string/notifications_screen_spinner_title"
                 android:textColor="?attr/colorOnSurface"
                 app:drawableEndCompat="@drawable/chevron_right_small"
                 app:drawableTint="?attr/colorOnSurface" />

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -288,6 +288,7 @@
     <dimen name="notifications_multiple_icon_height">44dp</dimen>
     <dimen name="notifications_multiple_icon_width">48dp</dimen>
     <dimen name="notifications_image_size">180dp</dimen>
+    <dimen name="notifications_filter_popup_width">200dp</dimen>
 
     <dimen name="progress_bar_height">3dp</dimen>
     <dimen name="activity_progress_bar_height">5dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="me_section_screen_title">Me</string>
     <string name="reader_screen_title">Reader</string>
     <string name="notifications_screen_title">Notifications</string>
+    <string name="notifications_screen_spinner_title">All Notifications</string>
     <string name="publicize_buttons_screen_title">Sharing buttons</string>
     <string name="media_settings_screen_title">File details</string>
     <string name="person_detail_screen_title">Person detail</string>


### PR DESCRIPTION
See pcdRpT-5aB-p2

| Light | Dark |
|--|--|
| ![Screenshot_20240423-094530](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/b54a967c-1b73-4897-ad23-128839f9b1c1) | ![Screenshot_20240423-094600](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/9ab7be19-0772-4e27-ac25-e852533d411d) |



-----

## To Test:

1. Sign in the JP app
2. Switch to the Notifications tab
3. Click on the title in the Toolbar
4. It should display a popup window
5. Click on the menu options
6. The popup should be dismissed, and then switch to the filter category you clicked, the title should be updated.
7. Rotate your screen
8. The title and filter category should be correct after the rotation.
9. Done! Thank you!

**Know issue**
The shadow of the popup window is not clear in dark mode.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

12. What automated tests I added (or what prevented me from doing so)

    - none

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)