### PR TITLE
Avoid tracking page accessed on static posters in the WP app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -136,13 +136,13 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         when (pageType) {
             PageType.MY_SITE -> analyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, site)
             PageType.READER -> {
-                if (!shouldShowStaticPage()) {
+                if (arePosterizedPagesVisible()) {
                     analyticsTrackerWrapper.track(AnalyticsTracker.Stat.READER_ACCESSED)
                 }
             }
 
             PageType.NOTIFS -> {
-                if (!shouldShowStaticPage()) {
+                if (arePosterizedPagesVisible()) {
                     analyticsTrackerWrapper.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED)
                 }
             }
@@ -178,6 +178,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     fun getPhaseFourOverlayFrequency(): Int {
         return jetpackPhaseFourOverlayFrequencyConfig.getValue()
     }
+
+    private fun arePosterizedPagesVisible() = !shouldShowStaticPage()
 }
 // Global overlay frequency is the frequency at which the overlay is shown across the features
 // no matter which feature was accessed last time

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelper.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.jetpackoverlay
 
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
@@ -9,7 +11,9 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseS
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseStaticPosters
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
+import org.wordpress.android.ui.main.WPMainNavigationView.PageType
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
@@ -40,7 +44,8 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
     private val jetpackFeatureRemovalNewUsersConfig: JetpackFeatureRemovalNewUsersConfig,
     private val jetpackFeatureRemovalSelfHostedUsersConfig: JetpackFeatureRemovalSelfHostedUsersConfig,
     private val jetpackFeatureRemovalStaticPostersConfig: JetpackFeatureRemovalStaticPostersConfig,
-    private val jetpackPhaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig
+    private val jetpackPhaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
 ) {
     fun getCurrentPhase(): JetpackFeatureRemovalPhase? {
         return if (buildConfigWrapper.isJetpackApp) null
@@ -123,6 +128,26 @@ class JetpackFeatureRemovalPhaseHelper @Inject constructor(
         return when (currentPhase) {
             is PhaseStaticPosters -> true
             is PhaseOne, PhaseTwo, PhaseThree, PhaseFour, PhaseNewUsers, PhaseSelfHostedUsers -> false
+        }
+    }
+
+    @JvmOverloads
+    fun trackPageAccessedEventIfNeeded(pageType: PageType, site: SiteModel? = null) {
+        when (pageType) {
+            PageType.MY_SITE -> analyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, site)
+            PageType.READER -> {
+                if (!shouldShowStaticPage()) {
+                    analyticsTrackerWrapper.track(AnalyticsTracker.Stat.READER_ACCESSED)
+                }
+            }
+
+            PageType.NOTIFS -> {
+                if (!shouldShowStaticPage()) {
+                    analyticsTrackerWrapper.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED)
+                }
+            }
+
+            PageType.ME -> analyticsTrackerWrapper.track(AnalyticsTracker.Stat.ME_ACCESSED)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1301,19 +1301,19 @@ public class WPMainActivity extends LocaleAwareActivity implements
         switch (pageType) {
             case MY_SITE:
                 ActivityId.trackLastActivity(ActivityId.MY_SITE);
-                mAnalyticsTrackerWrapper.track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, getSelectedSite());
+                mJetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(PageType.MY_SITE, getSelectedSite());
                 break;
             case READER:
                 ActivityId.trackLastActivity(ActivityId.READER);
-                AnalyticsTracker.track(AnalyticsTracker.Stat.READER_ACCESSED);
+                mJetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(PageType.READER);
                 break;
             case NOTIFS:
                 ActivityId.trackLastActivity(ActivityId.NOTIFICATIONS);
-                AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED);
+                mJetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(PageType.NOTIFS);
                 break;
             case ME:
                 ActivityId.trackLastActivity(ActivityId.ME);
-                AnalyticsTracker.track(Stat.ME_ACCESSED);
+                mJetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(PageType.ME);
                 break;
             default:
                 break;

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -220,7 +221,7 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
 
         jetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(WPMainNavigationView.PageType.READER)
 
-        verify(analyticsTrackerWrapper, times(0)).track(AnalyticsTracker.Stat.READER_ACCESSED)
+        verify(analyticsTrackerWrapper, never()).track(AnalyticsTracker.Stat.READER_ACCESSED)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackoverlay/JetpackFeatureRemovalPhaseHelperTest.kt
@@ -8,8 +8,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseFour
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseNewUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseOne
@@ -18,7 +22,9 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseT
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhase.PhaseSelfHostedUsers
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_ONE
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalSiteCreationPhase.PHASE_TWO
+import org.wordpress.android.ui.main.WPMainNavigationView
 import org.wordpress.android.util.BuildConfigWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.config.JetpackFeatureRemovalNewUsersConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseFourConfig
 import org.wordpress.android.util.config.JetpackFeatureRemovalPhaseOneConfig
@@ -58,6 +64,9 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
     @Mock
     private lateinit var phaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig
 
+    @Mock
+    private lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
     private lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
 
     @Before
@@ -71,7 +80,8 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
             jetpackFeatureRemovalNewUsersConfig,
             jetpackFeatureRemovalSelfHostedUsersConfig,
             jetpackFeatureRemovalStaticPostersConfig,
-            phaseFourOverlayFrequencyConfig
+            phaseFourOverlayFrequencyConfig,
+            analyticsTrackerWrapper
         )
     }
 
@@ -183,5 +193,42 @@ class JetpackFeatureRemovalPhaseHelperTest : BaseUnitTest() {
         val currentPhase = jetpackFeatureRemovalPhaseHelper.getSiteCreationPhase()
 
         assertEquals(currentPhase, PHASE_TWO)
+    }
+
+    @Test
+    fun `given it is the Jetpack app, when we track reader accessed event, then the proper event is tracked`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(true)
+
+        jetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(WPMainNavigationView.PageType.READER)
+
+        verify(analyticsTrackerWrapper, times(1)).track(AnalyticsTracker.Stat.READER_ACCESSED)
+    }
+
+    @Test
+    fun `given we do not show static posters, when we track reader accessed event, then the proper event is tracked`() {
+        whenever(buildConfigWrapper.isJetpackApp).thenReturn(false)
+        whenever(jetpackFeatureRemovalStaticPostersConfig.isEnabled()).thenReturn(false)
+
+        jetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(WPMainNavigationView.PageType.READER)
+
+        verify(analyticsTrackerWrapper, times(1)).track(AnalyticsTracker.Stat.READER_ACCESSED)
+    }
+
+    @Test
+    fun `given we do show static posters, when we track reader accessed event, then the event is not tracked`() {
+        whenever(jetpackFeatureRemovalStaticPostersConfig.isEnabled()).thenReturn(true)
+
+        jetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(WPMainNavigationView.PageType.READER)
+
+        verify(analyticsTrackerWrapper, times(0)).track(AnalyticsTracker.Stat.READER_ACCESSED)
+    }
+
+    @Test
+    fun `given we show static posters, when we track my site accessed event, then the proper event is tracked`() {
+        val site = SiteModel()
+
+        jetpackFeatureRemovalPhaseHelper.trackPageAccessedEventIfNeeded(WPMainNavigationView.PageType.MY_SITE, site)
+
+        verify(analyticsTrackerWrapper, times(1)).track(AnalyticsTracker.Stat.MY_SITE_ACCESSED, site)
     }
 }


### PR DESCRIPTION
Fixes #20780

This PR fixes an issue in the WP app where we track notifications and reader accessed events even if we are showing a Jetpack static poster.

Didn't go with a deep refactor but extracted some needed logic into a helper method in `JetpackFeatureRemovalPhaseHelper.kt` and added a minimal set of unit testing coverage.

-----

## To Test:

**WP app**
- install the WP app
- Go to the Notifications/Reader tab (note: afaiu, this should be possible only with existing users by backend logic, not for new users for which those tabs are not available in the first place)
- Check the Jetpack static poster is shown
- Check the `remove_static_poster_displayed` is triggered with source `notifications` or `reader`
- Check the "notifications_accessed" or "reader_accessed" is not triggered.
- Smoke test "_accessed" event for My Site and Me screens and check they are triggered as usual.

**JP app**
- install the JP app
- Go to the Notifications/Reader tab
- Check the Jetpack static poster is not shown
- Check the `remove_static_poster_displayed` is not triggered
- Check the "notifications_accessed" or "reader_accessed" is triggered.
- Smoke test "_accessed" event for My Site and Me screens and check they are triggered as usual.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Main tabs accessed tracking but the change should be safe enough.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Added a minimal set of unit testing coverage

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] ~~Portrait and landscape orientations.~~
- [ ] ~~Light and dark modes.~~
- [ ] ~~Fonts: Larger, smaller and bold text.~~
- [ ] ~~High contrast.~~
- [ ] ~~Talkback.~~
- [ ] ~~Languages with large words or with letters/accents not frequently used in English.~~
- [ ] ~~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~~
- [ ] ~~Large and small screen sizes. (Tablet and smaller phones)~~
- [ ] ~~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~~
