### PR TITLE
[Gutenberg] Upgrade target sdk version to Android API 34 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Fixed a rare crash on Posts List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20813]
 * [*] Fixed a rare crash on the Login screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20821]
 * [*] Fixed an ANR issue on the Post List screen [https://github.com/wordpress-mobile/WordPress-Android/pull/20833]
+* [*] [internal] Block Editor: Upgrade target sdk version to Android API 34 [https://github.com/wordpress-mobile/WordPress-Android/pull/20841]
 
 24.9
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = 'v1.119.0-alpha1'
+    gutenbergMobileVersion = '6870-da95fc52ce7b2b09286d34b6d78a2c8652e69799'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.79.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = '6870-cb4c2c1f2b0290eefde78817f576764cbe26e463'
+    gutenbergMobileVersion = 'v1.119.0-alpha2'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.79.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = '6870-da95fc52ce7b2b09286d34b6d78a2c8652e69799'
+    gutenbergMobileVersion = '6870-cb4c2c1f2b0290eefde78817f576764cbe26e463'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.79.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/6533

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6870
- https://github.com/WordPress/gutenberg/pull/61727

-----

## To Test:

Smoke test the editor.

-----

## Regression Notes

1. Potential unintended areas of impact

    - It should only affect the editor

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Relied in current tests.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
