### PR TITLE
Fix: Null Pointer Exception in PublishSettingsViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
@@ -73,8 +73,7 @@ constructor(
         editPostRepository = postRepository
         val startCalendar = postRepository?.takeIf { it.hasPost() }?.let {
             getCurrentPublishDateAsCalendar(it)
-        } ?:
-        localeManagerWrapper.getCurrentCalendar()
+        } ?: localeManagerWrapper.getCurrentCalendar()
         updateDateAndTimeFromCalendar(startCalendar)
         onPostStatusChanged(postRepository?.getPost())
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
@@ -71,8 +71,10 @@ constructor(
 
     open fun start(postRepository: EditPostRepository?) {
         editPostRepository = postRepository
-        val startCalendar = postRepository?.let { getCurrentPublishDateAsCalendar(it) }
-            ?: localeManagerWrapper.getCurrentCalendar()
+        val startCalendar = postRepository?.takeIf { it.hasPost() }?.let {
+            getCurrentPublishDateAsCalendar(it)
+        } ?:
+        localeManagerWrapper.getCurrentCalendar()
         updateDateAndTimeFromCalendar(startCalendar)
         onPostStatusChanged(postRepository?.getPost())
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -450,4 +450,25 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
 
         assertThat(schedulingReminderPeriod).isEqualTo(ONE_HOUR)
     }
+
+    @Test
+    fun `on start sets current date when post not present in the repository`() {
+        var uiModel: PublishUiModel? = null
+        viewModel.onUiModel.observeForever {
+            uiModel = it
+        }
+
+        whenever(editPostRepository.hasPost()).thenReturn(false)
+        whenever(editPostRepository.getPost()).thenReturn(null)
+
+        viewModel.start(editPostRepository)
+
+        assertThat(viewModel.year).isEqualTo(2019)
+        assertThat(viewModel.month).isEqualTo(6)
+        assertThat(viewModel.day).isEqualTo(6)
+        assertThat(viewModel.hour).isEqualTo(10)
+        assertThat(viewModel.minute).isEqualTo(20)
+
+        assertThat(uiModel!!.publishDateLabel).isEqualTo("Immediately")
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditPostPublishSettingsViewModelTest.kt
@@ -95,6 +95,7 @@ class EditPostPublishSettingsViewModelTest : BaseUnitTest() {
             null
         }
         whenever(editPostRepository.getPost()).thenReturn(post)
+        whenever(editPostRepository.hasPost()).thenReturn(true)
     }
 
     @Test


### PR DESCRIPTION
Fixes #20272 

This PR fixes a NPE when accessing `EditPostRepository.dateCreated`. The getter for `dateCreated` uses a `post!!` which will throw a NPE if the post is null. This PR replaces the use of `let` with `takeIf { it.hasPost() } `to ensure we don't call dateCreated when there is no post.

-----

## To Test:
I was unable to recreate the issue, but did write a unit test to validate the new `takeIf` logic.
Please verify that all unit tests pass CI

-----

## Regression Notes

1. Potential unintended areas of impact
Continue to experience the NPE crash

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Add unit test to `EditPostPublishSettingsViewModelTest`

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
