### PR TITLE
Bump to Gravatar-SDK to 0.3.0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -735,7 +735,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 startProgress(false);
                 mAvatarService.upload(file, new Email(mAccountStore.getAccount().getEmail()),
                         Objects.requireNonNull(mAccountStore.getAccessToken()),
-                        new GravatarListener<Unit>() {
+                        new GravatarListener<Unit, ErrorType>() {
                             @Override
                             public void onSuccess(@NonNull Unit response) {
                                 endProgress();
@@ -836,7 +836,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 Uri uri = MediaUtils.downloadExternalMedia(getContext(), Uri.parse(mUrl));
                 File file = new File(new URI(uri.toString()));
                 mAvatarService.upload(file, new Email(mEmail), mToken,
-                        new GravatarListener<Unit>() {
+                        new GravatarListener<Unit, ErrorType>() {
                             @Override
                             public void onSuccess(@NonNull Unit response) {
                                 AppLog.i(T.NUX, "Google avatar download and Gravatar upload succeeded.");

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -680,7 +680,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         }
         binding?.showGravatarProgressBar(true)
         avatarService.upload(file, Email(accountStore.account.email), accountStore.accessToken.orEmpty(),
-            object : GravatarListener<Unit> {
+            object : GravatarListener<Unit, ErrorType> {
                 override fun onSuccess(response: Unit) {
                     AnalyticsTracker.track(ME_GRAVATAR_UPLOADED)
                     EventBus.getDefault().post(GravatarUploadFinished(filePath, true))

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'
-    gravatarVersion = '0.2.0'
+    gravatarVersion = '0.3.0'
 
     // debug
     flipperVersion = '0.245.0'


### PR DESCRIPTION
Fixes #20739

Bump Gravatar-SDK from 0.2.0 to 0.3.0. Version 0.3.0 includes https://github.com/Automattic/Gravatar-SDK-Android/pull/143 that runs the onSuccess and onError callbacks on the UI thread.

cc @hamorillo 

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

3. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

~- [ ] WordPress.com sites and self-hosted Jetpack sites.~
~- [ ] Portrait and landscape orientations.~
~- [ ] Light and dark modes.~
~- [ ] Fonts: Larger, smaller and bold text.~
~- [ ] High contrast.~
~- [ ] Talkback.~
~- [ ] Languages with large words or with letters/accents not frequently used in English.~
~- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
~- [ ] Large and small screen sizes. (Tablet and smaller phones)~
~- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~