### PR TITLE
Add Renovate configuration for a8c dependencies only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "packagePatterns": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
+      "matchDepPatterns": [
+        "automattic"
+      ],
+      "separateMajorMinor": false
+    },
+    {
+      "enabled": true,
+      "enabledManagers": [
+        "gradle"
+      ],
+      "matchDepPatterns": [
+        "automattic"
+      ],
+      "separateMajorMinor": false,
+      "versioning": "semver-coerced"
+    }
+  ]
+}


### PR DESCRIPTION
- separateMajorMinor to not create seperate PRs for a single dependency
- versioning=semver-coerced to not create PRs for intermediate created for each PR/commit. We only care about released versions

Fixes #

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
