### PR TITLE
Fixes: publish post when device time is set manually

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
-    wordPressFluxCVersion = 'trunk-06ee04c35bda0fce542fcf9899b9f2c7bd5ba2ec'
+    wordPressFluxCVersion = '3003-c8422320abc782bc4d8a67cb17759e24582e18dd'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.2'
-    wordPressFluxCVersion = '3003-c8422320abc782bc4d8a67cb17759e24582e18dd'
+    wordPressFluxCVersion = 'trunk-eceaa9130d4307fc213d7acdad334104b8e57b16'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
Fixes #17375

This is a testing PR for the FluxC PR [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3003). 

Testing instructions there.