### PR TITLE
[Reader] Show filters in A8C and P2 feeds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/ReaderViewModel.kt
@@ -570,7 +570,7 @@ class ReaderViewModel @Inject constructor(
     }
 
     private fun shouldShowBlogsFilter(readerTag: ReaderTag): Boolean {
-        return readerTag.isFilterable && readerTag.isFollowedSites
+        return readerTag.isFilterable && !readerTag.isTags
     }
 
     private fun shouldShowTagsFilter(readerTag: ReaderTag): Boolean {


### PR DESCRIPTION
Some changes related to Tags Feed caused the `Blog` filter to disappear in other `Filterable` feeds, such as the `Automattic` and `P2` feeds. This PR fixes that issue by making sure the `Blog` filter ONLY doesn't show for `Tags Feed`.

-----

## To Test:
1. Open Jetpack
2. Login with an A8C account
3. Turn on `reader_tags_feed` FF
4. Go to Reader
5. Go to `Automattic` feed
6. **Verify** the `N Blogs` filter shows up and works

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

8. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
