### PR TITLE
Profile every 100th performance transaction

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1148,8 +1148,6 @@
             android:label="@string/site_monitoring"
             android:theme="@style/WordPress.NoActionBar"/>
 
-        <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />
-
     </application>
     <queries>
         <intent>

--- a/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfig.kt
@@ -18,7 +18,14 @@ class WPPerformanceMonitoringConfig @Inject constructor(
         return when {
             hasUserOptedOut || buildConfigWrapper.isDebug() -> PerformanceMonitoringConfig.Disabled
             sampleRate <= 0.0 || sampleRate > 1.0 -> PerformanceMonitoringConfig.Disabled
-            else -> PerformanceMonitoringConfig.Enabled(sampleRate)
+            else -> PerformanceMonitoringConfig.Enabled(
+                sampleRate = sampleRate,
+                profilesSampleRate = RELATIVE_PROFILES_SAMPLE_RATE
+            )
         }
+    }
+
+    companion object {
+        const val RELATIVE_PROFILES_SAMPLE_RATE = 0.01
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/crashlogging/WPPerformanceMonitoringConfigTest.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.mock
 import org.wordpress.android.util.config.RemoteConfigWrapper
+import org.wordpress.android.util.crashlogging.WPPerformanceMonitoringConfig.Companion.RELATIVE_PROFILES_SAMPLE_RATE
 
 private const val VALID_SAMPLE_RATE = 0.01
 private const val INVALID_SAMPLE_RATE = 0.0
@@ -49,7 +50,12 @@ class WPPerformanceMonitoringConfigTest {
 
         val result = sut.invoke()
 
-        assertThat(result).isEqualTo(PerformanceMonitoringConfig.Enabled(VALID_SAMPLE_RATE))
+        assertThat(result).isEqualTo(
+            PerformanceMonitoringConfig.Enabled(
+                VALID_SAMPLE_RATE,
+                RELATIVE_PROFILES_SAMPLE_RATE
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
This PR enabled Sentry Profiling with frequency of each 100th performance transaction.

-----

## To Test:

Not needed - we should see some profiles in release 24.9.

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
