### PR TITLE
Disable adding logs as breadcrumbs to Sentry

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -432,17 +432,6 @@ class AppInitializer @Inject constructor(
             AppLog.enableRecording(false)
             AppLog.e(T.UTILS, "Error enabling log file persistence", e)
         }
-        AppLog.addListener { tag, logLevel, message ->
-            val sb = StringBuffer()
-            sb.append(logLevel.toString())
-                .append("/")
-                .append(AppLog.TAG)
-                .append("-")
-                .append(tag.toString())
-                .append(": ")
-                .append(message)
-            crashLogging.recordEvent(sb.toString(), null)
-        }
     }
 
     private fun sanitizeMediaUploadStateForSite() {


### PR DESCRIPTION
To increase user privacy. We should use Encrypted Logging for this, which already contains these logs (+ more)

-----

## To Test:

Not needed - from now on Sentry breadcrumbs won't show application logs. But we still have access to them from Encrypted Logs.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - none

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - none

3. What automated tests I added (or what prevented me from doing so)

    - none

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
