### PR TITLE
Change the circular avatar to a rounded corner avatar.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/ChooseSiteViewHolder.kt
@@ -88,10 +88,7 @@ class ChooseSiteViewHolder(private val binding: ItemChooseSiteBinding) : Recycle
     }
 
     private fun handleAvatar(site: SiteRecord) {
-        imageManager.loadImageWithCorners(
-            binding.avatar, site.blavatarType, site.blavatarUrl,
-            itemView.context.resources.getDimensionPixelSize(R.dimen.blavatar_sz) / 2
-        )
+        imageManager.load(binding.avatar, site.blavatarType, site.blavatarUrl)
         val isDarkTheme = itemView.resources.configuration.isDarkTheme()
         val borderColor = ContextCompat.getColor(
             itemView.context,

--- a/WordPress/src/main/res/layout/item_choose_site.xml
+++ b/WordPress/src/main/res/layout/item_choose_site.xml
@@ -48,7 +48,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_large"
             android:layout_marginVertical="@dimen/margin_medium"
-            app:cardCornerRadius="@dimen/avatar_sz_medium_radius"
+            app:cardCornerRadius="@dimen/blavatar_sz_radius"
             app:cardElevation="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -189,6 +189,7 @@
     <dimen name="avatar_background_padding">1dp</dimen>
     <dimen name="blavatar_sz_small">32dp</dimen>
     <dimen name="blavatar_sz">40dp</dimen>
+    <dimen name="blavatar_sz_radius">8dp</dimen>
     <dimen name="blavatar_sz_extra_large">72dp</dimen>
     <dimen name="my_site_blavatar_sz">56dp</dimen>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -178,7 +178,6 @@
     <dimen name="avatar_sz_extra_small">24dp</dimen>
     <dimen name="avatar_sz_small">32dp</dimen>
     <dimen name="avatar_sz_medium">40dp</dimen>
-    <dimen name="avatar_sz_medium_radius">20dp</dimen>
     <dimen name="avatar_sz_inner_circle">48dp</dimen>
     <dimen name="avatar_sz_large">64dp</dimen>
     <dimen name="avatar_sz_extra_large">72dp</dimen>
@@ -189,7 +188,7 @@
     <dimen name="avatar_background_padding">1dp</dimen>
     <dimen name="blavatar_sz_small">32dp</dimen>
     <dimen name="blavatar_sz">40dp</dimen>
-    <dimen name="blavatar_sz_radius">8dp</dimen>
+    <dimen name="blavatar_sz_radius">5dp</dimen>
     <dimen name="blavatar_sz_extra_large">72dp</dimen>
     <dimen name="my_site_blavatar_sz">56dp</dimen>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1835,6 +1835,6 @@
 
     <style name="AvatarShapeAppearanceOverlay">
         <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">@dimen/avatar_sz_medium_radius</item>
+        <item name="cornerSize">@dimen/blavatar_sz_radius</item>
     </style>
 </resources>


### PR DESCRIPTION
See p1717167632890949/1717101371.395049-slack-C0180B5PRJ4

This is a UI update of site switcher.

Updated UI:

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/806a66d7-d6d5-4608-a86a-a095cc04c828" width="400"/>


-----

## To Test:

1. Sign in JP app
2. Click on the `v` icon at the top-right corner to open the site switcher
3. Those blavatars should be displayed with rounded corners
4. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - site switcher

5. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

6. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
