### PR TITLE
Offline mode: conflict on scheduled posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtils.kt
@@ -36,15 +36,23 @@ class PostConflictResolutionFeatureUtils @Inject constructor(
     private fun setLastModifiedForConflictResolution(payload: RemotePostPayload) {
         payload.post?.let { post ->
             payload.lastModifiedForConflictResolution = if (shouldUpdateLastModified(post)) {
-                dateTimeUtilsWrapper.currentTimeInIso8601()
-                //post.dateLocallyChanged
+                dateTimeUtilsWrapper.dateStringFromIso8601MinusMillis(
+                    payload.post.lastModified,
+                    MILLISECONDS_IN_A_MINUTE
+                )
             } else {
-                post.lastModified
+                null
             }
         }
     }
 
     private fun shouldUpdateLastModified(post: PostModel): Boolean {
-        return post.status == PostStatus.SCHEDULED.toString() && post.remotePostId > 0 && post.lastModified == post.dateCreated
+        return post.status == PostStatus.SCHEDULED.toString()
+                && post.remotePostId > 0
+                && post.lastModified == post.dateCreated
+    }
+
+    companion object {
+        const val MILLISECONDS_IN_A_MINUTE = 60L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtils.kt
@@ -33,12 +33,20 @@ class PostConflictResolutionFeatureUtils @Inject constructor(
         return payload
     }
 
+    /**
+     * Resolves post-conflict issues for scheduled posts by adjusting the `if_not_modified_since` field. Normally, when
+     * a post is scheduled for the future, both the `dateCreated` and `lastModified` fields are set to the future
+     * publication date, as returned by the backend. This setup can prevent effective post-conflict resolution.
+     * This function introduces an additional field in the payload that is used to override the `lastModified` value.
+     * By setting a past date in `if_not_modified_since`, it ensures that the conflict resolution mechanism can operate
+     * correctly.
+     */
     private fun setLastModifiedForConflictResolution(payload: RemotePostPayload) {
         payload.post?.let { post ->
-            payload.lastModifiedForConflictResolution = if (shouldUpdateLastModified(post)) {
+            payload.lastModifiedForConflictResolution = if (shouldUpdateLastModifiedForConflictResolution(post)) {
                 dateTimeUtilsWrapper.dateStringFromIso8601MinusMillis(
-                    payload.post.lastModified,
-                    MILLISECONDS_IN_A_MINUTE
+                    dateTimeUtilsWrapper.currentTimeInIso8601(),
+                    MILLISECONDS_IN_A_HOUR
                 )
             } else {
                 null
@@ -46,13 +54,13 @@ class PostConflictResolutionFeatureUtils @Inject constructor(
         }
     }
 
-    private fun shouldUpdateLastModified(post: PostModel): Boolean {
+    private fun shouldUpdateLastModifiedForConflictResolution(post: PostModel): Boolean {
         return post.status == PostStatus.SCHEDULED.toString()
                 && post.remotePostId > 0
                 && post.lastModified == post.dateCreated
     }
 
     companion object {
-        const val MILLISECONDS_IN_A_MINUTE = 60L
+        const val MILLISECONDS_IN_A_HOUR = 1000*60*60L
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/DateTimeUtilsWrapper.kt
@@ -63,4 +63,9 @@ class DateTimeUtilsWrapper @Inject constructor(
     fun getInstantNow(): Instant = Instant.now()
 
     fun timestampFromIso8601Millis(date: String) = DateTimeUtils.timestampFromIso8601Millis(date)
+
+    fun dateStringFromIso8601MinusMillis(date: String, millisecondsToSubtract: Long) =
+        runCatching {
+            DateTimeUtils.iso8601FromTimestamp((dateFromIso8601(date).time - millisecondsToSubtract) / 1000)
+        }.getOrNull()
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/PostConflictResolutionFeatureUtilsTest.kt
@@ -11,12 +11,16 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.PostModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
 
 @ExperimentalCoroutinesApi
 class PostConflictResolutionFeatureUtilsTest : BaseUnitTest() {
     @Mock
     lateinit var mPostConflictResolutionFeatureConfig: PostConflictResolutionFeatureConfig
+
+    @Mock
+    lateinit var dateTimeUtilsWrapper: DateTimeUtilsWrapper
 
     private val site: SiteModel = mock()
     private val post: PostModel = mock()
@@ -25,7 +29,10 @@ class PostConflictResolutionFeatureUtilsTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
-        mPostConflictResolutionFeatureUtils = PostConflictResolutionFeatureUtils(mPostConflictResolutionFeatureConfig)
+        mPostConflictResolutionFeatureUtils = PostConflictResolutionFeatureUtils(
+            mPostConflictResolutionFeatureConfig,
+            dateTimeUtilsWrapper
+        )
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.117.0'
     wordPressAztecVersion = 'v2.1.1'
-    wordPressFluxCVersion = 'trunk-b5daa1e612ae7ce5a248c5975f90b0e0093378b1'
+    wordPressFluxCVersion = 'trunk-e6bb1ab9b9b73ee49ca380e8e3b665358922e01e'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
This PR is the companion app for FluxC Post conflict resolution for scheduled posts.
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2994

Merge Instructions

Ensure FluxC PR has been merged to trunk
Update this PR with the CI Publish hash from the FluxC Merge into trunk
Remove the Not Ready for Merge label
Merge as normal

## To Test:
Follow the instructions in the FLuxC https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2994

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - The scheduled post or page is not updated properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual tests and existing unit tests

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
