### PR TITLE
[Tags Feed] Update feed tags as Diff, keeping existing tag content

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -94,18 +94,31 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
     ): ReaderTagsFeedViewModel.UiState.Loaded =
         ReaderTagsFeedViewModel.UiState.Loaded(
             data = tags.map { tag ->
-                ReaderTagsFeedViewModel.TagFeedItem(
-                    tagChip = ReaderTagsFeedViewModel.TagChip(
-                        tag = tag,
-                        onTagChipClick = onTagChipClick,
-                        onMoreFromTagClick = onMoreFromTagClick,
-                    ),
-                    postList = ReaderTagsFeedViewModel.PostList.Initial,
+                mapInitialTagFeedItem(
+                    tag = tag,
+                    onTagChipClick = onTagChipClick,
+                    onMoreFromTagClick = onMoreFromTagClick,
                     onItemEnteredView = onItemEnteredView,
                 )
             },
             isRefreshing = isRefreshing,
             onRefresh = onRefresh,
+        )
+
+    fun mapInitialTagFeedItem(
+        tag: ReaderTag,
+        onTagChipClick: (ReaderTag) -> Unit,
+        onMoreFromTagClick: (ReaderTag) -> Unit,
+        onItemEnteredView: (ReaderTagsFeedViewModel.TagFeedItem) -> Unit,
+    ): ReaderTagsFeedViewModel.TagFeedItem =
+        ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = tag,
+                onTagChipClick = onTagChipClick,
+                onMoreFromTagClick = onMoreFromTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Initial,
+            onItemEnteredView = onItemEnteredView,
         )
 
     fun mapLoadingTagFeedItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader.views.compose.tagsfeed
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -87,7 +88,7 @@ fun ReaderTagsFeed(uiState: UiState) {
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun Loaded(uiState: UiState.Loaded) {
     val pullRefreshState = rememberPullRefreshState(
@@ -108,6 +109,7 @@ private fun Loaded(uiState: UiState.Loaded) {
         ) {
             items(
                 items = uiState.data,
+                key = { it.tagChip.tag.tagSlug }
             ) { item ->
                 val tagChip = item.tagChip
                 val postList = item.postList
@@ -121,24 +123,33 @@ private fun Loaded(uiState: UiState.Loaded) {
                 } else {
                     AppColor.Black.copy(alpha = 0.08F)
                 }
-                Spacer(modifier = Modifier.height(Margin.Large.value))
-                // Tag chip UI
-                ReaderFilterChip(
-                    modifier = Modifier.padding(
-                        start = Margin.Large.value,
-                    ),
-                    text = UiString.UiStringText(tagChip.tag.tagTitle),
-                    onClick = { tagChip.onTagChipClick(tagChip.tag) },
-                    height = 36.dp,
-                )
-                Spacer(modifier = Modifier.height(Margin.Large.value))
-                // Posts list UI
-                when (postList) {
-                    is PostList.Initial, is PostList.Loading -> PostListLoading()
-                    is PostList.Loaded -> PostListLoaded(postList, tagChip, backgroundColor)
-                    is PostList.Error -> PostListError(postList, tagChip, backgroundColor)
+
+                Column(
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .fillMaxWidth()
+                        .padding(
+                            top = Margin.Large.value,
+                            bottom = Margin.ExtraExtraMediumLarge.value,
+                        )
+                ) {
+                    // Tag chip UI
+                    ReaderFilterChip(
+                        modifier = Modifier.padding(
+                            start = Margin.Large.value,
+                        ),
+                        text = UiString.UiStringText(tagChip.tag.tagTitle),
+                        onClick = { tagChip.onTagChipClick(tagChip.tag) },
+                        height = 36.dp,
+                    )
+                    Spacer(modifier = Modifier.height(Margin.Large.value))
+                    // Posts list UI
+                    when (postList) {
+                        is PostList.Initial, is PostList.Loading -> PostListLoading()
+                        is PostList.Loaded -> PostListLoaded(postList, tagChip, backgroundColor)
+                        is PostList.Error -> PostListError(postList, tagChip, backgroundColor)
+                    }
                 }
-                Spacer(modifier = Modifier.height(Margin.ExtraExtraMediumLarge.value))
             }
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
@@ -256,7 +256,75 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should map loading posts UI state correctly`() {
+    fun `Should map loading TagFeedItem correctly`() {
+        // Given
+        val readerTag = ReaderTag(
+            "tag",
+            "tag",
+            "tag",
+            "endpoint",
+            ReaderTagType.FOLLOWED,
+        )
+        val onTagChipClick: (ReaderTag) -> Unit = {}
+        val onMoreFromTagClick: (ReaderTag) -> Unit = {}
+        val onItemEnteredView: (ReaderTagsFeedViewModel.TagFeedItem) -> Unit = {}
+        // When
+        val actual = classToTest.mapLoadingTagFeedItem(
+            tag = readerTag,
+            onTagChipClick = onTagChipClick,
+            onMoreFromTagClick = onMoreFromTagClick,
+            onItemEnteredView = onItemEnteredView,
+        )
+
+        // Then
+        val expected = ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = readerTag,
+                onTagChipClick = onTagChipClick,
+                onMoreFromTagClick = onMoreFromTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Loading,
+            onItemEnteredView = onItemEnteredView,
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should map initial TagFeedItem correctly`() {
+        // Given
+        val readerTag = ReaderTag(
+            "tag",
+            "tag",
+            "tag",
+            "endpoint",
+            ReaderTagType.FOLLOWED,
+        )
+        val onTagChipClick: (ReaderTag) -> Unit = {}
+        val onMoreFromTagClick: (ReaderTag) -> Unit = {}
+        val onItemEnteredView: (ReaderTagsFeedViewModel.TagFeedItem) -> Unit = {}
+        // When
+        val actual = classToTest.mapInitialTagFeedItem(
+            tag = readerTag,
+            onTagChipClick = onTagChipClick,
+            onMoreFromTagClick = onMoreFromTagClick,
+            onItemEnteredView = onItemEnteredView,
+        )
+
+        // Then
+        val expected = ReaderTagsFeedViewModel.TagFeedItem(
+            tagChip = ReaderTagsFeedViewModel.TagChip(
+                tag = readerTag,
+                onTagChipClick = onTagChipClick,
+                onMoreFromTagClick = onMoreFromTagClick,
+            ),
+            postList = ReaderTagsFeedViewModel.PostList.Initial,
+            onItemEnteredView = onItemEnteredView,
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Should map initial posts UI state correctly`() {
         // Given
         val onTagChipClick: (ReaderTag) -> Unit = {}
         val onMoreFromTagClick: (ReaderTag) -> Unit = {}


### PR DESCRIPTION
Fixes #20811

When a new `onTagsChanged` is called and the current UI State is `Loaded`, let's just update the tags list and keep any content we already fetched before, by:
- Removing rows from tags that are not in the new call
- Adding rows for tags in the new call in the appropriate position, in the Initial state
- Using modifier to animate content to the correct place, using tag slug as key

-----

## To Test:
1. Open Jetpack
2. Make sure `reader_tags_feed` Feature Config is ON
3. Go to Reader
4. Go to `Your Tags` feed
5. Scroll horizontally in one of the tags and tap `More from`
6. Unfollow the tag
7. Go back
8. **Verify** the tag is removed from the list but the existing tags don't reload

You can also test adding a new tag by:
1. Go to `Your Tags` feed
2. Scroll horizontally in one of the tags and tap `More from`
2. Tap one of the posts
3. Tap a tag from the post that you don't follow yet
4. Follow that tag
5. Hit back until you're back in the `Your Tags` feed
6. **Verify** the new tag appears in the appropriate position and existing tags kept their state

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

10. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

11. What automated tests I added (or what prevented me from doing so)

    - Added unit tests for new scenarios
    - Update unit tests for existing scenarios

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
