### PR TITLE
[Reader] Use Body Small style for Announcement card descriptions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.designsystem.footnote
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.Margin
@@ -122,7 +121,7 @@ private fun ReaderAnnouncementCardItem(data: ReaderAnnouncementCardItemData) {
                     start = Margin.Large.value,
                 ),
                 text = stringResource(data.descriptionRes),
-                style = MaterialTheme.typography.footnote,
+                style = MaterialTheme.typography.bodySmall,
                 color = secondaryElementColor,
             )
         }


### PR DESCRIPTION
It uses 12sp instead of the 11sp used by the footnote style, making it more readable.

| Before | After |
|--------|--------|
| ![20621-reader-announcement-current-font](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/6d9260f6-5aa9-4f21-ab95-919a32cf66fc) | ![20621-reader-announcement-12sp-description](https://github.com/wordpress-mobile/WordPress-Android/assets/5091503/1dfdb11d-d9bd-423f-bd31-1f55a7a46782) | 

-----

## To Test:
Make sure the reader announcement was not previously dismissed.

1. Open Jetpack
2. Go to Reader
3. **Verify** the description font size is bigger (12sp) than it was before (11sp)

-----

## Regression Notes

1. Potential unintended areas of impact

    - NA

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - NA

5. What automated tests I added (or what prevented me from doing so)

    - NA

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
