### PR TITLE
Fix a rare crash on Post List screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 25.0
 -----
+* [*] Fixed a rare crash on Posts List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20813]
 
 
 24.9

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -209,6 +209,7 @@ class PostsListActivity : LocaleAwareActivity(),
             setupActionBar()
             setupContent()
             initViewModel(initPreviewState, currentBottomSheetPostId)
+            initSearchFragment()
             initBloggingReminders()
             initInAppReviews()
             initTabLayout(tabIndex)
@@ -492,7 +493,6 @@ class PostsListActivity : LocaleAwareActivity(),
         authorFilterMenuItem = menu.findItem(R.id.author_filter_menu_item)
         searchActionButton = menu.findItem(R.id.toggle_search)
 
-        initSearchFragment()
         binding.initSearchView()
         initAuthorFilter(authorFilterMenuItem)
         return true


### PR DESCRIPTION
This fixes some parts of #20535. 

The crash message is `Can not perform this action after onSaveInstanceState`. It indicates that `supportFragmentManager...commit()` function cannot be executed after `onSaveInstanceState` is called. Based on the logs, `onCreateOptionsMenu()` is invoked after the fragment is stopped. I moved `initSearchFragment()` function from `onCreateOptionsMenu()` to `onCreate()`. Apart from this issue, I believe `onCreate` is a more suitable location for it.

To reproduce this crash:
1. Pull `trunk`
2. Add a delay to the `initSearchFragment()` function in the PostsListActivity.onCreateOptionsMenu().  
<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/4fe36d90-0193-4db1-977b-99208305fbe9" width=540>

3. Open post list from Menu.
4. Immediately send the app to the background after opening the post list.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Test the reproduction steps above.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - This doesn't introduce any behavior change.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
