### PR TITLE
Integrate gutenberg-mobile release v1.118.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '4.0.2'
-    gutenbergMobileVersion = '6832-b5afe640373f481d9224ff5df4fdd77a0c81bf59'
+    gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
     wordPressFluxCVersion = 'trunk-e6bb1ab9b9b73ee49ca380e8e3b665358922e01e'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '4.0.2'
-    gutenbergMobileVersion = 'v1.117.0'
+    gutenbergMobileVersion = '6832-b5afe640373f481d9224ff5df4fdd77a0c81bf59'
     wordPressAztecVersion = 'v2.1.2'
     wordPressFluxCVersion = 'trunk-e6bb1ab9b9b73ee49ca380e8e3b665358922e01e'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.118.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6832

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.