### PR TITLE
Fix a crash that occurs when remove a user

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 * [*] Fixed a rare crash on Posts List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20813]
 * [*] Fixed a rare crash on the Login screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20821]
+* [*] Fix a crash that occurs when remove a user [https://github.com/wordpress-mobile/WordPress-Android/pull/20837]
 
 24.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -604,7 +604,7 @@ public class PeopleManagementActivity extends LocaleAwareActivity
 
     private boolean navigateBackToPeopleListFragment() {
         FragmentManager fragmentManager = getSupportFragmentManager();
-        if (fragmentManager.getBackStackEntryCount() > 0) {
+        if (!fragmentManager.isStateSaved() && fragmentManager.getBackStackEntryCount() > 0) {
             fragmentManager.popBackStack();
 
             ActionBar actionBar = getSupportActionBar();


### PR DESCRIPTION
This fixes some parts of https://github.com/wordpress-mobile/WordPress-Android/issues/20535.

The crash message is `Can not perform this action after onSaveInstanceState`. 

This PR adds a check for the fragment's state and doesn't run the `fragmentManager.popBackStack();` if the fragment's state is saved.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Log in.
2. Tap more button on "My Site".
3. Tap People.
4. Tap a user item.
5. Tap the trash icon at the top right to remove the user.
6. Tap the REMOVE button on the dialog but go to device home immediately after tapping the REMOVE button.
7. on `trunk` this should cause a crash with `Can not perform this action after onSaveInstanceState` message. Ensure it doesn't crash on this PR.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - This is a very hard case to reproduce. Not a proper case for UI tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
