### PR TITLE
Bump Tracks to `5.0.0`

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -564,6 +564,8 @@ dependencies {
     // Cascade - Compose nested menu
     implementation "me.saket.cascade:cascade-compose:2.3.0"
 
+    implementation "com.automattic.tracks:crashlogging:$automatticTracksVersion"
+
     // - Flipper
     debugImplementation ("com.facebook.flipper:flipper:$flipperVersion") {
         exclude group:'org.jetbrains.kotlinx', module:'kotlinx-serialization-json-jvm'

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -283,6 +283,7 @@ class AppInitializer @Inject constructor(
     }
 
     fun init() {
+        crashLogging.initialize()
         dispatcher.register(this)
         appConfig.init(appScope)
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     // libs
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
-    automatticTracksVersion = '4.0.2'
+    automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
     wordPressFluxCVersion = '2.77.0'

--- a/libs/editor/build.gradle
+++ b/libs/editor/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation "com.google.android.material:material:$googleMaterialVersion"
     implementation "com.android.volley:volley:$androidVolleyVersion"
     implementation "com.google.code.gson:gson:$googleGsonVersion"
-    implementation "com.automattic:Automattic-Tracks-Android:$automatticTracksVersion"
+    implementation "com.automattic.tracks:crashlogging:$automatticTracksVersion"
 
     lintChecks "org.wordpress:lint:$wordPressLintVersion"
 }


### PR DESCRIPTION
This PR bumps Tracks to `5.0.0`, addressing breaking changes.

-----

## To Test:

### WordPress

1. Add `CrashLogging#sendReport` somewhere in the app
2. Run the build in release mode
3. Verify that Sentry received the report

### Jetpack
Do as above but for Jetpack.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Sentry initialization

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

6. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
