### PR TITLE
[Reader] Fix "Your Tags" feed scrolling to top on screen orientation change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -374,7 +374,6 @@ class ReaderTagsFeedFragment : Fragment(R.layout.reader_tag_feed_fragment_layout
         }
     }
 
-
     override fun onScrollToTop() {
         // TODO scroll current content to top
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.core.view.ViewCompat.animate
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.commitNow
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
@@ -26,7 +27,6 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.ReaderTagFeedFragmentLayoutBinding
 import org.wordpress.android.models.ReaderTag
-import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
@@ -55,7 +55,7 @@ import javax.inject.Inject
  * main content of the ReaderFragment (e.g.: initializing the SubFilterViewModel), so a few changes might be needed.
  */
 @AndroidEntryPoint
-class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragment_layout),
+class ReaderTagsFeedFragment : Fragment(R.layout.reader_tag_feed_fragment_layout),
     WPMainActivity.OnScrollToTopListener {
     private val tagsFeedTag by lazy {
         // TODO maybe we can just create a static function somewhere that returns the Tags Feed ReaderTag, since it's
@@ -374,9 +374,6 @@ class ReaderTagsFeedFragment : ViewPagerFragment(R.layout.reader_tag_feed_fragme
         }
     }
 
-    override fun getScrollableViewForUniqueIdProvision(): View {
-        return binding.composeView
-    }
 
     override fun onScrollToTop() {
         // TODO scroll current content to top

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
@@ -100,16 +101,17 @@ private fun Loaded(uiState: UiState.Loaded) {
             uiState.onRefresh()
         }
     )
-
     Box(
         modifier = Modifier
             .fillMaxSize()
             .pullRefresh(state = pullRefreshState),
     ) {
+        val listState = rememberLazyListState()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(rememberNestedScrollInteropConnection()),
+            state = listState,
         ) {
             uiState.announcementItem?.let { announcementItem ->
                 item(key = "reader-announcement-card") {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -106,7 +108,8 @@ private fun Loaded(uiState: UiState.Loaded) {
     ) {
         LazyColumn(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .nestedScroll(rememberNestedScrollInteropConnection()),
         ) {
             uiState.announcementItem?.let { announcementItem ->
                 item(key = "reader-announcement-card") {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
@@ -106,12 +105,10 @@ private fun Loaded(uiState: UiState.Loaded) {
             .fillMaxSize()
             .pullRefresh(state = pullRefreshState),
     ) {
-        val listState = rememberLazyListState()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .nestedScroll(rememberNestedScrollInteropConnection()),
-            state = listState,
         ) {
             uiState.announcementItem?.let { announcementItem ->
                 item(key = "reader-announcement-card") {


### PR DESCRIPTION
Fixes #20834

This PR fixes two bugs:

1 - "Your Tags" feed was scrolling to top when screen orientation changed.
2 - "Your Tags" feed app bar was not collapsing on scroll (fixed by @thomashorta).

-----

## To Test:

### Setup
1 - Install JP and log in.
2 - Open Reader.
3 - Make sure you're subscribed to a few tags.

### Scrolling to top on screen orientation change
4 - Scroll to any item in the "Your Tags" feed.
5 - 🔍 Rotate the screen: the scroll should be at the position of the first visible item instead of scrolling to top.
6 - 🔍 Rotate the screen again: the scroll should be at the position of the first visible item instead of scrolling to top.

### App bar not collapsing on scroll
7 - 🔍 Scroll down in "Your Tags" feed: the app bar should be hidden.
8 - 🔍  Scroll up in "Your Tags" feed: the app bar that was previously hidden should be visible again.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing
    
3. What automated tests I added (or what prevented me from doing so)

    - UI only

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
