### PR TITLE
Fix crash in ReaderActivityLauncher

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -256,10 +256,9 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             }
 
             requireNotNull(notification).let { note ->
-                val maybeActivity: FragmentActivity? = activity
-                maybeActivity?.let { fragmentActivity ->
+                context?.let { nonNullContext ->
                     ReaderActivityLauncher.showReaderComments(
-                        fragmentActivity, note.siteId.toLong(), note.postId.toLong(),
+                        nonNullContext, note.siteId.toLong(), note.postId.toLong(),
                         note.commentId,
                         COMMENT_NOTIFICATION.sourceDescription
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ListView
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.ListFragment
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.lottie.LottieAnimationView
@@ -255,11 +256,14 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
             }
 
             requireNotNull(notification).let { note ->
-                ReaderActivityLauncher.showReaderComments(
-                    activity, note.siteId.toLong(), note.postId.toLong(),
-                    note.commentId,
-                    COMMENT_NOTIFICATION.sourceDescription
-                )
+                val maybeActivity: FragmentActivity? = activity
+                maybeActivity?.let { fragmentActivity ->
+                    ReaderActivityLauncher.showReaderComments(
+                        fragmentActivity, note.siteId.toLong(), note.postId.toLong(),
+                        note.commentId,
+                        COMMENT_NOTIFICATION.sourceDescription
+                    )
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -13,7 +13,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ListView
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.ListFragment
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.lottie.LottieAnimationView

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragmentPage.kt
@@ -225,13 +225,15 @@ class NotificationsListFragmentPage : ViewPagerFragment(R.layout.notifications_l
         viewModel.openNote(
             noteId,
             { siteId, postId, commentId ->
-                ReaderActivityLauncher.showReaderComments(
-                    activity,
-                    siteId,
-                    postId,
-                    commentId,
-                    ThreadedCommentsActionSource.COMMENT_NOTIFICATION.sourceDescription
-                )
+                activity?.let {
+                    ReaderActivityLauncher.showReaderComments(
+                        it,
+                        siteId,
+                        postId,
+                        commentId,
+                        ThreadedCommentsActionSource.COMMENT_NOTIFICATION.sourceDescription
+                    )
+                }
             },
             {
                 // Open the latest version of this note in case it has changed, which can happen if the note was

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -273,8 +273,8 @@ public class ReaderActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.READER_FOLLOW_CONVERSATION);
     }
 
-    private static Intent buildShowReaderCommentsIntent(@NonNull Context context, long blogId, long postId, DirectOperation
-            directOperation, long commentId, String interceptedUri, String source) {
+    private static Intent buildShowReaderCommentsIntent(@NonNull Context context, long blogId, long postId,
+            DirectOperation directOperation, long commentId, String interceptedUri, String source) {
         Intent intent = new Intent(
                 context,
                 ReaderCommentListActivity.class

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -13,7 +13,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 
-import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
@@ -256,7 +255,7 @@ public class ReaderActivityLauncher {
         showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, source);
     }
 
-    public static void showReaderCommentsForResult(@NotNull Fragment fragment, long blogId, long postId, DirectOperation
+    public static void showReaderCommentsForResult(@NonNull Fragment fragment, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
         if (fragment.getContext() == null) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -247,7 +247,7 @@ public class ReaderActivityLauncher {
     }
 
     public static void showReaderCommentsForResult(
-            Fragment fragment,
+            @NonNull Fragment fragment,
             long blogId,
             long postId,
             String source

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -13,6 +13,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
 
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
@@ -193,7 +194,7 @@ public class ReaderActivityLauncher {
     /*
      * show comments for the passed Ids
      */
-    public static void showReaderComments(Context context,
+    public static void showReaderComments(@NonNull Context context,
                                           long blogId,
                                           long postId,
                                           String source) {
@@ -205,7 +206,7 @@ public class ReaderActivityLauncher {
      * show specific comment for the passed Ids
      */
     public static void showReaderComments(
-        Context context,
+        @NonNull Context context,
         long blogId,
         long postId,
         long commentId,
@@ -232,11 +233,8 @@ public class ReaderActivityLauncher {
      * @param commentId       specific comment id to perform an action on
      * @param interceptedUri  URI to fall back into (i.e. to be able to open in external browser)
      */
-    public static void showReaderComments(Context context, long blogId, long postId, DirectOperation
+    public static void showReaderComments(@NonNull Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
-        if (context == null) {
-            return;
-        }
         Intent intent = buildShowReaderCommentsIntent(
                 context,
                 blogId,
@@ -258,7 +256,7 @@ public class ReaderActivityLauncher {
         showReaderCommentsForResult(fragment, blogId, postId, null, 0, null, source);
     }
 
-    public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, DirectOperation
+    public static void showReaderCommentsForResult(@NotNull Fragment fragment, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
         if (fragment.getContext() == null) {
             return;
@@ -275,7 +273,7 @@ public class ReaderActivityLauncher {
         fragment.startActivityForResult(intent, RequestCodes.READER_FOLLOW_CONVERSATION);
     }
 
-    private static Intent buildShowReaderCommentsIntent(Context context, long blogId, long postId, DirectOperation
+    private static Intent buildShowReaderCommentsIntent(@NonNull Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
         Intent intent = new Intent(
                 context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -234,6 +234,9 @@ public class ReaderActivityLauncher {
      */
     public static void showReaderComments(Context context, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
+        if (context == null) {
+            return;
+        }
         Intent intent = buildShowReaderCommentsIntent(
                 context,
                 blogId,
@@ -257,6 +260,9 @@ public class ReaderActivityLauncher {
 
     public static void showReaderCommentsForResult(Fragment fragment, long blogId, long postId, DirectOperation
             directOperation, long commentId, String interceptedUri, String source) {
+        if (fragment.getContext() == null) {
+            return;
+        }
         Intent intent = buildShowReaderCommentsIntent(
                 fragment.getContext(),
                 blogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -40,7 +40,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -40,6 +40,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
@@ -1580,11 +1581,14 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun handleDirectOperation() = when (directOperation) {
         DirectOperation.COMMENT_JUMP, DirectOperation.COMMENT_REPLY, DirectOperation.COMMENT_LIKE -> {
             viewModel.post?.let {
-                ReaderActivityLauncher.showReaderComments(
-                    activity, it.blogId, it.postId,
-                    directOperation, commentId.toLong(), viewModel.interceptedUri,
-                    DIRECT_OPERATION.sourceDescription
-                )
+                val maybeActivity: FragmentActivity? = activity
+                maybeActivity?.let { fragmentActivity ->
+                    ReaderActivityLauncher.showReaderComments(
+                        fragmentActivity, it.blogId, it.postId,
+                        directOperation, commentId.toLong(), viewModel.interceptedUri,
+                        DIRECT_OPERATION.sourceDescription
+                    )
+                }
             }
 
             activity?.finish()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -1581,10 +1581,9 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
     private fun handleDirectOperation() = when (directOperation) {
         DirectOperation.COMMENT_JUMP, DirectOperation.COMMENT_REPLY, DirectOperation.COMMENT_LIKE -> {
             viewModel.post?.let {
-                val maybeActivity: FragmentActivity? = activity
-                maybeActivity?.let { fragmentActivity ->
+                context?.let { nonNullContext ->
                     ReaderActivityLauncher.showReaderComments(
-                        fragmentActivity, it.blogId, it.postId,
+                        nonNullContext, it.blogId, it.postId,
                         directOperation, commentId.toLong(), viewModel.interceptedUri,
                         DIRECT_OPERATION.sourceDescription
                     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverFragment.kt
@@ -172,12 +172,14 @@ class ReaderDiscoverFragment : ViewPagerFragment(R.layout.reader_discover_fragme
         is ShowPostDetail -> ReaderActivityLauncher.showReaderPostDetail(context, event.post.blogId, event.post.postId)
         is SharePost -> ReaderActivityLauncher.sharePost(context, event.post)
         is OpenPost -> ReaderActivityLauncher.openPost(context, event.post)
-        is ShowReaderComments -> ReaderActivityLauncher.showReaderComments(
-            context,
-            event.blogId,
-            event.postId,
-            READER_POST_CARD.sourceDescription
-        )
+        is ShowReaderComments -> context?.let {
+            ReaderActivityLauncher.showReaderComments(
+                it,
+                event.blogId,
+                event.postId,
+                READER_POST_CARD.sourceDescription
+            )
+        }
         is ShowNoSitesToReblog -> ReaderActivityLauncher.showNoSiteToReblog(activity)
         is ShowSitePickerForResult -> ActivityLauncher.showSitePickerForResult(
             this@ReaderDiscoverFragment,


### PR DESCRIPTION
Fixes #20847

This PR addresses a crash related to `context` being null when calling `buildShowReaderCommentsIntent()`. 

-----

## To Test:

I haven't been able to reproduce this crash, so code check + smoke test comments on the Reader.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

4. What automated tests I added (or what prevented me from doing so)

    - None
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~

