### PR TITLE
Integrate gutenberg-mobile release v1.119.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = 'v1.119.0-alpha2'
+    gutenbergMobileVersion = '6886-4e63716d9dbf5096aa9d85c076d2b552af345989'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.79.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = '6886-4e63716d9dbf5096aa9d85c076d2b552af345989'
+    gutenbergMobileVersion = 'v1.119.0'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.79.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.119.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6886

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.