### PR TITLE
Fix editpost background issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -498,6 +498,16 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         }
     }
 
+    override fun onRestart() {
+        super.onRestart()
+        Log.i(javaClass.simpleName, "***=> onRestart")
+    }
+
+    override fun onStart() {
+        super.onStart()
+        Log.i(javaClass.simpleName, "***=> onStart")
+    }
+
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i(javaClass.simpleName, "***=> onCreate")
@@ -718,7 +728,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
             Log.i(javaClass.simpleName, "***=> Printing Bundle Contents")
             for (key in it.keySet()) {
                 val value = it.get(key)
-                Log.i(javaClass.simpleName, "$key: $value")
+                Log.i(javaClass.simpleName, "***=> $key: $value")
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2363,8 +2363,6 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
      * A [FragmentPagerAdapter] that returns a fragment corresponding to
      * one of the sections/tabs/pages.
      */
-
-    //
     inner class SectionsPagerAdapter internal constructor(fm: FragmentManager) :
         FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
         @Suppress("ReturnCount")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -39,6 +39,7 @@ import androidx.core.util.Pair
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
+import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.lifecycle.LiveData
 import androidx.viewpager.widget.ViewPager.SimpleOnPageChangeListener
 import com.automattic.android.tracks.crashlogging.CrashLogging
@@ -770,16 +771,26 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                 initializePostObject()
             }
 
-            (supportFragmentManager.getFragment(
-                state,
-                EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT
-            ) as EditorFragmentAbstract?)?.let { frag ->
-                Log.i(javaClass.simpleName, "***=> We have a frag $frag")
-                editorFragment = frag
-                if (frag is EditorMediaUploadListener) {
-                    editorMediaUploadListener = frag
+            val possibleFragment = supportFragmentManager.getFragment(state, EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT)
+            if (possibleFragment != null) {
+                Log.i(javaClass.simpleName, "***=> Retrieved a fragment using STATE_KEY_EDITOR_FRAGMENT key")
+                editorFragment = possibleFragment as EditorFragmentAbstract
+                if (possibleFragment is EditorMediaUploadListener) {
+                    editorMediaUploadListener = possibleFragment
                 }
             }
+
+            //. todo: annmarie this was the original code
+//            (supportFragmentManager.getFragment(
+//                state,
+//                EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT
+//            ) as EditorFragmentAbstract?)?.let { frag ->
+//                Log.i(javaClass.simpleName, "***=> We have a frag $frag")
+//                editorFragment = frag
+//                if (frag is EditorMediaUploadListener) {
+//                    editorMediaUploadListener = frag
+//                }
+//            }
         }
     }
 
@@ -2399,8 +2410,11 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
      * A [FragmentPagerAdapter] that returns a fragment corresponding to
      * one of the sections/tabs/pages.
      */
+
+    //
     inner class SectionsPagerAdapter internal constructor(fm: FragmentManager) :
-        FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        // FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
         @Suppress("ReturnCount")
         override fun getItem(position: Int): Fragment {
             // getItem is called to instantiate the fragment for the given page.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -749,16 +749,14 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
 
             // if we have a remote id saved, let's first try that, as the local Id might have changed after FETCH_POSTS
             if (state.containsKey(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID)) {
-                Log.i(javaClass.simpleName, "***=> We have a remote id, go get it from state ")
-                editPostRepository.loadPostByRemotePostId(
-                    state.getLong(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID),
-                    siteModel
-                )
+                val possibleValueOfPostRemoteId = state.getLong(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID)
+                Log.i(javaClass.simpleName, "***=> We have a remote id, and the value is $possibleValueOfPostRemoteId")
+                editPostRepository.loadPostByRemotePostId(possibleValueOfPostRemoteId, siteModel)
                 initializePostObject()
             } else if (state.containsKey(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID)) {
-                editPostRepository.loadPostByLocalPostId(
-                    state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID)
-                )
+                val possibleValueOfPostLocalId = state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID)
+                Log.i(javaClass.simpleName, "***=> We have a local id, and the value is $possibleValueOfPostLocalId")
+                editPostRepository.loadPostByLocalPostId(possibleValueOfPostLocalId)
                 initializePostObject()
             }
 
@@ -766,6 +764,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                 state,
                 EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT
             ) as EditorFragmentAbstract?)?.let { frag ->
+                Log.i(javaClass.simpleName, "***=> We have a frag $frag")
                 editorFragment = frag
                 if (frag is EditorMediaUploadListener) {
                     editorMediaUploadListener = frag

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -10,7 +10,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -201,7 +200,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @SuppressWarnings("unchecked")
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
-        Log.i("GutenbergEditorFragment", "***=> onCreate");
         super.onCreate(savedInstanceState);
 
         if (getGutenbergContainerFragment() == null) {
@@ -241,7 +239,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @SuppressWarnings("MethodLength")
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        Log.i("GutenbergEditorFragment", "***=> onCreateView");
         View view = inflater.inflate(R.layout.fragment_gutenberg_editor, container, false);
 
         initializeSavingProgressDialog();
@@ -755,7 +752,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override public void onResume() {
-        Log.i("GutenbergEditorFragment", "***=> onResume");
         super.onResume();
 
         setEditorProgressBarVisibility(!mEditorDidMount);
@@ -972,7 +968,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onAttach(Activity activity) {
-        Log.i("GutenbergEditorFragment", "***=> onAttach");
         super.onAttach(activity);
 
         try {
@@ -996,7 +991,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        Log.i("GutenbergEditorFragment", "***=> onSaveInstanceState");
         outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, mEditorDidMount);
         outState.putString(ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH, mExternallyEditedBlockOriginalHash);
@@ -1153,9 +1147,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @Override
     public Pair<CharSequence, CharSequence> getTitleAndContent(CharSequence originalContent) throws
             EditorFragmentNotAddedException {
-        Log.i("GutenbergEditorFragment", "***=> getTitleAndContent");
         if (!isAdded()) {
-            Log.i("GutenbergEditorFragment", "***=> getTitleAndContent THROW EXCEPTION");
             throw new EditorFragmentNotAddedException();
         }
         return getGutenbergContainerFragment().getTitleAndContent(originalContent, new OnGetContentInterrupted() {
@@ -1354,7 +1346,6 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onDestroy() {
-        Log.i("GutenbergEditorFragment", "***=> onDestroy");
         hideSavingProgressDialog();
         super.onDestroy();
     }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -200,6 +201,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @SuppressWarnings("unchecked")
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
+        Log.i("GutenbergEditorFragment", "***=> onCreate");
         super.onCreate(savedInstanceState);
 
         if (getGutenbergContainerFragment() == null) {
@@ -239,6 +241,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @SuppressWarnings("MethodLength")
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        Log.i("GutenbergEditorFragment", "***=> onCreateView");
         View view = inflater.inflate(R.layout.fragment_gutenberg_editor, container, false);
 
         initializeSavingProgressDialog();
@@ -752,6 +755,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override public void onResume() {
+        Log.i("GutenbergEditorFragment", "***=> onResume");
         super.onResume();
 
         setEditorProgressBarVisibility(!mEditorDidMount);
@@ -968,6 +972,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onAttach(Activity activity) {
+        Log.i("GutenbergEditorFragment", "***=> onAttach");
         super.onAttach(activity);
 
         try {
@@ -991,6 +996,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
+        Log.i("GutenbergEditorFragment", "***=> onSaveInstanceState");
         outState.putBoolean(KEY_HTML_MODE_ENABLED, mHtmlModeEnabled);
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, mEditorDidMount);
         outState.putString(ARG_STORY_BLOCK_EXTERNALLY_EDITED_ORIGINAL_HASH, mExternallyEditedBlockOriginalHash);
@@ -1147,7 +1153,9 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
     @Override
     public Pair<CharSequence, CharSequence> getTitleAndContent(CharSequence originalContent) throws
             EditorFragmentNotAddedException {
+        Log.i("GutenbergEditorFragment", "***=> getTitleAndContent");
         if (!isAdded()) {
+            Log.i("GutenbergEditorFragment", "***=> getTitleAndContent THROW EXCEPTION");
             throw new EditorFragmentNotAddedException();
         }
         return getGutenbergContainerFragment().getTitleAndContent(originalContent, new OnGetContentInterrupted() {
@@ -1346,6 +1354,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onDestroy() {
+        Log.i("GutenbergEditorFragment", "***=> onDestroy");
         hideSavingProgressDialog();
         super.onDestroy();
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/20667

There are instances in which the Edit Post view is not visible on return from background. The issue is hard to replicate and to date, have had a single developer able to reproduce this. As such, it's been difficult to find a fix.

This PR updates EditPostActivity.retrieveSavedInstanceState to use `supportFragmentManager` instead of `fragmentManager` while retrieving the EditorFragmentAbstract from the savedInstanceState bundle.

There is another change that I am contemplating, switching from `FragmentPagerAdapter` to `FragmentStatePagerAdapter`; however lifecycle management is a little different and I don't want to risk introducing other issues without fully thinking it through. I had switched it in the branch, but removed the change with the submitted PR.

-----

## To Test:
- Install the app from this PR
- On your Android device, navigate to developer settings
- Limit background apps to 1
 - Navigate back to the app, create a post and add some content
 - Background the app
- Launch another app
- Relaunch Jetpack
- Verify the app doesn't crash

-----

## Regression Notes

1. Potential unintended areas of impact
Edit post doesn't return from background correctly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
