### PR TITLE
Add a Share Post button in Likes Details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1210,6 +1210,8 @@ public class ActivityLauncher {
             Activity activity,
             long siteId,
             long postId,
+            String postTitle,
+            String postUrl,
             HeaderData headerData,
             EngagementNavigationSource source
     ) {
@@ -1223,6 +1225,8 @@ public class ActivityLauncher {
                         postId,
                         0L,
                         "",
+                        postTitle,
+                        postUrl,
                         headerData
                 )
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -6,15 +6,18 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.ui.ActionableEmptyView
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.engagement.BottomSheetAction.HideBottomSheet
 import org.wordpress.android.ui.engagement.BottomSheetAction.ShowBottomSheet
@@ -73,6 +76,8 @@ class EngagedPeopleListFragment : Fragment() {
     private lateinit var loadingView: View
     private lateinit var rootView: View
     private lateinit var emptyView: ActionableEmptyView
+    private lateinit var divider: View
+    private lateinit var shareButton: MaterialButton
     private val listScenario by lazy { requireNotNull(arguments?.getParcelableCompat<ListScenario>(KEY_LIST_SCENARIO)) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -94,6 +99,8 @@ class EngagedPeopleListFragment : Fragment() {
         recycler = view.findViewById(R.id.recycler)
         loadingView = view.findViewById(R.id.loading_view)
         emptyView = view.findViewById(R.id.actionable_empty_view)
+        divider = view.findViewById(R.id.divider)
+        shareButton = view.findViewById(R.id.button_share_post)
 
         val layoutManager = LinearLayoutManager(activity)
 
@@ -253,6 +260,18 @@ class EngagedPeopleListFragment : Fragment() {
         val recyclerViewState = recycler.layoutManager?.onSaveInstanceState()
         adapter.loadData(items)
         recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
+
+        val likeItem = items.first { it is EngageItem.LikedItem } as EngageItem.LikedItem
+        val visible = listScenario.type == ListScenarioType.LOAD_POST_LIKES
+        divider.isVisible = visible
+        shareButton.isVisible = visible
+        shareButton.setOnClickListener {
+            ActivityLauncher.openShareIntent(
+                it.context,
+                likeItem.likedItemSiteUrl,
+                likeItem.postOrCommentText.toString()
+            )
+        }
     }
 
     private fun showSnackbar(holder: SnackbarMessageHolder) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/EngagedPeopleListFragment.kt
@@ -261,15 +261,14 @@ class EngagedPeopleListFragment : Fragment() {
         adapter.loadData(items)
         recycler.layoutManager?.onRestoreInstanceState(recyclerViewState)
 
-        val likeItem = items.first { it is EngageItem.LikedItem } as EngageItem.LikedItem
         val visible = listScenario.type == ListScenarioType.LOAD_POST_LIKES
         divider.isVisible = visible
         shareButton.isVisible = visible
         shareButton.setOnClickListener {
             ActivityLauncher.openShareIntent(
                 it.context,
-                likeItem.likedItemSiteUrl,
-                likeItem.postOrCommentText.toString()
+                listScenario.postUrl,
+                listScenario.postTitle
             )
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenario.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenario.kt
@@ -13,6 +13,8 @@ data class ListScenario(
     val postOrCommentId: Long,
     val commentPostId: Long = 0,
     val commentSiteUrl: String,
+    val postTitle: String,
+    val postUrl: String,
     val headerData: HeaderData
 ) : Parcelable
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenarioUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/engagement/ListScenarioUtils.kt
@@ -60,6 +60,8 @@ class ListScenarioUtils @Inject constructor(
             postOrCommentId = if (note.isPostLikeType) note.postId.toLong() else note.commentId,
             commentPostId = if (note.isCommentLikeType) note.postId.toLong() else 0L,
             commentSiteUrl = if (note.isCommentLikeType) note.url else "",
+            postUrl = note.url,
+            postTitle = note.title,
             headerData = HeaderData(
                 authorName = AuthorNameCharSequence(spannable),
                 snippetText = headerNoteBlock.getHeader(1).getTextOrEmpty(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -927,6 +927,8 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                     activity,
                     this.siteId,
                     this.postId,
+                    this.postTitle,
+                    this.postUrl,
                     this.headerData,
                     EngagementNavigationSource.LIKE_READER_LIST
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderNavigationEvents.kt
@@ -65,6 +65,8 @@ sealed class ReaderNavigationEvents {
     data class ShowEngagedPeopleList(
         val siteId: Long,
         val postId: Long,
+        val postTitle: String,
+        val postUrl: String,
         val headerData: HeaderData
     ) : ReaderNavigationEvents()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderPostDetailViewModel.kt
@@ -838,6 +838,8 @@ class ReaderPostDetailViewModel @Inject constructor(
                 ShowEngagedPeopleList(
                     readerPost.blogId,
                     readerPost.postId,
+                    readerPost.title,
+                    readerPost.shortUrl,
                     HeaderData(
                         AuthorNameString(readerPost.authorName),
                         readerPost.title,

--- a/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
@@ -60,7 +60,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/margin_extra_large"
         android:layout_marginVertical="@dimen/margin_medium"
-        android:text="@string/stats_insights_share_post"
+        android:text="@string/likes_share_post"
         android:visibility="gone"
         app:icon="@drawable/block_share"
         app:iconGravity="textStart"

--- a/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
@@ -1,33 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/root_layout"
-    android:background="?attr/colorSurface"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/divider"
-        app:layout_constraintVertical_bias="0"
-        android:fadeScrollbars="true"
-        android:scrollbars="vertical" />
-
-    <org.wordpress.android.ui.ActionableEmptyView
-        android:id="@+id/actionable_empty_view"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/recycler"
-        app:aevButton="@string/retry"
-        app:aevTitle="@string/media_empty_list"
-        tools:visibility="visible" />
+    android:background="?attr/colorSurface">
 
     <LinearLayout
         android:id="@+id/loading_view"
@@ -53,26 +31,51 @@
             android:textSize="@dimen/text_sz_double_extra_large" />
     </LinearLayout>
 
-
     <View
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1px"
+        android:layout_marginBottom="@dimen/margin_extra_large"
         android:alpha="0.6"
         android:background="#3C3C43"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        app:layout_constraintBottom_toTopOf="@+id/button_share_post"/>
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/button_share_post"
+        tools:visibility="visible" />
 
-    <com.google.android.material.button.MaterialButton
-        style="@style/Widget.ShareButton"
-        android:id="@+id/button_share_post"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:fadeScrollbars="true"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0" />
+
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_share_post"
+        style="@style/Widget.ShareButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginVertical="@dimen/margin_medium"
+        android:text="@string/stats_insights_share_post"
+        android:visibility="gone"
         app:icon="@drawable/block_share"
         app:iconGravity="textStart"
         app:iconTint="?attr/colorSurface"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_marginHorizontal="@dimen/margin_extra_large"
-        android:layout_marginVertical="@dimen/margin_medium"
-        android:text="@string/stats_insights_share_post"/>
+        tools:visibility="visible" />
+
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:aevButton="@string/retry"
+        app:aevTitle="@string/media_empty_list"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/recycler"
+        tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
@@ -37,7 +37,7 @@
         android:layout_height="1px"
         android:layout_marginBottom="@dimen/margin_extra_large"
         android:alpha="0.6"
-        android:background="#3C3C43"
+        android:background="@color/divider_likes"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@+id/button_share_post"
         tools:visibility="visible" />

--- a/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/engaged_people_list_fragment.xml
@@ -13,6 +13,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/divider"
+        app:layout_constraintVertical_bias="0"
         android:fadeScrollbars="true"
         android:scrollbars="vertical" />
 
@@ -51,4 +53,26 @@
             android:textSize="@dimen/text_sz_double_extra_large" />
     </LinearLayout>
 
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:alpha="0.6"
+        android:background="#3C3C43"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        app:layout_constraintBottom_toTopOf="@+id/button_share_post"/>
+
+    <com.google.android.material.button.MaterialButton
+        style="@style/Widget.ShareButton"
+        android:id="@+id/button_share_post"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/block_share"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorSurface"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginVertical="@dimen/margin_medium"
+        android:text="@string/stats_insights_share_post"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -154,6 +154,7 @@
     <!-- Notifications -->
     <color name="inline_action_filled">@color/jetpack_green_50</color>
     <color name="background_like_header">@color/black_translucent_10</color>
+    <color name="divider_likes">#3C3C43</color>
 
     <!-- Gravatar Info Banners -->
     <color name="gravatar_info_banner">#F2F2F7</color>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1598,6 +1598,7 @@
     <string name="comments_on_my_site">Comments on my site</string>
     <string name="likes_on_my_comments">Likes on my comments</string>
     <string name="likes_on_my_posts">Likes on my posts</string>
+    <string name="likes_share_post">Share your post</string>
     <string name="site_follows">Site follows</string>
     <string name="site_achievements">Site achievements</string>
     <string name="username_mentions">Username mentions</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1832,6 +1832,12 @@
         <item name="android:backgroundTint">?attr/colorOnBackground</item>
     </style>
 
+    <style name="Widget.ShareButton" parent="Widget.LoginFlow.Button.Primary">
+        <item name="android:textColor">?attr/colorSurface</item>
+        <item name="android:backgroundTint">?attr/colorOnBackground</item>
+        <item name="cornerRadius">20dp</item>
+    </style>
+
     <style name="AvatarShapeAppearanceOverlay">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">@dimen/avatar_sz_medium_radius</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/engagement/ListScenarioUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/engagement/ListScenarioUtilsTest.kt
@@ -44,6 +44,8 @@ class ListScenarioUtilsTest {
 
     private val siteId = 100L
     private val postId = 1000L
+    private val noteUrl = "http://example.com/note/1000"
+    private val noteTitle = "Note Title"
 
     @Before
     fun setup() {
@@ -52,6 +54,8 @@ class ListScenarioUtilsTest {
         whenever(note.siteId).thenReturn(siteId.toInt())
         whenever(note.postId).thenReturn(postId.toInt())
         whenever(note.siteId).thenReturn(siteId.toInt())
+        whenever(note.url).thenReturn(noteUrl)
+        whenever(note.title).thenReturn(noteTitle)
         whenever(
             spannableBuilder.getSpans(anyInt(), anyInt(), eq(NoteBlockClickableSpan::class.java))
         ).thenReturn(listOf<NoteBlockClickableSpan>().toTypedArray())
@@ -83,6 +87,8 @@ class ListScenarioUtilsTest {
             assertThat(postId).isEqualTo(this@ListScenarioUtilsTest.postId)
             assertThat(commentPostId).isEqualTo(0L)
             assertThat(commentSiteUrl).isEqualTo("")
+            assertThat(postUrl).isEqualTo(note.url)
+            assertThat(postTitle).isEqualTo(note.title)
         }
     }
 


### PR DESCRIPTION
See the design on Figma yWt5gg3nWORhu079Qfv3mS-fi-1135%3A2576
Blocked by #20700

This is a UI redesign in Likes Details. We add a button in Likes Details for sharing the post link.

| Dark | Light |
|--|--|
| ![Screenshot_20240424-133033](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/14e1584b-8cb0-4ad5-9436-156d6c074340) | ![Screenshot_20240424-133018](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/db0c079c-d267-4e04-baae-f46431c878da) |


-----

## To Test:

1. Sign in the JP app
3. Switch to the tab of Notifications
4. Find a Post Like notification and click it
5. There should be a `Share your post` button at the bottom of screen
6. Click on the button, it should be able to share the link of that post to other apps.
7. Back to Notifications
8. Find a Comment Like notification and click it
9. There should **not** be the share button at the bottom of screen
11. Done, thank you!

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

3. What automated tests I added (or what prevented me from doing so)

    - updated an out-dated unit test

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
