### PR TITLE
Prevent the crash on stats chart that occurs when refreshing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/SubscribersChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/SubscribersChartViewHolder.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.stats.refresh.utils.LargeValueFormatter
 import org.wordpress.android.ui.stats.refresh.utils.LineChartAccessibilityHelper
 import org.wordpress.android.ui.stats.refresh.utils.LineChartAccessibilityHelper.LineChartAccessibilityEvent
 import org.wordpress.android.ui.stats.refresh.utils.SubscribersChartLabelFormatter
+import org.wordpress.android.util.AppLog
 import kotlin.math.max
 import kotlin.math.min
 
@@ -237,7 +238,11 @@ class SubscribersChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
 
     private fun LineChart.resetChart() {
         fitScreen()
-        data?.clearValues()
+        try {
+            data?.clearValues()
+        } catch (e: UnsupportedOperationException) {
+            AppLog.e(AppLog.T.STATS, e)
+        }
         xAxis.valueFormatter = null
         notifyDataSetChanged()
         clear()


### PR DESCRIPTION
The chart was sometimes crashing when refreshing the SUBSCRIBERS tab. This only catches the exception and logs it. I tested the case and ignoring the exception didn't cause a worse state.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Select a site with too many subscribers. _(I'm not sure about this step but you can test this on "en.blog")_
3. Enable stats_traffic_subscribers_tab flag from "Me → Debug settings"
4. Navigate back.
5. Open SUBSCRIBERS tabs from "My Site → Stats".
6. Refresh the page a couple of times.
7. Verify it's not crashing _(you can put a breakpoint on the catch block to ensure you are reproducing the crash)_

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Not a proper PR for automated tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~