### PR TITLE
Fix #20721: Guard against null site, account, site.email and account.avatarUrl values

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginHeaderViewHolder.java
@@ -7,6 +7,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -100,12 +101,18 @@ class LoginHeaderViewHolder extends RecyclerView.ViewHolder {
         return context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
     }
 
-    private String constructGravatarUrl(Context context, AccountModel account) {
+    private @NonNull String constructGravatarUrl(Context context, @Nullable AccountModel account) {
+        if (account == null || account.getAvatarUrl() == null) {
+            return "";
+        }
         return WPAvatarUtils.rewriteAvatarUrl(account.getAvatarUrl(), getAvatarSize(context),
                 DefaultAvatarOption.Status404.INSTANCE);
     }
 
-    private String constructGravatarUrl(Context context, SiteModel site) {
+    private @NonNull String constructGravatarUrl(Context context, @Nullable SiteModel site) {
+        if (site == null || site.getEmail() == null) {
+            return "";
+        }
         return new AvatarUrl(
                 new Email(site.getEmail()),
                 new AvatarQueryOptions(getAvatarSize(context), DefaultAvatarOption.Status404.INSTANCE, null, null)


### PR DESCRIPTION
Fixes #20721 

Guard against null site, account, site.email and account.avatarUrl values

## Regression Notes

1. Potential unintended areas of impact

    - This is very limited change
    - Returns an empty string as the avatar URL in case of an unexpected input, this will result in showing the avatar default (fallback image).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - No test

3. What automated tests I added (or what prevented me from doing so)

    - No automated tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):


~- [ ] WordPress.com sites and self-hosted Jetpack sites.~
~- [ ] Portrait and landscape orientations.~
~- [ ] Light and dark modes.~
~- [ ] Fonts: Larger, smaller and bold text.~
~- [ ] High contrast.~
~- [ ] Talkback.~
~- [ ] Languages with large words or with letters/accents not frequently used in English.~
~- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
~- [ ] Large and small screen sizes. (Tablet and smaller phones)~
~- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
