### PR TITLE
Fix NPE on History List screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -172,6 +172,9 @@ public class HistoryDetailContainerFragment extends Fragment {
             mRevision = getArguments().getParcelable(EXTRA_CURRENT_REVISION);
 
             final long[] previousRevisionsIds = getArguments().getLongArray(EXTRA_PREVIOUS_REVISIONS_IDS);
+            if (previousRevisionsIds == null) {
+                return null;
+            }
             final List<RevisionModel> revisionModels = new ArrayList<>();
             final long postId = getArguments().getLong(EXTRA_POST_ID);
             final long siteId = getArguments().getLong(EXTRA_SITE_ID);

--- a/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/history/HistoryDetailContainerFragment.java
@@ -192,7 +192,9 @@ public class HistoryDetailContainerFragment extends Fragment {
         final ArrayList<Revision> revisions = new ArrayList<>();
         for (int i = 0; i < revisionModels.size(); i++) {
             final RevisionModel current = revisionModels.get(i);
-            revisions.add(new Revision(current));
+            if (current != null) {
+                revisions.add(new Revision(current));
+            }
         }
         return revisions;
     }


### PR DESCRIPTION
Fixes #20808

This PR adds null checks to `HistoryDetailContainerFragment.java` to address a NPE crash in `mapRevisionModelsToRevisions()`. I have been unable to reproduce the crash myself but it occurs when `current` is null in `revisions.add(new Revision(current))` (line 195).

-----

## To Test:
1. Smoke test this screen: `My Site -> Pages -> Click on a page -> Meatball menu -> History -> Click on a revision`
<img width="306" alt="Screenshot 2024-05-14 at 6 32 54 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/7199140/8dc6cfc6-1f84-43f7-a899-d41b06017022">


<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

4. What automated tests I added (or what prevented me from doing so)

    - None
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
