### PR TITLE
Update FluxC reference to trunk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
-    wordPressFluxCVersion = '2993-d6cb0eded15c3dbbb924172ab3d1c5d8431f1be3'
+    wordPressFluxCVersion = 'trunk-c237f715b11e3005c841c43b94623d7ef92720a0'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
This only updates the FluxC version to the trunk version since I forgot to do it in https://github.com/wordpress-mobile/WordPress-Android/pull/20706.