### PR TITLE
Update background color for dropdown menus

### DIFF
--- a/WordPress/src/main/res/layout/notification_actions.xml
+++ b/WordPress/src/main/res/layout/notification_actions.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:cardBackgroundColor="?colorSurface"
+    app:cardBackgroundColor="@color/background_dropdown_menu"
     app:cardCornerRadius="@dimen/notifications_popup_radius">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/WordPress/src/main/res/layout/notification_filter_popup.xml
+++ b/WordPress/src/main/res/layout/notification_filter_popup.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    app:cardBackgroundColor="?colorSurface"
+    app:cardBackgroundColor="@color/background_dropdown_menu"
     app:cardCornerRadius="@dimen/notifications_popup_radius">
 
     <LinearLayout

--- a/WordPress/src/main/res/values-night/colors.xml
+++ b/WordPress/src/main/res/values-night/colors.xml
@@ -117,6 +117,7 @@
     <!-- Notifications -->
     <color name="inline_action_filled">@color/jetpack_green_30</color>
     <color name="background_like_header">@color/white_translucent_10</color>
+    <color name="background_dropdown_menu">#282728</color>
 
     <!-- Gravatar Info Banners -->
     <color name="gravatar_info_banner">#1C1C1E</color>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -154,6 +154,7 @@
     <!-- Notifications -->
     <color name="inline_action_filled">@color/jetpack_green_50</color>
     <color name="background_like_header">@color/black_translucent_10</color>
+    <color name="background_dropdown_menu">@color/white</color>
     <color name="divider_likes">#3C3C43</color>
 
     <!-- Gravatar Info Banners -->


### PR DESCRIPTION
This is a follow-up PR for https://github.com/wordpress-mobile/WordPress-Android/pull/20693

The background has been updated for both popup windows of `All Notifications` and `Mark all as read` in dark mode.

| All Notifications | Mark all as read |
|--|--|
| ![Screenshot_20240503-143838](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/66bdd4fd-3b67-4139-9283-9e2d86ddb98d) | ![Screenshot_20240503-143846](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/1769e415-8c86-418a-a0e5-0771b20a1805) |





-----

## To Test:

1. Sign in JP app.
2. Change your theme to dark mode.
3. Go to the tab of Notifications.
4. Click on the overflow menu icon at the top-right corner.
5. The background of the dropdown menu should be updated.
6. Click on `All Notifications`
7. The background of the dropdown menu should be updated.
8. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - n/a

10. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

Skipped

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
