### PR TITLE
Updates Aztec Editor to 2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '4.0.2'
     gutenbergMobileVersion = 'v1.118.0'
-    wordPressAztecVersion = 'v2.1.2'
+    wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.77.1'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/WordPress-Android/pull/20771 bringing the fix from https://github.com/wordpress-mobile/AztecEditor-Android/pull/1080 in `24.8` release.

Considering that this is the only change in [Aztec 2.1.3](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v2.1.3) the update should be safe.

-----

## To Test:

See https://github.com/wordpress-mobile/WordPress-Android/pull/20771

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
