### PR TITLE
[Reader] Fix post link deeplinks not loading properly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -290,14 +290,16 @@ public class ReaderPostActions {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
-                ReaderPost post = ReaderPost.fromJson(jsonObject);
                 new Thread(() -> {
+                    ReaderPost post = ReaderPost.fromJson(jsonObject);
+
                     ReaderPostTable.addPost(post);
                     handlePostLikes(post, jsonObject);
+
+                    if (requestListener != null) {
+                        requestListener.onSuccess(post.getBlogUrl());
+                    }
                 }).start();
-                if (requestListener != null) {
-                    requestListener.onSuccess(post.getBlogUrl());
-                }
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {


### PR DESCRIPTION
Fixes #20754

The issue was introduced in #20642, which just moved the local DB saving to a background thread, keeping the `requestListener` call outside. Having it outside the asynchronous thread execution block causes the callback to be called **BEFORE** the post is added to the table, which results in unexpected behavior, at least for posts opened via deep link.

This is fixed by moving the `requestListener` callback inside the background thread.

@antonis, can you also double-check the code changes here and test if everything still works as expected by the original PR expectations? I ran the test-steps from #20642 and things seem to be working fine.

-----

## To Test:

1. On a different app (e.g.: Slack, Chrome, e-mail) that has a link to a post for a site hosted by WP.com
2. Tap a post link you never opened before (the site must match `*.wordpress.com` to open Jetpack)
3. Verify the Jetpack app opens and shows the post content in the Reader

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):
N/A

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
