### PR TITLE
Fixes: NullPointerException in BlazeViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.blaze.blazepromote
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.blaze.blazepromote
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,6 +47,10 @@ class BlazePromoteParentActivity : AppCompatActivity() {
                 }
                 else -> {}
             }
+        }
+
+        viewModel.onSelectedSiteMissing.observe(this) {
+            finish()
         }
     }
 


### PR DESCRIPTION
Fixes #20644
This PR tries to fix the NullPointerException that is described on the above ticket. 
-----

## To Test:

1. Enable Developer options on your device
2. Go to Developer Options → Background Process limit → Set 1 as background process limit
3. Install a build from the trunk
4. Go to Pages screen
5. Pick a page and tap on the menu button (three dots menu)
6. Tap on "Promote with Blaze"
7. Wait for the blaze screen to load
8. Move the app to background and use 2+ other apps
9. Launch the app from app launcher
10. Verify that you see the crash in your LogCat 

`FATAL EXCEPTION: main
                 Process: com.jetpack.android.prealpha, PID: 17395
                 java.lang.RuntimeException: Unable to start activity ComponentInfo{com.jetpack.android.prealpha/org.wordpress.android.ui.blaze.blazepromote.BlazePromoteParentActivity}: java.lang.NullPointerException
                 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3822)
                 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3963)
                 	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
                 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
                 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
                 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2468)
                 	at android.os.Handler.dispatchMessage(Handler.java:106)
                 	at android.os.Looper.loopOnce(Looper.java:205)
                 	at android.os.Looper.loop(Looper.java:294)
                 	at android.app.ActivityThread.main(ActivityThread.java:8248)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)`

11. Check out this PR's branch
12. Follow again steps 4-9
13. Verify that you don't see the crash in your LogCat and you end up in the pages list screen

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

14. What automated tests I added (or what prevented me from doing so)

    - Relied on existing tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
