### PR TITLE
[Bug] Null check and return false if null.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -75,7 +75,7 @@ class EditPostRepository
     val status: PostStatus
         get() = fromPost(getPost())
     val isPage: Boolean
-        get() = post!!.isPage
+        get() = post?.isPage == true
     val isLocalDraft: Boolean
         get() = post!!.isLocalDraft
     val isLocallyChanged: Boolean


### PR DESCRIPTION
Fixes [Sentry Issue](https://a8c.sentry.io/issues/5274347067/) - [Github Issue](https://github.com/wordpress-mobile/WordPress-Android/issues/20880)

This crash is happening because we are using the `!!` bang operator to unsafely use a possibly nullable variable. Even if the expectation is to not have a null, crashing isn't the answer. So returning false in case it is null. I took a look at how `isPage` is being used, which is the source of the crash. And it's used to decide the height of the bottom sheet. I can't reproduce the issue.

An alternative solution here could be to just not allow a publish bottom sheet to show. This could be good because the post loading could be a result of a race condition.

-----

## To Test:

- [ ] Go to post list and drafts
- [ ] Click the overflow menu item on the right.
- [ ] Click publish
- [ ] Publish the post.
- [ ] If we made it here we are good to go.

-----

## Regression Notes

1. Potential unintended areas of impact

    If the post is null, allowing a publish could be problematic. We don't use the post for anything else. So I can't see how it could be an issue. But is a possibility.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    None.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
