### PR TITLE
[Bug] Remove flow and use callbacks instead. I know, pain.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
@@ -23,7 +22,7 @@ fun BarcodeScannerScreen(
     codeScanner: CodeScanner,
     permissionState: BarcodeScanningViewModel.PermissionState,
     onResult: (Boolean) -> Unit,
-    onScannedResult: (Flow<CodeScannerStatus>) -> Unit,
+    onScannedResult: CodeScannerCallback,
 ) {
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
@@ -12,11 +12,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.WPPermissionUtils
 import javax.inject.Inject
@@ -52,12 +48,10 @@ class BarcodeScanningFragment : Fragment() {
                                 shouldShowRequestPermissionRationale(KEY_CAMERA_PERMISSION)
                             )
                         },
-                        onScannedResult = { codeScannerStatus ->
-                            viewLifecycleOwner.lifecycleScope.launch {
-                                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                                    codeScannerStatus.collect { status ->
-                                        setResultAndPopStack(status)
-                                    }
+                        onScannedResult = object : CodeScannerCallback {
+                            override fun run(status: CodeScannerStatus?) {
+                                if (status != null) {
+                                    setResultAndPopStack(status)
                                 }
                             }
                         },

--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/CodeScanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/CodeScanner.kt
@@ -2,11 +2,14 @@ package org.wordpress.android.ui.barcodescanner
 
 import android.os.Parcelable
 import androidx.camera.core.ImageProxy
-import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
 interface CodeScanner {
-    fun startScan(imageProxy: ImageProxy): Flow<CodeScannerStatus>
+    fun startScan(imageProxy: ImageProxy, callback: CodeScannerCallback)
+}
+
+interface CodeScannerCallback {
+    fun run(status: CodeScannerStatus?)
 }
 
 sealed class CodeScannerStatus : Parcelable {

--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/GoogleMLKitCodeScanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/GoogleMLKitCodeScanner.kt
@@ -3,10 +3,6 @@ package org.wordpress.android.ui.barcodescanner
 import androidx.camera.core.ImageProxy
 import com.google.mlkit.vision.barcode.BarcodeScanner
 import com.google.mlkit.vision.barcode.common.Barcode
-import kotlinx.coroutines.channels.ProducerScope
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
 
 class GoogleMLKitCodeScanner @Inject constructor(
@@ -17,53 +13,41 @@ class GoogleMLKitCodeScanner @Inject constructor(
 ) : CodeScanner {
     private var barcodeFound = false
     @androidx.camera.core.ExperimentalGetImage
-    override fun startScan(imageProxy: ImageProxy): Flow<CodeScannerStatus> {
-        return callbackFlow {
-            val barcodeTask = barcodeScanner.process(inputImageProvider.provideImage(imageProxy))
-            barcodeTask.addOnCompleteListener {
-                // We must call image.close() on received images when finished using them.
-                // Otherwise, new images may not be received or the camera may stall.
-                imageProxy.close()
+    override fun startScan(imageProxy: ImageProxy, callback: CodeScannerCallback) {
+        val barcodeTask = barcodeScanner.process(inputImageProvider.provideImage(imageProxy))
+        barcodeTask.addOnCompleteListener {
+            // We must call image.close() on received images when finished using them.
+            // Otherwise, new images may not be received or the camera may stall.
+            imageProxy.close()
+        }
+        barcodeTask.addOnSuccessListener { barcodeList ->
+            // The check for barcodeFound is done because the startScan method will be called
+            // continuously by the library as long as we are in the scanning screen.
+            // There will be a good chance that the same barcode gets identified multiple times and as a result
+            // success callback will be called multiple times.
+            if (!barcodeList.isNullOrEmpty() && !barcodeFound) {
+                barcodeFound = true
+                callback.run(handleScanSuccess(barcodeList.firstOrNull()))
             }
-            barcodeTask.addOnSuccessListener { barcodeList ->
-                // The check for barcodeFound is done because the startScan method will be called
-                // continuously by the library as long as we are in the scanning screen.
-                // There will be a good chance that the same barcode gets identified multiple times and as a result
-                // success callback will be called multiple times.
-                if (!barcodeList.isNullOrEmpty() && !barcodeFound) {
-                    barcodeFound = true
-                    handleScanSuccess(barcodeList.firstOrNull())
-                    this@callbackFlow.close()
-                }
-            }
-            barcodeTask.addOnFailureListener { exception ->
-                this@callbackFlow.trySend(
-                    CodeScannerStatus.Failure(
-                        error = exception.message,
-                        type = errorMapper.mapGoogleMLKitScanningErrors(exception)
-                    )
-                )
-                this@callbackFlow.close()
-            }
-
-            awaitClose()
+        }
+        barcodeTask.addOnFailureListener { exception ->
+            callback.run(CodeScannerStatus.Failure(
+                error = exception.message,
+                type = errorMapper.mapGoogleMLKitScanningErrors(exception)
+            ))
         }
     }
 
-    private fun ProducerScope<CodeScannerStatus>.handleScanSuccess(code: Barcode?) {
-        code?.rawValue?.let {
-            trySend(
-                CodeScannerStatus.Success(
-                    it,
-                    barcodeFormatMapper.mapBarcodeFormat(code.format)
-                )
+    private fun handleScanSuccess(code: Barcode?): CodeScannerStatus {
+        return code?.rawValue?.let {
+            CodeScannerStatus.Success(
+                it,
+                barcodeFormatMapper.mapBarcodeFormat(code.format)
             )
         } ?: run {
-            trySend(
-                CodeScannerStatus.Failure(
-                    error = "Failed to find a valid raw value!",
-                    type = CodeScanningErrorType.Other(Throwable("Empty raw value"))
-                )
+            CodeScannerStatus.Failure(
+                error = "Failed to find a valid raw value!",
+                type = CodeScanningErrorType.Other(Throwable("Empty raw value"))
             )
         }
     }


### PR DESCRIPTION
Fixes [Sentry issue](https://a8c.sentry.io/issues/5299933951/) - [Github Issue](https://github.com/wordpress-mobile/WordPress-Android/issues/20778)

There is a bug where scanning for a QR code causes an "Image is already closed" `IllegalStateException`. As it turns out this occurs anytime you are mid scan and you go `onPause`. Coming back causes the crash 100% of the time.

During my investigation I partially learned why the crash occurred. During the `ImageAnalysis.Analyzer` we are grabbing the `ImageProxy` and scanning it. Before doing the actual scanning though, we create a callback flow. When the user puts the app in the background and comes back, the old frames from the flow are still present. The reason this is a problem is because the `ImageProxy` is closed. When we come back the flow is restarted, and BAM, crash.

I attempted multiple different things to make the flow work as if it was on the main thread. I couldn't find a way to throw away  flow "events" currently awaiting processing. Why would we throw any away? According to the documentation for [Image Analysis](https://developer.android.com/media/camera/camerax/analyze#create-analyzer), our app should be analyzing frames in under 32ms, and then closing the ImageProxy. The expectation is that this be done quickly and efficiently in the same thread.

I should note that a `try/catch` does work in solving this problem while changing minimal code. But it's not the right approach. I couldn't figure out a solution while still using flows since there exists a requirement to analyze images quickly without the need to process them in the background. So I did the unthinkable... I went to good ol' callbacks 😅 . I removed the flows and kept everything in the same thread. And surprisingly it works. Using a Pixel 4 XL it ran fairly smooth. I tested logging in with QR code and it still works fine.

I should note I ran a quick test to figure out how long the processing takes. With the exception of the initial process, which takes the longest, all other images take under 15ms to process. Meaning we shouldn't notice any performance issues.

If you have a better solution that avoids the crash while still using flows, I'd be interested in hearing about it. Good learning opportunity.

-----

## To Test:

Pre-req: You need to be logged in without a admin account or any 2FA. So use a test account.

- [ ] On web while not logged into wordpress.com, select the option to login via app.
- [ ] On your phone install this build and go to the **Me** tab.
- [ ] Select **Scan Login Code**.
- [ ] Before scanning the barcode background the app or lock the screen and go back while the camera is running.
- [ ] Assuming no crash occurs, then scan the barcode.
- [ ] If you successfully logged in on web with the barcode this was successful.

-----

## Regression Notes

1. Potential unintended areas of impact

    Scanning barcode could be slow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual testing.

3. What automated tests I added (or what prevented me from doing so)

    N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

