### PR TITLE
[Reader] Also add announcement card into the new Tags Feed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapper.kt
@@ -86,6 +86,7 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
     @Suppress("LongParameterList")
     fun mapInitialPostsUiState(
         tags: List<ReaderTag>,
+        announcementItem: ReaderTagsFeedViewModel.ReaderAnnouncementItem?,
         isRefreshing: Boolean,
         onTagChipClick: (ReaderTag) -> Unit,
         onMoreFromTagClick: (ReaderTag) -> Unit,
@@ -101,6 +102,7 @@ class ReaderTagsFeedUiStateMapper @Inject constructor(
                     onItemEnteredView = onItemEnteredView,
                 )
             },
+            announcementItem = announcementItem,
             isRefreshing = isRefreshing,
             onRefresh = onRefresh,
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderAnnouncementCardView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderAnnouncementCardView.kt
@@ -23,7 +23,6 @@ class ReaderAnnouncementCardView @JvmOverloads constructor(
     override fun Content() {
         AppTheme {
             ReaderAnnouncementCard(
-                shouldShow = true,
                 items = items.value,
                 onAnnouncementCardDoneClick = { onDoneClickListener.value?.onDoneClick() }
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
@@ -3,9 +3,6 @@ package org.wordpress.android.ui.reader.views.compose
 import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandIn
-import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -35,57 +32,48 @@ import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
 fun ReaderAnnouncementCard(
-    shouldShow: Boolean,
     items: List<ReaderAnnouncementCardItemData>,
     onAnnouncementCardDoneClick: () -> Unit,
 ) {
     val primaryColor = if (isSystemInDarkTheme()) AppColor.White else AppColor.Black
     val secondaryColor = if (isSystemInDarkTheme()) AppColor.Black else AppColor.White
-    AnimatedVisibility(
-        visible = shouldShow,
-        enter = expandIn(),
-        exit = shrinkOut(
-            shrinkTowards = Alignment.TopCenter,
-        ),
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(Margin.ExtraLarge.value),
+        verticalArrangement = Arrangement.spacedBy(Margin.ExtraLarge.value),
     ) {
+        // Title
+        Text(
+            text = stringResource(R.string.reader_announcement_card_title),
+            style = MaterialTheme.typography.labelLarge,
+            color = primaryColor,
+        )
+        // Items
         Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(Margin.ExtraLarge.value),
-            verticalArrangement = Arrangement.spacedBy(Margin.ExtraLarge.value),
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(Margin.ExtraLarge.value)
         ) {
-            // Title
+            items.forEach {
+                ReaderAnnouncementCardItem(it)
+            }
+        }
+        // Done button
+        Button(
+            modifier = Modifier
+                .fillMaxWidth(),
+            onClick = { onAnnouncementCardDoneClick() },
+            elevation = ButtonDefaults.elevation(0.dp),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = primaryColor,
+            ),
+        ) {
             Text(
-                text = stringResource(R.string.reader_announcement_card_title),
+                text = stringResource(id = R.string.reader_btn_done),
+                color = secondaryColor,
                 style = MaterialTheme.typography.labelLarge,
-                color = primaryColor,
             )
-            // Items
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(Margin.ExtraLarge.value)
-            ) {
-                items.forEach {
-                    ReaderAnnouncementCardItem(it)
-                }
-            }
-            // Done button
-            Button(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                onClick = { onAnnouncementCardDoneClick() },
-                elevation = ButtonDefaults.elevation(0.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = primaryColor,
-                ),
-            ) {
-                Text(
-                    text = stringResource(id = R.string.reader_btn_done),
-                    color = secondaryColor,
-                    style = MaterialTheme.typography.labelLarge,
-                )
-            }
         }
     }
 }
@@ -158,7 +146,6 @@ fun ReaderTagsFeedPostListItemPreview() {
                 .fillMaxWidth()
         ) {
             ReaderAnnouncementCard(
-                shouldShow = false,
                 items = listOf(
                     ReaderAnnouncementCardItemData(
                         iconRes = R.drawable.ic_wifi_off_24px,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -65,6 +65,7 @@ import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewMod
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.TagChip
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.TagFeedItem
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.UiState
+import org.wordpress.android.ui.reader.views.compose.ReaderAnnouncementCard
 import org.wordpress.android.ui.reader.views.compose.filter.ReaderFilterChip
 import org.wordpress.android.ui.utils.UiString
 
@@ -107,6 +108,16 @@ private fun Loaded(uiState: UiState.Loaded) {
             modifier = Modifier
                 .fillMaxSize(),
         ) {
+            uiState.announcementItem?.let { announcementItem ->
+                item(key = "reader-announcement-card") {
+                    ReaderAnnouncementCard(
+                        shouldShow = true,
+                        items = announcementItem.items,
+                        onAnnouncementCardDoneClick = announcementItem.onDoneClicked,
+                    )
+                }
+            }
+
             items(
                 items = uiState.data,
                 key = { it.tagChip.tag.tagSlug }
@@ -611,33 +622,25 @@ fun ReaderTagsFeedLoaded() {
                 ),
             )
         )
-        val readerTag = ReaderTag(
-            "Tag 1",
-            "Tag 1",
-            "Tag 1",
-            "Tag 1",
-            ReaderTagType.TAGS,
-        )
         ReaderTagsFeed(
             uiState = UiState.Loaded(
-                data = listOf(
+                data = List(4) {
+                    val tagName = "Tag ${it + 1}"
                     TagFeedItem(
-                        tagChip = TagChip(readerTag, {}, {}),
+                        tagChip = TagChip(
+                            tag = ReaderTag(
+                                tagName,
+                                tagName,
+                                tagName,
+                                tagName,
+                                ReaderTagType.TAGS,
+                            ),
+                            onTagChipClick = {},
+                            onMoreFromTagClick = {},
+                        ),
                         postList = postListLoaded
-                    ),
-                    TagFeedItem(
-                        tagChip = TagChip(readerTag, {}, {}),
-                        postList = PostList.Initial,
-                    ),
-                    TagFeedItem(
-                        tagChip = TagChip(readerTag, {}, {}),
-                        postList = PostList.Error(ErrorType.Default, {}),
-                    ),
-                    TagFeedItem(
-                        tagChip = TagChip(readerTag, {}, {}),
-                        postList = PostList.Error(ErrorType.NoContent, {}),
-                    ),
-                )
+                    )
+                }
             )
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -111,7 +111,6 @@ private fun Loaded(uiState: UiState.Loaded) {
             uiState.announcementItem?.let { announcementItem ->
                 item(key = "reader-announcement-card") {
                     ReaderAnnouncementCard(
-                        shouldShow = true,
                         items = announcementItem.items,
                         onAnnouncementCardDoneClick = announcementItem.onDoneClicked,
                     )

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/ReaderTagsFeedViewModelTest.kt
@@ -14,7 +14,9 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -35,12 +37,14 @@ import org.wordpress.android.ui.reader.discover.ReaderPostCardActionsHandler
 import org.wordpress.android.ui.reader.discover.ReaderPostMoreButtonUiStateBuilder
 import org.wordpress.android.ui.reader.discover.ReaderPostUiStateBuilder
 import org.wordpress.android.ui.reader.exceptions.ReaderPostFetchException
+import org.wordpress.android.ui.reader.repository.ReaderAnnouncementRepository
 import org.wordpress.android.ui.reader.repository.ReaderPostRepository
 import org.wordpress.android.ui.reader.repository.usecases.PostLikeUseCase
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedUiStateMapper
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.ActionEvent
+import org.wordpress.android.ui.reader.views.compose.ReaderAnnouncementCardItemData
 import org.wordpress.android.ui.reader.views.compose.tagsfeed.TagsFeedPostItem
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.NetworkUtilsWrapper
@@ -86,6 +90,9 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
+    @Mock
+    lateinit var readerAnnouncementRepository: ReaderAnnouncementRepository
+
     private lateinit var viewModel: ReaderTagsFeedViewModel
 
     private val collectedUiStates: MutableList<ReaderTagsFeedViewModel.UiState> = mutableListOf()
@@ -116,6 +123,7 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
             displayUtilsWrapper = displayUtilsWrapper,
             readerTracker = readerTracker,
             networkUtilsWrapper = networkUtilsWrapper,
+            readerAnnouncementRepository = readerAnnouncementRepository,
         )
         whenever(readerPostCardActionsHandler.navigationEvents)
             .thenReturn(navigationEvents)
@@ -124,6 +132,69 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
         observeActionEvents()
         observeNavigationEvents()
         observeErrorMessageEvents()
+    }
+
+    @Test
+    fun `when tags changed, then UI state should update properly`() = testCollectingUiStates {
+        // Given
+        val tag = ReaderTestUtils.createTag("tag")
+        mockMapInitialTagFeedItems()
+
+        // When
+        viewModel.onTagsChanged(listOf(tag))
+        advanceUntilIdle()
+
+        // Then
+        assertThat(collectedUiStates).contains(
+            ReaderTagsFeedViewModel.UiState.Loaded(
+                data = listOf(getInitialTagFeedItem(tag)),
+            )
+        )
+    }
+
+    @Test
+    fun `given has announcement, when tags changed, then UI state should update properly`() = testCollectingUiStates {
+        // Given
+        val tag = ReaderTestUtils.createTag("tag")
+        val announcementItems = listOf<ReaderAnnouncementCardItemData>(mock(), mock())
+        mockMapInitialTagFeedItems()
+        whenever(readerAnnouncementRepository.hasReaderAnnouncement()).thenReturn(true)
+        whenever(readerAnnouncementRepository.getReaderAnnouncementItems()).thenReturn(announcementItems)
+
+        // When
+        viewModel.onTagsChanged(listOf(tag))
+        advanceUntilIdle()
+
+        // Then
+        val loadedState = collectedUiStates.last() as ReaderTagsFeedViewModel.UiState.Loaded
+        assertThat(loadedState.data).isEqualTo(listOf(getInitialTagFeedItem(tag)))
+        assertThat(loadedState.announcementItem!!.items).isEqualTo(announcementItems)
+    }
+
+    @Test
+    fun `given has announcement, when done clicked, then UI state should update properly`() = testCollectingUiStates {
+        // Given
+        val tag = ReaderTestUtils.createTag("tag")
+        val announcementItems = listOf<ReaderAnnouncementCardItemData>(mock(), mock())
+        mockMapInitialTagFeedItems()
+        whenever(readerAnnouncementRepository.hasReaderAnnouncement()).thenReturn(true)
+        whenever(readerAnnouncementRepository.getReaderAnnouncementItems()).thenReturn(announcementItems)
+
+        viewModel.onTagsChanged(listOf(tag))
+        advanceUntilIdle()
+
+        // When
+        val loadedState = collectedUiStates.last() as ReaderTagsFeedViewModel.UiState.Loaded
+        loadedState.announcementItem!!.onDoneClicked()
+        advanceUntilIdle()
+
+        // Then
+        verify(readerAnnouncementRepository).dismissReaderAnnouncement()
+        assertThat(collectedUiStates.last()).isEqualTo(
+            ReaderTagsFeedViewModel.UiState.Loaded(
+                data = listOf(getInitialTagFeedItem(tag)),
+            )
+        )
     }
 
     @Test
@@ -899,13 +970,18 @@ class ReaderTagsFeedViewModelTest : BaseUnitTest() {
         }
 
     private fun mockMapInitialTagFeedItems() {
-        whenever(readerTagsFeedUiStateMapper.mapInitialPostsUiState(any(), any(), any(), any(), any(), any()))
-            .thenAnswer {
-                val tags = it.getArgument<List<ReaderTag>>(0)
-                ReaderTagsFeedViewModel.UiState.Loaded(
-                    tags.map { tag -> getInitialTagFeedItem(tag) }
-                )
-            }
+        whenever(
+            readerTagsFeedUiStateMapper.mapInitialPostsUiState(
+                any(), anyOrNull(), any(), any(), any(), any(), any()
+            )
+        ).thenAnswer {
+            val tags = it.getArgument<List<ReaderTag>>(0)
+            val announcementItem = it.getArgument<ReaderTagsFeedViewModel.ReaderAnnouncementItem?>(1)
+            ReaderTagsFeedViewModel.UiState.Loaded(
+                data = tags.map { tag -> getInitialTagFeedItem(tag) },
+                announcementItem = announcementItem,
+            )
+        }
     }
 
     private fun mockMapLoadingTagFeedItems() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/viewmodels/tagsfeed/ReaderTagsFeedUiStateMapperTest.kt
@@ -323,6 +323,7 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
         assertEquals(expected, actual)
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `Should map initial posts UI state correctly`() {
         // Given
@@ -345,10 +346,15 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
             ReaderTagType.FOLLOWED,
         )
         val tags = listOf(tag1, tag2)
+        val announcementItem = ReaderTagsFeedViewModel.ReaderAnnouncementItem(
+            items = listOf(mock(), mock()),
+            onDoneClicked = {},
+        )
 
         // When
         val actual = classToTest.mapInitialPostsUiState(
             tags = tags,
+            announcementItem = announcementItem,
             isRefreshing = true,
             onTagChipClick = onTagChipClick,
             onMoreFromTagClick = onMoreFromTagClick,
@@ -378,6 +384,7 @@ class ReaderTagsFeedUiStateMapperTest : BaseUnitTest() {
                     onItemEnteredView = onItemEnteredView,
                 )
             ),
+            announcementItem = announcementItem,
             isRefreshing = true,
             onRefresh = onRefresh,
         )


### PR DESCRIPTION
Part of #20621

- Similar to what was done in #20872, this adds the Reader Announcement card inside the Tags Feed
- Remove `shouldShow` from ReaderAnnouncementCard, since the visibility is managed by the Recycler Views and Lazy Columns. 

> [!warning]
> Should be merged after #20872

-----

## To Test:
This relies on a shared pref that is set when the card is dismissed, so to test multiple times you will need to clear app data (or if using an emulator push a shared pref file without the dismiss pref to override the app prefs file).

1. Open Jetpack
2. Turn off the `reader_announcement_card` feature config (in Debug settings)
3. Restart the app
4. Go to Reader
5. **Verify** the announcement card does not show in any feeds
6. Turn on the `reader_announcement_card` feature config (in Debug settings)
7. Restart the app
8. Go to Reader
9. **Verify** the announcement card is shown in all feeds INCLUDING `Your Tags` and except non-main feeds (e.g.: tag preview, blog preview, and filtered tags/blogs in `Your Tags` and `Subscriptions`)

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Updated existing tests
    - Added unit tests for new scenarios

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
