### PR TITLE
Prevents the app from crashing when the user agent has not been initialised

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -68,7 +68,9 @@ public abstract class WebViewActivity extends LocaleAwareActivity {
         mWebView = (WebView) findViewById(R.id.webView);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
         // Setting this user agent makes Calypso sites hide any WordPress UIs (e.g. Masterbar, banners, etc.).
-        mWebView.getSettings().setUserAgentString(mUserAgent.toString());
+        if (mUserAgent != null) {
+            mWebView.getSettings().setUserAgentString(mUserAgent.toString());
+        }
         configureWebView();
 
         if (savedInstanceState == null) {


### PR DESCRIPTION
Fixes #20786

## Description
This PR adds a `null` check preventing the app from crashing when the user agent has not been initialised.
The crash was appeared after the https://github.com/wordpress-mobile/WordPress-Android/pull/20603 fix in 23.7

-----

## To Test:
1. Open the app in a logged out state
2. Tap `Enter your existing site address`
3. Enter a site with an erroneous SSL certificate (you can find one [in the crash reports](https://a8c.sentry.io/issues/5286693126/?referrer=github_integration))
4. Tap `Details`
5. **Verify** that you see the certificate details without a crash


https://github.com/wordpress-mobile/WordPress-Android/assets/304044/d86a3898-390e-4c11-833d-d0a70f8611d6



-----

## Regression Notes

1. Potential unintended areas of impact

    - Login SSL flow

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

8. What automated tests I added (or what prevented me from doing so)

    - Adding a test for the specific case would require changes outside the scope of this PR

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
