### PR TITLE
[Bug] Fix crash caused by requireContext in GutenbergEditorFragment.

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -694,7 +694,8 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
 
         Bundle arguments = getArguments();
         FragmentActivity activity = getActivity();
-        if (activity == null || arguments == null) {
+        final Context context = getContext();
+        if (activity == null || context == null || arguments == null) {
             AppLog.e(T.EDITOR,
                     "Failed to initialize other media options because the activity or getArguments() is null");
             return otherMediaOptions;
@@ -710,13 +711,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         String packageName = activity.getApplication().getPackageName();
         if (supportStockPhotos) {
             int stockMediaResourceId =
-                    getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
+                    context.getResources().getIdentifier("photo_picker_stock_media", "string", packageName);
 
             otherMediaOptions.add(new MediaOption(MEDIA_SOURCE_STOCK_MEDIA, getString(stockMediaResourceId)));
         }
         if (supportsTenor) {
             int gifMediaResourceId =
-                    getResources().getIdentifier("photo_picker_gif", "string", packageName);
+                    context.getResources().getIdentifier("photo_picker_gif", "string", packageName);
             otherMediaOptions.add(new MediaOption(GIF_MEDIA, getString(gifMediaResourceId)));
         }
 


### PR DESCRIPTION
Fixes [Sentry Issue](https://a8c.sentry.io/issues/4445203744/)

There is a crash on the `GutenbergEditorFragment` that occurs when opening the media menu items. It happens when calling `Fragment#getResources()`, which internally uses `requireContext`. The thing about `requireContext` is that it throws an exception when the context is null. Generally `requireContext` should only be called within the normal course of the fragment Lifecycle. Because that method is called by a non-lifecycle callback, related to react native as far as I can tell, this issue occurs.

I could not reproduce it. Instead I removed the `requireContext` use and called `getContext` directly.

-----

## To Test:

- [x] Go to any one of your posts and edit it (gutenberg editor).
- [x] At the bottom you should see some actions to take. The image icon is enough.
- [x] Make sure it opens just fine. No crash should occur.

![Screenshot_20240516_163511](https://github.com/wordpress-mobile/WordPress-Android/assets/1571223/7df0682e-ae80-457a-80ce-8eef01851344)

-----

## Regression Notes

1. Potential unintended areas of impact

    N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

