### PR TITLE
Replaces OAuth2 section with self-hosted test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To build, install, and test the project from the command line:
 You can use your own WordPress site for developing and testing the app. If you don't have one, you can create a temporary test site for free at https://jurassic.ninja/.
 On the app start up screen, choose "Enter your existing site address" and enter the URL of your site and your credentials.
 
+Note: Access to WordPress.com features is temporarily disabled in the development environment.
+
 ## Directory structure ##
     .
     ├── libs                    # dependencies used to build debug variants

--- a/README.md
+++ b/README.md
@@ -16,40 +16,7 @@ If you're a developer wanting to contribute, read on.
 
 Notes:
 
-* To use WordPress.com features (login to WordPress.com, access Reader and Stats, etc) you need a WordPress.com OAuth2 ID and secret. Please read the [OAuth2 Authentication](#oauth2-authentication) section.
 * While loading/building the app in Android Studio ignore the prompt to update the gradle plugin version as that will probably introduce build errors. On the other hand, feel free to update if you are planning to work on ensuring the compatibility of the newer version.
-
-
-## OAuth2 Authentication ##
-
-In order to use WordPress.com functions you will need a client ID and
-a client secret key. These details will be used to authenticate your
-application and verify that the API calls being made are valid. You can
-create an application or view details for your existing applications with
-our [WordPress.com applications manager][5].
-
-When creating your application, you should select "Native client" for the application type.
-The "**Website URL**", "**Redirect URLs**", and "**Javascript Origins**" fields are required but not used for
-the mobile apps. Just use "**[https://localhost](https://localhost)**".
-
-Once you've created your application in the [applications manager][5], you'll
-need to edit the `./gradle.properties` file and change the
-`wp.oauth.app_id` and `wp.oauth.app_secret` fields. Then you can compile and
-run the app on a device or an emulator and try to login with a WordPress.com
-account. Note that authenticating to WordPress.com via Google is not supported
-in development builds of the app, only in the official release.
-
-Note that credentials created with our [WordPress.com applications manager][5]
-allow login only and not signup. New accounts must be created using the [official app][1]
-or [on the web](https://wordpress.com/start). Login is restricted to the WordPress.com
-account with which the credentials were created. In other words, if the credentials
-were created with foo@email.com, you will only be able to login with foo@email.com.
-Using another account like bar@email.com will cause the `Client cannot use "password" grant_type` error.
-
-For security reasons, some account-related actions aren't supported for development
-builds when using a WordPress.com account with 2-factor authentication enabled.
-
-Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
 
 ## Build and Test ##
 
@@ -60,6 +27,11 @@ To build, install, and test the project from the command line:
                                                                      # emulator or an Android device connected
     $ ./gradlew :WordPress:testWordPressVanillaDebugUnitTest         # assemble, install and run unit tests
     $ ./gradlew :WordPress:connectedWordPressVanillaDebugAndroidTest # assemble, install and run Android tests
+
+## Running the app ##
+
+You can use your own WordPress site for developing and testing the app. If you don't have one, you can create a temporary test site for free at https://jurassic.ninja/.
+On the app start up screen choose "Enter your existing site address" and enter the URL of your site and your credentials.
 
 ## Directory structure ##
     .

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build, install, and test the project from the command line:
 ## Running the app ##
 
 You can use your own WordPress site for developing and testing the app. If you don't have one, you can create a temporary test site for free at https://jurassic.ninja/.
-On the app start up screen choose "Enter your existing site address" and enter the URL of your site and your credentials.
+On the app start up screen, choose "Enter your existing site address" and enter the URL of your site and your credentials.
 
 ## Directory structure ##
     .


### PR DESCRIPTION
## Description
This PR temporarily removes the OAuth2 section of the readme and adds instructions for testing with a self-hosted site. The reason for this change is that the introduction of [Passkey support](https://github.com/wordpress-mobile/WordPress-Android/pull/19591) and the related WordPress.com API changes have broken the WordPress.com OAuth2 Authentication flow in the apps.

Internal ref: pbArwn-6qJ-p2

-----

## To Test:
Check the [README](https://github.com/wordpress-mobile/WordPress-Android/blob/task/removed-wpcom-oauth-section/README.md)

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)