### PR TITLE
Integrate gutenberg-mobile release v1.119.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = '6907-ca42a8ba3299d377b2bbcac2ccf9bfd298b40ec9'
+    gutenbergMobileVersion = 'v1.119.1'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.81.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = '6907-85bc1c05040c7be9a9d3ce1c933f4ef67e623975'
+    gutenbergMobileVersion = '6907-ca42a8ba3299d377b2bbcac2ccf9bfd298b40ec9'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.81.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.0.0'
-    gutenbergMobileVersion = 'v1.119.0'
+    gutenbergMobileVersion = '6907-85bc1c05040c7be9a9d3ce1c933f4ef67e623975'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.81.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.119.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6907

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.