### PR TITLE
Comment details pending moderation redesign

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -28,7 +28,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.databinding.CommentDetailFragmentBinding;
-import org.wordpress.android.databinding.ReaderIncludeCommentBoxBinding;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.UserSuggestionTable;
 import org.wordpress.android.fluxc.action.CommentAction;
@@ -39,7 +38,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.CommentStore.OnCommentChanged;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
-import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
 import org.wordpress.android.fluxc.store.CommentsStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -50,8 +48,6 @@ import org.wordpress.android.models.UserSuggestion;
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateHandler;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment;
-import org.wordpress.android.ui.CollapseFullScreenDialogFragment.OnCollapseListener;
-import org.wordpress.android.ui.CollapseFullScreenDialogFragment.OnConfirmListener;
 import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
@@ -72,11 +68,9 @@ import org.wordpress.android.ui.suggestion.Suggestion;
 import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
 import org.wordpress.android.ui.suggestion.service.SuggestionEvents;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
-import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
-import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -88,7 +82,6 @@ import org.wordpress.android.util.image.ImageType;
 
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -243,7 +236,11 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         if (mBinding != null) {
             showComment(mBinding, mSite, mComment, mNote);
         }
+
+        updateModerationStatus();
     }
+
+    abstract void updateModerationStatus();
 
     public void enableShouldFocusReplyField() {
         mShouldFocusReplyField = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -3,15 +3,10 @@ package org.wordpress.android.ui.comments;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.text.Editable;
 import android.text.TextUtils;
-import android.text.TextWatcher;
-import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.EditorInfo;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -20,7 +15,6 @@ import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.google.android.material.elevation.ElevationOverlayProvider;
 import com.gravatar.AvatarQueryOptions;
 import com.gravatar.AvatarUrl;
 import com.gravatar.types.Email;
@@ -56,10 +50,8 @@ import org.wordpress.android.models.UserSuggestion;
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateHandler;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment;
-import org.wordpress.android.ui.CollapseFullScreenDialogFragment.Builder;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment.OnCollapseListener;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment.OnConfirmListener;
-import org.wordpress.android.ui.CommentFullScreenDialogFragment;
 import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
@@ -81,7 +73,6 @@ import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
 import org.wordpress.android.ui.suggestion.service.SuggestionEvents;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
 import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
-import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -92,7 +83,6 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPAvatarUtils;
 import org.wordpress.android.util.WPLinkMovementMethod;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
-import org.wordpress.android.util.extensions.ViewExtensionsKt;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
@@ -119,8 +109,7 @@ import kotlinx.coroutines.GlobalScope;
  */
 @Deprecated
 @SuppressWarnings("DeprecatedIsStillUsed")
-public abstract class CommentDetailFragment extends ViewPagerFragment implements NotificationFragment,
-        OnConfirmListener, OnCollapseListener {
+public abstract class CommentDetailFragment extends ViewPagerFragment implements NotificationFragment {
     protected static final String KEY_MODE = "KEY_MODE";
     protected static final String KEY_SITE_LOCAL_ID = "KEY_SITE_LOCAL_ID";
     protected static final String KEY_COMMENT_ID = "KEY_COMMENT_ID";
@@ -164,7 +153,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     @NonNull private EnumSet<EnabledActions> mEnabledActions = EnumSet.allOf(EnabledActions.class);
 
     @Nullable protected CommentDetailFragmentBinding mBinding = null;
-    @Nullable protected ReaderIncludeCommentBoxBinding mReplyBinding = null;
 
     private final OnActionClickListener mOnActionClickListener = new OnActionClickListener() {
         @Override public void onEditCommentClicked() {
@@ -212,81 +200,10 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
             @Nullable Bundle savedInstanceState
     ) {
         mBinding = CommentDetailFragmentBinding.inflate(inflater, container, false);
-        mReplyBinding = mBinding.layoutCommentBox;
-
         mMediumOpacity = ResourcesCompat.getFloat(
                 getResources(),
                 com.google.android.material.R.dimen.material_emphasis_medium
         );
-
-        ElevationOverlayProvider elevationOverlayProvider = new ElevationOverlayProvider(
-                mBinding.getRoot().getContext()
-        );
-        float appbarElevation = getResources().getDimension(R.dimen.appbar_elevation);
-        int elevatedColor = elevationOverlayProvider.compositeOverlayWithThemeSurfaceColorIfNeeded(appbarElevation);
-
-        mReplyBinding.layoutContainer.setBackgroundColor(elevatedColor);
-
-        mReplyBinding.btnSubmitReply.setEnabled(false);
-        mReplyBinding.btnSubmitReply.setOnLongClickListener(view1 -> {
-            if (view1.isHapticFeedbackEnabled()) {
-                view1.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-            }
-
-            Toast.makeText(view1.getContext(), R.string.send, Toast.LENGTH_SHORT).show();
-            return true;
-        });
-        ViewExtensionsKt.redirectContextClickToLongPressListener(mReplyBinding.btnSubmitReply);
-
-        mReplyBinding.editComment.initializeWithPrefix('@');
-        mReplyBinding.editComment.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(@NonNull CharSequence s, int start, int count, int after) {
-            }
-
-            @Override
-            public void onTextChanged(@NonNull CharSequence s, int start, int before, int count) {
-            }
-
-            @Override
-            public void afterTextChanged(@NonNull Editable s) {
-                mReplyBinding.btnSubmitReply.setEnabled(!TextUtils.isEmpty(s.toString().trim()));
-            }
-        });
-
-        mReplyBinding.buttonExpand.setOnClickListener(
-                v -> {
-                    if (mSite != null && mComment != null) {
-                        Bundle bundle = CommentFullScreenDialogFragment.Companion.newBundle(
-                                mReplyBinding.editComment.getText().toString(),
-                                mReplyBinding.editComment.getSelectionStart(),
-                                mReplyBinding.editComment.getSelectionEnd(),
-                                mSite.getSiteId()
-                        );
-
-                        new Builder(requireContext())
-                                .setTitle(R.string.comment)
-                                .setOnCollapseListener(this)
-                                .setOnConfirmListener(this)
-                                .setContent(CommentFullScreenDialogFragment.class, bundle)
-                                .setAction(R.string.send)
-                                .setHideActivityBar(true)
-                                .build()
-                                .show(requireActivity().getSupportFragmentManager(),
-                                        getCommentSpecificFragmentTagSuffix(mComment));
-                    }
-                }
-        );
-        mReplyBinding.buttonExpand.setOnLongClickListener(v -> {
-            if (v.isHapticFeedbackEnabled()) {
-                v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-            }
-
-            Toast.makeText(v.getContext(), R.string.description_expand, Toast.LENGTH_SHORT).show();
-            return true;
-        });
-        ViewExtensionsKt.redirectContextClickToLongPressListener(mReplyBinding.buttonExpand);
-        setReplyUniqueId(mReplyBinding, mSite, mComment, mNote);
 
         // this is necessary in order for anchor tags in the comment text to be clickable
         mBinding.textContent.setLinksClickable(true);
@@ -295,30 +212,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         mBinding.imageMore.setOnClickListener(v ->
                 CommentActionPopupHandler.show(mBinding.imageMore, mOnActionClickListener)
         );
-
-        mReplyBinding.editComment.setHint(R.string.reader_hint_comment_on_comment);
-        mReplyBinding.editComment.setOnEditorActionListener((v, actionId, event) -> {
-            if (mSite != null && mComment != null
-                && (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_SEND)) {
-                submitReply(mReplyBinding, mSite, mComment);
-            }
-            return false;
-        });
-
-        if (!TextUtils.isEmpty(mRestoredReplyText)) {
-            mReplyBinding.editComment.setText(mRestoredReplyText);
-            mRestoredReplyText = null;
-        }
-
-        mReplyBinding.btnSubmitReply.setOnClickListener(v -> {
-            if (mSite != null && mComment != null) {
-                submitReply(mReplyBinding, mSite, mComment);
-            }
-        });
-
-        if (mSite != null) {
-            setupSuggestionServiceAndAdapter(mReplyBinding, mSite);
-        }
 
         return mBinding.getRoot();
     }
@@ -331,77 +224,9 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     }
 
     @Override
-    public void onConfirm(@Nullable Bundle result) {
-        if (mReplyBinding != null && result != null && mSite != null && mComment != null) {
-            mReplyBinding.editComment.setText(result.getString(CommentFullScreenDialogFragment.RESULT_REPLY));
-            submitReply(mReplyBinding, mSite, mComment);
-        }
-    }
-
-    @Override
-    public void onCollapse(@Nullable Bundle result) {
-        if (mReplyBinding != null && result != null) {
-            mReplyBinding.editComment.setText(result.getString(CommentFullScreenDialogFragment.RESULT_REPLY));
-            mReplyBinding.editComment.setSelection(result.getInt(
-                            CommentFullScreenDialogFragment.RESULT_SELECTION_START),
-                    result.getInt(CommentFullScreenDialogFragment.RESULT_SELECTION_END));
-            mReplyBinding.editComment.requestFocus();
-        }
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
         ActivityId.trackLastActivity(ActivityId.COMMENT_DETAIL);
-
-        CollapseFullScreenDialogFragment fragment = null;
-        if (mComment != null) {
-            // reattach listeners to collapsible reply dialog
-            // we need to to it in onResume to make sure mComment is already initialized
-            fragment = (CollapseFullScreenDialogFragment) requireActivity()
-                    .getSupportFragmentManager().findFragmentByTag(getCommentSpecificFragmentTagSuffix(mComment));
-        }
-
-        if (fragment != null && fragment.isAdded()) {
-            fragment.setOnCollapseListener(this);
-            fragment.setOnConfirmListener(this);
-        }
-    }
-
-    private void setupSuggestionServiceAndAdapter(
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
-            @NonNull SiteModel site
-    ) {
-        if (!isAdded() || !SiteUtils.isAccessedViaWPComRest(site)) {
-            return;
-        }
-        mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(getActivity(), site.getSiteId());
-        mSuggestionAdapter = SuggestionUtils.setupUserSuggestions(
-                site,
-                requireActivity(),
-                mSuggestionServiceConnectionManager
-        );
-        replyBinding.editComment.setAdapter(mSuggestionAdapter);
-    }
-
-    private void setReplyUniqueId(
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
-            @Nullable SiteModel site,
-            @Nullable CommentModel comment,
-            @Nullable Note note
-    ) {
-        if (isAdded()) {
-            String sId = null;
-            if (site != null && comment != null) {
-                sId = String.format(Locale.US, "%d-%d", site.getSiteId(), comment.getRemoteCommentId());
-            } else if (note != null) {
-                sId = String.format(Locale.US, "%d-%d", note.getSiteId(), note.getCommentId());
-            }
-            if (sId != null) {
-                replyBinding.editComment.getAutoSaveTextHelper().setUniqueId(sId);
-                replyBinding.editComment.getAutoSaveTextHelper().loadString(replyBinding.editComment);
-            }
-        }
     }
 
     protected void setComment(
@@ -415,16 +240,9 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         // notification about a reply to a comment this user posted on someone else's blog
         mIsUsersBlog = (comment != null);
 
-        if (mBinding != null && mReplyBinding != null) {
-            showComment(mBinding, mReplyBinding, mSite, mComment, mNote);
+        if (mBinding != null) {
+            showComment(mBinding, mSite, mComment, mNote);
         }
-
-        // Reset the reply unique id since mComment just changed.
-        if (mReplyBinding != null) setReplyUniqueId(mReplyBinding, mSite, mComment, mNote);
-    }
-
-    private void disableShouldFocusReplyField() {
-        mShouldFocusReplyField = false;
     }
 
     public void enableShouldFocusReplyField() {
@@ -463,8 +281,8 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         super.onStart();
         EventBus.getDefault().register(this);
         mCommentsStoreAdapter.register(this);
-        if (mBinding != null && mReplyBinding != null && mSite != null) {
-            showComment(mBinding, mReplyBinding, mSite, mComment, mNote);
+        if (mBinding != null && mSite != null) {
+            showComment(mBinding, mSite, mComment, mNote);
         }
     }
 
@@ -561,7 +379,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
      */
     protected void showComment(
             @NonNull CommentDetailFragmentBinding binding,
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
             @NonNull SiteModel site,
             @Nullable CommentModel comment,
             @Nullable Note note
@@ -572,15 +389,14 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
         if (comment == null) {
             // Hide container views when comment is null (will happen when opened from a notification).
-            showCommentWhenNull(binding, replyBinding, note);
+            showCommentWhenNull(binding, note);
         } else {
-            showCommentWhenNonNull(binding, replyBinding, site, comment);
+            showCommentWhenNonNull(binding, site, comment);
         }
     }
 
     private void showCommentWhenNull(
             @NonNull CommentDetailFragmentBinding binding,
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
             @Nullable Note note
     ) {
         // These two views contain all the other views except the progress bar.
@@ -599,7 +415,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
             CommentModel comment = mCommentsStoreAdapter.getCommentBySiteAndRemoteId(site, note.getCommentId());
             if (comment != null) {
                 // It exists, then show it as a "Notification"
-                showCommentAsNotification(binding, replyBinding, site, comment, note);
+                showCommentAsNotification(binding, site, comment, note);
             } else {
                 // It's not in our store yet, request it.
                 RemoteCommentPayload payload = new RemoteCommentPayload(site, note.getCommentId());
@@ -608,14 +424,13 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
                 // Show a "temporary" comment built from the note data, the view will be refreshed once the
                 // comment has been fetched.
-                showCommentAsNotification(binding, replyBinding, site, null, note);
+                showCommentAsNotification(binding, site, null, note);
             }
         }
     }
 
     private void showCommentWhenNonNull(
             @NonNull CommentDetailFragmentBinding binding,
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
             @NonNull SiteModel site,
             @NonNull CommentModel comment
     ) {
@@ -657,15 +472,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         showPostTitle(binding, comment, site);
         binding.textSite.setText(DateTimeUtils.javaDateToTimeSpan(
                 DateTimeUtils.dateFromIso8601(comment.getDatePublished()), WordPress.getContext()));
-
-        // make sure reply box is showing
-        if (replyBinding.layoutContainer.getVisibility() != View.VISIBLE && canReply()) {
-            AniUtils.animateBottomBar(replyBinding.layoutContainer, true);
-            if (mShouldFocusReplyField) {
-                replyBinding.editComment.performClick();
-                disableShouldFocusReplyField();
-            }
-        }
 
         requireActivity().invalidateOptionsMenu();
     }
@@ -909,63 +715,10 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     }
 
     /*
-     * post comment box text as a reply to the current comment
-     */
-    @SuppressWarnings("deprecation")
-    private void submitReply(
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
-            @NonNull SiteModel site,
-            @NonNull CommentModel comment
-    ) {
-        if (!isAdded() || mIsSubmittingReply) {
-            return;
-        }
-
-        if (!NetworkUtils.checkConnection(getActivity())) {
-            return;
-        }
-
-        final String replyText = EditTextUtils.getText(replyBinding.editComment);
-        if (TextUtils.isEmpty(replyText)) {
-            return;
-        }
-
-        // disable editor, hide soft keyboard, hide submit icon, and show progress spinner while submitting
-        replyBinding.editComment.setEnabled(false);
-        EditTextUtils.hideSoftInput(replyBinding.editComment);
-        replyBinding.btnSubmitReply.setVisibility(View.GONE);
-        replyBinding.progressSubmitComment.setVisibility(View.VISIBLE);
-
-        mIsSubmittingReply = true;
-
-        if (mCommentSource != null) {
-            AnalyticsUtils.trackCommentReplyWithDetails(
-                    false,
-                    site,
-                    comment,
-                    mCommentSource.toAnalyticsCommentActionSource()
-            );
-        }
-
-        // Pseudo comment reply
-        CommentModel reply = new CommentModel();
-        reply.setContent(replyText);
-
-        mCommentsStoreAdapter.dispatch(
-                CommentActionBuilder.newCreateNewCommentAction(new RemoteCreateCommentPayload(site, comment, reply))
-        );
-    }
-
-    private boolean canReply() {
-        return mEnabledActions.contains(EnabledActions.ACTION_REPLY);
-    }
-
-    /*
      * display the comment associated with the passed notification
      */
     private void showCommentAsNotification(
             @NonNull CommentDetailFragmentBinding binding,
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
             @NonNull SiteModel site,
             @Nullable CommentModel comment,
             @Nullable Note note
@@ -982,15 +735,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
          */
         if (note != null) {
             mEnabledActions = note.getEnabledCommentActions();
-        }
-
-        // Set 'Reply to (Name)' in comment reply EditText if it's a reasonable size
-        if (note != null
-            && !TextUtils.isEmpty(note.getCommentAuthorName())
-            && note.getCommentAuthorName().length() < 28) {
-            replyBinding.editComment.setHint(
-                    String.format(getString(R.string.comment_reply_to_user), note.getCommentAuthorName())
-            );
         }
 
         if (comment != null) {
@@ -1053,23 +797,17 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
     @SuppressWarnings("deprecation")
     private void onCommentCreated(
-            @NonNull ReaderIncludeCommentBoxBinding replyBinding,
             @NonNull SiteModel site,
             @NonNull CommentModel comment,
             @Nullable Note note,
             OnCommentChanged event
     ) {
         mIsSubmittingReply = false;
-        replyBinding.editComment.setEnabled(true);
-        replyBinding.btnSubmitReply.setVisibility(View.VISIBLE);
-        replyBinding.progressSubmitComment.setVisibility(View.GONE);
 
         if (event.isError()) {
             if (isAdded()) {
                 String strUnEscapeHTML = StringEscapeUtils.unescapeHtml4(event.error.message);
                 ToastUtils.showToast(getActivity(), strUnEscapeHTML, ToastUtils.Duration.LONG);
-                // refocus editor on failure and show soft keyboard
-                EditTextUtils.showSoftInput(replyBinding.editComment);
             }
             return;
         }
@@ -1078,8 +816,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
         if (isAdded()) {
             ToastUtils.showToast(getActivity(), getString(R.string.note_reply_successful));
-            replyBinding.editComment.setText(null);
-            replyBinding.editComment.getAutoSaveTextHelper().clearSavedText(replyBinding.editComment);
         }
 
         // Self Hosted site does not return a newly created comment, so we need to fetch it manually.
@@ -1112,7 +848,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
                 (coroutineScope, continuation) -> mLocalCommentCacheUpdateHandler.requestCommentsUpdate(continuation)
         );
 
-        if (mBinding != null && mReplyBinding != null) {
+        if (mBinding != null) {
             setProgressVisible(mBinding, false);
 
             if (mSite != null && mComment != null) {
@@ -1125,7 +861,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
                 // New comment (reply)
                 if (event.causeOfChange == CommentAction.CREATE_NEW_COMMENT) {
-                    onCommentCreated(mReplyBinding, mSite, mComment, mNote, event);
+                    onCommentCreated(mSite, mComment, mNote, event);
                     return;
                 }
             }
@@ -1153,7 +889,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     public void onDestroyView() {
         super.onDestroyView();
         mBinding = null;
-        mReplyBinding = null;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.comments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.wordpress.android.databinding.CommentModerationBinding
+
+class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
+    private var binding: CommentModerationBinding? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
+        CommentModerationBinding.inflate(inflater, container, false).apply {
+            binding = this
+        }.root
+
+    override fun onDestroyView() {
+        binding = null
+        super.onDestroyView()
+    }
+
+    companion object {
+        const val TAG = "ModerationBottomSheetDialogFragment"
+        fun newInstance() = ModerationBottomSheetDialogFragment()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
@@ -2,7 +2,12 @@ package org.wordpress.android.ui.comments
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.google.android.material.R
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wordpress.android.databinding.CommentModerationBinding
 
@@ -13,6 +18,25 @@ class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
         CommentModerationBinding.inflate(inflater, container, false).apply {
             binding = this
         }.root
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // define the peekHeight to avoid it expanding partially
+        dialog?.setOnShowListener { dialogInterface ->
+            val sheetDialog = dialogInterface as? BottomSheetDialog
+
+            val bottomSheet = sheetDialog?.findViewById<View>(
+                R.id.design_bottom_sheet
+            ) as? FrameLayout
+
+            bottomSheet?.let {
+                val behavior = BottomSheetBehavior.from(it)
+                val metrics = resources.displayMetrics
+                behavior.peekHeight = metrics.heightPixels
+            }
+        }
+    }
 
     override fun onDestroyView() {
         binding = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.comments
 
 import android.os.Bundle
+import android.view.View
 import androidx.core.view.isGone
 import org.wordpress.android.R
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.fluxc.tools.FormattableRangeType
-import org.wordpress.android.models.Note
 import org.wordpress.android.ui.comments.unified.CommentIdentifier
 import org.wordpress.android.ui.comments.unified.CommentSource
 import org.wordpress.android.ui.engagement.BottomSheetUiState
@@ -19,9 +19,8 @@ import org.wordpress.android.util.ToastUtils
  * It'd be better to have multiple fragments for different sources for different purposes
  */
 class NotificationCommentDetailFragment : SharedCommentDetailFragment() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         if (savedInstanceState?.getString(KEY_NOTE_ID) != null) {
             handleNote(savedInstanceState.getString(KEY_NOTE_ID)!!)
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package org.wordpress.android.ui.comments
 
 import android.os.Bundle
@@ -20,10 +18,7 @@ import org.wordpress.android.util.ToastUtils
  * [CommentDetailFragment] is too big to be reused
  * It'd be better to have multiple fragments for different sources for different purposes
  */
-class NotificationCommentDetailFragment : CommentDetailFragment() {
-    private val note: Note // note will be non-null after onCreate
-        get() = mNote!!
-
+class NotificationCommentDetailFragment : SharedCommentDetailFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -72,8 +67,8 @@ class NotificationCommentDetailFragment : CommentDetailFragment() {
                 // This should not exist, we should clean that screen so a note without a site/comment can be displayed
                 mSite = createDummyWordPressComSite(note.siteId.toLong())
             }
-            if (mBinding != null && mReplyBinding != null) {
-                showComment(mBinding!!, mReplyBinding!!, mSite!!, mComment, note)
+            if (mBinding != null) {
+                showComment(mBinding!!, mSite!!, mComment, note)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -7,34 +7,45 @@ import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.models.Note
 
-
 /**
  * Used when we want to write Kotlin in [CommentDetailFragment]
  * Move converted code to this class
  */
 abstract class SharedCommentDetailFragment:CommentDetailFragment() {
-    protected val note: Note // it will be non-null when users from a notification
+    // it will be non-null after view created when users from a notification
+    // it will be null when users from comment list
+    protected val note: Note
         get() = mNote!!
 
+    // it will be non-null after view created when users from comment list
+    // it will be non-null in a different time point when users from a notification
     protected val comment: CommentModel
         get() = mComment!!
 
-    protected fun updateModerationStatus() {
+    override fun updateModerationStatus() {
         val commentStatus = CommentStatus.fromString(comment.status)
         when(commentStatus){
-            CommentStatus.APPROVED -> TODO()
+            CommentStatus.APPROVED -> {}
             CommentStatus.UNAPPROVED -> mBinding?.layoutCommentPending?.handlePendingView()
-            CommentStatus.SPAM -> TODO()
-            CommentStatus.TRASH -> TODO()
-            CommentStatus.DELETED -> TODO()
-            CommentStatus.ALL -> TODO()
-            CommentStatus.UNREPLIED -> TODO()
-            CommentStatus.UNSPAM -> TODO()
-            CommentStatus.UNTRASH -> TODO()
+            CommentStatus.SPAM -> {}
+            CommentStatus.TRASH -> {}
+            CommentStatus.DELETED -> {}
+            CommentStatus.ALL -> {}
+            CommentStatus.UNREPLIED -> {}
+            CommentStatus.UNSPAM -> {}
+            CommentStatus.UNTRASH -> {}
         }
+
+        mBinding?.layoutCommentPending?.handlePendingView() // todo: remove this line after PR review
     }
 
     private fun CommentPendingBinding.handlePendingView() {
         layoutRoot.isVisible = true
+        textMoreOptions.setOnClickListener { showModerationBottomSheet() }
+    }
+
+    private fun showModerationBottomSheet() {
+        ModerationBottomSheetDialogFragment.newInstance()
+            .show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -1,0 +1,40 @@
+@file:Suppress("DEPRECATION")
+package org.wordpress.android.ui.comments
+
+import androidx.core.view.isVisible
+import org.wordpress.android.databinding.CommentPendingBinding
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.models.Note
+
+
+/**
+ * Used when we want to write Kotlin in [CommentDetailFragment]
+ * Move converted code to this class
+ */
+abstract class SharedCommentDetailFragment:CommentDetailFragment() {
+    protected val note: Note // it will be non-null when users from a notification
+        get() = mNote!!
+
+    protected val comment: CommentModel
+        get() = mComment!!
+
+    protected fun updateModerationStatus() {
+        val commentStatus = CommentStatus.fromString(comment.status)
+        when(commentStatus){
+            CommentStatus.APPROVED -> TODO()
+            CommentStatus.UNAPPROVED -> mBinding?.layoutCommentPending?.handlePendingView()
+            CommentStatus.SPAM -> TODO()
+            CommentStatus.TRASH -> TODO()
+            CommentStatus.DELETED -> TODO()
+            CommentStatus.ALL -> TODO()
+            CommentStatus.UNREPLIED -> TODO()
+            CommentStatus.UNSPAM -> TODO()
+            CommentStatus.UNTRASH -> TODO()
+        }
+    }
+
+    private fun CommentPendingBinding.handlePendingView() {
+        layoutRoot.isVisible = true
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.comments
 
 import android.os.Bundle
+import android.view.View
 import androidx.core.view.isVisible
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
@@ -20,8 +21,8 @@ import org.wordpress.android.util.WPAvatarUtils
  * It'd be better to have multiple fragments for different sources for different purposes
  */
 class SiteCommentDetailFragment : SharedCommentDetailFragment() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         if (savedInstanceState != null) {
             handleComment(savedInstanceState.getLong(KEY_COMMENT_ID), savedInstanceState.getInt(KEY_SITE_LOCAL_ID))
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package org.wordpress.android.ui.comments
 
 import android.os.Bundle
@@ -21,10 +19,7 @@ import org.wordpress.android.util.WPAvatarUtils
  * [CommentDetailFragment] is too big to be reused
  * It'd be better to have multiple fragments for different sources for different purposes
  */
-class SiteCommentDetailFragment : CommentDetailFragment() {
-    private val comment: CommentModel
-        get() = mComment!!
-
+class SiteCommentDetailFragment : SharedCommentDetailFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (savedInstanceState != null) {

--- a/WordPress/src/main/res/drawable/delete_24.xml
+++ b/WordPress/src/main/res/drawable/delete_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#D67709" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM8,9h8v10L8,19L8,9zM15.5,4l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/error_outline_24.xml
+++ b/WordPress/src/main/res/drawable/error_outline_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FF3B30"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF3B30" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_time_16dp.xml
+++ b/WordPress/src/main/res/drawable/ic_time_16dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,4c4.411,0 8,3.589 8,8s-3.589,8 -8,8 -8,-3.589 -8,-8 3.589,-8 8,-8m0,-2C6.477,2 2,6.477 2,12s4.477,10 10,10 10,-4.477 10,-10S17.523,2 12,2zM15.8,15.4L13,11.667L13,7h-2v5.333l3.2,4.266 1.6,-1.199z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/watch_later_24.xml
+++ b/WordPress/src/main/res/drawable/watch_later_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+    <path android:fillColor="#000000" android:pathData="M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
+</vector>

--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -18,10 +18,9 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent">
 
-
         <include
-            android:id="@+id/layout_comment_box"
-            layout="@layout/reader_include_comment_box"
+            android:id="@+id/layout_comment_pending"
+            layout="@layout/comment_pending"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </FrameLayout>

--- a/WordPress/src/main/res/layout/comment_moderation.xml
+++ b/WordPress/src/main/res/layout/comment_moderation.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        layout="@layout/bottom_sheet_handle_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:fontFamily="sans-serif-medium"
+        android:text="Choose status"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="@dimen/text_sz_large" />
+
+    <com.google.android.material.button.MaterialButton
+        style="@style/Widget.ModerationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:text="Approved"
+        app:icon="@drawable/ic_check_24px"
+        app:iconTint="@color/primary" />
+
+    <com.google.android.material.button.MaterialButton
+        style="@style/Widget.ModerationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:text="Pending"
+        app:icon="@drawable/watch_later_24"
+        app:iconTint="@color/menu_more" />
+
+    <com.google.android.material.button.MaterialButton
+        style="@style/Widget.ModerationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:text="Trash"
+        app:icon="@drawable/delete_24"
+        app:iconTint="@null"/>
+
+    <com.google.android.material.button.MaterialButton
+        style="@style/Widget.ModerationButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:layout_marginBottom="@dimen/margin_extra_small_large"
+        android:text="Spam"
+        app:icon="@drawable/error_outline_24"
+        app:iconTint="@null" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/comment_moderation.xml
+++ b/WordPress/src/main/res/layout/comment_moderation.xml
@@ -25,6 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
+        android:textAlignment="viewStart"
         android:text="@string/comment_moderation_status_approved"
         app:icon="@drawable/ic_check_24px"
         app:iconTint="@color/primary" />
@@ -34,6 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
+        android:textAlignment="viewStart"
         android:text="@string/comment_moderation_status_pending"
         app:icon="@drawable/watch_later_24"
         app:iconTint="@color/menu_more" />
@@ -43,6 +45,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
+        android:textAlignment="viewStart"
         android:text="@string/comment_moderation_status_trash"
         app:icon="@drawable/delete_24"
         app:iconTint="@null"/>
@@ -53,6 +56,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
         android:layout_marginBottom="@dimen/margin_extra_small_large"
+        android:textAlignment="viewStart"
         android:text="@string/comment_moderation_status_spam"
         app:icon="@drawable/error_outline_24"
         app:iconTint="@null" />

--- a/WordPress/src/main/res/layout/comment_moderation.xml
+++ b/WordPress/src/main/res/layout/comment_moderation.xml
@@ -16,7 +16,7 @@
         android:layout_marginHorizontal="@dimen/margin_extra_large"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:fontFamily="sans-serif-medium"
-        android:text="Choose status"
+        android:text="@string/comment_moderation_status_title"
         android:textColor="?attr/colorOnSurface"
         android:textSize="@dimen/text_sz_large" />
 
@@ -25,7 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
-        android:text="Approved"
+        android:text="@string/comment_moderation_status_approved"
         app:icon="@drawable/ic_check_24px"
         app:iconTint="@color/primary" />
 
@@ -34,7 +34,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
-        android:text="Pending"
+        android:text="@string/comment_moderation_status_pending"
         app:icon="@drawable/watch_later_24"
         app:iconTint="@color/menu_more" />
 
@@ -43,7 +43,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
-        android:text="Trash"
+        android:text="@string/comment_moderation_status_trash"
         app:icon="@drawable/delete_24"
         app:iconTint="@null"/>
 
@@ -53,7 +53,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
         android:layout_marginBottom="@dimen/margin_extra_small_large"
-        android:text="Spam"
+        android:text="@string/comment_moderation_status_spam"
         app:icon="@drawable/error_outline_24"
         app:iconTint="@null" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/comment_pending.xml
+++ b/WordPress/src/main/res/layout/comment_pending.xml
@@ -39,11 +39,12 @@
 
     <TextView
         android:id="@+id/text_more_options"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:fontFamily="sans-serif-medium"
-        android:gravity="center"
-        android:paddingVertical="@dimen/margin_medium_large"
+        android:layout_gravity="center_horizontal"
+        android:padding="@dimen/margin_medium_large"
         android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
         android:text="More options"
         android:textColor="?attr/colorOnSurface" />

--- a/WordPress/src/main/res/layout/comment_pending.xml
+++ b/WordPress/src/main/res/layout/comment_pending.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:id="@+id/layout_root"
+    android:orientation="vertical">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:background="@color/divider_likes" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:drawablePadding="@dimen/margin_small"
+        android:gravity="center_vertical"
+        android:includeFontPadding="false"
+        android:text="Comment pending moderation"
+        android:textColor="@color/menu_more"
+        android:textSize="@dimen/text_sz_small"
+        app:drawableStartCompat="@drawable/ic_time_16dp"
+        app:drawableTint="@color/menu_more" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_approve_comment"
+        style="@style/Widget.ShareButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginVertical="@dimen/margin_medium"
+        android:text="Approve comment"
+        app:icon="@drawable/ic_check_24px"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorSurface" />
+
+    <TextView
+        android:id="@+id/text_more_options"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center"
+        android:paddingVertical="@dimen/margin_medium_large"
+        android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
+        android:text="More options"
+        android:textColor="?attr/colorOnSurface" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/comment_pending.xml
+++ b/WordPress/src/main/res/layout/comment_pending.xml
@@ -19,7 +19,7 @@
         android:drawablePadding="@dimen/margin_small"
         android:gravity="center_vertical"
         android:includeFontPadding="false"
-        android:text="Comment pending moderation"
+        android:text="@string/comment_moderation_pending"
         android:textColor="@color/menu_more"
         android:textSize="@dimen/text_sz_small"
         app:drawableStartCompat="@drawable/ic_time_16dp"
@@ -32,7 +32,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/margin_extra_large"
         android:layout_marginVertical="@dimen/margin_medium"
-        android:text="Approve comment"
+        android:text="@string/comment_moderation_approve"
         app:icon="@drawable/ic_check_24px"
         app:iconGravity="textStart"
         app:iconTint="?attr/colorSurface" />
@@ -46,6 +46,6 @@
         android:layout_gravity="center_horizontal"
         android:padding="@dimen/margin_medium_large"
         android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
-        android:text="More options"
+        android:text="@string/comment_moderation_more"
         android:textColor="?attr/colorOnSurface" />
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -461,6 +461,15 @@
     <string name="comment_action_edit_comment">Edit comment</string>
     <string name="comment_action_change_status">Change status</string>
 
+    <string name="comment_moderation_pending">Comment pending moderation</string>
+    <string name="comment_moderation_approve">Approve comment</string>
+    <string name="comment_moderation_more">More options</string>
+    <string name="comment_moderation_status_title">Choose status</string>
+    <string name="comment_moderation_status_approved">Approved</string>
+    <string name="comment_moderation_status_pending">Pending</string>
+    <string name="comment_moderation_status_trash">Trash</string>
+    <string name="comment_moderation_status_spam">Spam</string>
+
     <!-- comment menu and buttons on comment detail - keep these short! -->
     <string name="mnu_comment_approve">Approve</string>
     <string name="mnu_comment_unapprove">Unapprove</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1812,6 +1812,21 @@
         <item name="android:backgroundTint">?attr/colorOnBackground</item>
     </style>
 
+    <style name="Widget.ModerationButton" parent="">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:minHeight">40dp</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:backgroundTint">@color/transparent</item>
+        <item name="android:paddingStart">@dimen/margin_extra_medium_large</item>
+        <item name="android:paddingEnd">@dimen/margin_extra_medium_large</item>
+        <item name="cornerRadius">0dp</item>
+        <item name="iconGravity">textStart</item>
+        <item name="iconPadding">@dimen/margin_extra_medium_large</item>
+    </style>
+
     <style name="Widget.ShareButton" parent="Widget.LoginFlow.Button.Primary">
         <item name="android:textColor">?attr/colorSurface</item>
         <item name="android:backgroundTint">?attr/colorOnBackground</item>


### PR DESCRIPTION
See https://github.com/orgs/Automattic/projects/944/views/1?pane=issue&itemId=60397816
Design yWt5gg3nWORhu079Qfv3mS-fi-1135_4600

This PR mainly implemented the redesign of pending moderation, but also removed lot of logic related to unused UI component.

| Screenshot 1 | Screenshot 2 |
|--|--|
| ![Screenshot_20240528-161610](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/6458d154-65c2-4642-8b51-54292f30fe37) | ![Screenshot_20240528-161624](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/a10a60c8-0100-4f59-8021-6565cc59d05f) |

-----

## To Test:

1. Sign in JP app
2. Go to `Notifications` tab
3. Click on a notification with comment type
4. It should display the UI of pending status, currently the `Approve comment` button is not actionable
5. Click on `More options`
6. It should display a bottom sheet of moderation, currently the buttons on the bottom sheet are not actionable
7. Go to My site -> More -> Comments
8. Click on a comment
9. Repeat step 4 - 6.
10. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - notification, comment

11. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

12. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

Skipped

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
