### PR TITLE
[Bug] Fixed lateinit UninitializedPropertyAccessException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/SiteCreationMainVM.kt
@@ -347,9 +347,10 @@ class SiteCreationMainVM @Inject constructor(
         _onCompleted.value = NotCreated to isSiteTitleTaskCompleted()
     }
 
-    fun onWizardFinished(result: Created) {
-        siteCreationState = siteCreationState.copy(result = result)
-        _onCompleted.value = result to isSiteTitleTaskCompleted()
+    fun onWizardFinished(result: Created?) {
+        val nullCheckedResult = result ?: NotCreated
+        siteCreationState = siteCreationState.copy(result = nullCheckedResult)
+        _onCompleted.value = nullCheckedResult to isSiteTitleTaskCompleted()
     }
 
     private fun isSiteTitleTaskCompleted() = !siteCreationState.siteName.isNullOrBlank()

--- a/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/sitecreation/previews/SitePreviewViewModelTest.kt
@@ -62,7 +62,7 @@ class SitePreviewViewModelTest : BaseUnitTest() {
     private lateinit var uiStateObserver: Observer<SitePreviewUiState>
 
     @Mock
-    private lateinit var onOkClickedObserver: Observer<Created>
+    private lateinit var onOkClickedObserver: Observer<Created?>
 
     @Mock
     private lateinit var preloadPreviewObserver: Observer<String>


### PR DESCRIPTION
Fixes [Sentry Issue](https://a8c.sentry.io/issues/5286234853/?project=5731682&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&sort=user&statsPeriod=7d&stream_index=13)

There is a crash that occurs when during the site creation process, the preview's `SiteCreationResult` is not of the type `Created`. It's not entirely clear why this happens, but there is explicit code that check for this:

```
        if (siteCreationState.result !is Created) {
            updateUiState(SiteNotCreatedErrorUiState)
            return
        }
```

The problem is `result` and `domain` are never initialized. When on the `SiteCreationPreviewFragment` and selecting ok, the result is never initialized, hence the crash. The simplest solution was to make `result` nullable. I removed domain since it was also a `lateinit` and is only used in one place.

I tested this by forcing the SiteCreationState to be not `Created`. This forces the bug and I can confirm the crash no longer occurs. I had to make a change in `SiteCreationMainVM` because it needed to expect a nullable creation status. Otherwise the "OK" button on the site creation preview screen does nothing and the user is stuck there.

-----

## To Test:

- [ ] Add a new wordpress.com site
- [ ] Go through the process and select a theme
- [ ] Make sure you see a preview of your site after it was created.
- [ ] Clicking ok will take you back to the my site without a crash.

-----

## Regression Notes

1. Potential unintended areas of impact

    Site creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    I tested the crashed scenarion and also the regular site creating flow.

3. What automated tests I added (or what prevented me from doing so)

    None.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

