### PR TITLE
[Reader] Implement announcement card improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/discover/ReaderDiscoverViewModel.kt
@@ -154,11 +154,13 @@ class ReaderDiscoverViewModel @Inject constructor(
                 // since new users have the dailyprompt tag followed by default, we need to ignore them when
                 // checking if the user has any tags followed, so we show the onboarding state (ShowNoFollowedTags)
                 if (userTags.filterNot { it.tagSlug == BLOGGING_PROMPT_TAG }.isEmpty()) {
+                    parentViewModel.onFeedEmptyStateLoaded()
                     _uiState.value = DiscoverUiState.EmptyUiState.ShowNoFollowedTagsUiState {
                         parentViewModel.onShowReaderInterests()
                     }
                 } else {
                     if (posts != null && posts.cards.isNotEmpty()) {
+                        parentViewModel.onFeedContentLoaded()
                         _uiState.value = DiscoverUiState.ContentUiState(
                             convertCardsToUiStates(posts),
                             reloadProgressVisibility = false,
@@ -169,6 +171,7 @@ class ReaderDiscoverViewModel @Inject constructor(
                             swipeToRefreshTriggered = false
                         }
                     } else {
+                        parentViewModel.onFeedEmptyStateLoaded()
                         _uiState.value = DiscoverUiState.EmptyUiState.ShowNoPostsUiState {
                             _navigationEvents.value = Event(ShowReaderSubs)
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -142,6 +142,20 @@ class ReaderViewModel @Inject constructor(
         }
     }
 
+    fun onFeedEmptyStateLoaded() {
+        hideAnnouncementCard()
+    }
+
+    fun onFeedContentLoaded() {
+        updateAnnouncementCard()
+    }
+    
+    private fun hideAnnouncementCard() {
+        _announcementCardState.value = _announcementCardState.value?.copy(
+            shouldShow = false,
+        )
+    }
+
     private fun showJetpackPoweredBottomSheet() {
 //        _showJetpackPoweredBottomSheet.value = Event(true)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -132,7 +132,6 @@ class ReaderViewModel @Inject constructor(
         if (initialized) return
         loadTabs(savedInstanceState)
         if (jetpackBrandingUtils.shouldShowJetpackPoweredBottomSheet()) showJetpackPoweredBottomSheet()
-        updateAnnouncementCard()
     }
 
     fun onSaveInstanceState(out: Bundle) {
@@ -213,7 +212,9 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun onTagChanged(selectedTag: ReaderTag?) {
-        updateAnnouncementCard()
+        if (selectedTag?.isDiscover == false) {
+            hideAnnouncementCard()
+        }
         selectedTag?.let {
             trackReaderTabShownIfNecessary(it)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -180,9 +180,9 @@ class ReaderViewModel @Inject constructor(
                 descriptionRes = R.string.reader_announcement_card_reading_preferences_description,
             )
         )
-
+        val isDiscoverSelected = selectedReaderTag()?.isDiscover == true
         _announcementCardState.value = AnnouncementCardUiState(
-            shouldShow = readerAnnouncementCardFeatureConfig.isEnabled() &&
+            shouldShow = isDiscoverSelected && readerAnnouncementCardFeatureConfig.isEnabled() &&
                     appPrefsWrapper.shouldShowReaderAnnouncementCard(),
             items = items,
         )
@@ -213,6 +213,7 @@ class ReaderViewModel @Inject constructor(
     }
 
     fun onTagChanged(selectedTag: ReaderTag?) {
+        updateAnnouncementCard()
         selectedTag?.let {
             trackReaderTabShownIfNecessary(it)
         }

--- a/WordPress/src/main/res/layout/reader_fragment_layout.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_layout.xml
@@ -16,47 +16,26 @@
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|enterAlways" />
 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingBottom="56dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <FrameLayout
-            android:id="@+id/container"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/reader_announcement_card_compose_view" />
-
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/reader_announcement_card_compose_view"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_scrollFlags="scroll|enterAlways" />
 
-        <FrameLayout
-            android:id="@+id/interests_fragment_container"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    </com.google.android.material.appbar.AppBarLayout>
 
-        <include
-            android:id="@+id/jetpack_banner"
-            layout="@layout/jetpack_banner"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <include
+        android:id="@+id/jetpack_banner"
+        layout="@layout/jetpack_banner" />
 
+    <FrameLayout
+        android:id="@+id/interests_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModelTest.kt
@@ -510,10 +510,10 @@ class ReaderViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should load announcement card correctly with tags item`() = testWithNonEmptyTags {
+    fun `Should update announcement card UI correctly with tags item`() = testWithNonEmptyTags {
         whenever(readerTagsFeedFeatureConfig.isEnabled()).thenReturn(true)
 
-        triggerContentDisplay()
+        viewModel.onFeedContentLoaded()
         val observers = initObservers()
 
         val announcementCardUiState = observers.announcementCardStateEvents.first()
@@ -536,10 +536,10 @@ class ReaderViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should load announcement card correctly without tags item`() = testWithNonEmptyTags {
+    fun `Should update announcement card UI correctly without tags item onFeedContentLoaded`() = testWithNonEmptyTags {
         whenever(readerTagsFeedFeatureConfig.isEnabled()).thenReturn(false)
 
-        triggerContentDisplay()
+        viewModel.onFeedContentLoaded()
         val observers = initObservers()
 
         val announcementCardUiState = observers.announcementCardStateEvents.first()
@@ -557,32 +557,41 @@ class ReaderViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should show announcement card if feature flag is enabled and app preference returns true`() =
+    fun `Should show announcement card if feature flag is enabled, app preference returns true and feed is Discover`() =
         testWithNonEmptyTags {
-        whenever(readerAnnouncementCardFeatureConfig.isEnabled()).thenReturn(true)
-        whenever(appPrefsWrapper.shouldShowReaderAnnouncementCard()).thenReturn(true)
-        triggerContentDisplay()
-        val observers = initObservers()
-
-        val announcementCardUiState = observers.announcementCardStateEvents.first()
-        assertTrue(announcementCardUiState.shouldShow)
-    }
-
-    @Test
-    fun `Should NOT show announcement card if feature flag is disabled`() = testWithNonEmptyTags {
-            whenever(readerAnnouncementCardFeatureConfig.isEnabled()).thenReturn(false)
-            triggerContentDisplay()
+            val readerTag = ReaderTag("Discover", "Discover", "Discover", DISCOVER_PATH, ReaderTagType.DEFAULT)
+            whenever(readerAnnouncementCardFeatureConfig.isEnabled()).thenReturn(true)
+            whenever(appPrefsWrapper.shouldShowReaderAnnouncementCard()).thenReturn(true)
             val observers = initObservers()
+            triggerContentDisplay()
+            viewModel.updateSelectedContent(readerTag)
+            viewModel.onFeedContentLoaded()
 
             val announcementCardUiState = observers.announcementCardStateEvents.first()
-            assertFalse(announcementCardUiState.shouldShow)
+            assertTrue(announcementCardUiState.shouldShow)
         }
 
     @Test
+    fun `Should NOT show announcement card if feature flag is disabled`() = testWithNonEmptyTags {
+        val readerTag = ReaderTag("Discover", "Discover", "Discover", DISCOVER_PATH, ReaderTagType.DEFAULT)
+        whenever(readerAnnouncementCardFeatureConfig.isEnabled()).thenReturn(false)
+        val observers = initObservers()
+        triggerContentDisplay()
+        viewModel.updateSelectedContent(readerTag)
+        viewModel.onFeedContentLoaded()
+
+        val announcementCardUiState = observers.announcementCardStateEvents.first()
+        assertFalse(announcementCardUiState.shouldShow)
+    }
+
+    @Test
     fun `Should NOT show announcement card if app preference returns false`() = testWithNonEmptyTags {
+        val readerTag = ReaderTag("Discover", "Discover", "Discover", DISCOVER_PATH, ReaderTagType.DEFAULT)
         whenever(readerAnnouncementCardFeatureConfig.isEnabled()).thenReturn(true)
         whenever(appPrefsWrapper.shouldShowReaderAnnouncementCard()).thenReturn(false)
         triggerContentDisplay()
+        viewModel.updateSelectedContent(readerTag)
+        viewModel.onFeedContentLoaded()
         val observers = initObservers()
 
         val announcementCardUiState = observers.announcementCardStateEvents.first()


### PR DESCRIPTION
Fixes #20621 

Shows the Reader announcement card just on "Discover" feed and implements the suggestions [made by @develric](https://github.com/wordpress-mobile/WordPress-Android/pull/20846#pullrequestreview-2068338331).

https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/afed09f6-7435-4d33-8c1f-ed120e4f9692

-----

## To Test:

- Install JP and log in.
- Make sure the `reader_announcement_card` feature flag is *disabled*.
- Open Reader.
- 🔍 Verify the announcement card is not shown in any feed.
- Enable `reader_announcement_card` feature flag.
- Open Reader.
- 🔍 Verify the announcement card appears as expected **only on Discover feed**.
- 🔍 Unfollow all tags and open Discover feed: the empty state UI should be shown and the announcement card should be hidden.
- 🔍 Tap "Done" button: make sure the announcement card disappears and is never shown again (unless the app data is cleared).

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)

    - Updated `ReaderViewModelTest`.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
