### PR TITLE
Add total subscribers count to subscribers detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCase.kt
@@ -24,8 +24,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.lists.sections.subscribers.usecases.SubscribersUseCase.SubscribersUiState
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
+import org.wordpress.android.ui.stats.refresh.utils.MILLION
 import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import javax.inject.Inject
@@ -37,6 +39,7 @@ class SubscribersUseCase @Inject constructor(
     private val followersStore: FollowersStore,
     private val statsSiteProvider: StatsSiteProvider,
     private val statsSinceLabelFormatter: StatsSinceLabelFormatter,
+    private val statsUtils: StatsUtils,
     private val analyticsTracker: AnalyticsTrackerWrapper,
     private val useCaseMode: UseCaseMode,
     private val contentDescriptionHelper: ContentDescriptionHelper
@@ -75,6 +78,16 @@ class SubscribersUseCase @Inject constructor(
 
     override fun buildUiModel(domainModel: FollowersModel, uiState: SubscribersUiState): List<BlockListItem> {
         val items = mutableListOf<BlockListItem>()
+
+        if (useCaseMode == VIEW_ALL) {
+            items.add(Title(R.string.stats_view_total_subscribers))
+            items.add(
+                BlockListItem.ValueWithChartItem(
+                    value = statsUtils.toFormattedString(domainModel.totalCount, MILLION),
+                    extraBottomMargin = true
+                )
+            )
+        }
 
         if (useCaseMode == UseCaseMode.BLOCK) {
             items.add(buildTitle())
@@ -138,6 +151,7 @@ class SubscribersUseCase @Inject constructor(
         private val followersStore: FollowersStore,
         private val statsSiteProvider: StatsSiteProvider,
         private val statsSinceLabelFormatter: StatsSinceLabelFormatter,
+        private val statsUtils: StatsUtils,
         private val analyticsTracker: AnalyticsTrackerWrapper,
         private val contentDescriptionHelper: ContentDescriptionHelper
     ) : InsightUseCaseFactory {
@@ -147,6 +161,7 @@ class SubscribersUseCase @Inject constructor(
             followersStore,
             statsSiteProvider,
             statsSinceLabelFormatter,
+            statsUtils,
             analyticsTracker,
             useCaseMode,
             contentDescriptionHelper

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCaseTest.kt
@@ -34,6 +34,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.subscribers.usecase
 import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSinceLabelFormatter
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
+import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import java.util.Date
 
@@ -44,6 +45,9 @@ class SubscribersUseCaseTest : BaseUnitTest() {
 
     @Mock
     lateinit var statsSinceLabelFormatter: StatsSinceLabelFormatter
+
+    @Mock
+    lateinit var statsUtils: StatsUtils
 
     @Mock
     lateinit var statsSiteProvider: StatsSiteProvider
@@ -79,11 +83,13 @@ class SubscribersUseCaseTest : BaseUnitTest() {
             store,
             statsSiteProvider,
             statsSinceLabelFormatter,
+            statsUtils,
             tracker,
             contentDescriptionHelper
         )
         useCase = useCaseFactory.build(BLOCK)
         whenever(statsSinceLabelFormatter.getSinceLabelLowerCase(dateSubscribed)).thenReturn(sinceLabel)
+        whenever(statsUtils.toFormattedString(any<Int>(), any())).then { (it.arguments[0] as Int).toString() }
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(contentDescriptionHelper.buildContentDescription(any(), any<String>(), any()))
             .thenReturn(contentDescription)
@@ -159,7 +165,7 @@ class SubscribersUseCaseTest : BaseUnitTest() {
         useCase.liveData.observeForever { if (it != null) updatedResult = it }
 
         button.loadMore()
-        assertThat(updatedResult.data).hasSize(12)
+        assertThat(updatedResult.data).hasSize(14)
     }
 
     private suspend fun loadFollowers(refresh: Boolean, forced: Boolean = false): UseCaseModel {
@@ -176,19 +182,19 @@ class SubscribersUseCaseTest : BaseUnitTest() {
     }
 
     private fun List<BlockListItem>.assertViewAllFollowersFirstLoad(): LoadingItem {
-        assertThat(this).hasSize(12)
-        assertThat(this[0]).isEqualTo(Header(R.string.stats_name_label, R.string.stats_subscriber_since_label))
-        val follower = this[1] as ListItemWithIcon
+        assertThat(this).hasSize(14)
+        assertThat(this[2]).isEqualTo(Header(R.string.stats_name_label, R.string.stats_subscriber_since_label))
+        val follower = this[3] as ListItemWithIcon
         assertThat(follower.iconUrl).isEqualTo(avatar)
         assertThat(follower.iconStyle).isEqualTo(AVATAR)
         assertThat(follower.text).isEqualTo(user)
         assertThat(follower.value).isEqualTo(sinceLabel)
         assertThat(follower.contentDescription).isEqualTo(contentDescription)
 
-        assertThat(this[10] is ListItemWithIcon).isTrue()
+        assertThat(this[12] is ListItemWithIcon).isTrue()
 
-        assertThat(this[11] is LoadingItem).isTrue()
-        return this[11] as LoadingItem
+        assertThat(this[13] is LoadingItem).isTrue()
+        return this[13] as LoadingItem
     }
 
     private fun List<BlockListItem>.assertFollowers() {


### PR DESCRIPTION
This adds the total subscribers count to the detail screen of the Subscribers card.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/624defa9-e7f0-4a69-8031-859d13b18fde" width=320>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Enable stats_traffic_subscribers_tab flag from "Me → Debug settings"
3. Navigate back.
4. Open Subscriber tabs from "My Site → Stats".
5. Tap the View more button on the Subscribers card.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated `SubscribersUseCaseTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
