### PR TITLE
Fix: NPE when calling autoCreateLinks with null text

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -448,7 +448,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         } else {
             val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
             val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-            val content = migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text))
+            val content = migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text?:""))
             newPostSetup(title, content)
         }
     }


### PR DESCRIPTION
Fixes #20758 

This PR replaces the direct usage of text when calling the `autoCreateLinks` method with a null-safe expression `text ?: ""`. This change ensures that even if text is null, the `autoCreateLinks` method will receive a non-null value, thereby preventing potential NullPointerExceptions.

-----

## To Test:
I am unable to recreate the issue, so please review the code for correctness.

-----

## Regression Notes

1. Potential unintended areas of impact
The app still crashes when the text is null

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
