### PR TITLE
Fixes:  Personalization screen not respecting translation or RTL

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -52,9 +52,11 @@ import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
 import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.utils.LocaleAwareComposable
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
 import org.wordpress.android.ui.utils.UiString
+import org.wordpress.android.util.LocaleManager
 
 @AndroidEntryPoint
 class PersonalizationActivity : AppCompatActivity() {
@@ -64,8 +66,14 @@ class PersonalizationActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             AppTheme {
-                viewModel.start()
-                PersonalizationScreen()
+                val language by viewModel.appLanguage.observeAsState("")
+
+                LocaleAwareComposable(
+                    locale = LocaleManager.languageLocale(language),
+                ) {
+                    viewModel.start()
+                    PersonalizationScreen()
+                }
             }
         }
         viewModel.onSelectedSiteMissing.observe(this) { finish() }
@@ -193,7 +201,7 @@ class PersonalizationActivity : AppCompatActivity() {
                             state = shortcutState,
                             actionIcon = R.drawable.ic_personalization_quick_link_remove_circle,
                             actionIconTint = Color(0xFFD63638),
-                            actionButtonClick = { viewModel.removeShortcut(shortcutState)}
+                            actionButtonClick = { viewModel.removeShortcut(shortcutState) }
                         )
                     }
                 }


### PR DESCRIPTION
Fixes #19256 


## Description 
This PR fixes the issue in which the Personalization screen was not reflecting change in app language. RTL or any other language. 


| Before (In arabic language)  |  After | 
|---|---|
| ![1000000357](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/83275af1-b8fa-472f-9538-84c4585dcbad)|![1000000359](https://github.com/wordpress-mobile/WordPress-Android/assets/17463767/c48f7daf-f92f-47d1-aa57-060eb60fad8b)|  

-----

## To Test:

1. Go to the app → me → app settings → languages
2. Change language to an RTL language 
3. Go to Dashboard →Personalize your home tab 
4. Verify that the screen is translated to the RTL language 
5. Verify that the screen supports RTL

-----

## Regression Notes

1. Potential unintended areas of impact
Missing language support on Personalization screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing 

3. What automated tests I added (or what prevented me from doing so)
Manual testing
-----

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] Large and small screen sizes. (Tablet and smaller phones)
- [x] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
