### PR TITLE
Fix IllegalStateException by using postValue() in clearMenuStep()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/quickstart/QuickStartRepository.kt
@@ -302,7 +302,7 @@ class QuickStartRepository
 
     fun clearMenuStep() {
         if (_quickStartMenuStep.value != null) {
-            _quickStartMenuStep.value = null
+            _quickStartMenuStep.postValue(null)
         }
     }
 


### PR DESCRIPTION
(cherry picked from commit f980e0dd4f6b685a8fe0c09cb248b7276ce90473)

## Fixes
Merges the changes in this https://github.com/wordpress-mobile/WordPress-Android/pull/20654 to the trunk as the issue is surging in 24.7 


-----

## Regression Notes

1. Potential unintended areas of impact
Crash is still happening

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

-----
PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)