### PR TITLE
[Notifications] Renames follows to subscribers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.kt
@@ -143,7 +143,7 @@ class NotificationsListFragment : Fragment(R.layout.notifications_list_fragment)
                 textFilterAll.setOnClickListener(getFilterClickListener(TabPosition.All, popupWindow))
                 textFilterUnread.setOnClickListener(getFilterClickListener(TabPosition.Unread, popupWindow))
                 textFilterComments.setOnClickListener(getFilterClickListener(TabPosition.Comment, popupWindow))
-                textFilterFollows.setOnClickListener(getFilterClickListener(TabPosition.Follow, popupWindow))
+                textFilterSubscribers.setOnClickListener(getFilterClickListener(TabPosition.Subscribers, popupWindow))
                 textFilterLikes.setOnClickListener(getFilterClickListener(TabPosition.Like, popupWindow))
             }.root
         popupWindow.showAsDropDown(anchorView)

--- a/WordPress/src/main/res/layout/notification_filter_popup.xml
+++ b/WordPress/src/main/res/layout/notification_filter_popup.xml
@@ -50,12 +50,12 @@
             android:textSize="@dimen/text_sz_large" />
 
         <TextView
-            android:id="@+id/text_filter_follows"
+            android:id="@+id/text_filter_subscribers"
             android:layout_width="match_parent"
             android:background="?attr/selectableItemBackground"
             android:layout_height="wrap_content"
             android:padding="@dimen/notifications_item_action_padding"
-            android:text="@string/notifications_tab_title_follows"
+            android:text="@string/notifications_tab_title_subscribers"
             android:textColor="?wpColorOnSurfaceHigh"
             android:textSize="@dimen/text_sz_large" />
 


### PR DESCRIPTION
## Description

This PR fixes a breakage in https://github.com/wordpress-mobile/WordPress-Android/pull/20697/ introduced by renaming "follow" to "subscribe" with https://github.com/wordpress-mobile/WordPress-Android/pull/20769

|Before|After|
|---|---|
|![before](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/b66790d5-dff4-4aa7-8508-6392c6494b19)|![after](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/31a20444-4237-43ae-8685-cd443d2cc743)|

-----

## To Test:

1. Open the notifications tab
2. Tap on the menu
3. Verify that "Follows" has been renamed to "Subscribers"
-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

6. What automated tests I added (or what prevented me from doing so)

    - This PR involves just a copy change

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
