### PR TITLE
Fix NPE on Publish Settings screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsViewModel.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.util.LocaleManagerWrapper
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ResourceProvider
 import java.util.Calendar
+import java.util.Date
 
 abstract class PublishSettingsViewModel
 constructor(
@@ -212,7 +213,10 @@ constructor(
         val dateCreated = postRepository.dateCreated
         // Set the currently selected time if available
         if (!TextUtils.isEmpty(dateCreated)) {
-            calendar.time = DateTimeUtils.dateFromIso8601(dateCreated)
+            // Calendar.setTime(Date date) expects a non-null Date object
+            val maybeDate: Date? = DateTimeUtils.dateFromIso8601(dateCreated)
+            maybeDate?.let { date -> calendar.time = date }
+
             calendar.timeZone = localeManagerWrapper.getTimeZone()
         }
         return calendar


### PR DESCRIPTION
Fixes #20826 

This PR adds a null check to `DateTimeUtils.dateFromIso8601(dateCreated)`. I haven't been able to reproduce the crash but it's caused by `Calendar.setTime(Date date)` receiving a null Date object. 

-----

## To Test:
1. Code review and smoketest post publishing. 

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

4. What automated tests I added (or what prevented me from doing so)

    - None
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~

