### PR TITLE
Fix a rare crash on featured image confirmation dialog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Fixed a rare crash on Posts List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20813]
 * [*] Fixed a rare crash on the Login screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20821]
+* [*] Fixed a rare crash on the featured image confirmation dialog [https://github.com/wordpress-mobile/WordPress-Android/pull/20836]
 
 24.9
 -----

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -900,6 +900,10 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
     @UiThread
     public void showFeaturedImageConfirmationDialog(final int mediaId) {
+        if (isStateSaved()) {
+            return;
+        }
+
         GutenbergDialogFragment dialog = new GutenbergDialogFragment();
         dialog.initialize(
                 TAG_REPLACE_FEATURED_DIALOG,


### PR DESCRIPTION
This fixes some parts of https://github.com/wordpress-mobile/WordPress-Android/issues/20535.

The crash message is "Can not perform this action after onSaveInstanceState" and occurs when attempting to show the featured image confirmation dialog after `onSaveInstanceState` has been called. This indicates that the code attempts to display the dialog even when the fragment is not active.

This PR adds a check to the fragment's state and doesn't run the code to show the dialog if the fragment's state is saved.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

I couldn't reproduce the crash. But follow the following items to test this change doesn't break anything.

1. Log in and open Posts.
2. Edit a post. 
3. Add an image block. 
4. Select the image block and tap the cog icon at the bottom bar.
5. Tap "Set as featured image".
6. Repeat 4-5.
7. Ensure you see the featured image confirmation dialog as below.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/2471769/094c8b9a-f2a3-49c0-9a9b-b0e3e36f3e73" width=300>

-----

## Regression Notes

1. Potential unintended areas of impact

    - None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    -N/A

3. What automated tests I added (or what prevented me from doing so)

    - Since I can't reproduce it, I'm not adding any tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
