### PR TITLE
Fix accessibility issue on emails card

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BlockListItem.kt
@@ -168,7 +168,8 @@ sealed class BlockListItem(val type: Type) {
     data class ListItemWithTwoValues(
         val text: String,
         val value1: String,
-        val value2: String
+        val value2: String,
+        val contentDescription: String
     ) : BlockListItem(LIST_ITEM_WITH_TWO_VALUES) {
         override val itemId: Int
             get() = text.hashCode()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithTwoValuesViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/ListItemWithTwoValuesViewHolder.kt
@@ -17,5 +17,6 @@ class ListItemWithTwoValuesViewHolder(parent: ViewGroup) : BlockListItemViewHold
         text.text = item.text
         value1.text = item.value1
         value2.text = item.value2
+        itemView.contentDescription = item.contentDescription
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/ContentDescriptionHelper.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.refresh.utils
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
+import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListHeader
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.viewmodel.ResourceProvider
 import javax.inject.Inject
@@ -12,6 +13,17 @@ class ContentDescriptionHelper
     fun buildContentDescription(header: Header, key: String, value: Any): String {
         return buildContentDescription(header.startLabel, key, header.endLabel, value)
     }
+
+    fun buildContentDescription(header: ListHeader, key: String, value1: String, value2: String) =
+        resourceProvider.getString(
+            R.string.stats_list_item_with_two_values_description,
+            resourceProvider.getString(header.label),
+            key,
+            resourceProvider.getString(header.valueLabel1),
+            value1,
+            resourceProvider.getString(header.valueLabel2),
+            value2
+        )
 
     fun buildContentDescription(
         @StringRes keyLabel: Int,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1050,6 +1050,7 @@
     <string name="stats_item_expanded">Item expanded</string>
     <string name="stats_item_collapsed">Item collapsed</string>
     <string name="stats_list_item_description">%1$s: %2$s, %3$s: %4$s</string>
+    <string name="stats_list_item_with_two_values_description">%1$s: %2$s, %3$s: %4$s, %5$s: %6$s</string>
     <string name="stats_bar_chart_accessibility_entry">%1$s, %2$d %3$s</string>
     <string name="stats_bar_chart_accessibility_overlapping_entry">  &amp; %1$d %2$s</string>
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/EmailsUseCaseTest.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListH
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_HEADER
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
+import org.wordpress.android.ui.stats.refresh.utils.ContentDescriptionHelper
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
@@ -46,10 +47,14 @@ class EmailsUseCaseTest : BaseUnitTest() {
     @Mock
     lateinit var tracker: AnalyticsTrackerWrapper
 
+    @Mock
+    lateinit var contentDescriptionHelper: ContentDescriptionHelper
+
     private lateinit var useCase: EmailsUseCase
     private val itemsToLoad = 30
     private val firstPost = PostsModel.PostModel(1, "post1", "url.com", 10, 20)
     private val secondPost = PostsModel.PostModel(2, "post2", "url2.com", 30, 40)
+    private val contentDescription = "latest emails, opens, clicks"
 
     @Before
     fun setUp() {
@@ -59,11 +64,14 @@ class EmailsUseCaseTest : BaseUnitTest() {
             emailsStore,
             statsSiteProvider,
             statsUtils,
+            contentDescriptionHelper,
             tracker,
             BLOCK
         )
         whenever(statsSiteProvider.siteModel).thenReturn(site)
         whenever(statsUtils.toFormattedString(any<Int>(), any())).then { (it.arguments[0] as Int).toString() }
+        whenever(contentDescriptionHelper.buildContentDescription(any(), any<String>(), any<String>(), any<String>()))
+            .thenReturn(contentDescription)
     }
 
     @Test


### PR DESCRIPTION
This fixed the accessibility issue on emails card.

Before, Talkback was reading only the email's title. Now it reads "Lates emails: My email title, Opens: 1, Clicks: 1"

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Enable Talkback from device's system settings.
2. Log in.
3. Open SUBSCRIBERS tab from "My Site → Stats".
4. Select an email item from the Emails card.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated `EmailsUseCaseTest`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [x] Talkback.
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
