### PR TITLE
[Voice to Content] Implement eligibility and limitation checks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtils.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.voicetocontent
 
+import org.wordpress.android.fluxc.model.jetpackai.JetpackAIAssistantFeature
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.VoiceToContentFeatureConfig
 import javax.inject.Inject
@@ -9,4 +10,28 @@ class VoiceToContentFeatureUtils @Inject constructor(
     private val voiceToContentFeatureConfig: VoiceToContentFeatureConfig
 ) {
     fun isVoiceToContentEnabled() = buildConfigWrapper.isJetpackApp && voiceToContentFeatureConfig.isEnabled()
+
+    fun isEligibleForVoiceToContent(jetpackFeatureAIAssistantFeature: JetpackAIAssistantFeature) =
+        !jetpackFeatureAIAssistantFeature.siteRequireUpgrade
+
+    fun getRequestLimit(jetpackFeatureAIAssistantFeature: JetpackAIAssistantFeature): Int {
+        with (jetpackFeatureAIAssistantFeature) {
+            if (currentTier?.slug == JETPACK_AI_FREE) {
+                return maxOf(0, requestsLimit - requestsCount)
+            }
+            // The backend uses `1` as an indicator of unlimited requests.
+            if (currentTier?.value == 1) {
+                return Int.MAX_VALUE
+            }
+            // The `usage-period.requests-count` is only valid for paid plans with
+            // a limited number of requests.
+            val requestsLimit = currentTier?.limit ?: requestsLimit
+            val requestsCount = usagePeriod?.requestsCount ?: requestsCount
+            return maxOf(0, requestsLimit - requestsCount)
+        }
+    }
+
+    companion object {
+       private const val JETPACK_AI_FREE = "jetpack_ai_free"
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtils.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtils.kt
@@ -15,19 +15,17 @@ class VoiceToContentFeatureUtils @Inject constructor(
         !jetpackFeatureAIAssistantFeature.siteRequireUpgrade
 
     fun getRequestLimit(jetpackFeatureAIAssistantFeature: JetpackAIAssistantFeature): Int {
-        with (jetpackFeatureAIAssistantFeature) {
-            if (currentTier?.slug == JETPACK_AI_FREE) {
-                return maxOf(0, requestsLimit - requestsCount)
+        return with(jetpackFeatureAIAssistantFeature) {
+            val calculatedLimit = if (currentTier?.slug == JETPACK_AI_FREE) {
+                maxOf(0, requestsLimit - requestsCount)
+            } else if (currentTier?.value == 1) {
+                Int.MAX_VALUE
+            } else {
+                val requestsLimit = currentTier?.limit ?: requestsLimit
+                val requestsCount = usagePeriod?.requestsCount ?: requestsCount
+                maxOf(0, requestsLimit - requestsCount)
             }
-            // The backend uses `1` as an indicator of unlimited requests.
-            if (currentTier?.value == 1) {
-                return Int.MAX_VALUE
-            }
-            // The `usage-period.requests-count` is only valid for paid plans with
-            // a limited number of requests.
-            val requestsLimit = currentTier?.limit ?: requestsLimit
-            val requestsCount = usagePeriod?.requestsCount ?: requestsCount
-            return maxOf(0, requestsLimit - requestsCount)
+            calculatedLimit
         }
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtilsTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/voicetocontent/VoiceToContentFeatureUtilsTest.kt
@@ -2,12 +2,17 @@ package org.wordpress.android.ui.voicetocontent
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
+import org.wordpress.android.fluxc.model.jetpackai.JetpackAIAssistantFeature
+import org.wordpress.android.fluxc.model.jetpackai.Tier
+import org.wordpress.android.fluxc.model.jetpackai.UsagePeriod
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.config.VoiceToContentFeatureConfig
 
@@ -63,5 +68,112 @@ class VoiceToContentFeatureUtilsTest {
 
         // Assert
         assertEquals(false, result)
+    }
+
+    @Test
+    fun `when site requires an upgrade, then is not eligible for voiceToContent`() {
+        val feature = JetpackAIAssistantFeature(
+            hasFeature = false,
+            isOverLimit = false,
+            requestsCount = 0,
+            requestsLimit = 0,
+            usagePeriod = null,
+            siteRequireUpgrade = true,
+            upgradeType = "",
+            currentTier = null,
+            nextTier = null,
+            tierPlans = emptyList(),
+            tierPlansEnabled = false,
+            costs = null
+        )
+        assertFalse(utils.isEligibleForVoiceToContent(feature))
+    }
+
+    @Test
+    fun `when site does not require an upgrade, then is eligible for voiceToContent`() {
+        val feature = JetpackAIAssistantFeature(
+            hasFeature = false,
+            isOverLimit = false,
+            requestsCount = 0,
+            requestsLimit = 0,
+            usagePeriod = null,
+            siteRequireUpgrade = false,
+            upgradeType = "",
+            currentTier = null,
+            nextTier = null,
+            tierPlans = emptyList(),
+            tierPlansEnabled = false,
+            costs = null
+        )
+        assertTrue(utils.isEligibleForVoiceToContent(feature))
+    }
+
+    @Test
+    fun `when is free plan, then request limit is calculate for free plan`() {
+        val freePlanFeature = JetpackAIAssistantFeature(
+            hasFeature = false,
+            isOverLimit = false,
+            requestsCount = 50,
+            requestsLimit = 100,
+            usagePeriod = null,
+            siteRequireUpgrade = false,
+            upgradeType = "",
+            currentTier = Tier(JETPACK_AI_FREE, 0, 0, null),
+            nextTier = null,
+            tierPlans = emptyList(),
+            tierPlansEnabled = false,
+            costs = null
+        )
+        assertEquals(50, utils.getRequestLimit(freePlanFeature))
+
+        val freePlanFeatureExceed = freePlanFeature.copy(requestsCount = 150)
+        assertEquals(0, utils.getRequestLimit(freePlanFeatureExceed))
+    }
+
+    @Test
+    fun `when unlimited plan, then request limit is calculated for unlimited plan`() {
+        val unlimitedPlanFeature = JetpackAIAssistantFeature(
+            hasFeature = false,
+            isOverLimit = false,
+            requestsCount = 0,
+            requestsLimit = 0,
+            usagePeriod = null,
+            siteRequireUpgrade = false,
+            upgradeType = "",
+            currentTier = Tier("", 0, 1, null),
+            nextTier = null,
+            tierPlans = emptyList(),
+            tierPlansEnabled = false,
+            costs = null
+        )
+        assertEquals(Int.MAX_VALUE, utils.getRequestLimit(unlimitedPlanFeature))
+    }
+
+    @Test
+    fun `when limited plan, then request limit is calculated for limited plan`() {
+        val limitedPlanFeature = JetpackAIAssistantFeature(
+            hasFeature = false,
+            isOverLimit = false,
+            requestsCount = 0,
+            requestsLimit = 0,
+            usagePeriod = UsagePeriod("2024-01-01", "2024-02-01", 100),
+            siteRequireUpgrade = false,
+            upgradeType = "",
+            currentTier = Tier("", 200, 0, null),
+            nextTier = null,
+            tierPlans = emptyList(),
+            tierPlansEnabled = false,
+            costs = null
+        )
+        assertEquals(100, utils.getRequestLimit(limitedPlanFeature))
+
+        val limitedPlanFeatureExceed = limitedPlanFeature.copy(
+            usagePeriod = UsagePeriod("2024-01-01", "2024-02-01", 250)
+        )
+        assertEquals(0, utils.getRequestLimit(limitedPlanFeatureExceed))
+    }
+
+    companion object {
+        private const val JETPACK_AI_FREE = "jetpack_ai_free"
     }
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wordpress-mobile/issues/72) and https://github.com/Automattic/wordpress-mobile/issues/73

This PR adds the following to the `VoiceToContentFeatureUtils`
- Eligibility check based upon SiteRequiresUpgrade
- Determines the request limit based on the site tier/plan


-----

## To Test:
Note: The logic is not hooked up to any visual indicators
✅ Verify CI passes the all `VoiceToContentFeatureUtilsTest` unit tests 


-----

## Regression Notes

1. Potential unintended areas of impact
The eligibility and request limits algorithms are not correct

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Add tests to `VoiceToContentFeatureUtilsTest`

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
