### PR TITLE
[Tags Feed] Fix duplicate tracking in Reader subfilter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -95,6 +96,14 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     private var readerSearchResultLauncher: ActivityResultLauncher<Intent>? = null
 
     private var readerSubsActivityResultLauncher: ActivityResultLauncher<Intent>? = null
+
+    /**
+     * Stores the keys for [SubFilterViewModel] that have already been initialized (observers) and started.
+     * It is only cleared when:
+     *   - the [ReaderFragment] is destroyed, to allow proper initialization in cases like screen rotation
+     *   - the [SubFilterViewModel] is cleared, to allow proper initialization when the ViewModel is created again
+     */
+    private val initializedSubFilterViewModelKeys: MutableList<String> = mutableListOf()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding = ReaderFragmentLayoutBinding.bind(view).apply {
@@ -444,11 +453,21 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     }
 
     override fun getSubFilterViewModelForTag(tag: ReaderTag, savedInstanceState: Bundle?): SubFilterViewModel {
+        val keyForTag = SubFilterViewModel.getViewModelKeyForTag(tag)
         return ViewModelProvider(getSubFilterViewModelOwner(), viewModelFactory)[
-            SubFilterViewModel.getViewModelKeyForTag(tag),
+            keyForTag,
             SubFilterViewModel::class.java
         ].also {
-            it.initSubFilterViewModel(tag, savedInstanceState)
+            // only initialize if it hasn't been initialized yet
+            if (keyForTag !in initializedSubFilterViewModelKeys) {
+                it.initSubFilterViewModel(tag, savedInstanceState)
+
+                // setup mechanism for proper one-time initialization and clearing
+                initializedSubFilterViewModelKeys.add(keyForTag)
+                it.onCleared.observeEvent(viewLifecycleOwner) {
+                    initializedSubFilterViewModelKeys.remove(keyForTag)
+                }
+            }
         }
     }
 
@@ -458,6 +477,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         currentSubFilter.observe(
             viewLifecycleOwner
         ) { subfilterListItem: SubfilterListItem ->
+            Log.d("ReaderFragment", "currentSubFilter.observe")
             onSubfilterSelected(subfilterListItem)
             viewModel.onSubFilterItemSelected(subfilterListItem)
         }
@@ -466,6 +486,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         updateTagsAndSites.observe(
             viewLifecycleOwner
         ) { event: Event<EnumSet<UpdateTask>> ->
+            Log.d("ReaderFragment", "updateTagsAndSites.observe")
             event.applyIfNotHandled {
                 if (NetworkUtils.isNetworkAvailable(activity)) {
                     ReaderUpdateServiceStarter.startService(activity, this)
@@ -503,6 +524,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         bottomSheetUiState.observe(
             viewLifecycleOwner
         ) { event: Event<BottomSheetUiState> ->
+            Log.d("ReaderFragment", "bottomSheetUiState.observe")
             event.applyIfNotHandled {
                 val fm = childFragmentManager
                 var bottomSheet = fm.findFragmentByTag(SUBFILTER_BOTTOM_SHEET_TAG) as SubfilterBottomSheetFragment?
@@ -524,6 +546,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
         bottomSheetAction.observe(
             viewLifecycleOwner
         ) { event: Event<ActionType> ->
+            Log.d("ReaderFragment", "bottomSheetAction.observe")
             event.applyIfNotHandled {
                 when (this) {
                     is OpenSubsAtPage -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -38,6 +38,7 @@ import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
+import java.util.Comparator
 import java.util.EnumSet
 import javax.inject.Inject
 import javax.inject.Named
@@ -68,9 +69,6 @@ class SubFilterViewModel @Inject constructor(
 
     private val _updateTagsAndSites = MutableLiveData<Event<EnumSet<UpdateTask>>>()
     val updateTagsAndSites: LiveData<Event<EnumSet<UpdateTask>>> = _updateTagsAndSites
-
-    private val _onCleared = MutableLiveData<Event<Unit>>()
-    val onCleared: LiveData<Event<Unit>> = _onCleared
 
     private val _isTitleContainerVisible = MutableLiveData<Boolean>(true)
     val isTitleContainerVisible: LiveData<Boolean> = _isTitleContainerVisible
@@ -141,12 +139,12 @@ class SubFilterViewModel @Inject constructor(
                             blog.organizationId == organization.orgId
                         } ?: false
                     }
-                }.sortedWith { blog1, blog2 ->
+                }.sortedWith(Comparator { blog1, blog2 ->
                     // sort followed blogs by name/domain to match display
                     val blogOneName = getBlogNameForComparison(blog1)
                     val blogTwoName = getBlogNameForComparison(blog2)
                     blogOneName.compareTo(blogTwoName, true)
-                }
+                })
 
                 filterList.addAll(
                     followedBlogs.map { blog ->
@@ -416,7 +414,7 @@ class SubFilterViewModel @Inject constructor(
         loadSubFilters()
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsFetched) {
         if(event.didChange()) {
@@ -428,7 +426,6 @@ class SubFilterViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         eventBusWrapper.unregister(this)
-        _onCleared.value = Event(Unit)
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
-import org.wordpress.android.datasets.ReaderBlogTable
-import org.wordpress.android.datasets.ReaderTagTable
+import org.wordpress.android.datasets.ReaderBlogTableWrapper
+import org.wordpress.android.datasets.wrappers.ReaderTagTableWrapper
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.models.ReaderTag
@@ -49,7 +49,9 @@ class SubFilterViewModel @Inject constructor(
     private val subfilterListItemMapper: SubfilterListItemMapper,
     private val eventBusWrapper: EventBusWrapper,
     private val accountStore: AccountStore,
-    private val readerTracker: ReaderTracker
+    private val readerTracker: ReaderTracker,
+    private val readerTagTableWrapper: ReaderTagTableWrapper,
+    private val readerBlogTableWrapper: ReaderBlogTableWrapper,
 ) : ScopedViewModel(bgDispatcher) {
     private val _subFilters = MutableLiveData<List<SubfilterListItem>>()
     val subFilters: LiveData<List<SubfilterListItem>> = _subFilters
@@ -132,7 +134,7 @@ class SubFilterViewModel @Inject constructor(
             if (accountStore.hasAccessToken()) {
                 val organization = mTagFragmentStartedWith?.organization
 
-                val followedBlogs = ReaderBlogTable.getFollowedBlogs().let { blogList ->
+                val followedBlogs = readerBlogTableWrapper.getFollowedBlogs().let { blogList ->
                     // Filtering out all blogs not belonging to this VM organization if valid
                     blogList.filter { blog ->
                         organization?.let {
@@ -157,7 +159,7 @@ class SubFilterViewModel @Inject constructor(
                 )
             }
 
-            val tags = ReaderTagTable.getFollowedTags()
+            val tags = readerTagTableWrapper.getFollowedTags()
 
             for (tag in tags) {
                 filterList.add(
@@ -354,8 +356,8 @@ class SubFilterViewModel @Inject constructor(
         } else {
             readerTracker.stop(ReaderTrackerType.SUBFILTERED_LIST)
         }
-        onSubfilterSelected(filter)
         _currentSubFilter.value = filter
+        onSubfilterSelected(filter)
     }
 
     fun onUserComesToReader() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -38,7 +38,6 @@ import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
-import java.util.Comparator
 import java.util.EnumSet
 import javax.inject.Inject
 import javax.inject.Named
@@ -125,6 +124,7 @@ class SubFilterViewModel @Inject constructor(
             ""
         }
     }
+
     fun loadSubFilters() {
         launch {
             val filterList = ArrayList<SubfilterListItem>()
@@ -139,12 +139,12 @@ class SubFilterViewModel @Inject constructor(
                             blog.organizationId == organization.orgId
                         } ?: false
                     }
-                }.sortedWith(Comparator { blog1, blog2 ->
+                }.sortedWith { blog1, blog2 ->
                     // sort followed blogs by name/domain to match display
                     val blogOneName = getBlogNameForComparison(blog1)
                     val blogTwoName = getBlogNameForComparison(blog2)
                     blogOneName.compareTo(blogTwoName, true)
-                })
+                }
 
                 filterList.addAll(
                     followedBlogs.map { blog ->
@@ -239,13 +239,14 @@ class SubFilterViewModel @Inject constructor(
         category: SubfilterCategory,
     ) {
         updateTagsAndSites()
+        loadSubFilters()
         _bottomSheetUiState.value = Event(
             BottomSheetVisible(
                 UiStringRes(category.titleRes),
                 category
             )
         )
-        val source = when(category) {
+        val source = when (category) {
             SubfilterCategory.SITES -> "blogs"
             SubfilterCategory.TAGS -> "tags"
         }
@@ -353,6 +354,7 @@ class SubFilterViewModel @Inject constructor(
         } else {
             readerTracker.stop(ReaderTrackerType.SUBFILTERED_LIST)
         }
+        onSubfilterSelected(filter)
         _currentSubFilter.value = filter
     }
 
@@ -414,10 +416,10 @@ class SubFilterViewModel @Inject constructor(
         loadSubFilters()
     }
 
-    @Suppress("unused", "UNUSED_PARAMETER")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsFetched) {
-        if(event.didChange()) {
+        if (event.didChange()) {
             AppLog.d(T.READER, "Subfilter bottom sheet > followed blogs changed")
             loadSubFilters()
         }
@@ -449,7 +451,7 @@ class SubFilterViewModel @Inject constructor(
 
         companion object {
             fun fromSubfilterListItem(subfilterListItem: SubfilterListItem): FilterItemType? =
-                when(subfilterListItem.type) {
+                when (subfilterListItem.type) {
                     SubfilterListItem.ItemType.SITE -> Blog
                     SubfilterListItem.ItemType.TAG -> Tag
                     else -> null

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -325,8 +325,8 @@ class SubFilterViewModel @Inject constructor(
     }
 
     fun onSubfilterSelected(subfilterListItem: SubfilterListItem) {
-        // We should not track subfilter selected if we're clearing a filter that is currently applied.
-        if (!subfilterListItem.isClearingFilter) {
+        // We should only track the selection of a subfilter if it's a tracked item (meaning it's a valid tag or site)
+        if (subfilterListItem.isTrackedItem) {
             val filterItemType = FilterItemType.fromSubfilterListItem(subfilterListItem)
             if (filterItemType != null) {
                 readerTracker.track(
@@ -334,7 +334,7 @@ class SubFilterViewModel @Inject constructor(
                     mutableMapOf(FilterItemType.trackingEntry(filterItemType))
                 )
             } else {
-                readerTracker.track(Stat.READER_FILTER_SHEET_ITEM_SELECTED,)
+                readerTracker.track(Stat.READER_FILTER_SHEET_ITEM_SELECTED)
             }
         }
         changeSubfilter(subfilterListItem, true, mTagFragmentStartedWith)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModel.kt
@@ -38,7 +38,6 @@ import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.ScopedViewModel
 import org.wordpress.android.viewmodel.SingleLiveEvent
-import java.util.Comparator
 import java.util.EnumSet
 import javax.inject.Inject
 import javax.inject.Named
@@ -69,6 +68,9 @@ class SubFilterViewModel @Inject constructor(
 
     private val _updateTagsAndSites = MutableLiveData<Event<EnumSet<UpdateTask>>>()
     val updateTagsAndSites: LiveData<Event<EnumSet<UpdateTask>>> = _updateTagsAndSites
+
+    private val _onCleared = MutableLiveData<Event<Unit>>()
+    val onCleared: LiveData<Event<Unit>> = _onCleared
 
     private val _isTitleContainerVisible = MutableLiveData<Boolean>(true)
     val isTitleContainerVisible: LiveData<Boolean> = _isTitleContainerVisible
@@ -139,12 +141,12 @@ class SubFilterViewModel @Inject constructor(
                             blog.organizationId == organization.orgId
                         } ?: false
                     }
-                }.sortedWith(Comparator { blog1, blog2 ->
+                }.sortedWith { blog1, blog2 ->
                     // sort followed blogs by name/domain to match display
                     val blogOneName = getBlogNameForComparison(blog1)
                     val blogTwoName = getBlogNameForComparison(blog2)
                     blogOneName.compareTo(blogTwoName, true)
-                })
+                }
 
                 filterList.addAll(
                     followedBlogs.map { blog ->
@@ -414,7 +416,7 @@ class SubFilterViewModel @Inject constructor(
         loadSubFilters()
     }
 
-    @Suppress("unused", "UNUSED_PARAMETER")
+    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ReaderEvents.FollowedBlogsFetched) {
         if(event.didChange()) {
@@ -426,6 +428,7 @@ class SubFilterViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         eventBusWrapper.unregister(this)
+        _onCleared.value = Event(Unit)
     }
 
     companion object {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -17,17 +17,20 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.datasets.ReaderBlogTableWrapper
+import org.wordpress.android.datasets.wrappers.ReaderTagTableWrapper
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.getOrAwaitValue
 import org.wordpress.android.models.ReaderBlog
 import org.wordpress.android.models.ReaderTag
+import org.wordpress.android.models.ReaderTagList
 import org.wordpress.android.models.ReaderTagType.BOOKMARKED
 import org.wordpress.android.models.ReaderTagType.TAGS
+import org.wordpress.android.ui.Organization
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.reader.ReaderSubsActivity
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
-import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenLoginPage
 import org.wordpress.android.ui.reader.subfilter.ActionType.OpenSubsAtPage
@@ -78,7 +81,10 @@ class SubFilterViewModelTest : BaseUnitTest() {
     private lateinit var savedState: Bundle
 
     @Mock
-    private lateinit var filter: SubfilterListItem
+    private lateinit var readerTagTableWrapper: ReaderTagTableWrapper
+
+    @Mock
+    private lateinit var readerBlogTableWrapper: ReaderBlogTableWrapper
 
     private lateinit var viewModel: SubFilterViewModel
 
@@ -93,7 +99,9 @@ class SubFilterViewModelTest : BaseUnitTest() {
             subfilterListItemMapper,
             eventBusWrapper,
             accountStore,
-            readerTracker
+            readerTracker,
+            readerTagTableWrapper,
+            readerBlogTableWrapper,
         )
 
         viewModel.start(initialTag, savedTag, savedState)
@@ -102,6 +110,10 @@ class SubFilterViewModelTest : BaseUnitTest() {
     @Test
     fun `current subfilter is set back when we have a previous intance state`() {
         val json = "{\"blogId\":0,\"feedId\":0,\"tagSlug\":\"news\",\"tagType\":1,\"type\":4}"
+        val filter = Site(
+            blog = ReaderBlog(),
+            onClickAction = mock(),
+        )
 
         whenever(savedState.getString(SubFilterViewModel.ARG_CURRENT_SUBFILTER_JSON)).thenReturn(json)
         whenever(subfilterListItemMapper.fromJson(eq(json), any(), any())).thenReturn(filter)
@@ -113,7 +125,9 @@ class SubFilterViewModelTest : BaseUnitTest() {
             subfilterListItemMapper,
             eventBusWrapper,
             accountStore,
-            readerTracker
+            readerTracker,
+            readerTagTableWrapper,
+            readerBlogTableWrapper,
         )
 
         viewModel.start(initialTag, savedTag, savedState)
@@ -288,11 +302,9 @@ class SubFilterViewModelTest : BaseUnitTest() {
 
     @Test
     fun `view model updates the tags and sites and asks to show the bottom sheet when filters button is tapped`() {
-        var updateTasks: EnumSet<ReaderUpdateLogic.UpdateTask>? = null
-        var uiState: BottomSheetUiState? = null
+        var updateTasks: EnumSet<UpdateTask>? = null
 
         viewModel.updateTagsAndSites.observeForever { updateTasks = it.peekContent() }
-        viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
 
         viewModel.onSubFiltersListButtonClicked(SubfilterCategory.SITES)
 
@@ -302,8 +314,45 @@ class SubFilterViewModelTest : BaseUnitTest() {
                 UpdateTask.FOLLOWED_BLOGS
             )
         )
+    }
+
+    @Test
+    fun `view model asks to show the bottom sheet when filters button is tapped`() {
+        var uiState: BottomSheetUiState? = null
+
+        viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
+
+        viewModel.onSubFiltersListButtonClicked(SubfilterCategory.SITES)
 
         assertThat(uiState).isInstanceOf(BottomSheetVisible::class.java)
+    }
+
+    @Test
+    fun `view model updates subfilters when filters button is tapped`() = test {
+        whenever(initialTag.organization).thenReturn(Organization.NO_ORGANIZATION)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(readerTagTableWrapper.getFollowedTags()).thenReturn(
+            ReaderTagList().apply {
+                add(ReaderTag("a", "a", "a", "endpoint-a", TAGS))
+                add(ReaderTag("b", "b", "b", "endpoint-b", TAGS))
+                add(ReaderTag("c", "c", "c", "endpoint-c", TAGS))
+            }
+        )
+
+        whenever(readerBlogTableWrapper.getFollowedBlogs()).thenReturn(
+            List(2) {
+                ReaderBlog().apply { organizationId = Organization.NO_ORGANIZATION.orgId }
+            }
+        )
+
+        var subFilters: List<SubfilterListItem>? = null
+
+        viewModel.subFilters.observeForever { subFilters = it }
+
+        viewModel.onSubFiltersListButtonClicked(SubfilterCategory.SITES)
+        advanceUntilIdle()
+
+        assertThat(subFilters).hasSize(5)
     }
 
     @Test
@@ -320,7 +369,11 @@ class SubFilterViewModelTest : BaseUnitTest() {
     @Test
     fun `bottom sheet is hidden when a filter is tapped on`() {
         var uiState: BottomSheetUiState? = null
-        val filter: SubfilterListItem = mock()
+        val filter: SubfilterListItem = Site(
+            isSelected = false,
+            onClickAction = mock(),
+            blog = ReaderBlog(),
+        )
 
         viewModel.setSubfilterFromTag(savedTag)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -328,7 +328,7 @@ class SubFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `view model updates subfilters when filters button is tapped`() = test {
+    fun `view model updates subfilters when filters button is tapped`() {
         whenever(initialTag.organization).thenReturn(Organization.NO_ORGANIZATION)
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(readerTagTableWrapper.getFollowedTags()).thenReturn(
@@ -350,7 +350,6 @@ class SubFilterViewModelTest : BaseUnitTest() {
         viewModel.subFilters.observeForever { subFilters = it }
 
         viewModel.onSubFiltersListButtonClicked(SubfilterCategory.SITES)
-        advanceUntilIdle()
 
         assertThat(subFilters).hasSize(5)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -430,9 +430,8 @@ class SubFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should NOT track READER_FILTER_SHEET_ITEM_SELECTED if clearing filter when onSubfilterSelected is called`() {
+    fun `Should NOT track READER_FILTER_SHEET_ITEM_SELECTED if SiteAll when onSubfilterSelected is called`() {
         val filter = SiteAll(
-            isClearingFilter = true,
             onClickAction = {},
         )
         viewModel.onSubfilterSelected(filter)
@@ -440,13 +439,17 @@ class SubFilterViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should track READER_FILTER_SHEET_ITEM_SELECTED if NOT clearing filter when onSubfilterSelected is called`() {
-        val filter = SiteAll(
-            isClearingFilter = false,
-            onClickAction = {},
-        )
+    fun `Should NOT track READER_FILTER_SHEET_ITEM_SELECTED if Divider when onSubfilterSelected is called`() {
+        val filter = SubfilterListItem.Divider
         viewModel.onSubfilterSelected(filter)
-        verify(readerTracker).track(AnalyticsTracker.Stat.READER_FILTER_SHEET_ITEM_SELECTED)
+        verify(readerTracker, times(0)).track(AnalyticsTracker.Stat.READER_FILTER_SHEET_ITEM_SELECTED)
+    }
+
+    @Test
+    fun `Should NOT track READER_FILTER_SHEET_ITEM_SELECTED if SectionTitle when onSubfilterSelected is called`() {
+        val filter = SubfilterListItem.SectionTitle(UiStringText("test"))
+        viewModel.onSubfilterSelected(filter)
+        verify(readerTracker, times(0)).track(AnalyticsTracker.Stat.READER_FILTER_SHEET_ITEM_SELECTED)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/subfilter/SubFilterViewModelTest.kt
@@ -302,6 +302,8 @@ class SubFilterViewModelTest : BaseUnitTest() {
 
     @Test
     fun `view model updates the tags and sites and asks to show the bottom sheet when filters button is tapped`() {
+        mockReaderTableEmpty()
+
         var updateTasks: EnumSet<UpdateTask>? = null
 
         viewModel.updateTagsAndSites.observeForever { updateTasks = it.peekContent() }
@@ -318,6 +320,8 @@ class SubFilterViewModelTest : BaseUnitTest() {
 
     @Test
     fun `view model asks to show the bottom sheet when filters button is tapped`() {
+        mockReaderTableEmpty()
+
         var uiState: BottomSheetUiState? = null
 
         viewModel.bottomSheetUiState.observeForever { uiState = it.peekContent() }
@@ -538,5 +542,12 @@ class SubFilterViewModelTest : BaseUnitTest() {
             viewModel.setTitleContainerVisibility(isTitleContainerVisible)
             assertThat(viewModel.isTitleContainerVisible.getOrAwaitValue()).isEqualTo(isTitleContainerVisible)
         }
+    }
+
+    private fun mockReaderTableEmpty() {
+        whenever(initialTag.organization).thenReturn(Organization.NO_ORGANIZATION)
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(readerTagTableWrapper.getFollowedTags()).thenReturn(ReaderTagList())
+        whenever(readerBlogTableWrapper.getFollowedBlogs()).thenReturn(emptyList())
     }
 }


### PR DESCRIPTION
Fixes #20814 

- Keep a consistent reference to the SubFilterViewModel observers to leverage the existing Observable APIs, which handle duplicate observation, removal, and re-observation in case of multiple observe call and lifecycle state changes
- Fix sending the `reader_filter_sheet_item_selected` when selecting a filterable feed (e.g.: Subscriptions and Your Tags)

-----

## To Test:

1. Install Jetpack
2. Make sure `App Setting` -> `Privacy` -> `Collect Information` is enabled
3. Make sure `reader_tags_feed` Feature config is enabled (`Debug Settings` -> `Remote Features`
4. Go to Reader
5. Go to Subscriptions
6. **Verify** `reader_filter_sheet_item_selected` is not tracked
7. Tap the subfilter pill
8. **Verify** appropriate events are tracked ONLY ONCE
9. Tap a Site
10. **Verify** `reader_filter_sheet_item_selected` is tracked ONLY ONCE
11. Tap the pill again
12. Repeat 9-11 multiple times making sure events are tracked ONLY ONCE per trigger
13. Go to Your Tags
14. Repeat 6-12

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

15. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

16. What automated tests I added (or what prevented me from doing so)

    - Unit tests not added for the one-time initialization mechanism since it is done completely in Fragment and ViewModel non-exposed APIs (`onCleared`)
    - Unit tests updated for bug fix related to sending `reader_filter_sheet_item_selected` when opening a filterable feed

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
