### PR TITLE
[Voice to Content] Capture transcription error logs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUseCase.kt
@@ -36,7 +36,11 @@ class VoiceToContentUseCase @Inject constructor(
                     transcriptionResponse.model
                 }
                 is JetpackAITranscriptionResponse.Error -> {
-                    Log.i(javaClass.simpleName, "Error transcribing audio file: ${transcriptionResponse.type} ${transcriptionResponse.message}")
+                    val message = "${transcriptionResponse.type} ${transcriptionResponse.message}"
+                    Log.i(
+                        javaClass.simpleName,
+                        "Error transcribing audio file: $message"
+                    )
                     null
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUseCase.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.voicetocontent
 
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.wordpress.android.fluxc.model.SiteModel
@@ -35,6 +36,7 @@ class VoiceToContentUseCase @Inject constructor(
                     transcriptionResponse.model
                 }
                 is JetpackAITranscriptionResponse.Error -> {
+                    Log.i(javaClass.simpleName, "Error transcribing audio file: ${transcriptionResponse.type} ${transcriptionResponse.message}")
                     null
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.120.0-alpha1'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = 'trunk-a9a471914d3ebd1093986d3d0a95c2a29b29dca0'
+    wordPressFluxCVersion = '3026-6c41807a193ee1eaa5967eb34221895a6282f4e3'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticTracksVersion = '5.0.0'
     gutenbergMobileVersion = 'v1.120.0-alpha1'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = '3026-6c41807a193ee1eaa5967eb34221895a6282f4e3'
+    wordPressFluxCVersion = 'trunk-8b7eeade00f33c5b4296722fb3854b3a32e06ad8'
     wordPressLoginVersion = '1.15.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
This is the companion PR for https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3026

Merge Instructions
- Make sure the FLuxC PR has been merged to trunk
- Grab the FluxC trunk has from CI and update build.gradle
- Remove the Not Ready for Merge label
- Merge as normal
-----

## To Test:
- Install and launch the app
- Navigate to Me > Debug Settings > Remote Features
- Enable voice_to_content and restart the app
- Select a non-p2 site that has a limited number of AI calls (I believe the default limit is 20)
- Navigate to My Site > Tap the FAB > Select Post from audio
- Tap the microphone > record > stop 
- Repeat this until you get an error message in the log

-----

## Regression Notes

1. Potential unintended areas of impact
The error message doesn't show

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
