### PR TITLE
[Tags Feed] Implement Post Item UI improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -5,11 +5,13 @@ import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.reader.views.compose.tagsfeed.TagsFeedPostItem
 import org.wordpress.android.util.DateTimeUtilsWrapper
+import org.wordpress.android.util.UrlUtilsWrapper
 import javax.inject.Inject
 
 class ReaderTagsFeedUiStateMapper @Inject constructor(
     private val dateTimeUtilsWrapper: DateTimeUtilsWrapper,
     private val readerUtilsWrapper: ReaderUtilsWrapper,
+    private val urlUtilsWrapper: UrlUtilsWrapper,
 ) {
     @Suppress("LongParameterList")
     fun mapLoadedTagFeedItem(
@@ -27,25 +29,26 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
             onTagClick = onTagClick,
         ),
         postList = ReaderTagsFeedViewModel.PostList.Loaded(
-            posts.map {
+            posts.map { post ->
                 TagsFeedPostItem(
-                    siteName = it.blogName,
+                    siteName = post.blogName.takeIf { it.isNotBlank() }
+                        ?: post.blogUrl.let { urlUtilsWrapper.removeScheme(it) },
                     postDateLine = dateTimeUtilsWrapper.javaDateToTimeSpan(
-                        it.getDisplayDate(dateTimeUtilsWrapper)
+                        post.getDisplayDate(dateTimeUtilsWrapper)
                     ),
-                    postTitle = it.title,
-                    postExcerpt = it.excerpt,
-                    postImageUrl = it.featuredImage,
-                    postNumberOfLikesText = if (it.numLikes > 0) readerUtilsWrapper.getShortLikeLabelText(
-                        numLikes = it.numLikes
+                    postTitle = post.title,
+                    postExcerpt = post.excerpt,
+                    postImageUrl = post.featuredImage,
+                    postNumberOfLikesText = if (post.numLikes > 0) readerUtilsWrapper.getShortLikeLabelText(
+                        numLikes = post.numLikes
                     ) else "",
-                    postNumberOfCommentsText = if (it.numReplies > 0) readerUtilsWrapper.getShortCommentLabelText(
-                        numComments = it.numReplies
+                    postNumberOfCommentsText = if (post.numReplies > 0) readerUtilsWrapper.getShortCommentLabelText(
+                        numComments = post.numReplies
                     ) else "",
-                    isPostLiked = it.isLikedByCurrentUser,
+                    isPostLiked = post.isLikedByCurrentUser,
                     isLikeButtonEnabled = true,
-                    postId = it.postId,
-                    blogId = it.blogId,
+                    postId = post.postId,
+                    blogId = post.blogId,
                     onSiteClick = onSiteClick,
                     onPostCardClick = onPostCardClick,
                     onPostLikeClick = onPostLikeClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -303,7 +303,7 @@ private fun PostListLoaded(
             )
             Box(
                 modifier = Modifier
-                    .height(ReaderTagsFeedComposeUtils.POST_ITEM_HEIGHT)
+                    .height(ReaderTagsFeedComposeUtils.PostItemHeight)
                     .padding(
                         start = Margin.ExtraLarge.value,
                         end = Margin.ExtraLarge.value,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -62,9 +62,6 @@ import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChip
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 
-private const val LOADING_POSTS_COUNT = 5
-val READER_TAGS_FEED_ITEM_HEIGHT = 150.dp // TODO thomashortadev do we want SP? to change based on font size)
-
 @Composable
 fun ReaderTagsFeed(uiState: UiState) {
     Box(
@@ -179,7 +176,7 @@ private fun Loading() {
                     horizontalArrangement = Arrangement.spacedBy(Margin.Large.value),
                     contentPadding = PaddingValues(horizontal = Margin.Large.value),
                 ) {
-                    items(LOADING_POSTS_COUNT) {
+                    items(ReaderTagsFeedComposeUtils.LOADING_POSTS_COUNT) {
                         ReaderTagsFeedPostListItemLoading()
                     }
                 }
@@ -271,7 +268,7 @@ private fun PostListLoading() {
             end = Margin.Large.value
         ),
     ) {
-        items(LOADING_POSTS_COUNT) {
+        items(ReaderTagsFeedComposeUtils.LOADING_POSTS_COUNT) {
             ReaderTagsFeedPostListItemLoading()
         }
     }
@@ -306,7 +303,7 @@ private fun PostListLoaded(
             )
             Box(
                 modifier = Modifier
-                    .height(READER_TAGS_FEED_ITEM_HEIGHT)
+                    .height(ReaderTagsFeedComposeUtils.POST_ITEM_HEIGHT)
                     .padding(
                         start = Margin.ExtraLarge.value,
                         end = Margin.ExtraLarge.value,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -63,6 +63,7 @@ import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
 
 private const val LOADING_POSTS_COUNT = 5
+val READER_TAGS_FEED_ITEM_HEIGHT = 150.dp // TODO thomashortadev do we want SP? to change based on font size)
 
 @Composable
 fun ReaderTagsFeed(uiState: UiState) {
@@ -305,7 +306,7 @@ private fun PostListLoaded(
             )
             Box(
                 modifier = Modifier
-                    .height(340.dp)
+                    .height(READER_TAGS_FEED_ITEM_HEIGHT)
                     .padding(
                         start = Margin.ExtraLarge.value,
                         end = Margin.ExtraLarge.value,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedComposeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedComposeUtils.kt
@@ -1,0 +1,28 @@
+package org.wordpress.android.ui.reader.views.compose.tagsfeed
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
+
+object ReaderTagsFeedComposeUtils {
+    const val LOADING_POSTS_COUNT = 5
+
+    const val POST_ITEM_TITLE_MAX_LINES = 2
+    val POST_ITEM_HEIGHT = 150.dp // TODO thomashortadev do we want SP? to change based on font size)
+    val POST_ITEM_IMAGE_SIZE = 64.dp
+    private val POST_ITEM_MAX_WIDTH = 320.dp
+    private const val POST_ITEM_WIDTH_PERCENTAGE = 0.8f
+
+    val PostItemWidth: Dp
+        @Composable
+        get() {
+            val localConfiguration = LocalConfiguration.current
+            val screenWidth = remember(localConfiguration) {
+                localConfiguration.screenWidthDp.dp
+            }
+            return min((screenWidth * POST_ITEM_WIDTH_PERCENTAGE), POST_ITEM_MAX_WIDTH)
+        }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedComposeUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedComposeUtils.kt
@@ -3,18 +3,28 @@ package org.wordpress.android.ui.reader.views.compose.tagsfeed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
+import androidx.compose.ui.unit.sp
 
 object ReaderTagsFeedComposeUtils {
     const val LOADING_POSTS_COUNT = 5
 
     const val POST_ITEM_TITLE_MAX_LINES = 2
-    val POST_ITEM_HEIGHT = 150.dp // TODO thomashortadev do we want SP? to change based on font size)
     val POST_ITEM_IMAGE_SIZE = 64.dp
+    private val POST_ITEM_HEIGHT = 150.sp // use SP to scale with text size, which is the main content of the item
     private val POST_ITEM_MAX_WIDTH = 320.dp
     private const val POST_ITEM_WIDTH_PERCENTAGE = 0.8f
+
+    val PostItemHeight: Dp
+        @Composable
+        get() {
+            with(LocalDensity.current) {
+                return POST_ITEM_HEIGHT.toDp()
+            }
+        }
 
     val PostItemWidth: Dp
         @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -35,7 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -49,10 +47,7 @@ import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
-private val ITEM_MAX_WIDTH = 320.dp
-private const val ITEM_WIDTH_PERCENTAGE = 0.8f
-private const val CONTENT_MAX_LINES = 3
-private const val TITLE_MAX_LINES = 2
+private const val CONTENT_TOTAL_LINES = 3
 
 @Composable
 fun ReaderTagsFeedPostListItem(
@@ -66,16 +61,10 @@ fun ReaderTagsFeedPostListItem(
         alpha = 0.6F
     )
 
-    val localConfiguration = LocalConfiguration.current
-    val screenWidth = remember(localConfiguration) {
-        localConfiguration.screenWidthDp.dp
-    }
-
     Column(
         modifier = Modifier
-            .widthIn(max = ITEM_MAX_WIDTH)
-            .width(screenWidth * ITEM_WIDTH_PERCENTAGE)
-            .height(READER_TAGS_FEED_ITEM_HEIGHT)
+            .width(ReaderTagsFeedComposeUtils.PostItemWidth)
+            .height(ReaderTagsFeedComposeUtils.POST_ITEM_HEIGHT)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -124,6 +113,7 @@ fun ReaderTagsFeedPostListItem(
             // Post title and excerpt Column
             Column(
                 modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(Margin.Medium.value),
             ) {
                 // TODO thomashortadev improve this to avoid an initial composition with the wrong value
                 var excerptMaxLines by remember { mutableIntStateOf(2) }
@@ -139,13 +129,13 @@ fun ReaderTagsFeedPostListItem(
                     text = postTitle,
                     style = MaterialTheme.typography.titleMedium,
                     color = baseColor,
-                    maxLines = TITLE_MAX_LINES,
+                    maxLines = ReaderTagsFeedComposeUtils.POST_ITEM_TITLE_MAX_LINES,
                     overflow = TextOverflow.Ellipsis,
                     onTextLayout = { layoutResult ->
-                        excerptMaxLines = CONTENT_MAX_LINES - layoutResult.lineCount
+                        excerptMaxLines = CONTENT_TOTAL_LINES - layoutResult.lineCount
                     },
                 )
-                Spacer(Modifier.height(Margin.Medium.value))
+
                 // Post excerpt
                 Text(
                     modifier = Modifier
@@ -173,6 +163,7 @@ fun ReaderTagsFeedPostListItem(
 
         Spacer(Modifier.weight(1f))
 
+        // Likes and comments row
         Row(
             modifier = Modifier
                 .fillMaxWidth(),
@@ -208,6 +199,7 @@ fun ReaderTagsFeedPostListItem(
 
         Spacer(Modifier.height(Margin.Small.value))
 
+        // Actions row
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -277,7 +269,7 @@ fun PostImage(
 ) {
     AsyncImage(
         modifier = modifier
-            .size(64.dp)
+            .size(ReaderTagsFeedComposeUtils.POST_ITEM_IMAGE_SIZE)
             .clip(RoundedCornerShape(corner = CornerSize(8.dp)))
             .clickable { onClick() },
         model = ImageRequest.Builder(LocalContext.current)
@@ -298,12 +290,12 @@ fun ReaderTagsFeedPostListItemPreview() {
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight()
-                .padding(top = 16.dp, bottom = 16.dp)
         ) {
             LazyRow(
                 modifier = Modifier
                     .fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 24.dp),
+                contentPadding = PaddingValues(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(Margin.ExtraMediumLarge.value),
             ) {
                 item {
                     ReaderTagsFeedPostListItem(
@@ -340,7 +332,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
@@ -375,7 +368,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
@@ -396,7 +390,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
@@ -417,7 +412,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
@@ -439,7 +435,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer" +
@@ -461,7 +458,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +
@@ -495,7 +493,8 @@ fun ReaderTagsFeedPostListItemPreview() {
                             onPostMoreMenuClick = {},
                         )
                     )
-                    Spacer(Modifier.width(24.dp))
+                }
+                item {
                     ReaderTagsFeedPostListItem(
                         item = TagsFeedPostItem(
                             siteName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pellentesque" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -49,8 +50,8 @@ import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
-private const val CONTENT_TOTAL_LINES_WITH_INTERACTIONS = 4
-private const val CONTENT_TOTAL_LINES_NO_INTERACTIONS = 5
+private const val CONTENT_TOTAL_LINES = 3
+
 
 @Composable
 fun ReaderTagsFeedPostListItem(
@@ -69,10 +70,13 @@ fun ReaderTagsFeedPostListItem(
     Column(
         modifier = Modifier
             .width(ReaderTagsFeedComposeUtils.PostItemWidth)
-            .height(ReaderTagsFeedComposeUtils.PostItemHeight)
+            .height(ReaderTagsFeedComposeUtils.PostItemHeight),
+        verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .heightIn(min = 24.dp)
+                .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // Site name
@@ -107,8 +111,6 @@ fun ReaderTagsFeedPostListItem(
             )
         }
 
-        Spacer(modifier = Modifier.height(Margin.Small.value))
-
         // Post content row
         Row(
             modifier = Modifier
@@ -124,10 +126,8 @@ fun ReaderTagsFeedPostListItem(
                 onClick = { onPostCardClick(item) },
                 titleColor = baseColor,
                 excerptColor = primaryElementColor,
-                hasInteractions = hasInteractions,
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
+                    .weight(1f),
             )
 
             // Post image
@@ -141,6 +141,8 @@ fun ReaderTagsFeedPostListItem(
 
         // Likes and comments row
         if (hasInteractions) {
+            val interactionTextStyle = MaterialTheme.typography.bodySmall
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth(),
@@ -149,7 +151,7 @@ fun ReaderTagsFeedPostListItem(
                 // Number of likes
                 Text(
                     text = postNumberOfLikesText,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = interactionTextStyle,
                     color = secondaryElementColor,
                     maxLines = 1,
                 )
@@ -161,20 +163,18 @@ fun ReaderTagsFeedPostListItem(
                             horizontal = Margin.Small.value
                         ),
                         text = "•",
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = interactionTextStyle,
                         color = secondaryElementColor,
                     )
                 }
                 // Number of comments
                 Text(
                     text = postNumberOfCommentsText,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = interactionTextStyle,
                     color = secondaryElementColor,
                     maxLines = 1,
                 )
             }
-
-            Spacer(Modifier.height(Margin.Small.value))
         }
 
         // Actions row
@@ -267,18 +267,9 @@ fun PostTextContent(
     excerpt: String,
     titleColor: Color,
     excerptColor: Color,
-    hasInteractions: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val totalLines = remember(hasInteractions) {
-        if (hasInteractions) {
-            CONTENT_TOTAL_LINES_WITH_INTERACTIONS
-        } else {
-            CONTENT_TOTAL_LINES_NO_INTERACTIONS
-        }
-    }
-
     BoxWithConstraints(
         modifier = modifier,
     ) {
@@ -288,28 +279,24 @@ fun PostTextContent(
         }
 
         val textMeasurer = rememberTextMeasurer()
-        val titleLayoutResult = textMeasurer.measure(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            maxLines = ReaderTagsFeedComposeUtils.POST_ITEM_TITLE_MAX_LINES,
-            overflow = TextOverflow.Ellipsis,
-            constraints = Constraints(maxWidth = maxWidthPx),
-        )
-        val titleLines = titleLayoutResult.lineCount
+        val titleStyle = MaterialTheme.typography.titleMedium
 
-        // Check if excerpt is ellipsized
-        val excerptMaxLines = totalLines - titleLines
-        val excerptLayoutResult = textMeasurer.measure(
-            text = excerpt,
-            style = MaterialTheme.typography.bodySmall,
-            maxLines = excerptMaxLines,
-            overflow = TextOverflow.Ellipsis,
-            constraints = Constraints(maxWidth = maxWidthPx),
-        )
-        val isExcerptFullHeight = excerptLayoutResult.lineCount == excerptMaxLines
+        val excerptMaxLines = remember(title, titleStyle, maxWidthPx) {
+            val titleLayoutResult = textMeasurer.measure(
+                text = title,
+                style = titleStyle,
+                maxLines = ReaderTagsFeedComposeUtils.POST_ITEM_TITLE_MAX_LINES,
+                overflow = TextOverflow.Ellipsis,
+                constraints = Constraints(maxWidth = maxWidthPx),
+            )
+
+            val titleLines = titleLayoutResult.lineCount
+            CONTENT_TOTAL_LINES - titleLines
+        }
 
         Column(
             modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
         ) {
             // Post title
             Text(
@@ -326,10 +313,6 @@ fun PostTextContent(
                 overflow = TextOverflow.Ellipsis,
             )
 
-            Spacer(
-                if (isExcerptFullHeight) Modifier.weight(1f) else Modifier.height(Margin.Medium.value)
-            )
-
             // Post excerpt
             Text(
                 modifier = Modifier
@@ -344,10 +327,6 @@ fun PostTextContent(
                 maxLines = excerptMaxLines,
                 overflow = TextOverflow.Ellipsis,
             )
-
-            if (isExcerptFullHeight) {
-                Spacer(Modifier.weight(1f))
-            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -50,7 +50,6 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
 private val ITEM_MAX_WIDTH = 320.dp
-private val ITEM_HEIGHT = 150.dp // TODO thomashortadev do we want SP instead of DP? to change based on font size)
 private const val ITEM_WIDTH_PERCENTAGE = 0.8f
 private const val CONTENT_MAX_LINES = 3
 private const val TITLE_MAX_LINES = 2
@@ -76,7 +75,7 @@ fun ReaderTagsFeedPostListItem(
         modifier = Modifier
             .widthIn(max = ITEM_MAX_WIDTH)
             .width(screenWidth * ITEM_WIDTH_PERCENTAGE)
-            .height(ITEM_HEIGHT)
+            .height(READER_TAGS_FEED_ITEM_HEIGHT)
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -36,11 +36,14 @@ fun ReaderTagsFeedPostListItemLoading() {
     Column(
         modifier = Modifier
             .width(ReaderTagsFeedComposeUtils.PostItemWidth)
-            .height(ReaderTagsFeedComposeUtils.PostItemHeight)
+            .height(ReaderTagsFeedComposeUtils.PostItemHeight),
+        verticalArrangement = Arrangement.SpaceBetween,
     ) {
         // Site info placeholder
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(
@@ -52,27 +55,38 @@ fun ReaderTagsFeedPostListItemLoading() {
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f))
-
         // Content row placeholder
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(Margin.Medium.value),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             // Post title and excerpt Column placeholder
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(Margin.Medium.value),
+                modifier = Modifier
+                    .weight(1f),
             ) {
                 // Title placeholder
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth(0.75f)
+                        .fillMaxWidth(0.9f)
                         .height(18.dp)
                         .clip(shape = RoundedCornerShape(16.dp))
                         .background(contentColor),
                 )
+
+                Spacer(modifier = Modifier.height(Margin.Medium.value))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .height(18.dp)
+                        .clip(shape = RoundedCornerShape(16.dp))
+                        .background(contentColor),
+                )
+
+                Spacer(modifier = Modifier.height(Margin.Medium.value))
 
                 // Excerpt placeholder
                 Column(
@@ -93,6 +107,20 @@ fun ReaderTagsFeedPostListItemLoading() {
                             .clip(shape = RoundedCornerShape(16.dp))
                             .background(contentColor),
                     )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.85f)
+                            .height(8.dp)
+                            .clip(shape = RoundedCornerShape(16.dp))
+                            .background(contentColor),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.8f)
+                            .height(8.dp)
+                            .clip(shape = RoundedCornerShape(16.dp))
+                            .background(contentColor),
+                    )
                 }
             }
 
@@ -105,24 +133,22 @@ fun ReaderTagsFeedPostListItemLoading() {
             )
         }
 
-        Spacer(Modifier.weight(1f))
-
         // Likes and comments placeholder
-        Box(
-            modifier = Modifier
-                .width(170.dp)
-                .height(8.dp)
-                .clip(shape = RoundedCornerShape(16.dp))
-                .background(contentColor),
-        )
+//        Box(
+//            modifier = Modifier
+//                .width(170.dp)
+//                .height(12.dp)
+//                .clip(shape = RoundedCornerShape(16.dp))
+//                .background(contentColor),
+//        )
 
-        Spacer(Modifier.height(Margin.Medium.value))
+//        Spacer(Modifier.height(Margin.Medium.value))
 
         // Actions placeholder
         Box(
             modifier = Modifier
                 .width(170.dp)
-                .height(8.dp)
+                .height(16.dp)
                 .clip(shape = RoundedCornerShape(16.dp))
                 .background(contentColor),
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -3,14 +3,16 @@ package org.wordpress.android.ui.reader.views.compose.tagsfeed
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,16 +28,17 @@ import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
 fun ReaderTagsFeedPostListItemLoading() {
-    val backgroundColor = if (isSystemInDarkTheme()) {
+    val contentColor = if (isSystemInDarkTheme()) {
         AppColor.White.copy(alpha = 0.12F)
     } else {
         AppColor.Black.copy(alpha = 0.08F)
     }
     Column(
         modifier = Modifier
-            .width(240.dp)
-            .height(340.dp),
+            .width(ReaderTagsFeedComposeUtils.PostItemWidth)
+            .height(ReaderTagsFeedComposeUtils.POST_ITEM_HEIGHT)
     ) {
+        // Site info placeholder
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -45,54 +48,83 @@ fun ReaderTagsFeedPostListItemLoading() {
                     .width(99.dp)
                     .height(8.dp)
                     .clip(shape = RoundedCornerShape(16.dp))
-                    .background(backgroundColor),
+                    .background(contentColor),
             )
         }
-        Box(
-            modifier = Modifier
-                .padding(top = Margin.Large.value)
-                .width(204.dp)
-                .height(18.dp)
-                .clip(shape = RoundedCornerShape(16.dp))
-                .background(backgroundColor),
-        )
-        Box(
-            modifier = Modifier
-                .padding(top = Margin.Large.value)
-                .width(140.dp)
-                .height(18.dp)
-                .clip(shape = RoundedCornerShape(16.dp))
-                .background(backgroundColor),
-        )
-        Box(
-            modifier = Modifier
-                .padding(top = Margin.Large.value)
-                .fillMaxWidth()
-                .height(150.dp)
-                .clip(shape = RoundedCornerShape(8.dp))
-                .background(backgroundColor),
-        )
-        Box(
-            modifier = Modifier
-                .padding(
-                    start = Margin.Small.value,
-                    top = Margin.Large.value,
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Content row placeholder
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Margin.Medium.value),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Post title and excerpt Column placeholder
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(Margin.Medium.value),
+            ) {
+                // Title placeholder
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.75f)
+                        .height(18.dp)
+                        .clip(shape = RoundedCornerShape(16.dp))
+                        .background(contentColor),
                 )
+
+                // Excerpt placeholder
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                            .clip(shape = RoundedCornerShape(16.dp))
+                            .background(contentColor),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.9f)
+                            .height(8.dp)
+                            .clip(shape = RoundedCornerShape(16.dp))
+                            .background(contentColor),
+                    )
+                }
+            }
+
+            // Image placeholder
+            Box(
+                modifier = Modifier
+                    .size(ReaderTagsFeedComposeUtils.POST_ITEM_IMAGE_SIZE)
+                    .clip(shape = RoundedCornerShape(8.dp))
+                    .background(contentColor),
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        // Likes and comments placeholder
+        Box(
+            modifier = Modifier
                 .width(170.dp)
                 .height(8.dp)
                 .clip(shape = RoundedCornerShape(16.dp))
-                .background(backgroundColor),
+                .background(contentColor),
         )
+
+        Spacer(Modifier.height(Margin.Medium.value))
+
+        // Actions placeholder
         Box(
             modifier = Modifier
-                .padding(
-                    start = Margin.Small.value,
-                    top = Margin.Large.value,
-                )
                 .width(170.dp)
                 .height(8.dp)
                 .clip(shape = RoundedCornerShape(16.dp))
-                .background(backgroundColor),
+                .background(contentColor),
         )
     }
 }
@@ -110,14 +142,10 @@ fun ReaderTagsFeedPostListItemLoadingPreview() {
             LazyRow(
                 modifier = Modifier
                     .fillMaxWidth(),
+                contentPadding = PaddingValues(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(Margin.ExtraMediumLarge.value),
             ) {
-                item {
-                    ReaderTagsFeedPostListItemLoading()
-                    Spacer(Modifier.width(12.dp))
-                    ReaderTagsFeedPostListItemLoading()
-                    Spacer(Modifier.width(12.dp))
-                    ReaderTagsFeedPostListItemLoading()
-                    Spacer(Modifier.width(12.dp))
+                items(5) {
                     ReaderTagsFeedPostListItemLoading()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -25,6 +25,9 @@ import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
 
+private val ThinLineHeight = 10.dp
+private val ThickLineHeight = 16.dp
+
 @Composable
 fun ReaderTagsFeedPostListItemLoading() {
     val contentColor = if (isSystemInDarkTheme()) {
@@ -48,7 +51,7 @@ fun ReaderTagsFeedPostListItemLoading() {
             Box(
                 modifier = Modifier
                     .width(150.dp)
-                    .height(8.dp)
+                    .height(ThinLineHeight)
                     .clip(shape = RoundedCornerShape(16.dp))
                     .background(contentColor),
             )
@@ -71,14 +74,14 @@ fun ReaderTagsFeedPostListItemLoading() {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(0.95f)
-                        .height(16.dp)
+                        .height(ThickLineHeight)
                         .clip(shape = RoundedCornerShape(16.dp))
                         .background(contentColor),
                 )
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(0.8f)
-                        .height(16.dp)
+                        .height(ThickLineHeight)
                         .clip(shape = RoundedCornerShape(16.dp))
                         .background(contentColor),
                 )
@@ -102,14 +105,14 @@ fun ReaderTagsFeedPostListItemLoading() {
             Box(
                 modifier = Modifier
                     .fillMaxWidth(0.6f)
-                    .height(8.dp)
+                    .height(ThinLineHeight)
                     .clip(shape = RoundedCornerShape(16.dp))
                     .background(contentColor),
             )
             Box(
                 modifier = Modifier
                     .fillMaxWidth(0.5f)
-                    .height(8.dp)
+                    .height(ThinLineHeight)
                     .clip(shape = RoundedCornerShape(16.dp))
                     .background(contentColor),
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -36,7 +36,7 @@ fun ReaderTagsFeedPostListItemLoading() {
     Column(
         modifier = Modifier
             .width(ReaderTagsFeedComposeUtils.PostItemWidth)
-            .height(ReaderTagsFeedComposeUtils.POST_ITEM_HEIGHT)
+            .height(ReaderTagsFeedComposeUtils.PostItemHeight)
     ) {
         // Site info placeholder
         Row(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -48,7 +47,7 @@ fun ReaderTagsFeedPostListItemLoading() {
         ) {
             Box(
                 modifier = Modifier
-                    .width(99.dp)
+                    .width(150.dp)
                     .height(8.dp)
                     .clip(shape = RoundedCornerShape(16.dp))
                     .background(contentColor),
@@ -66,62 +65,23 @@ fun ReaderTagsFeedPostListItemLoading() {
             Column(
                 modifier = Modifier
                     .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(Margin.Medium.value),
             ) {
                 // Title placeholder
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth(0.9f)
-                        .height(18.dp)
+                        .fillMaxWidth(0.95f)
+                        .height(16.dp)
                         .clip(shape = RoundedCornerShape(16.dp))
                         .background(contentColor),
                 )
-
-                Spacer(modifier = Modifier.height(Margin.Medium.value))
-
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(0.8f)
-                        .height(18.dp)
+                        .height(16.dp)
                         .clip(shape = RoundedCornerShape(16.dp))
                         .background(contentColor),
                 )
-
-                Spacer(modifier = Modifier.height(Margin.Medium.value))
-
-                // Excerpt placeholder
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(8.dp)
-                            .clip(shape = RoundedCornerShape(16.dp))
-                            .background(contentColor),
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth(0.9f)
-                            .height(8.dp)
-                            .clip(shape = RoundedCornerShape(16.dp))
-                            .background(contentColor),
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth(0.85f)
-                            .height(8.dp)
-                            .clip(shape = RoundedCornerShape(16.dp))
-                            .background(contentColor),
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth(0.8f)
-                            .height(8.dp)
-                            .clip(shape = RoundedCornerShape(16.dp))
-                            .background(contentColor),
-                    )
-                }
             }
 
             // Image placeholder
@@ -133,25 +93,27 @@ fun ReaderTagsFeedPostListItemLoading() {
             )
         }
 
-        // Likes and comments placeholder
-//        Box(
-//            modifier = Modifier
-//                .width(170.dp)
-//                .height(12.dp)
-//                .clip(shape = RoundedCornerShape(16.dp))
-//                .background(contentColor),
-//        )
-
-//        Spacer(Modifier.height(Margin.Medium.value))
-
-        // Actions placeholder
-        Box(
+        // Likes and comments + actions placeholder
+        Column(
             modifier = Modifier
-                .width(170.dp)
-                .height(16.dp)
-                .clip(shape = RoundedCornerShape(16.dp))
-                .background(contentColor),
-        )
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(Margin.MediumLarge.value),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .height(8.dp)
+                    .clip(shape = RoundedCornerShape(16.dp))
+                    .background(contentColor),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(8.dp)
+                    .clip(shape = RoundedCornerShape(16.dp))
+                    .background(contentColor),
+            )
+        }
     }
 }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
@@ -146,11 +146,12 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
             "endpoint",
             ReaderTagType.FOLLOWED,
         )
-        val onTagClick = { _: ReaderTag -> }
+        val onTagChipClick = { _: ReaderTag -> }
+        val onMoreFromTagClick = { _: ReaderTag -> }
         val onSiteClick: (TagsFeedPostItem) -> Unit = {}
         val onPostCardClick: (TagsFeedPostItem) -> Unit = {}
         val onPostLikeClick: (TagsFeedPostItem) -> Unit = {}
-        val onPostMoreMenuClick = {}
+        val onPostMoreMenuClick: (TagsFeedPostItem) -> Unit = {}
         val onItemEnteredView: (ReaderTagsFeedViewModel.TagFeedItem) -> Unit = {}
 
         val dateLine = "dateLine"
@@ -172,7 +173,8 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
         val actual = classToTest.mapLoadedTagFeedItem(
             tag = readerTag,
             posts = postList,
-            onTagClick = onTagClick,
+            onTagChipClick = onTagChipClick,
+            onMoreFromTagClick = onMoreFromTagClick,
             onSiteClick = onSiteClick,
             onPostCardClick = onPostCardClick,
             onPostLikeClick = onPostLikeClick,
@@ -183,7 +185,8 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
         val expected = ReaderTagsFeedViewModel.TagFeedItem(
             tagChip = ReaderTagsFeedViewModel.TagChip(
                 tag = readerTag,
-                onTagClick = onTagClick,
+                onTagChipClick = onTagChipClick,
+                onMoreFromTagClick = onMoreFromTagClick,
             ),
             postList = ReaderTagsFeedViewModel.PostList.Loaded(
                 listOf(


### PR DESCRIPTION
Fixes #20788 

Implement UI improvements to the post item in Tags Feed, making it more compact.

-----

## To Test:

1. Open Jetpack
2. Make sure the `reader_tags_feed` Feature Config is ON
3. Go to Reader
4. Select `Tags` feed
5. **Verify** the post items have the new design

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

7. What automated tests I added (or what prevented me from doing so)

    - N/A, UI changes only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
