### PR TITLE
Fix crash in GutenbergContainerFragment

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -680,6 +680,13 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                 String blockId = data.getStringExtra(WPGutenbergWebViewActivity.ARG_BLOCK_ID);
                 String content = data.getStringExtra(WPGutenbergWebViewActivity.ARG_BLOCK_CONTENT);
                 getGutenbergContainerFragment().replaceUnsupportedBlock(content, blockId);
+                if (mCurrentGutenbergPropsBuilder == null) {
+                    SavedInstanceDatabase db = SavedInstanceDatabase.Companion.getDatabase(getContext());
+                    if (db != null) {
+                        mCurrentGutenbergPropsBuilder = db.getParcel(ARG_GUTENBERG_PROPS_BUILDER,
+                                GutenbergPropsBuilder.CREATOR);
+                    }
+                }
                 // We need to send latest capabilities as JS side clears them
                 getGutenbergContainerFragment().updateCapabilities(mCurrentGutenbergPropsBuilder);
                 trackWebViewClosed("save");


### PR DESCRIPTION
Fixes #20831


This PR fixes a crash in `GutenbergContainerFragment` caused by `gutenbergPropsBuilder` being null. Since it is possible for `gutenbergPropsBuilder == null` if `db == null` in `GutenbergEditorFragment.java (line 208)`, I've annotated it to be `@NonNull` and added a null check in the function calling it.

-----

## To Test:

I haven't been able to reproduce, so code check + smoke test the post editor. 

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

4. What automated tests I added (or what prevented me from doing so)

    - None
-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
