### PR TITLE
[Reader] Connect fetch tags logic with compose UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -2,28 +2,8 @@ package org.wordpress.android.ui.reader
 
 import android.os.Bundle
 import android.view.View
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,6 +19,7 @@ import org.wordpress.android.ui.reader.subfilter.SubFilterViewModel.Companion.ge
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
 import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
+import org.wordpress.android.ui.reader.views.compose.tagsfeed.ReaderTagsFeed
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.extensions.getSerializableCompat
 import javax.inject.Inject
@@ -79,10 +60,7 @@ class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragme
         binding.composeView.setContent {
             AppThemeWithoutBackground {
                 val uiState by viewModel.uiStateFlow.collectAsState()
-                ReaderTagsFeedScreen(
-                    uiState = uiState,
-                    onRetryClicked = viewModel::fetchTag,
-                )
+                ReaderTagsFeed(uiState)
             }
         }
 
@@ -132,100 +110,6 @@ class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragme
         ): ReaderTagsFeedFragment = ReaderTagsFeedFragment().apply {
             arguments = Bundle().apply {
                 putSerializable(ARG_TAGS_FEED_TAG, feedTag)
-            }
-        }
-    }
-}
-
-/**
- * Throwaway UI code just for testing the initial Tags Feed fetching code.
- * TODO remove this and replace with the final Compose content.
- */
-@Composable
-private fun ReaderTagsFeedScreen(
-    uiState: ReaderTagsFeedViewModel.UiState,
-    onRetryClicked: (ReaderTag) -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxHeight()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        uiState.tagStates.forEach { (tag, fetchState) ->
-            Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = tag.tagTitle,
-                    style = MaterialTheme.typography.h4,
-                )
-
-                when (fetchState) {
-                    is ReaderTagsFeedViewModel.FetchState.Loading -> {
-                        Text(
-                            text = "Loading...",
-                            style = MaterialTheme.typography.body1,
-                        )
-                    }
-
-                    is ReaderTagsFeedViewModel.FetchState.Error -> {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(2.dp),
-                        ) {
-                            Text(
-                                text = "Error loading posts.",
-                                style = MaterialTheme.typography.body1,
-                            )
-
-                            Text(
-                                text = "Retry",
-                                style = MaterialTheme.typography.body1,
-                                textDecoration = TextDecoration.Underline,
-                                color = MaterialTheme.colors.primary,
-                                modifier = Modifier
-                                    .padding(start = 8.dp)
-                                    .clickable { onRetryClicked(tag) },
-                            )
-                        }
-                    }
-
-                    is ReaderTagsFeedViewModel.FetchState.Success -> {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .horizontalScroll(rememberScrollState()),
-                        ) {
-                            fetchState.posts.forEach { post ->
-                                Column(
-                                    modifier = Modifier
-                                        .width(300.dp)
-                                        .background(
-                                            MaterialTheme.colors.surface,
-                                            RoundedCornerShape(4.dp)
-                                        )
-                                        .padding(4.dp),
-                                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                                ) {
-                                    Text(
-                                        text = post.title,
-                                        style = MaterialTheme.typography.h5,
-                                        maxLines = 2,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-
-                                    Text(
-                                        text = post.excerpt,
-                                        style = MaterialTheme.typography.body1,
-                                        maxLines = 4,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -90,7 +90,7 @@ class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragme
             )
 
             val tags = subFilters.filterIsInstance<SubfilterListItem.Tag>().map { it.tag }
-            viewModel.fetchAll(tags)
+            viewModel.start(tags)
         }
         subFilterViewModel.updateTagsAndSites()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -82,6 +82,7 @@ class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragme
             }
         }
 
+        // TODO not triggered when there's no internet, so the error/no connection UI is not shown.
         subFilterViewModel.subFilters.observe(viewLifecycleOwner) { subFilters ->
             readerViewModel.showTopBarFilterGroup(
                 tagsFeedTag,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -17,7 +17,7 @@ import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarte
 import org.wordpress.android.ui.reader.subfilter.SubFilterViewModel
 import org.wordpress.android.ui.reader.subfilter.SubFilterViewModel.Companion.getViewModelKeyForTag
 import org.wordpress.android.ui.reader.subfilter.SubfilterListItem
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
 import org.wordpress.android.ui.reader.views.compose.tagsfeed.ReaderTagsFeed
 import org.wordpress.android.util.NetworkUtils

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/repository/ReaderPostRepository.kt
@@ -35,7 +35,7 @@ class ReaderPostRepository @Inject constructor(
      * Fetches and returns the most recent posts for the passed tag, respecting the maxPosts limit.
      * It always fetches the most recent posts, saves them to the local DB and returns the latest from that cache.
      */
-    suspend fun fetchNewerPostsForTag(tag: ReaderTag, maxPosts: Int = 7): ReaderPostList {
+    suspend fun fetchNewerPostsForTag(tag: ReaderTag, maxPosts: Int = 10): ReaderPostList {
         return suspendCancellableCoroutine { cont ->
             val resultListener = UpdateResultListener { result ->
                 if (result == ReaderActions.UpdateResult.FAILED) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtilsWrapper.kt
@@ -63,4 +63,10 @@ class ReaderUtilsWrapper @Inject constructor(
     fun isSelfHosted(authorBlogId: Long) = ReaderUtils.isSelfHosted(authorBlogId)
 
     fun getTagFromTagUrl(url: String): String = ReaderUtils.getTagFromTagUrl(url)
+
+    fun getShortLikeLabelText(numLikes: Int): String =
+        ReaderUtils.getShortLikeLabelText(contextProvider.getContext(), numLikes)
+
+    fun getShortCommentLabelText(numComments: Int): String =
+        ReaderUtils.getShortCommentLabelText(contextProvider.getContext(), numComments)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModel.kt
@@ -11,6 +11,7 @@ import org.wordpress.android.ui.reader.exceptions.ReaderPostFetchException
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.views.compose.tagsfeed.TagsFeedPostItem
+import org.wordpress.android.util.DateTimeUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -20,6 +21,7 @@ class ReaderTagsFeedViewModel @Inject constructor(
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val readerPostRepository: ReaderPostRepository,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
 ) : ScopedViewModel(bgDispatcher) {
     private val _uiStateFlow: MutableStateFlow<UiState> = MutableStateFlow(UiState.Initial)
     val uiStateFlow: StateFlow<UiState> = _uiStateFlow
@@ -67,7 +69,9 @@ class ReaderTagsFeedViewModel @Inject constructor(
                                 posts.map {
                                     TagsFeedPostItem(
                                         siteName = it.blogName,
-                                        postDateLine = "1H",
+                                        postDateLine = dateTimeUtilsWrapper.javaDateToTimeSpan(
+                                            it.getDisplayDate(dateTimeUtilsWrapper)
+                                        ),
                                         postTitle = it.title,
                                         postExcerpt = it.excerpt,
                                         postImageUrl = it.blogImageUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -49,4 +49,37 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
             }
         ),
     )
+
+    fun mapErrorTagFeedItem(
+        tag: ReaderTag,
+        errorType: ReaderTagsFeedViewModel.ErrorType,
+        onTagClick: () -> Unit,
+        onRetryClick: () -> Unit,
+    ): ReaderTagsFeedViewModel.TagFeedItem =
+        ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = tag,
+                onTagClick = onTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Error(
+                type = errorType,
+                onRetryClick = onRetryClick,
+            ),
+        )
+
+    fun mapLoadingTagsUiState(
+        tags: List<ReaderTag>,
+        onTagClick: () -> Unit,
+    ): ReaderTagsFeedViewModel.UiState.Loaded =
+        ReaderTagsFeedViewModel.UiState.Loaded(
+            tags.map { tag ->
+                ReaderTagsFeedViewModel.TagFeedItem(
+                    tagChip = ReaderTagsFeedViewModel.TagChip(
+                        tag = tag,
+                        onTagClick = onTagClick,
+                    ),
+                    postList = ReaderTagsFeedViewModel.PostList.Loading,
+                )
+            }
+        )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -11,6 +11,7 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
 ) {
+    @Suppress("LongParameterList")
     fun mapLoadedTagFeedItem(
         tag: ReaderTag,
         posts: ReaderPostList,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -67,7 +67,7 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
             ),
         )
 
-    fun mapLoadingTagsUiState(
+    fun mapLoadingPostsUiState(
         tags: List<ReaderTag>,
         onTagClick: () -> Unit,
     ): ReaderTagsFeedViewModel.UiState.Loaded =

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -1,0 +1,52 @@
+package org.wordpress.android.ui.reader.viewmodels.tagsfeed
+
+import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.views.compose.tagsfeed.TagsFeedPostItem
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import javax.inject.Inject
+
+class ReaderTagsFeedUiStateMapper @Inject constructor(
+    private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
+    private val readerUtilsWrapper: ReaderUtilsWrapper,
+) {
+    fun mapLoadedTagFeedItem(
+        tag: ReaderTag,
+        posts: ReaderPostList,
+        onTagClick: () -> Unit,
+        onSiteClick: () -> Unit,
+        onPostImageClick: () -> Unit,
+        onPostLikeClick: () -> Unit,
+        onPostMoreMenuClick: () -> Unit,
+    ) = ReaderTagsFeedViewModel.TagFeedItem(
+        tagChip = ReaderTagsFeedViewModel.TagChip(
+            tag = tag,
+            onTagClick = onTagClick,
+        ),
+        postList = ReaderTagsFeedViewModel.PostList.Loaded(
+            posts.map {
+                TagsFeedPostItem(
+                    siteName = it.blogName,
+                    postDateLine = dateTimeUtilsWrapper.javaDateToTimeSpan(
+                        it.getDisplayDate(dateTimeUtilsWrapper)
+                    ),
+                    postTitle = it.title,
+                    postExcerpt = it.excerpt,
+                    postImageUrl = it.blogImageUrl,
+                    postNumberOfLikesText = readerUtilsWrapper.getShortLikeLabelText(
+                        numLikes = it.numLikes
+                    ),
+                    postNumberOfCommentsText = readerUtilsWrapper.getShortCommentLabelText(
+                        numComments = it.numReplies
+                    ),
+                    isPostLiked = it.isLikedByCurrentUser,
+                    onSiteClick = onSiteClick,
+                    onPostImageClick = onPostImageClick,
+                    onPostLikeClick = onPostLikeClick,
+                    onPostMoreMenuClick = onPostMoreMenuClick,
+                )
+            }
+        ),
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedViewModel.kt
@@ -51,6 +51,7 @@ class ReaderTagsFeedViewModel @Inject constructor(
      *
      * Can be used for retrying a failed fetch, for instance.
      */
+    @Suppress("SwallowedException")
     private suspend fun fetchTag(tag: ReaderTag) {
         val updatedLoadedData = getUpdatedLoadedData()
         // At this point, all tag feed items already exist in the UI with the loading status.

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedViewModel.kt
@@ -28,14 +28,14 @@ class ReaderTagsFeedViewModel @Inject constructor(
      * [uiStateFlow] are expected when calling this method for each tag, since each can go through the following
      * [UiState]s: [UiState.Initial], [UiState.Loaded], [UiState.Loading], [UiState.Empty].
      */
-    fun fetchAll(tags: List<ReaderTag>) {
+    fun start(tags: List<ReaderTag>) {
         if (tags.isEmpty()) {
             _uiStateFlow.value = UiState.Empty(::onOpenTagsListClick)
             return
         }
         // Initially add all tags to the list with the posts loading UI
         _uiStateFlow.update {
-            readerTagsFeedUiStateMapper.mapLoadingTagsUiState(tags, ::onTagClick)
+            readerTagsFeedUiStateMapper.mapLoadingPostsUiState(tags, ::onTagClick)
         }
         // Fetch all posts and update the posts loading UI to either loaded or error when the request finishes
         launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -48,6 +48,11 @@ import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
+import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.ErrorType
+import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.PostList
+import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.TagChip
+import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.TagFeedItem
+import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.UiState
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChip
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
@@ -63,6 +68,9 @@ fun ReaderTagsFeed(uiState: UiState) {
             is UiState.Loading -> Loading()
             is UiState.Loaded -> Loaded(uiState)
             is UiState.Empty -> Empty(uiState)
+            is UiState.Initial -> {
+                // no-op
+            }
         }
     }
 }
@@ -405,42 +413,6 @@ private fun PostListError(
             )
         }
     }
-}
-
-// TODO move to VM
-sealed class UiState {
-    data class Loaded(val data: List<TagFeedItem>) : UiState()
-
-    object Loading : UiState()
-
-    data class Empty(val onOpenTagsListClick: () -> Unit) : UiState()
-}
-
-data class TagFeedItem(
-    val tagChip: TagChip,
-    val postList: PostList,
-)
-
-data class TagChip(
-    val tag: ReaderTag,
-    val onTagClicked: () -> Unit,
-)
-
-sealed class PostList {
-    data class Loaded(val items: List<TagsFeedPostItem>) : PostList()
-
-    object Loading : PostList()
-
-    data class Error(
-        val type: ErrorType,
-        val onRetryClick: () -> Unit
-    ) : PostList()
-}
-
-sealed interface ErrorType {
-    data object Loading : ErrorType
-
-    data object NoContent : ErrorType
 }
 
 data class TagsFeedPostItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -48,11 +48,11 @@ import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.ErrorType
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.PostList
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.TagChip
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.TagFeedItem
-import org.wordpress.android.ui.reader.viewmodels.ReaderTagsFeedViewModel.UiState
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.ErrorType
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.PostList
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.TagChip
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.TagFeedItem
+import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.UiState
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChip
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -96,7 +96,7 @@ private fun Loaded(uiState: UiState.Loaded) {
                     start = Margin.Large.value,
                 ),
                 text = UiString.UiStringText(tagChip.tag.tagTitle),
-                onClick = tagChip.onTagClicked,
+                onClick = tagChip.onTagClick,
                 height = 36.dp,
             )
             Spacer(modifier = Modifier.height(Margin.Large.value))
@@ -300,7 +300,7 @@ private fun PostListLoaded(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = rememberRipple(bounded = false),
                             onClick = {
-                                tagChip.onTagClicked()
+                                tagChip.onTagClick()
                                 AppLog.e(AppLog.T.READER, "RL-> Tag clicked")
                             }
                         ),
@@ -374,7 +374,7 @@ private fun PostListError(
         )
         Spacer(modifier = Modifier.height(Margin.Medium.value))
         val errorMessage = when (postList.type) {
-            is ErrorType.Loading -> stringResource(R.string.reader_tags_feed_loading_error_description)
+            is ErrorType.Default -> stringResource(R.string.reader_tags_feed_loading_error_description)
             is ErrorType.NoContent -> stringResource(R.string.reader_tags_feed_no_content_error_description, tagName)
         }
         Text(
@@ -529,7 +529,7 @@ fun ReaderTagsFeedLoaded() {
                     ),
                     TagFeedItem(
                         tagChip = TagChip(readerTag, {}),
-                        postList = PostList.Error(ErrorType.Loading, {}),
+                        postList = PostList.Error(ErrorType.Default, {}),
                     ),
                     TagFeedItem(
                         tagChip = TagChip(readerTag, {}),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -140,7 +140,7 @@ fun ReaderTagsFeedPostListItem(
             text = postExcerpt,
             style = MaterialTheme.typography.bodySmall,
             color = primaryElementColor,
-            maxLines = if (!postImageUrl.isNullOrBlank()) 2 else Int.MAX_VALUE,
+            maxLines = if (!postImageUrl.isNullOrBlank()) 2 else 10,
             overflow = TextOverflow.Ellipsis,
         )
         // Post image

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModelTest.kt
@@ -126,6 +126,7 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `given valid tags, when fetchAll, then UI state should update properly`() = testCollectingUiStates {
         // Given
@@ -200,6 +201,7 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
         )
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `given valid and invalid tags, when fetchAll, then UI state should update properly`() = testCollectingUiStates {
         // Given

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
@@ -27,6 +27,7 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
         readerUtilsWrapper = readerUtilsWrapper,
     )
 
+    @Suppress("LongMethod")
     @Test
     fun `Should map loaded TagFeedItem correctly`() {
         // Given

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
@@ -1,0 +1,192 @@
+package org.wordpress.android.ui.reader.viewmodels.tagsfeed
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.models.ReaderPost
+import org.wordpress.android.models.ReaderPostList
+import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagType
+import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
+import org.wordpress.android.ui.reader.views.compose.tagsfeed.TagsFeedPostItem
+import org.wordpress.android.util.DateTimeUtilsWrapper
+import java.util.Date
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
+    private val dateTimeUtilsWrapper = mock<DateTimeUtilsWrapper>()
+
+    private val readerUtilsWrapper = mock<ReaderUtilsWrapper>()
+
+    private val classToTest: ReaderTagsFeedUiStateMapper = ReaderTagsFeedUiStateMapper(
+        dateTimeUtilsWrapper = dateTimeUtilsWrapper,
+        readerUtilsWrapper = readerUtilsWrapper,
+    )
+
+    @Test
+    fun `Should map loaded TagFeedItem correctly`() {
+        // Given
+        val readerPost = ReaderPost().apply {
+            blogName = "Name"
+            title = "Title"
+            excerpt = "Excerpt"
+            blogImageUrl = "url"
+            numLikes = 5
+            numReplies = 10
+            isLikedByCurrentUser = true
+            datePublished = ""
+        }
+        val postList = ReaderPostList().apply {
+            add(readerPost)
+        }
+        val readerTag = ReaderTag(
+            "tag",
+            "tag",
+            "tag",
+            "endpoint",
+            ReaderTagType.FOLLOWED,
+        )
+        val onTagClick = {}
+        val onSiteClick = {}
+        val onPostImageClick = {}
+        val onPostLikeClick = {}
+        val onPostMoreMenuClick = {}
+
+        val dateLine = "dateLine"
+        val numberLikesText = "numberLikesText"
+        val numberCommentsText = "numberCommentsText"
+
+        // When
+        whenever(dateTimeUtilsWrapper.dateFromIso8601(any()))
+            .thenReturn(Date(0))
+        whenever(dateTimeUtilsWrapper.javaDateToTimeSpan(any()))
+            .thenReturn(dateLine)
+        whenever(readerUtilsWrapper.getShortLikeLabelText(readerPost.numLikes))
+            .thenReturn(numberLikesText)
+        whenever(readerUtilsWrapper.getShortCommentLabelText(readerPost.numReplies))
+            .thenReturn(numberCommentsText)
+
+        val actual = classToTest.mapLoadedTagFeedItem(
+            tag = readerTag,
+            posts = postList,
+            onTagClick = onTagClick,
+            onSiteClick = onSiteClick,
+            onPostImageClick = onPostImageClick,
+            onPostLikeClick = onPostLikeClick,
+            onPostMoreMenuClick = onPostMoreMenuClick,
+        )
+        // Then
+        val expected = ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = readerTag,
+                onTagClick = onTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Loaded(
+                listOf(
+                    TagsFeedPostItem(
+                        siteName = readerPost.blogName,
+                        postDateLine = dateLine,
+                        postTitle = readerPost.title,
+                        postExcerpt = readerPost.excerpt,
+                        postImageUrl = readerPost.blogImageUrl,
+                        postNumberOfLikesText = numberLikesText,
+                        postNumberOfCommentsText = numberCommentsText,
+                        isPostLiked = readerPost.isLikedByCurrentUser,
+                        onSiteClick = onSiteClick,
+                        onPostLikeClick = onPostLikeClick,
+                        onPostImageClick = onPostImageClick,
+                        onPostMoreMenuClick = onPostMoreMenuClick,
+                    )
+                )
+            ),
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should map error TagFeedItem correctly`() {
+        // Given
+        val readerTag = ReaderTag(
+            "tag",
+            "tag",
+            "tag",
+            "endpoint",
+            ReaderTagType.FOLLOWED,
+        )
+        val errorType = ReaderTagsFeedViewModel.ErrorType.Default
+        val onTagClick = {}
+        val onRetryClick = {}
+        // When
+        val actual = classToTest.mapErrorTagFeedItem(
+            tag = readerTag,
+            errorType = errorType,
+            onTagClick = onTagClick,
+            onRetryClick = onRetryClick,
+        )
+
+        // Then
+        val expected = ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = readerTag,
+                onTagClick = onTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Error(
+                type = errorType,
+                onRetryClick = onRetryClick,
+            )
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should map loading posts UI state correctly`() {
+        // Given
+        val onTagClick = {}
+        val tag1 = ReaderTag(
+            "tag",
+            "tag",
+            "tag",
+            "endpoint",
+            ReaderTagType.FOLLOWED,
+        )
+        val tag2 = ReaderTag(
+            "tag2",
+            "tag2",
+            "tag2",
+            "endpoint2",
+            ReaderTagType.FOLLOWED,
+        )
+        val tags = listOf(tag1, tag2)
+
+        // When
+        val actual = classToTest.mapLoadingPostsUiState(
+            tags = tags,
+            onTagClick = onTagClick,
+        )
+
+        // Then
+        val expected = ReaderTagsFeedViewModel.UiState.Loaded(
+            data = listOf(
+                ReaderTagsFeedViewModel.TagFeedItem(
+                    tagChip = ReaderTagsFeedViewModel.TagChip(
+                        tag = tag1,
+                        onTagClick = onTagClick,
+                    ),
+                    postList = ReaderTagsFeedViewModel.PostList.Loading,
+                ),
+                ReaderTagsFeedViewModel.TagFeedItem(
+                    tagChip = ReaderTagsFeedViewModel.TagChip(
+                        tag = tag2,
+                        onTagClick = onTagClick,
+                    ),
+                    postList = ReaderTagsFeedViewModel.PostList.Loading,
+                )
+            )
+        )
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
Fixes #20624 

https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/b5a79353-49f6-47b8-8366-5836f3388106

-----

## To Test:

- Install JP and sign in.
- Open "Reader".
- 🔍  Select "Tags" feed: loading, loaded, error and empty states should be displayed correctly ([actions not working yet](https://github.com/wordpress-mobile/WordPress-Android/issues/20670)).

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Updated `ReaderTagsFeedViewModelTest.kt` and implemented `ReaderTagsFeedUiStateMapperTest.kt`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
