### PR TITLE
[Crash Fix] Update FluxC version to fix crash related to Woo DB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
-    wordPressFluxCVersion = '3000-4ad5eeeeda4c5db74d75fd405fa5d19250ed0501'
+    wordPressFluxCVersion = '2.77.1'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
-    wordPressFluxCVersion = '2.77.0'
+    wordPressFluxCVersion = '3000-4ad5eeeeda4c5db74d75fd405fa5d19250ed0501'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
FluxC PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3000

Internal Ref: p1714495849353259-slack-C0180B5PRJ4

FluxC `2.77.0` introduces a crash for WordPress/Jetpack since a DB migration tries to update a table that only exists in WooCommerce. This PR points to a FluxC version fixing this issue, which adds the required checks before trying to update that non-existent table.

-----

## To Test:
Make sure to use Jalapeno Debug versions so you can use the builds generated by the CI for testing this, though the previous installed versions will likely have to be compiled locally.

1. Install an old working version of Jetpack that is not from the `release/24.8` branch
2. Open the app, log in, use it for a bit (create draft posts, go to Reader and save posts for later, etc)
3. Install a version of Jetpack from `release/24.8` branch (after commit 47cf3cb6b854f44752f28405da424f1e6dee41da)
4. Try to open the app
5. **Verify** it crashes on startup
6. Install the Jetpack version from this PR
7. Open the app
8. **Verify** it opens
9. Use the app
10. **Verify** the app is still logged in with the same account from the last working version
11. **Verify** the app data is still the same as well

Note: do not uninstall the app nor clear data between the testing steps.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

13. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

14. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [x] WordPress.com sites and self-hosted Jetpack sites.