### PR TITLE
Fix: Blaze views not respecting translation or RTL

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/BlazeCampaignParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/BlazeCampaignParentActivity.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.blaze.blazecampaigns
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/BlazeCampaignParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/BlazeCampaignParentActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
+import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.campaigndetail.CampaignDetailFragment
 import org.wordpress.android.ui.blaze.blazecampaigns.campaignlisting.CampaignListingFragment
 import org.wordpress.android.util.extensions.getParcelableExtraCompat
@@ -12,7 +13,7 @@ import org.wordpress.android.util.extensions.getParcelableExtraCompat
 const val ARG_EXTRA_BLAZE_CAMPAIGN_PAGE = "blaze_campaign_page"
 
 @AndroidEntryPoint
-class BlazeCampaignParentActivity : AppCompatActivity() {
+class BlazeCampaignParentActivity : LocaleAwareActivity() {
     private val viewModel: CampaignViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteParentActivity.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.blaze.blazepromote
 
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import org.wordpress.android.R
+import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.blaze.BlazeFlowSource
 import org.wordpress.android.ui.blaze.BlazeUIModel
 import org.wordpress.android.ui.blaze.BlazeUiState
@@ -18,7 +18,7 @@ const val ARG_BLAZE_FLOW_SOURCE = "blaze_flow_source"
 const val ARG_BLAZE_SHOULD_SHOW_OVERLAY = "blaze_flow_should_show_overlay"
 
 @AndroidEntryPoint
-class BlazePromoteParentActivity : AppCompatActivity() {
+class BlazePromoteParentActivity : LocaleAwareActivity() {
     private val viewModel: BlazeViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
This PR adjusts the Blaze compose views so they respect translation and RTL . This was accomplished by extending `LocaleAwareActivity` instead of `AppCompatActivity`.  See https://github.com/wordpress-mobile/WordPress-Android/pull/20785#pullrequestreview-2048506200 for a description.

Before | After
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/9dec257d-5d7e-495b-803c-5863cce9af47"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/3e9858bb-8ea7-482a-88f2-f69c11393436">

Before | After
-- | --
<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/f95247a1-5b4f-4fce-a6f3-a332edbf0d28"> | <img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/0f64f654-914c-4594-8767-4a7356ffbc15">
-----


## To Test:
- Go to the app → me → app settings → languages
- Change language to an RTL language or a language not native to you
- Go to Dashboard → Blaze tab
- ✅ Verify that the screen is translated to the RTL language (or the language you chose above)
- ✅ Verify that the screen supports RTL  (or the language you chose above)
- Navigate back to Me > More
- Tap on the Blaze item
- ✅ Verify that the screen is translated to the RTL language  (or the language you chose above)
- ✅  Verify that the screen supports RTL  (or the language you chose above)

-----

## Regression Notes

1. Potential unintended areas of impact
The blaze views do no support language translations or RTL

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Testing

3. What automated tests I added (or what prevented me from doing so)
Manual Testing

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):
- [X] WordPress.com sites and self-hosted Jetpack sites.
- [X] Portrait and landscape orientations.
- [X] Light and dark modes.
- [X] Fonts: Larger, smaller and bold text.
- [X] High contrast.
- [X] Talkback.
- [X] Languages with large words or with letters/accents not frequently used in English.
- [X] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [X] Large and small screen sizes. (Tablet and smaller phones)
- [X] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
