### PR TITLE
[Reader] Implement "Tags" feed empty state UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
@@ -40,6 +42,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
@@ -60,7 +63,7 @@ fun ReaderTagsFeed(uiState: UiState) {
         when (uiState) {
             is UiState.Loading -> Loading()
             is UiState.Loaded -> Loaded(uiState)
-            is UiState.Empty -> Empty()
+            is UiState.Empty -> Empty(uiState)
         }
     }
 }
@@ -145,8 +148,76 @@ private fun Loading() {
 }
 
 @Composable
-private fun Empty() {
-// TODO empty state (https://github.com/wordpress-mobile/WordPress-Android/issues/20584)
+private fun Empty(uiState: UiState.Empty) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Title
+        Text(
+            modifier = Modifier
+                .padding(
+                    start = Margin.ExtraExtraMediumLarge.value,
+                    end = Margin.ExtraExtraMediumLarge.value,
+                    bottom = Margin.Medium.value,
+                ),
+            text = stringResource(id = R.string.reader_discover_empty_title),
+            textAlign = TextAlign.Center,
+            fontSize = 20.sp,
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface.copy(
+                alpha = ContentAlpha.medium,
+            ),
+        )
+        // Subtitle
+        Text(
+            modifier = Modifier
+                .padding(
+                    start = Margin.ExtraExtraMediumLarge.value,
+                    end = Margin.ExtraExtraMediumLarge.value,
+                    bottom = Margin.Large.value,
+                ),
+            text = stringResource(id = R.string.reader_discover_empty_subtitle_follow),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.subtitle1,
+            color = MaterialTheme.colors.onSurface.copy(
+                alpha = ContentAlpha.medium,
+            ),
+        )
+        // Button
+        Button(
+            onClick = uiState.onOpenTagsListClick,
+            modifier = Modifier.padding(
+                start = Margin.ExtraMediumLarge.value,
+                end = Margin.ExtraMediumLarge.value,
+                bottom = Margin.ExtraLarge.value,
+            ),
+            contentPadding = PaddingValues(
+                horizontal = 32.dp,
+                vertical = 8.dp,
+            ),
+            elevation = ButtonDefaults.elevation(
+                defaultElevation = 0.dp,
+                pressedElevation = 0.dp,
+            ),
+            colors = ButtonDefaults.buttonColors(
+                contentColor = MaterialTheme.colors.onPrimary,
+                backgroundColor = MaterialTheme.colors.onSurface,
+            ),
+        ) {
+            Row() {
+                androidx.compose.material.Text(
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically),
+                    style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                    text = stringResource(id = R.string.reader_discover_empty_button_text),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
 }
 
 @Composable
@@ -341,7 +412,7 @@ sealed class UiState {
 
     object Loading : UiState()
 
-    object Empty : UiState()
+    data class Empty(val onOpenTagsListClick: () -> Unit) : UiState()
 }
 
 data class TagChip(
@@ -487,7 +558,9 @@ fun ReaderTagsFeedLoading() {
 fun ReaderTagsFeedEmpty() {
     AppTheme {
         ReaderTagsFeed(
-            uiState = UiState.Empty
+            uiState = UiState.Empty(
+                onOpenTagsListClick = {},
+            )
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -206,16 +205,14 @@ private fun Empty(uiState: UiState.Empty) {
                 backgroundColor = MaterialTheme.colors.onSurface,
             ),
         ) {
-            Row() {
-                androidx.compose.material.Text(
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically),
-                    style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-                    text = stringResource(id = R.string.reader_discover_empty_button_text),
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                )
-            }
+            androidx.compose.material.Text(
+                modifier = Modifier
+                    .align(Alignment.CenterVertically),
+                style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                text = stringResource(id = R.string.reader_discover_empty_button_text),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+            )
         }
     }
 }


### PR DESCRIPTION
> [!WARNING]  
> Should be merged after https://github.com/wordpress-mobile/WordPress-Android/pull/20686

Fixes #20584 

<p float="left">
<img width="300" alt="Screenshot 2024-04-22 at 5 01 20 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/33005de8-96c6-469b-b0c7-a0b9c961694d">
<img width="300" alt="Screenshot 2024-04-22 at 5 01 38 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/4c61f255-83c4-4073-851c-0242c040f7f2">

</p>

-----

## To Test:

The UI component is not being used yet, so in order to test it you can run `ReaderTagsFeedEmpty` preview and compare it with the existing `Discover` feed empty state:

<img width="300" alt="image" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/bbbd58cd-c476-4f21-9d8f-f722339b78ef">

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    --

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
