### PR TITLE
Fix Total Subscribers count

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/sections/subscribers/usecases/SubscribersUseCaseTest.kt
@@ -103,8 +103,8 @@ class SubscribersUseCaseTest : BaseUnitTest() {
             listOf(FollowerModel(avatar, user, url, dateSubscribed)),
             hasMore = false
         )
-        whenever(store.getWpComFollowers(site, LimitMode.Top(blockPageSize))).thenReturn(model)
-        whenever(store.fetchWpComFollowers(site, blockInitialMode)).thenReturn(OnStatsFetched(model))
+        whenever(store.getFollowers(site, LimitMode.Top(blockPageSize))).thenReturn(model)
+        whenever(store.fetchFollowers(site, blockInitialMode)).thenReturn(OnStatsFetched(model))
 
         val result = loadFollowers(refresh)
 
@@ -115,7 +115,7 @@ class SubscribersUseCaseTest : BaseUnitTest() {
     @Test
     fun `maps empty followers to UI model`() = test {
         val refresh = true
-        whenever(store.fetchWpComFollowers(site, blockInitialMode))
+        whenever(store.fetchFollowers(site, blockInitialMode))
             .thenReturn(OnStatsFetched(model = FollowersModel(0, listOf(), hasMore = false)))
 
         val result = loadFollowers(refresh)
@@ -127,7 +127,7 @@ class SubscribersUseCaseTest : BaseUnitTest() {
     fun `maps error item to UI model`() = test {
         val refresh = true
         val message = "Generic error"
-        whenever(store.fetchWpComFollowers(site, blockInitialMode))
+        whenever(store.fetchFollowers(site, blockInitialMode))
             .thenReturn(OnStatsFetched(StatsError(GENERIC_ERROR, message)))
 
         val result = loadFollowers(refresh)
@@ -145,15 +145,15 @@ class SubscribersUseCaseTest : BaseUnitTest() {
             List(10) { FollowerModel(avatar, user, url, dateSubscribed) },
             hasMore = true
         )
-        whenever(store.getWpComFollowers(site, LimitMode.All)).thenReturn(model)
-        whenever(store.fetchWpComFollowers(site, viewAllInitialLoadMode)).thenReturn(OnStatsFetched(model))
+        whenever(store.getFollowers(site, LimitMode.All)).thenReturn(model)
+        whenever(store.fetchFollowers(site, viewAllInitialLoadMode)).thenReturn(OnStatsFetched(model))
 
         val updatedModel = FollowersModel(
             totalCount,
             List(11) { FollowerModel(avatar, user, url, dateSubscribed) },
             hasMore = false
         )
-        whenever(store.fetchWpComFollowers(site, viewAllMoreLoadMode, true)).thenReturn(OnStatsFetched(updatedModel))
+        whenever(store.fetchFollowers(site, viewAllMoreLoadMode, true)).thenReturn(OnStatsFetched(updatedModel))
 
         val result = loadFollowers(refresh)
 
@@ -198,7 +198,7 @@ class SubscribersUseCaseTest : BaseUnitTest() {
     }
 
     private fun List<BlockListItem>.assertFollowers() {
-        assertThat(this).hasSize(3)
+        assertThat(this).hasSize(4)
         assertTitle(this[0])
         assertThat(this[1]).isEqualTo(Header(R.string.stats_name_label, R.string.stats_subscriber_since_label))
         val follower = this[2] as ListItemWithIcon

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = 'trunk-eceaa9130d4307fc213d7acdad334104b8e57b16'
+    wordPressFluxCVersion = '3006-01bba8478517c6d1d65ed1a0039b9c718d29df84'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.118.0'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = '3006-01bba8478517c6d1d65ed1a0039b9c718d29df84'
+    wordPressFluxCVersion = 'trunk-935a54775a4086640c7ac1c9fcd2d494d8acdf65'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_followers.json
+++ b/libs/mocks/src/main/assets/mocks/mappings/wpcom/stats/stats_followers.json
@@ -1,0 +1,42 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/rest/v1.1/sites/.*/stats/followers/.*",
+    "queryParameters": {
+      "locale": {
+        "matches": "(.*)"
+      },
+      "max": {
+        "matches": "(.*)"
+      },
+      "type": {
+        "equalTo": "all"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "page": 1,
+      "pages": 1,
+      "total": 1,
+      "total_email": 0,
+      "total_wpcom": 1,
+      "subscribers": [
+        {
+          "avatar": "https://0.gravatar.com/avatar/69a6814a8e85942fee3e846b17554972?s=64&amp;d=https%3A%2F%2F0.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D64&amp;r=G",
+          "label": "follower@example.com",
+          "ID": "12345",
+          "url": null,
+          "follow_data": null,
+          "date_subscribed": "2024-05-09T02:46:00+00:00"
+        }
+      ]
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache, must-revalidate, max-age=0"
+    }
+  }
+}


### PR DESCRIPTION
This fixes the wrong Total Subscribers count on the detail screen of the Subscribers card.

Before, email followers were not included in the count. Now, `SubscribersUseCase` will use `all` as the type parameter while fetching followers.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3006 should be merged first.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/ba303d07-d210-4427-b32d-d35df4f78001" width=320>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Select a site that has wpcom and email followers of more than 10.
3. Enable `stats_traffic_subcribers_tab` from "Me → Debug settings"
4. navigate back.
5. Open the SUBSCRIBERS tab from "My Site → Stats"
6. Tap the "View more" button on the Subscribers card.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated current tests

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
