### PR TITLE
Adds Firebase PN icon

### DIFF
--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -64,9 +64,11 @@
                 android:resource="@xml/stats_week_views_widget_info"/>
         </receiver>
 
+        <!-- Set custom default icon. This is used when no icon is set for incoming notification messages.
+            See README(https://goo.gl/l4GJaQ) for more. -->
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
-            android:resource="@drawable/app_icon_foreground" />
+            android:resource="@drawable/app_notification_icon" />
         <!-- Set color used with incoming notification messages. This is used when no color is set for the incoming
              notification message. See README(https://goo.gl/6BKBk7) for more. -->
         <meta-data

--- a/WordPress/src/jetpack/AndroidManifest.xml
+++ b/WordPress/src/jetpack/AndroidManifest.xml
@@ -63,6 +63,15 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/stats_week_views_widget_info"/>
         </receiver>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/app_icon_foreground" />
+        <!-- Set color used with incoming notification messages. This is used when no color is set for the incoming
+             notification message. See README(https://goo.gl/6BKBk7) for more. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/primary" />
     </application>
 
 </manifest>

--- a/WordPress/src/jetpack/res/drawable/app_notification_icon.xml
+++ b/WordPress/src/jetpack/res/drawable/app_notification_icon.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm-1 12H6l5-10v10zm2 6V10h5l-5 10z" />
+</vector>


### PR DESCRIPTION
## Description
This PR adds a Firebase notification icon and background color in the Jetpack app's manifest ([documentation](https://firebase.google.com/docs/cloud-messaging/android/client#manifest)).

Internal ref: paqN3M-1bC-p2 and paqN3M-168-p2

-----

## To Test:
_Use [the Jetpack CI build from this PR](https://github.com/wordpress-mobile/WordPress-Android/pull/20893#issuecomment-2135324126) or a Jalapeno local build for the test._
1. Login with an account that has the FCM HTTP V1 API enabled (an A8C account should work)
2. Trigger a PN (e.g. by logging in with a test account on another device and liking or commenting on your user's post)
3. **Verify** that the PN icon is visible
4. Login with an account that still has the legacy API enabled (an non-A8C account should work)
5. Repeat 2-3 above

|Before (`trunk`)|After (this PR)|
|---|---|
|![Screenshot_20240529_182900](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/decaba6a-26be-4f99-b7f4-79626ea7c725)|![Screenshot_20240529_182118](https://github.com/wordpress-mobile/WordPress-Android/assets/304044/5aab9dc1-6b3b-4fc0-bbd2-35fc68731d42)|

-----

## Regression Notes

1. Potential unintended areas of impact

    - Push Notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual Testing

3. What automated tests I added (or what prevented me from doing so)

    - This is a configuration change

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)