### PR TITLE
Fix blank Views & Visitors detail screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -114,6 +114,9 @@ class ViewsAndVisitorsDetailUseCase constructor(
         }
     }
 
+    private fun getErrorMessage(response: StatsStore.OnStatsFetched<VisitsAndViewsModel>?) =
+        response?.error?.message ?: response?.error?.type?.name
+
     @Suppress("LongMethod")
     override fun buildUiModel(
         domainModel: VisitsAndViewsModel,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -8,6 +8,7 @@ import org.wordpress.android.fluxc.model.stats.LimitMode
 import org.wordpress.android.fluxc.model.stats.time.VisitsAndViewsModel
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.fluxc.network.utils.StatsGranularity.DAYS
+import org.wordpress.android.fluxc.network.utils.StatsGranularity.WEEKS
 import org.wordpress.android.fluxc.store.StatsStore.InsightType.VIEWS_AND_VISITORS
 import org.wordpress.android.fluxc.store.stats.time.VisitsAndViewsStore
 import org.wordpress.android.modules.BG_THREAD
@@ -38,7 +39,6 @@ import javax.inject.Named
 
 @Suppress("LongParameterList")
 class ViewsAndVisitorsDetailUseCase constructor(
-    statsGranularity: StatsGranularity,
     private val visitsAndViewsStore: VisitsAndViewsStore,
     selectedDateProvider: SelectedDateProvider,
     statsSiteProvider: StatsSiteProvider,
@@ -179,7 +179,7 @@ class ViewsAndVisitorsDetailUseCase constructor(
                 )
             )
         } else {
-            selectedDateProvider.onDateLoadingFailed(statsGranularity)
+            selectedDateProvider.onDateLoadingFailed(WEEKS)
             AppLog.e(T.STATS, "There is no data to be shown in the views & visitors block")
         }
         return items
@@ -242,19 +242,17 @@ class ViewsAndVisitorsDetailUseCase constructor(
         private val statsWidgetUpdaters: StatsWidgetUpdaters,
         private val resourceProvider: ResourceProvider
     ) : GranularUseCaseFactory {
-        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) =
-            ViewsAndVisitorsDetailUseCase(
-                granularity,
-                visitsAndViewsStore,
-                selectedDateProvider,
-                statsSiteProvider,
-                statsDateFormatter,
-                viewsAndVisitorsMapper,
-                mainDispatcher,
-                backgroundDispatcher,
-                analyticsTracker,
-                statsWidgetUpdaters,
-                resourceProvider
-            )
+        override fun build(granularity: StatsGranularity, useCaseMode: UseCaseMode) = ViewsAndVisitorsDetailUseCase(
+            visitsAndViewsStore,
+            selectedDateProvider,
+            statsSiteProvider,
+            statsDateFormatter,
+            viewsAndVisitorsMapper,
+            mainDispatcher,
+            backgroundDispatcher,
+            analyticsTracker,
+            statsWidgetUpdaters,
+            resourceProvider
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -180,7 +180,7 @@ class ViewsAndVisitorsDetailUseCase constructor(
             )
         } else {
             selectedDateProvider.onDateLoadingFailed(statsGranularity)
-            AppLog.e(T.STATS, "There is no data to be shown in the overview block")
+            AppLog.e(T.STATS, "There is no data to be shown in the views & visitors block")
         }
         return items
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -218,6 +218,17 @@ class ViewsAndVisitorsDetailUseCase constructor(
 
     data class UiState(val selectedPosition: Int = 0, val visibleLineCount: Int? = null)
 
+    data class ViewsAndVisitorsDetailUiModel(
+        val period: String,
+        val dates: List<VisitsAndViewsModel.PeriodData>,
+        val daysDates: List<VisitsAndViewsModel.PeriodData>
+    ) {
+        constructor(
+            weeksModel: VisitsAndViewsModel,
+            daysModel: VisitsAndViewsModel
+        ) : this(weeksModel.period, weeksModel.dates, daysModel.dates)
+    }
+
     class ViewsAndVisitorsGranularUseCaseFactory
     @Inject constructor(
         @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -77,7 +77,8 @@ class ViewsAndVisitorsDetailUseCase constructor(
                 statsSiteProvider.siteModel,
                 DAYS,
                 LimitMode.Top(VIEWS_AND_VISITORS_ITEMS_TO_LOAD),
-                it
+                it,
+                false
             )
         }
         return if (weeksCachedData != null && daysCachedData != null) {
@@ -110,7 +111,8 @@ class ViewsAndVisitorsDetailUseCase constructor(
                 DAYS,
                 LimitMode.Top(VIEWS_AND_VISITORS_ITEMS_TO_LOAD),
                 it,
-                forced
+                forced,
+                false
             )
         }
         val daysModel = daysResponse?.model
@@ -124,9 +126,9 @@ class ViewsAndVisitorsDetailUseCase constructor(
             }
 
             weeksModel != null &&
-                    weeksModel.dates.isNotEmpty() &&
-                    daysModel != null &&
-                    daysModel.dates.isNotEmpty() -> {
+                weeksModel.dates.isNotEmpty() &&
+                daysModel != null &&
+                daysModel.dates.isNotEmpty() -> {
                 selectedDateProvider.onDateLoadingSucceeded(WEEKS)
                 State.Data(ViewsAndVisitorsDetailUiModel(weeksModel, daysModel))
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/granular/usecases/ViewsAndVisitorsDetailUseCase.kt
@@ -143,11 +143,6 @@ class ViewsAndVisitorsDetailUseCase constructor(
             val selectedDate = dateFromProvider ?: availableDates.last()
             val index = availableDates.indexOf(selectedDate)
 
-            selectedDateProvider.selectDate(
-                selectedDate,
-                availableDates.takeLast(visibleLineCount),
-                DAYS
-            )
             val selectedItem = domainModel.dates.getOrNull(index) ?: domainModel.dates.last()
 
             items.add(
@@ -163,7 +158,7 @@ class ViewsAndVisitorsDetailUseCase constructor(
                     domainModel.dates,
                     DAYS,
                     this::onLineSelected,
-                    this::onLineChartDrawn,
+                    {},
                     uiState.selectedPosition,
                     selectedItem.period
                 )
@@ -206,10 +201,6 @@ class ViewsAndVisitorsDetailUseCase constructor(
         }
     }
 
-    private fun onLineChartDrawn(visibleLineCount: Int) {
-        updateUiState { it.copy(visibleLineCount = visibleLineCount) }
-    }
-
     private fun onTopTipsLinkClick() {
         navigateTo(ViewUrl(TOP_TIPS_URL))
     }
@@ -219,7 +210,7 @@ class ViewsAndVisitorsDetailUseCase constructor(
         updateUiState { it.copy(selectedPosition = position) }
     }
 
-    data class UiState(val selectedPosition: Int = 0, val visibleLineCount: Int? = null)
+    data class UiState(val selectedPosition: Int = 0)
 
     data class ViewsAndVisitorsDetailUiModel(
         val period: String,


### PR DESCRIPTION
This fixes the blank screen issue for the Views & Visitors detail screen. 

|before|after|
|-|-|
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ba80dedf-49ad-44fc-a67c-f38be3de0c6c" width=320>|<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/3beebfe9-f579-4017-b360-fa3d7f694edb" width=320>|

> [!TIP]
> **Review tip:** Before consolidating granular tabs, data for the WEEKS tab was always automatically fetched, causing the week dates list to always exist. However, after consolidating granular tabs, weeks are no longer fetched automatically. Consequently, when we open the Views & Visitors detail screen, the screen opens blank because the date selector lacks weeks data. To address this issue, I added an extra endpoint call in `ViewsAndVisitorsDetailUseCase` using weeks granularity. This extra call helps determine dates on the date selector, such as `Apr 29 - May 5`, `Apr 22- Apr 28`... While it may seem redundant to make an extra call solely for fetching week dates, otherwise, we would have to determine weeks on the client by copying the logic to the clients. Additionally, please note that this card is set to be removed once the Subscribers project has been successfully shipped.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Enable stats_traffic_subscribers_tab flag from "Me → Debug settings"
3. Navigate back.
4. Open INSIGHTS tabs from "My Site → Stats".
5. Tap VIEW MORE button on the Views & Visitors card.

-----

## Regression Notes

1. Potential unintended areas of impact

    - The chart on the Views & Visitors detail screen. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Tested manually.

3. What automated tests I added (or what prevented me from doing so)

    - This bug is not a good case for automated tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
