### PR TITLE
Add .aiexclude file for safer Gemini usage

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,39 @@
+# OS X generated file
+.DS_Store
+
+# Build-related files
+fastlane/
+
+# Key-related files
+.jks
+.keystore
+
+# Backup files
+.bak
+
+# Generated files
+bin/
+gen/
+build/
+build.log
+
+# Built application files
+.apk
+.ap_
+.aab
+
+# Dex VM files
+.dex
+
+# Configuration files
+.configure
+.configure-files/
+google-services.json
+google-upload-credentials.json
+firebase.secrets.json
+sentry.properties
+
+# Gradle files
+gradle.properties
+local.properties
+local-builds.gradle


### PR DESCRIPTION
Gemini is now embedded in Android Studio but it shares data with Google to provide code assistance, therefore we should include an `.aiexclude` file (similar to `.gitignore`) to avoid sensitive data being shared (like keys).

This PR adds an initial `.aiexclude` file containing such files.

Based on:
https://developer.android.com/studio/preview/gemini/aiexclude
