### PR TITLE
Fix: ActivityNotFound on Publish when no calendar activity found

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -83,7 +83,19 @@ abstract class PublishSettingsFragment : Fragment() {
             calIntent.putExtra(Events.TITLE, calendarEvent.title)
             calIntent.putExtra(Events.DESCRIPTION, calendarEvent.description)
             calIntent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, calendarEvent.startTime)
-            startActivity(calIntent)
+            // Check if there's an activity that can handle the intent
+            activity?.let {
+                if (calIntent.resolveActivity(it.packageManager) != null) {
+                    startActivity(calIntent)
+                } else {
+                    ToastUtils.showToast(
+                        context,
+                        getString(R.string.post_settings_no_calendar_app_exists),
+                        SHORT,
+                        Gravity.TOP
+                    )
+                }
+            }
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1793,6 +1793,7 @@
     <string name="post_settings_time_and_date">Date and Time</string>
     <string name="post_settings_notification">Notification</string>
     <string name="post_settings_add_to_calendar">Add to calendar</string>
+    <string name="post_settings_no_calendar_app_exists">No app found to handle the request to add to calendar</string>
     <string name="post_settings_jetpack_social_header">Social Sharing</string>
     <string name="post_settings_jetpack_social_connect_social_profiles_message">Increase your traffic by auto-sharing your posts with your friends on social media.</string>
     <string name="post_settings_jetpack_social_connect_social_profiles_button">Connect accounts</string>


### PR DESCRIPTION
Fixes #18674

This PR adjusts `observeOnAddToCalendar()` to provide better handling when attempting to add an event to the calendar. Previously, the method directly started the calendar intent without checking if there was an app available to handle it.

In this update, a check has been added to verify if there's an activity capable of handling the calendar intent before starting it. A toast will be shown if there is no activity to handle the event.

-----

## To Test:
I was unable to reproduce this without manually editing the name of the intent in the code.
- Download the branch
- Open `PublishSettingsFragment`
- Navigate to `observeOnAddToCalendar` 
- Change `calIntent.setDataAndType(Events.CONTENT_URI, "vnd.android.cursor.item/event")` to `calIntent.setDataAndType(Events.CONTENT_URI, "does_not_exist/event")`
- Build and run the app
- Tap FAB > Blog Post > Add some content
- Tap Publish > Publish Date > Date and Time
- Select a date and time in the future and click OK
- On the Publish Date bottom pane > Tap Add to calendar
- ✅ Verify a toast is shown stating "No app found to handle the request to add to calendar"

-----

## Regression Notes

1. Potential unintended areas of impact
The app continues to crash if the activity is not found

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
