### PR TITLE
[Tags Feed] Enable FFs by default for Tags Feed and Announcement

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/config/ReaderAnnouncementCardFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ReaderAnnouncementCardFeatureConfig.kt
@@ -5,7 +5,7 @@ import org.wordpress.android.annotation.Feature
 import javax.inject.Inject
 
 private const val READER_ANNOUNCEMENT_CARD_REMOTE_FIELD = "reader_announcement_card"
-@Feature(remoteField = READER_ANNOUNCEMENT_CARD_REMOTE_FIELD, defaultValue = false)
+@Feature(remoteField = READER_ANNOUNCEMENT_CARD_REMOTE_FIELD, defaultValue = true)
 class ReaderAnnouncementCardFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(

--- a/WordPress/src/main/java/org/wordpress/android/util/config/ReaderTagsFeedFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/ReaderTagsFeedFeatureConfig.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 
 private const val READER_TAGS_FEED_REMOTE_FIELD = "reader_tags_feed"
 
-@Feature(remoteField = READER_TAGS_FEED_REMOTE_FIELD, defaultValue = false)
+@Feature(remoteField = READER_TAGS_FEED_REMOTE_FIELD, defaultValue = true)
 class ReaderTagsFeedFeatureConfig @Inject constructor(
     appConfig: AppConfig
 ) : FeatureConfig(


### PR DESCRIPTION
- Turn `ReaderAnnouncementCardFeatureConfig` ON by default (`reader_announcement_card`)
- Turn `ReaderTagsFeedFeatureConfig` ON by default (`reader_tags_feed`)

> [!warning]
> Only merge after https://github.com/wordpress-mobile/WordPress-Android/pull/20872 and https://github.com/wordpress-mobile/WordPress-Android/pull/20877 are merged.
> When this is ready to merge, please remove the `Not Ready for Merge` label.

-----

## To Test:

1. Make sure you have a version that is not based on `feature/tags-ia` or uninstall any previous versions
2. Install and open Jetpack
3. Go to Reader
4. **Verify** the Reader Announcement card shows up in the feeds
   1. All "top-level" feeds, except empty states, full screen loading states, and filtered Subscriptions/You Tags
5. Tap the Reader top bar menu
6. **Verify** `Your Tags` is available
7. Tap `Your Tags`
8. **Verify** the Tags feed shows up and works as expected

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

10. What automated tests I added (or what prevented me from doing so)

    - N/A, just turning on the Feature Flags

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
