### PR TITLE
Fixes: ActivityNotFoundException for camera

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -795,6 +795,10 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
         mMediaCapturePath = mediaCapturePath;
     }
 
+    @Override public void onCameraError(String errorMessage) {
+        ToastUtils.showToast(this, errorMessage, LONG);
+    }
+
     private void showMediaToastError(@StringRes int message, @Nullable String messageDetail) {
         if (isFinishing()) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerActivity.kt
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.posts.editor.ImageEditorTracker
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MEDIA
+import org.wordpress.android.util.ToastUtils
 import org.wordpress.android.util.WPMediaUtils
 import org.wordpress.android.util.extensions.getSerializableCompat
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
@@ -316,7 +317,23 @@ class MediaPickerActivity : LocaleAwareActivity(), MediaPickerListener {
                 startActivityForResult(buildIntent(this, action.mediaPickerSetup, site, localPostId), PHOTO_PICKER)
             }
             OpenCameraForPhotos -> {
-                WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID) { mediaCapturePath = it }
+                WPMediaUtils.launchCamera(
+                    this,
+                    BuildConfig.APPLICATION_ID,
+                    object : WPMediaUtils.LaunchCameraCallback {
+                        override fun onMediaCapturePathReady(mediaCapturePath: String?) {
+                            this@MediaPickerActivity.mediaCapturePath = mediaCapturePath
+                        }
+
+                        override fun onCameraError(errorMessage: String?) {
+                            ToastUtils.showToast(
+                                this@MediaPickerActivity,
+                                errorMessage,
+                                ToastUtils.Duration.SHORT
+                            )
+                        }
+                    }
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -34,6 +34,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.WPMediaUtils.LaunchCameraCallback;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -230,7 +231,20 @@ public class PhotoPickerActivity extends LocaleAwareActivity
 
     private void launchCameraForImage() {
         WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID,
-                mediaCapturePath -> mMediaCapturePath = mediaCapturePath);
+                new LaunchCameraCallback() {
+                    @Override
+                    public void onMediaCapturePathReady(String mediaCapturePath) {
+                        // Handle the path for the captured media
+                        mMediaCapturePath = mediaCapturePath;
+                    }
+
+                    @Override
+                    public void onCameraError(String errorMessage) {
+                        // Handle the error, e.g., display an error message to the user
+                        ToastUtils.showToast(PhotoPickerActivity.this, errorMessage);
+                    }
+                }
+        );
     }
 
     private void launchPictureLibrary(boolean multiSelect) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2648,9 +2648,23 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     private fun launchCamera() {
-        WPMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID) { mediaCapturePath ->
-            this.mediaCapturePath = mediaCapturePath
-        }
+        WPMediaUtils.launchCamera(
+            this,
+            BuildConfig.APPLICATION_ID,
+            object : WPMediaUtils.LaunchCameraCallback {
+                override fun onMediaCapturePathReady(mediaCapturePath: String?) {
+                  this@EditPostActivity.mediaCapturePath = mediaCapturePath
+                }
+
+                override fun onCameraError(errorMessage: String?) {
+                    ToastUtils.showToast(
+                        this@EditPostActivity,
+                        errorMessage,
+                        ToastUtils.Duration.SHORT
+                    )
+                }
+            }
+        )
     }
 
     private fun setPostContentFromShareAction() {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -48,6 +48,8 @@ import java.util.List;
 public class WPMediaUtils {
     public interface LaunchCameraCallback {
         void onMediaCapturePathReady(String mediaCapturePath);
+
+        void onCameraError(String errorMessage);
     }
 
     // 3000px is the utmost max resolution you can set in the picker but 2000px is the default max for optimized images.
@@ -300,7 +302,13 @@ public class WPMediaUtils {
     public static void launchCamera(Activity activity, String applicationId, LaunchCameraCallback callback) {
         Intent intent = prepareLaunchCamera(activity, applicationId, callback);
         if (intent != null) {
-            activity.startActivityForResult(intent, RequestCodes.TAKE_PHOTO);
+            // Check if there is an app that can handle the camera intent
+            if (intent.resolveActivity(activity.getPackageManager()) != null) {
+                activity.startActivityForResult(intent, RequestCodes.TAKE_PHOTO);
+            } else {
+                // Handle the case where no camera app is available
+                callback.onCameraError(activity.getString(R.string.error_no_camera_available));
+            }
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2084,6 +2084,7 @@
     <string name="error_browser_no_network">Unable to load this page right now.</string>
     <string name="error_network_connection">Check your network connection and try again.</string>
     <string name="error_update_site_title_network">Couldn\'t update site title. Check your network connection and try again.</string>
+    <string name="error_no_camera_available">No camera app available.</string>
 
     <!-- Post Error -->
     <string name="error_unknown_post">Could not find the post on the server</string>


### PR DESCRIPTION
Fixes #20279

This PR tries to fix the crash reported in this Sentry [issue](https://a8c.sentry.io/issues/5005511301/?project=1438088&referrer=github_integration). 

This seems to be a minor crash that occurs when a device is trying to launch camera but it cannot access it. 

Adds a `onCameraError(String errorMessage);` function in the `interface LaunchCameraCallback` that can be used also with other camera related errors in the future. 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Check the code
2. Try to launch camera and take a photo from the following screens and verify that everything works as it should
      MediaBrowserActivity
      MediaPickerActivity
      PhotoPickerActivity
      EditPostActivity

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

5. What automated tests I added (or what prevented me from doing so)

    - Relied on the existing tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
