### PR TITLE
 Updates: the interval between saving editor changes to DB

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/StorePostViewModel.kt
@@ -40,7 +40,7 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
-private const val CHANGE_SAVE_DELAY = 500L
+private const val CHANGE_SAVE_DELAY = 1000L
 private const val MAX_UNSAVED_POSTS = 50
 
 class StorePostViewModel


### PR DESCRIPTION
### Partially Fixes the performance issue described in the 
#19630 

## Description
This PR increases the delay in saving the post to db. To be exact, the `CHANGE_SAVE_DELAY` value.   The pages list is refreshed everytime, there is a change in the editor which is not good. Tried to fix it, but this opened a lot of issues. 


-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Test the editing experience and see if the post is updated properly


-----

## Regression Notes

1. Potential unintended areas of impact
Editing doesn't work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
