### PR TITLE
[Voice to Content] Implement voice to content feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -151,6 +151,7 @@ android {
         buildConfigField "boolean", "READER_DISCOVER_NEW_ENDPOINT", "false"
         buildConfigField "boolean", "READER_READING_PREFERENCES", "false"
         buildConfigField "boolean", "READER_READING_PREFERENCES_FEEDBACK", "false"
+        buildConfigField "boolean", "VOICE_TO_CONTENT", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/VoiceToContentFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/VoiceToContentFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val VOICE_TO_CONTENT_REMOTE_FIELD = "voice_to_content"
+
+@Feature(remoteField = VOICE_TO_CONTENT_REMOTE_FIELD, defaultValue = false)
+class VoiceToContentFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.VOICE_TO_CONTENT,
+    VOICE_TO_CONTENT_REMOTE_FIELD,
+)


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/63

-----

## To Test:
- Install and launch the JP app.
- Go to My Site -> Me -> App Settings -> Debug settings.
- Notice that VoiceToContent exists 

-----

## Regression Notes

1. Potential unintended areas of impact
The feature flag does not show in the list of flags

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
    
-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A

