### PR TITLE
Remote config crash when retrieving integer value

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -171,6 +171,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.analytics.service.InstallationReferrerServiceStarter;
 import org.wordpress.android.util.config.OpenWebLinksWithJetpackFlowFeatureConfig;
 import org.wordpress.android.util.config.QRCodeAuthFlowFeatureConfig;
+import org.wordpress.android.util.config.RemoteConfigWrapper;
 import org.wordpress.android.util.extensions.CompatExtensionsKt;
 import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel;
@@ -308,6 +309,8 @@ public class WPMainActivity extends LocaleAwareActivity implements
     @Inject ActivityNavigator mActivityNavigator;
 
     @Inject SnackbarSequencer mSnackbarSequencer;
+
+    @Inject RemoteConfigWrapper mRemoteConfigWrapper;
 
     /*
      * fragments implement this if their contents can be scrolled, called when user
@@ -527,6 +530,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
+
+        Log.d("RemoteConfigTest", "getPhaseFourOverlayFrequencyConfig value = "
+                        + mRemoteConfigWrapper.getPhaseFourOverlayFrequencyConfig());
     }
 
     private void initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/RemoteConfigWrapper.kt
@@ -10,10 +10,12 @@ class RemoteConfigWrapper @Inject constructor(
     private val performanceMonitoringSampleRateConfig: PerformanceMonitoringSampleRateConfig,
     private val inAppUpdateBlockingVersionConfig: InAppUpdateBlockingVersionConfig,
     private val inAppUpdateFlexibleIntervalConfig: InAppUpdateFlexibleIntervalConfig,
+    private val phaseFourOverlayFrequencyConfig: PhaseFourOverlayFrequencyConfig,
 ) {
     fun getOpenWebLinksWithJetpackFlowFrequency() = openWebLinksWithJetpackFlowFrequencyConfig.getValue<Long>()
     fun getPerformanceMonitoringSampleRate() = performanceMonitoringSampleRateConfig.getValue<Double>()
     fun getCodeableGetFreeEstimateUrl() = codeableGetFreeEstimateUrlConfig.getValue<String>()
     fun getInAppUpdateBlockingVersion() = inAppUpdateBlockingVersionConfig.getValue<Int>()
     fun getInAppUpdateFlexibleIntervalInDays() = inAppUpdateFlexibleIntervalConfig.getValue<Int>()
+    fun getPhaseFourOverlayFrequencyConfig() = phaseFourOverlayFrequencyConfig.getValue<Int>()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.119.0-alpha2'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = '2.79.0'
+    wordPressFluxCVersion = '3017-0a696ccc0424a1a90ee4b3cdd87cd13ce564796f'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
Testing PR for this FluxC [PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3017).

Check the other PR for context. 

Testing Steps: 
1. Install the app from this PR.
2. Login with an account.
3. Check that after login the app does not crash and you can see this line in the logcat. 
 `RemoteConfigTest        com.jetpack.android.prealpha         D  getPhaseFourOverlayFrequencyConfig value = 7`