### PR TITLE
Comment details approve moderation redesign

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -136,7 +136,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     @Nullable private OnPostClickListener mOnPostClickListener;
     @Nullable private OnCommentActionListener mOnCommentActionListener;
     @Nullable private OnNoteCommentActionListener mOnNoteCommentActionListener;
-    protected CommentSource mCommentSource; // this will be non-null when onCreate()
+    @NonNull protected CommentSource mCommentSource; // this will be non-null when onCreate()
 
     /*
      * these determine which actions (moderation, replying, marking as spam) to enable

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -136,7 +136,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     @Nullable private OnPostClickListener mOnPostClickListener;
     @Nullable private OnCommentActionListener mOnCommentActionListener;
     @Nullable private OnNoteCommentActionListener mOnNoteCommentActionListener;
-    @Nullable private CommentSource mCommentSource; // this will be non-null when onCreate()
+    protected CommentSource mCommentSource; // this will be non-null when onCreate()
 
     /*
      * these determine which actions (moderation, replying, marking as spam) to enable

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -56,13 +56,12 @@ class CommentDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Dispatch a moderation action to the server, it does not include [CommentStatus.DELETED] status
+     */
     fun dispatchModerationAction(site: SiteModel, comment: CommentModel, status: CommentStatus) {
         commentsStoreAdapter.dispatch(
-            if (status == CommentStatus.DELETED) {
-                CommentActionBuilder.newDeleteCommentAction(CommentStore.RemoteCommentPayload(site, comment))
-            } else {
-                CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
-            }
+            CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
         )
 
         comment.apply { this.status = status.toString() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -1,0 +1,57 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.comments
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
+import org.wordpress.android.fluxc.generated.CommentActionBuilder
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.CommentStore.RemoteLikeCommentPayload
+import org.wordpress.android.fluxc.store.CommentsStore
+import org.wordpress.android.models.Note
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.comments.unified.CommentsStoreAdapter
+import org.wordpress.android.ui.notifications.NotificationEvents.OnNoteCommentLikeChanged
+import org.wordpress.android.util.EventBusWrapper
+import org.wordpress.android.viewmodel.ScopedViewModel
+import javax.inject.Inject
+import javax.inject.Named
+
+
+@HiltViewModel
+class CommentDetailViewModel @Inject constructor(
+    @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
+    private val commentStore: CommentsStore,
+    private val commentsStoreAdapter: CommentsStoreAdapter,
+    private val eventBusWrapper: EventBusWrapper,
+    private val notificationsTableWrapper: NotificationsTableWrapper,
+) : ScopedViewModel(bgDispatcher) {
+    private val _updatedComment = MutableLiveData<CommentModel>()
+    val updatedComment: LiveData<CommentModel> = _updatedComment
+
+    /**
+     * Like or unlike a comment
+     * @param comment the comment to like or unlike
+     * @param site the site the comment belongs to
+     * @param note the note the comment belongs to, non-null if the comment is from a notification
+     */
+    fun likeComment(comment: CommentModel, site: SiteModel, note: Note? = null) = launch {
+        val liked = comment.iLike.not()
+        comment.apply { iLike = liked }
+            .let { _updatedComment.postValue(it) }
+
+        commentsStoreAdapter.dispatch(
+            CommentActionBuilder.newLikeCommentAction(
+                RemoteLikeCommentPayload(site, comment, liked)
+            )
+        )
+
+        note?.let {
+            eventBusWrapper.postSticky(OnNoteCommentLikeChanged(note, liked))
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import org.wordpress.android.datasets.wrappers.NotificationsTableWrapper
 import org.wordpress.android.fluxc.generated.CommentActionBuilder
 import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.CommentStatus
@@ -24,14 +23,12 @@ import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
 
-
 @HiltViewModel
 class CommentDetailViewModel @Inject constructor(
     @Named(BG_THREAD) bgDispatcher: CoroutineDispatcher,
     private val commentsStore: CommentsStore,
     private val commentsStoreAdapter: CommentsStoreAdapter,
     private val eventBusWrapper: EventBusWrapper,
-    private val notificationsTableWrapper: NotificationsTableWrapper,
     private val commentsMapper: CommentsMapper
 ) : ScopedViewModel(bgDispatcher) {
     private val _updatedComment = MutableLiveData<CommentModel>()

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
@@ -60,10 +60,22 @@ class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
         buttonTrash.isVisible = state.canTrash
 
         // handle clicks
-        buttonApprove.setOnClickListener { onApprovedClicked() }
-        buttonPending.setOnClickListener { onPendingClicked }
-        buttonSpam.setOnClickListener { onSpamClicked() }
-        buttonTrash.setOnClickListener { onTrashClicked }
+        buttonApprove.setOnClickListener {
+            onApprovedClicked()
+            dismiss()
+        }
+        buttonPending.setOnClickListener {
+            onPendingClicked()
+            dismiss()
+        }
+        buttonSpam.setOnClickListener {
+            onSpamClicked()
+            dismiss()
+        }
+        buttonTrash.setOnClickListener {
+            onTrashClicked()
+            dismiss()
+        }
     }
 
     override fun onDestroyView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
@@ -5,14 +5,26 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.isVisible
 import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wordpress.android.databinding.CommentModerationBinding
+import org.wordpress.android.util.extensions.getSerializableCompat
+import java.io.Serializable
 
 class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
     private var binding: CommentModerationBinding? = null
+    private val state by lazy {
+        arguments?.getSerializableCompat<CommentState>(KEY_STATE)
+            ?: throw IllegalArgumentException("CommentState not provided")
+    }
+
+    var onApprovedClicked = {}
+    var onPendingClicked = {}
+    var onSpamClicked = {}
+    var onTrashClicked = {}
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
         CommentModerationBinding.inflate(inflater, container, false).apply {
@@ -36,6 +48,22 @@ class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
                 behavior.peekHeight = metrics.heightPixels
             }
         }
+
+        binding?.setupLayout()
+    }
+
+    private fun CommentModerationBinding.setupLayout() {
+        // handle visibilities
+        buttonApprove.isVisible = state.canModerate
+        buttonPending.isVisible = state.canModerate
+        buttonSpam.isVisible = state.canMarkAsSpam
+        buttonTrash.isVisible = state.canTrash
+
+        // handle clicks
+        buttonApprove.setOnClickListener { onApprovedClicked() }
+        buttonPending.setOnClickListener { onPendingClicked }
+        buttonSpam.setOnClickListener { onSpamClicked() }
+        buttonTrash.setOnClickListener { onTrashClicked }
     }
 
     override fun onDestroyView() {
@@ -45,6 +73,19 @@ class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
 
     companion object {
         const val TAG = "ModerationBottomSheetDialogFragment"
-        fun newInstance() = ModerationBottomSheetDialogFragment()
+        private const val KEY_STATE = "state"
+        fun newInstance(state: CommentState) = ModerationBottomSheetDialogFragment()
+            .apply {
+                arguments = Bundle().apply { putSerializable(KEY_STATE, state) }
+            }
     }
+
+    /**
+     * For handling the UI state of the comment moderation bottom sheet
+     */
+    data class CommentState(
+        val canModerate: Boolean,
+        val canTrash: Boolean,
+        val canMarkAsSpam: Boolean,
+    ) : Serializable
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/ModerationBottomSheetDialogFragment.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.comments
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,14 +11,14 @@ import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.parcelize.Parcelize
 import org.wordpress.android.databinding.CommentModerationBinding
-import org.wordpress.android.util.extensions.getSerializableCompat
-import java.io.Serializable
+import org.wordpress.android.util.extensions.getParcelableCompat
 
 class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
     private var binding: CommentModerationBinding? = null
     private val state by lazy {
-        arguments?.getSerializableCompat<CommentState>(KEY_STATE)
+        arguments?.getParcelableCompat<CommentState>(KEY_STATE)
             ?: throw IllegalArgumentException("CommentState not provided")
     }
 
@@ -88,16 +89,17 @@ class ModerationBottomSheetDialogFragment : BottomSheetDialogFragment() {
         private const val KEY_STATE = "state"
         fun newInstance(state: CommentState) = ModerationBottomSheetDialogFragment()
             .apply {
-                arguments = Bundle().apply { putSerializable(KEY_STATE, state) }
+                arguments = Bundle().apply { putParcelable(KEY_STATE, state) }
             }
     }
 
     /**
      * For handling the UI state of the comment moderation bottom sheet
      */
+    @Parcelize
     data class CommentState(
         val canModerate: Boolean,
         val canTrash: Boolean,
         val canMarkAsSpam: Boolean,
-    ) : Serializable
+    ) : Parcelable
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
@@ -33,6 +33,8 @@ class NotificationCommentDetailFragment : SharedCommentDetailFragment() {
         } else {
             handleNote(requireArguments().getString(KEY_NOTE_ID)!!)
         }
+
+        viewModel.fetchComment(site, note.commentId)
     }
 
     override fun sendLikeCommentEvent(liked: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isGone
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.fluxc.tools.FormattableRangeType
 import org.wordpress.android.models.Note
@@ -31,6 +33,14 @@ class NotificationCommentDetailFragment : SharedCommentDetailFragment() {
         } else {
             handleNote(requireArguments().getString(KEY_NOTE_ID)!!)
         }
+    }
+
+    override fun sendLikeCommentEvent(liked: Boolean) {
+        super.sendLikeCommentEvent(liked)
+        // it should also track the notification liked/unliked event
+        AnalyticsTracker.track(
+            if (liked) Stat.NOTIFICATION_LIKED else Stat.NOTIFICATION_UNLIKED
+        )
     }
 
     override fun getUserProfileUiState(): BottomSheetUiState.UserProfileUiState {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/NotificationCommentDetailFragment.kt
@@ -6,12 +6,14 @@ import androidx.core.view.isGone
 import org.wordpress.android.R
 import org.wordpress.android.datasets.NotificationsTable
 import org.wordpress.android.fluxc.tools.FormattableRangeType
+import org.wordpress.android.models.Note
 import org.wordpress.android.ui.comments.unified.CommentIdentifier
 import org.wordpress.android.ui.comments.unified.CommentSource
 import org.wordpress.android.ui.engagement.BottomSheetUiState
 import org.wordpress.android.ui.reader.tracker.ReaderTracker.Companion.SOURCE_NOTIF_COMMENT_USER_PROFILE
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.ToastUtils
+import java.util.EnumSet
 
 /**
  * Used when called from notification list for a comment notification
@@ -19,6 +21,9 @@ import org.wordpress.android.util.ToastUtils
  * It'd be better to have multiple fragments for different sources for different purposes
  */
 class NotificationCommentDetailFragment : SharedCommentDetailFragment() {
+    override val enabledActions: EnumSet<Note.EnabledActions>
+        get() = note.enabledCommentActions
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (savedInstanceState?.getString(KEY_NOTE_ID) != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -33,7 +33,6 @@ import org.wordpress.android.util.image.ImageType
 import java.util.EnumSet
 import javax.inject.Inject
 
-
 /**
  * Used when we want to write Kotlin in [CommentDetailFragment]
  * Move converted code to this class

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -92,6 +92,13 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
 
     private fun CommentPendingBinding.bindPendingView() {
         root.isVisible = true
+        buttonApproveComment.setOnClickListener {
+            viewModel.dispatchModerationAction(
+                site,
+                comment,
+                CommentStatus.APPROVED
+            )
+        }
         textMoreOptions.setOnClickListener { showModerationBottomSheet() }
     }
 
@@ -100,7 +107,7 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
         meGravatarLoader.load(
             newAvatarUploaded = false,
             avatarUrl = meGravatarLoader.constructGravatarUrl(accountStore.account.avatarUrl),
-            imageView = imageAvatar,
+            imageView = replyAvatar,
             imageType = ImageType.USER,
             injectFilePath = null,
         )
@@ -156,7 +163,9 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
                 canMarkAsSpam = enabledActions.canMarkAsSpam(),
                 canTrash = enabledActions.canTrash(),
             )
-        ).show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
+        ).apply {
+            onApprovedClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.APPROVED) }
+        }.show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -1,17 +1,33 @@
 @file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.comments
 
 import androidx.core.view.isVisible
+import com.gravatar.AvatarQueryOptions
+import com.gravatar.AvatarUrl
+import com.gravatar.types.Email
 import org.wordpress.android.databinding.CommentPendingBinding
 import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.models.Note
+import org.wordpress.android.models.Note.EnabledActions
+import org.wordpress.android.ui.comments.CommentExtension.canLike
+import org.wordpress.android.ui.comments.CommentExtension.canMarkAsSpam
+import org.wordpress.android.ui.comments.CommentExtension.canModerate
+import org.wordpress.android.ui.comments.CommentExtension.canReply
+import org.wordpress.android.ui.comments.CommentExtension.canTrash
+import org.wordpress.android.ui.comments.CommentExtension.liked
+import org.wordpress.android.util.SiteUtils
+import org.wordpress.android.util.WPAvatarUtils
+import java.util.EnumSet
+
 
 /**
  * Used when we want to write Kotlin in [CommentDetailFragment]
  * Move converted code to this class
  */
-abstract class SharedCommentDetailFragment:CommentDetailFragment() {
+abstract class SharedCommentDetailFragment : CommentDetailFragment() {
     // it will be non-null after view created when users from a notification
     // it will be null when users from comment list
     protected val note: Note
@@ -22,9 +38,11 @@ abstract class SharedCommentDetailFragment:CommentDetailFragment() {
     protected val comment: CommentModel
         get() = mComment!!
 
+    abstract val enabledActions: EnumSet<EnabledActions>
+
     override fun updateModerationStatus() {
         val commentStatus = CommentStatus.fromString(comment.status)
-        when(commentStatus){
+        when (commentStatus) {
             CommentStatus.APPROVED -> {}
             CommentStatus.UNAPPROVED -> mBinding?.layoutCommentPending?.handlePendingView()
             CommentStatus.SPAM -> {}
@@ -35,8 +53,6 @@ abstract class SharedCommentDetailFragment:CommentDetailFragment() {
             CommentStatus.UNSPAM -> {}
             CommentStatus.UNTRASH -> {}
         }
-
-        mBinding?.layoutCommentPending?.handlePendingView() // todo: remove this line after PR review
     }
 
     private fun CommentPendingBinding.handlePendingView() {
@@ -45,7 +61,47 @@ abstract class SharedCommentDetailFragment:CommentDetailFragment() {
     }
 
     private fun showModerationBottomSheet() {
-        ModerationBottomSheetDialogFragment.newInstance()
-            .show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
+        ModerationBottomSheetDialogFragment.newInstance(
+            ModerationBottomSheetDialogFragment.CommentState(
+                canModerate = enabledActions.canModerate(),
+                canMarkAsSpam = enabledActions.canMarkAsSpam(),
+                canTrash = enabledActions.canTrash(),
+            )
+        ).show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
+}
+
+object CommentExtension {
+    /**
+     * Have permission to moderate/reply/spam this comment
+     */
+    fun EnumSet<EnabledActions>.canModerate(): Boolean = contains(EnabledActions.ACTION_APPROVE)
+            || contains(EnabledActions.ACTION_UNAPPROVE)
+
+    fun EnumSet<EnabledActions>.canMarkAsSpam(): Boolean = contains(EnabledActions.ACTION_SPAM)
+
+    fun EnumSet<EnabledActions>.canReply(): Boolean = contains(EnabledActions.ACTION_REPLY)
+
+    fun EnumSet<EnabledActions>.canTrash(): Boolean = canModerate()
+
+    fun canEdit(site: SiteModel): Boolean = site.hasCapabilityEditOthersPosts || site.isSelfHostedAdmin
+
+    fun EnumSet<EnabledActions>.canLike(site: SiteModel): Boolean =
+        (contains(EnabledActions.ACTION_LIKE_COMMENT) && SiteUtils.isAccessedViaWPComRest(site))
+
+    fun CommentModel.getAvatarUrl(size: Int): String = when {
+        authorProfileImageUrl != null -> WPAvatarUtils.rewriteAvatarUrl(
+            authorProfileImageUrl!!,
+            size
+        )
+
+        authorEmail != null -> AvatarUrl(
+            Email(authorEmail!!),
+            AvatarQueryOptions(size, null, null, null)
+        ).url().toString()
+
+        else -> ""
+    }
+
+    fun CommentModel.liked() = this.iLike
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
@@ -30,6 +30,7 @@ class SiteCommentDetailFragment : SharedCommentDetailFragment() {
         } else {
             handleComment(requireArguments().getLong(KEY_COMMENT_ID), requireArguments().getInt(KEY_SITE_LOCAL_ID))
         }
+        viewModel.fetchComment(site, comment.remoteCommentId)
     }
 
     override fun getUserProfileUiState(): BottomSheetUiState.UserProfileUiState =

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SiteCommentDetailFragment.kt
@@ -3,17 +3,16 @@ package org.wordpress.android.ui.comments
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import com.gravatar.AvatarQueryOptions
-import com.gravatar.AvatarUrl
-import com.gravatar.types.Email
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.models.Note.EnabledActions
+import org.wordpress.android.ui.comments.CommentExtension.getAvatarUrl
 import org.wordpress.android.ui.comments.unified.CommentIdentifier
 import org.wordpress.android.ui.comments.unified.CommentSource
 import org.wordpress.android.ui.engagement.BottomSheetUiState
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
-import org.wordpress.android.util.WPAvatarUtils
+import java.util.EnumSet
 
 /**
  * Used when called from comment list
@@ -21,6 +20,9 @@ import org.wordpress.android.util.WPAvatarUtils
  * It'd be better to have multiple fragments for different sources for different purposes
  */
 class SiteCommentDetailFragment : SharedCommentDetailFragment() {
+    override val enabledActions: EnumSet<EnabledActions>
+        get() = EnumSet.allOf(EnabledActions::class.java)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (savedInstanceState != null) {
@@ -30,10 +32,9 @@ class SiteCommentDetailFragment : SharedCommentDetailFragment() {
         }
     }
 
-    override fun getUserProfileUiState(): BottomSheetUiState.UserProfileUiState {
-        return BottomSheetUiState.UserProfileUiState(
-            userAvatarUrl = CommentExtension.getAvatarUrl(
-                comment,
+    override fun getUserProfileUiState(): BottomSheetUiState.UserProfileUiState =
+        BottomSheetUiState.UserProfileUiState(
+            userAvatarUrl = comment.getAvatarUrl(
                 resources.getDimensionPixelSize(R.dimen.avatar_sz_large)
             ),
             blavatarUrl = "",
@@ -46,7 +47,6 @@ class SiteCommentDetailFragment : SharedCommentDetailFragment() {
             siteId = 0L,
             blogPreviewSource = ReaderTracker.SOURCE_SITE_COMMENTS_USER_PROFILE
         )
-    }
 
     override fun getCommentIdentifier(): CommentIdentifier =
         CommentIdentifier.SiteCommentIdentifier(comment.id, comment.remoteCommentId)
@@ -75,21 +75,5 @@ class SiteCommentDetailFragment : SharedCommentDetailFragment() {
                 putLong(KEY_COMMENT_ID, commentModel.remoteCommentId)
             }
         }
-    }
-}
-
-object CommentExtension {
-    fun getAvatarUrl(comment: CommentModel, size: Int): String = when {
-        comment.authorProfileImageUrl != null -> WPAvatarUtils.rewriteAvatarUrl(
-            comment.authorProfileImageUrl!!,
-            size
-        )
-
-        comment.authorEmail != null -> AvatarUrl(
-            Email(comment.authorEmail!!),
-            AvatarQueryOptions(size, null, null, null)
-        ).url().toString()
-
-        else -> ""
     }
 }

--- a/WordPress/src/main/res/drawable/baseline_check_16.xml
+++ b/WordPress/src/main/res/drawable/baseline_check_16.xml
@@ -1,0 +1,5 @@
+<vector android:height="16dp" android:tint="#3C3C43"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="16dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/WordPress/src/main/res/layout/comment_approved.xml
+++ b/WordPress/src/main/res/layout/comment_approved.xml
@@ -31,7 +31,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/margin_extra_large"
-        android:layout_marginTop="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_extra_small_large"
         app:cardCornerRadius="20dp"
         app:cardElevation="0dp"
         app:strokeColor="@color/divider"
@@ -56,7 +56,6 @@
                 android:id="@+id/text_reply"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:fontFamily="sans-serif-medium"
                 android:layout_marginStart="@dimen/margin_medium"
                 android:textColor="@color/menu_more"
                 android:lines="1"
@@ -80,7 +79,7 @@
         android:textSize="@dimen/text_sz_medium"
         android:drawablePadding="@dimen/margin_small"
         android:layout_marginBottom="@dimen/margin_extra_medium_large"
-        tools:text="Like Edna’s comment"
+        tools:text="Like comment"
         android:layout_height="wrap_content"
         app:drawableStartCompat="@drawable/star_empty" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/comment_approved.xml
+++ b/WordPress/src/main/res/layout/comment_approved.xml
@@ -44,7 +44,7 @@
             android:layout_marginVertical="@dimen/margin_medium">
 
             <ImageView
-                android:id="@+id/image_avatar"
+                android:id="@+id/reply_avatar"
                 android:layout_width="@dimen/avatar_sz_extra_small"
                 android:layout_height="@dimen/avatar_sz_extra_small"
                 android:importantForAccessibility="no"
@@ -63,7 +63,7 @@
                 android:textSize="@dimen/text_sz_medium"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/image_avatar"
+                app:layout_constraintStart_toEndOf="@+id/reply_avatar"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="Reply to Adam" />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/layout/comment_approved.xml
+++ b/WordPress/src/main/res/layout/comment_approved.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:background="@color/divider_likes" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:drawablePadding="@dimen/margin_small"
+        android:fontFamily="sans-serif-medium"
+        android:gravity="center_vertical"
+        android:includeFontPadding="false"
+        android:text="@string/comment_moderation_approved"
+        android:textColor="@color/menu_more"
+        android:textSize="@dimen/text_sz_small"
+        app:drawableStartCompat="@drawable/baseline_check_16"
+        app:drawableTint="@color/menu_more" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_reply"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_large"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/divider"
+        app:strokeWidth="1dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_extra_large"
+            android:layout_marginVertical="@dimen/margin_medium">
+
+            <ImageView
+                android:id="@+id/image_avatar"
+                android:layout_width="@dimen/avatar_sz_extra_small"
+                android:layout_height="@dimen/avatar_sz_extra_small"
+                android:importantForAccessibility="no"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/text_reply"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:layout_marginStart="@dimen/margin_medium"
+                android:textColor="@color/menu_more"
+                android:lines="1"
+                android:textSize="@dimen/text_sz_medium"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/image_avatar"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Reply to Adam" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/text_like_comment"
+        android:layout_marginTop="@dimen/margin_large"
+        android:layout_gravity="center_horizontal"
+        android:layout_width="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:gravity="center"
+        android:paddingVertical="@dimen/margin_medium_large"
+        android:textSize="@dimen/text_sz_medium"
+        android:drawablePadding="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_extra_medium_large"
+        tools:text="Like Edna’s comment"
+        android:layout_height="wrap_content"
+        app:drawableStartCompat="@drawable/star_empty" />
+</LinearLayout>

--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -23,6 +23,12 @@
             layout="@layout/comment_pending"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <include
+            android:id="@+id/layout_comment_approved"
+            layout="@layout/comment_approved"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
     </FrameLayout>
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -22,13 +22,15 @@
             android:id="@+id/layout_comment_pending"
             layout="@layout/comment_pending"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
 
         <include
             android:id="@+id/layout_comment_approved"
             layout="@layout/comment_approved"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
     </FrameLayout>
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/comment_moderation.xml
+++ b/WordPress/src/main/res/layout/comment_moderation.xml
@@ -21,6 +21,7 @@
         android:textSize="@dimen/text_sz_large" />
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_approve"
         style="@style/Widget.ModerationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -31,6 +32,7 @@
         app:iconTint="@color/primary" />
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_pending"
         style="@style/Widget.ModerationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -41,6 +43,7 @@
         app:iconTint="@color/menu_more" />
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_trash"
         style="@style/Widget.ModerationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -51,6 +54,7 @@
         app:iconTint="@null"/>
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_spam"
         style="@style/Widget.ModerationButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/comment_pending.xml
+++ b/WordPress/src/main/res/layout/comment_pending.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:id="@+id/layout_root"
     android:orientation="vertical">
 
     <View
@@ -19,6 +18,7 @@
         android:drawablePadding="@dimen/margin_small"
         android:gravity="center_vertical"
         android:includeFontPadding="false"
+        android:fontFamily="sans-serif-medium"
         android:text="@string/comment_moderation_pending"
         android:textColor="@color/menu_more"
         android:textSize="@dimen/text_sz_small"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -465,6 +465,7 @@
     <string name="comment_action_change_status">Change status</string>
 
     <string name="comment_moderation_pending">Comment pending moderation</string>
+    <string name="comment_moderation_approved">Comment Approved</string>
     <string name="comment_moderation_approve">Approve comment</string>
     <string name="comment_moderation_more">More options</string>
     <string name="comment_moderation_status_title">Choose status</string>
@@ -503,6 +504,7 @@
     <string name="copy_link_address">Copy link address</string>
     <string name="comment_moderated_approved">Comment approved!</string>
     <string name="comment_liked">Comment liked</string>
+    <string name="like_comment">Like comment</string>
     <string name="comment_q_action_done_generic">Action done!</string>
     <string name="comment_q_action_processing">Processing…</string>
     <string name="comment_q_action_liking">Liking…</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1820,6 +1820,7 @@
         <item name="android:fontFamily">sans-serif</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:backgroundTint">@color/transparent</item>
+        <item name="android:foreground">?attr/selectableItemBackground</item>
         <item name="android:paddingStart">@dimen/margin_extra_medium_large</item>
         <item name="android:paddingEnd">@dimen/margin_extra_medium_large</item>
         <item name="cornerRadius">0dp</item>

--- a/WordPress/src/test/java/org/wordpress/android/ui/comments/CommentDetailViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/comments/CommentDetailViewModelTest.kt
@@ -1,0 +1,117 @@
+@file:Suppress("DEPRECATION")
+
+package org.wordpress.android.ui.comments
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.CommentModel
+import org.wordpress.android.fluxc.model.CommentStatus
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.comments.CommentsMapper
+import org.wordpress.android.fluxc.persistence.comments.CommentsDao
+import org.wordpress.android.fluxc.store.CommentsStore
+import org.wordpress.android.models.Note
+import org.wordpress.android.ui.comments.unified.CommentsStoreAdapter
+import org.wordpress.android.ui.notifications.NotificationEvents
+import org.wordpress.android.util.EventBusWrapper
+
+@ExperimentalCoroutinesApi
+class CommentDetailViewModelTest : BaseUnitTest() {
+    private val commentsStore: CommentsStore = mock()
+    private val commentsStoreAdapter: CommentsStoreAdapter = mock()
+    private val eventBusWrapper: EventBusWrapper = mock()
+    private val commentsMapper: CommentsMapper = mock()
+    private lateinit var viewModel: CommentDetailViewModel
+
+    @Before
+    fun setup() {
+        viewModel = CommentDetailViewModel(
+            testDispatcher(),
+            commentsStore,
+            commentsStoreAdapter,
+            eventBusWrapper,
+            commentsMapper
+        )
+    }
+
+    @Test
+    fun `when like a comment from comment list, then update comment`() {
+        // Given
+        val comment: CommentModel = mock()
+        val site: SiteModel = mock()
+
+        whenever(comment.iLike).thenReturn(false)
+
+        // When
+        viewModel.likeComment(comment, site)
+
+        // Then
+        verify(comment).setILike(true)
+        verify(commentsStoreAdapter).dispatch(any())
+        assert(viewModel.updatedComment.value == comment)
+    }
+
+    @Test
+    fun `when like a comment from a notification, then update comment and notification`() {
+        // Given
+        val comment: CommentModel = mock()
+        val site: SiteModel = mock()
+        val note: Note = mock()
+
+        whenever(comment.iLike).thenReturn(false)
+
+        // When
+        viewModel.likeComment(comment, site, note)
+
+        // Then
+        verify(comment).setILike(true)
+        verify(commentsStoreAdapter).dispatch(any())
+        verify(eventBusWrapper).postSticky(isA<NotificationEvents.OnNoteCommentLikeChanged>())
+        assert(viewModel.updatedComment.value == comment)
+    }
+
+    @Test
+    fun `when dispatch moderation action, then update comment`() {
+        // Given
+        val comment: CommentModel = mock()
+        val site: SiteModel = mock()
+
+        // When
+        viewModel.dispatchModerationAction(site, comment, CommentStatus.APPROVED)
+
+        // Then
+        verify(commentsStoreAdapter).dispatch(any())
+        verify(comment).setStatus(CommentStatus.APPROVED.toString())
+        assert(viewModel.updatedComment.value == comment)
+    }
+
+    @Test
+    fun `when comment fetched, then update comment`() = test {
+        // Given
+        val commentId = 123L
+        val site: SiteModel = mock()
+        val comment:CommentModel = mock()
+        val commentEntity: CommentsDao.CommentEntity = mock()
+        val result: CommentsStore.CommentsActionPayload<CommentsStore.CommentsData.CommentsActionData> = mock()
+
+        whenever(result.data).thenReturn(mock())
+        whenever(result.data?.comments).thenReturn(listOf(commentEntity))
+        whenever(commentsStore.fetchComment(any(), any(), eq(null))).thenReturn(result)
+        whenever(commentsMapper.commentEntityToLegacyModel(commentEntity)).thenReturn(comment)
+
+        // When
+        viewModel.fetchComment(site, commentId)
+
+        // Then
+        verify(commentsStore).fetchComment(site, commentId, null)
+        assert(viewModel.updatedComment.value == comment)
+    }
+}


### PR DESCRIPTION
See: https://github.com/Automattic/wordpress-mobile/issues/42

Design: yWt5gg3nWORhu079Qfv3mS-fi-1135_5126

This PR implements the redesign of Approved UI. It also refactors some codebase.

-----

## To Test:

**Approve a comment**
1. Sign in JP app
2. Go to `Notifications` tab
3. Click on a notification with comment type
4. It should display the approved status UI (if this is an approved comment)
5. Back to `Notifications` tab
6. Use the web console and unapprove the comment you just viewed
7. Click on the notification again
8. It should display the `pending` status UI
9. Click on the `Approve comment` button
10. It should display the `approved` status UI
11. Back to Notifications tab
12. Unapprove the comment and click on the notification again
13. Click on the `More options` text
14. Click on `Approved` on the bottom sheet.
15. Go to My site -> More -> Comments -> Comment
16. Test approved/unapproved comment as above.

**Like a comment**
1. Click on an approved comment via `Notifications` tab
2. Like/Unlike the comment
3. It should work as usual.
4. Go to My site -> More -> Comments
5. Click on an approved comment
6. Repeat step 2 & 3.
7. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - comment, notification

18. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

19. What automated tests I added (or what prevented me from doing so)

    - unit tests

-----

## PR Submission Checklist:

skipped

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)