### PR TITLE
[Post List] Make "more" button focusable by screen readers

### DIFF
--- a/WordPress/src/main/res/layout/post_list_item.xml
+++ b/WordPress/src/main/res/layout/post_list_item.xml
@@ -46,7 +46,6 @@
             android:id="@+id/more"
             android:layout_width="@dimen/post_list_more_icon_size"
             android:layout_height="@dimen/post_list_more_icon_size"
-            android:importantForAccessibility="no"
             android:src="@drawable/gb_ic_more_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             android:background="?attr/selectableItemBackgroundBorderless"


### PR DESCRIPTION
Fixes #20770 

Make the "more" button important for accessibility, so it can be focused and used by users that use screen readers for navigation. To close the popup the user needs to perform a screen reader back gesture, which is expected (all other overflow menus have this behavior).

https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/94308f30-31f1-4ed5-bd1f-2cc388694076

-----

## To Test:
With Talkback on:

1. Open Jetpack/Wordpress
2. Go to the Post List
3. Navigate using talkback
4. **Verify** the more button for each post in the list is focusable
5. Interact with the more button
6. **Verify** it's possible to navigate and select items from the popup menu

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

8. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [x] Talkback.
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
