### PR TITLE
Move the code snippet which caused ANR to background thread

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Fixed a rare crash on Posts List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20813]
 * [*] Fixed a rare crash on the Login screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20821]
+* [*] Fixed an ANR issue on the Post List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20833]
 
 24.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.reader.views;
 import android.content.Context;
 import android.icu.text.CompactDecimalFormat;
 import android.icu.text.NumberFormat;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -31,6 +33,9 @@ import org.wordpress.android.util.config.ReaderImprovementsFeatureConfig;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageManager;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import javax.inject.Inject;
 
 /**
@@ -54,6 +59,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
     private ReaderBlog mBlogInfo;
     private OnBlogInfoLoadedListener mBlogInfoListener;
     private OnFollowListener mFollowListener;
+
+    private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
+    private final Handler mMainHandler = new Handler(Looper.getMainLooper());
+
 
     @Inject AccountStore mAccountStore;
     @Inject ImageManager mImageManager;
@@ -103,7 +112,6 @@ public class ReaderSiteHeaderView extends LinearLayout {
         mBlogId = blogId;
         mFeedId = feedId;
 
-        final ReaderBlog localBlogInfo;
         if (blogId == 0 && feedId == 0) {
             ToastUtils.showToast(getContext(), R.string.reader_toast_err_show_blog);
             return;
@@ -111,33 +119,35 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
         mIsFeed = ReaderUtils.isExternalFeed(mBlogId, mFeedId);
 
-        if (mIsFeed) {
-            localBlogInfo = ReaderBlogTable.getFeedInfo(mFeedId);
-        } else {
-            localBlogInfo = ReaderBlogTable.getBlogInfo(mBlogId);
-        }
+        // run in background to avoid ANR
+        mExecutorService.execute(() -> {
+            final ReaderBlog localBlogInfo;
+            if (mIsFeed) {
+                localBlogInfo = ReaderBlogTable.getFeedInfo(mFeedId);
+            } else {
+                localBlogInfo = ReaderBlogTable.getBlogInfo(mBlogId);
+            }
 
-        if (localBlogInfo != null) {
-            showBlogInfo(localBlogInfo, source);
-        }
+            mMainHandler.post(() -> {
+                if (localBlogInfo != null) {
+                    showBlogInfo(localBlogInfo, source);
+                }
+                // then get from server if doesn't exist locally or is time to update it
+                if (localBlogInfo == null || ReaderBlogTable.isTimeToUpdateBlogInfo(localBlogInfo)) {
+                    ReaderActions.UpdateBlogInfoListener listener = serverBlogInfo -> {
+                        if (isAttachedToWindow()) {
+                            showBlogInfo(serverBlogInfo, source);
+                        }
+                    };
 
-        // then get from server if doesn't exist locally or is time to update it
-        if (localBlogInfo == null || ReaderBlogTable.isTimeToUpdateBlogInfo(localBlogInfo)) {
-            ReaderActions.UpdateBlogInfoListener listener = new ReaderActions.UpdateBlogInfoListener() {
-                @Override
-                public void onResult(ReaderBlog serverBlogInfo) {
-                    if (isAttachedToWindow()) {
-                        showBlogInfo(serverBlogInfo, source);
+                    if (mIsFeed) {
+                        ReaderBlogActions.updateFeedInfo(mFeedId, null, listener);
+                    } else {
+                        ReaderBlogActions.updateBlogInfo(mBlogId, null, listener);
                     }
                 }
-            };
-
-            if (mIsFeed) {
-                ReaderBlogActions.updateFeedInfo(mFeedId, null, listener);
-            } else {
-                ReaderBlogActions.updateBlogInfo(mBlogId, null, listener);
-            }
-        }
+            });
+        });
     }
 
     private void showBlogInfo(ReaderBlog blogInfo, String source) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -62,8 +62,7 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
     private final ExecutorService mExecutorService = Executors.newSingleThreadExecutor();
     private final Handler mMainHandler = new Handler(Looper.getMainLooper());
-
-
+    
     @Inject AccountStore mAccountStore;
     @Inject ImageManager mImageManager;
     @Inject ReaderTracker mReaderTracker;


### PR DESCRIPTION
Fixes #20832

This is an ANR issue, we fetched data from database in main thread in the class of site header.

This PR moves the code snippet which caused ANR to background thread by using `ExecutorService`, and then handles the UI related code in main thread with `Handler`.

-----

## To Test:

1. Sign in JP app.
2. Switch to the `Notifications` tab.
3. Find a comment type notification and click on it.
4. Click on user's avatar.
5. It will navigate you to ReaderPostList.
6. It should display the site header correctly.
7. Done, thank you!

![Screenshot_20240516-112830 (1)](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/fdb922c2-0488-472d-b124-eedc2349bd72)


-----

## Regression Notes

1. Potential unintended areas of impact

    - reader

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

10. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

Skipped
