### PR TITLE
[Tags Feed] Improve accessibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -145,8 +148,14 @@ private fun Loaded(uiState: UiState.Loaded) {
 
 @Composable
 private fun Loading() {
+    val fetchingPostsLabel = stringResource(id = R.string.posts_fetching)
+
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .clearAndSetSemantics {
+                contentDescription = fetchingPostsLabel
+            },
         userScrollEnabled = false,
     ) {
         val numberOfLoadingRows = 3
@@ -257,9 +266,13 @@ private fun Empty(uiState: UiState.Empty) {
 
 @Composable
 private fun PostListLoading() {
+    val loadingLabel = stringResource(id = R.string.loading)
     LazyRow(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                contentDescription = loadingLabel
+            },
         userScrollEnabled = false,
         horizontalArrangement = Arrangement.spacedBy(Margin.ExtraMediumLarge.value),
         contentPadding = PaddingValues(
@@ -362,6 +375,7 @@ private fun PostListError(
         modifier = Modifier
             .height(250.dp)
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {}
             .padding(start = 60.dp, end = 60.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -40,6 +41,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -76,7 +82,8 @@ fun ReaderTagsFeedPostListItem(
     Column(
         modifier = Modifier
             .width(ReaderTagsFeedComposeUtils.PostItemWidth)
-            .height(ReaderTagsFeedComposeUtils.PostItemHeight),
+            .height(ReaderTagsFeedComposeUtils.PostItemHeight)
+            .itemSemanticsModifier(item),
         verticalArrangement = Arrangement.spacedBy(Margin.Small.value),
     ) {
         Row(
@@ -257,6 +264,43 @@ fun ReaderTagsFeedPostListItem(
                 }
             )
         }
+    }
+}
+
+private fun Modifier.itemSemanticsModifier(item: TagsFeedPostItem): Modifier = composed {
+    val openPostActionLabel = stringResource(R.string.reader_tags_feed_action_label_open_post)
+    val openBlogActionLabel = stringResource(R.string.reader_tags_feed_action_label_open_blog)
+
+    val likeStateDescription = if (item.isPostLiked) stringResource(R.string.mnu_comment_liked) else null
+    val likeActionLabel = if (item.isPostLiked) {
+        stringResource(R.string.reader_tags_feed_action_label_unlike_post)
+    } else {
+        stringResource(R.string.reader_tags_feed_action_label_like_post)
+    }
+
+    val openMenuActionLabel = stringResource(R.string.reader_tags_feed_action_label_open_menu)
+
+    clearAndSetSemantics {
+        contentDescription = "${item.siteName}, ${item.postDateLine}, ${item.postTitle}"
+        customActions = listOf(
+            CustomAccessibilityAction(openPostActionLabel) {
+                item.onPostCardClick(item)
+                true
+            },
+            CustomAccessibilityAction(openBlogActionLabel) {
+                item.onSiteClick(item)
+                true
+            },
+            CustomAccessibilityAction(likeActionLabel) {
+                item.onPostLikeClick(item)
+                true
+            },
+            CustomAccessibilityAction(openMenuActionLabel) {
+                item.onPostMoreMenuClick(item)
+                true
+            },
+        )
+        likeStateDescription?.let { stateDescription = it }
     }
 }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2332,6 +2332,11 @@
     <string name="reader_tags_feed_loading_error_description">We couldn\'t load posts from this tag right now</string>
     <string name="reader_tags_feed_no_content_error_description">We couldn\'t find any posts tagged %s right now</string>
     <string name="reader_tags_feed_error_retry">Retry</string>
+    <string name="reader_tags_feed_action_label_open_post">open post</string>
+    <string name="reader_tags_feed_action_label_open_blog">open blog</string>
+    <string name="reader_tags_feed_action_label_like_post">like post</string>
+    <string name="reader_tags_feed_action_label_unlike_post">remove post like</string>
+    <string name="reader_tags_feed_action_label_open_menu">open menu</string>
 
     <!-- connection bar which appears on main activity when there's no connection -->
     <string name="connectionbar_no_connection">No connection</string>


### PR DESCRIPTION
Fixes #20671

Improve overall accessibility and talkback navigation in the Tags Feed by:
- Grouping the loaded item into a single semantic item and using custom actions for user actions
- Grouping the error item into a single semantic item and allowing navigation to "retry"
- Grouping the loading row into a single semantic with "loading" content description
- Making the full-screen loading state have a single "fetching posts" content description

-----

## To Test:

Use the `test/20671-reader-tags-feed-a11y` [branch](https://github.com/wordpress-mobile/WordPress-Android/tree/test/20671-reader-tags-feed-a11y) to test this PR, since it has some testing code that forces:
- the 1st tag in the list to load normally
- the 2nd tag to show an empty state
- the 3rd tag to show an error state
- the 4th tag to show the loading state forever

Note: the "Retry" button is not working currently and will be implemented in #20823 

1. Open Jetpack
2. Make sure the `reader_tags_feed` Feature Config is on
3. Go to Reader
4. Go to "Your Tags" feed
5. Turn on Talkback
6. Test the screen and actions using Talkback
7. **Verify** things work as expected and you can navigate using Talkback

Tip: custom accessibility actions are accessed through the Talkback menu, for which the reader suggests using a "3-finger tap action" to open, but you can also use a 1-finger action to do so, in case you want to test in the emulator, the action is: slide the finger up then right (without lifting the finger in between).

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

10. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
