### PR TITLE
Adds: delays for app restart in InAppUpdateManagerImpl

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/inappupdate/InAppUpdateAnalyticsTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/inappupdate/InAppUpdateAnalyticsTracker.kt
@@ -21,7 +21,7 @@ class InAppUpdateAnalyticsTracker @Inject constructor(
     }
 
     fun trackAppRestartToCompleteUpdate() {
-        tracker.track(AnalyticsTracker.Stat.IN_APP_UPDATE_COMPLETED_WITH_APP_RESTART)
+        tracker.track(AnalyticsTracker.Stat.IN_APP_UPDATE_COMPLETED_WITH_APP_RESTART_BY_USER)
     }
 
     private fun createPropertyMap(updateType: Int): Map<String, String> {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -34,6 +34,8 @@ import org.wordpress.android.util.wizard.WizardManager;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
 
+import javax.inject.Named;
+
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -41,6 +43,8 @@ import dagger.android.AndroidInjectionModule;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import dagger.hilt.components.SingletonComponent;
+import kotlinx.coroutines.CoroutineScope;
+import static org.wordpress.android.modules.ThreadModuleKt.APPLICATION_SCOPE;
 
 @InstallIn(SingletonComponent.class)
 @Module(includes = AndroidInjectionModule.class)
@@ -93,6 +97,7 @@ public abstract class ApplicationModule {
     @Provides
     public static IInAppUpdateManager provideInAppUpdateManager(
             @ApplicationContext Context context,
+            @Named(APPLICATION_SCOPE) CoroutineScope appScope,
             AppUpdateManager appUpdateManager,
             RemoteConfigWrapper remoteConfigWrapper,
             BuildConfigWrapper buildConfigWrapper,
@@ -103,6 +108,7 @@ public abstract class ApplicationModule {
         return inAppUpdatesFeatureConfig.isEnabled()
                 ? new InAppUpdateManagerImpl(
                 context,
+                appScope,
                 appUpdateManager,
                 remoteConfigWrapper,
                 buildConfigWrapper,

--- a/WordPress/src/test/java/org/wordpress/android/inappupdate/InAppUpdateManagerImplTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/inappupdate/InAppUpdateManagerImplTest.kt
@@ -12,6 +12,7 @@ import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
+import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -82,6 +83,7 @@ class InAppUpdateManagerImplTest {
 
         inAppUpdateManager = InAppUpdateManagerImpl(
             applicationContext,
+            TestScope(),
             appUpdateManager,
             remoteConfigWrapper,
             buildConfigWrapper,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1140,7 +1140,7 @@ public final class AnalyticsTracker {
         IN_APP_UPDATE_SHOWN,
         IN_APP_UPDATE_DISMISSED,
         IN_APP_UPDATE_ACCEPTED,
-        IN_APP_UPDATE_COMPLETED_WITH_APP_RESTART;
+        IN_APP_UPDATE_COMPLETED_WITH_APP_RESTART_BY_USER;
 
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.


### PR DESCRIPTION
This PR fixes a bug that was discovered after the pe7hp4-R0-p2. 

During the flexible flow, when user has accepted the update and it is being downloaded in the background while the app is in the foreground, once it is ready to install, a snackbar appears with a "Restart" action. We want to log an event there before the app is restarted. 

This PR adds a delay between the logging of the event the app's restart so the logging have enough time to complete. 

cc @oguzkocer 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Check PR [here](https://github.com/wordpress-mobile/WordPress-Android/pull/20822) for more details. 

ATTENTION: The current remote config value is 80000. This means that when you try to update a version of the app that is < 80000, the immediate flow will be launched.

To test this feature, we use Internal app sharing as Google suggests [here](https://developer.android.com/guide/playcore/in-app-updates/test).

Please read how Internal app sharing works [here](https://support.google.com/googleplay/android-developer/answer/9844679).

ATTENTION: As app bundle links in Internal app sharing might expire, you may need to reupload an app bundle to get a new link to use. The page for uploading is [here](https://play.google.com/console/internal-app-sharing). If you have the [Release apps to testing tracks](https://support.google.com/googleplay/android-developer/answer/9844686#release_testing) permission, you’re authorized to upload app bundles and APKs for internal sharing by default. If you don't, you can make a request in Systems P2 like pMz3w-jQU-p2.

1. Enable internal app sharing on your device following the instructions:
```
Open the Google Play Store app Google Play.
Tap Menu Menu > Settings.
In the "About" section, tap the Play Store version 7 times.
After the Internal app sharing setting appears, tap the switch to turn on internal app sharing.
Tap Turn on.  
```
2. Download the 2 app versions on your computer. Having these versions on your machine will allow you to reupload them as many times as you want and get new links if the old ones have expired. Link [here](https://drive.google.com/drive/folders/1eoos_RbEgKNprVRxRpuMNUoVNkvNpzVn?usp=sharing). Upload the 2 files using the [page](https://play.google.com/console/internal-app-sharing) for uploading. Get the 2 links and send them to your device so you can tap on them from there (You could send the links with an email).
3. Uninstall all versions of the Jetpack app that you have on your device.
4. Tap on the first link for version 90004.
5. A Google Play page appears. Tap on the "Install" button. When the download is over, tap on "Open".
6. Login with a non-automattic account.
7. From your device, tap the second link for version 90005. You will see a page with an "Update" button. DO NOT tap on it and go back to the app.
8. Check that nothing happens and no update is shown.
9. Tap on "Me" button in the bottom navigation bar and tap on "Debug settings".
10. Enable "in app updates" FF.
11. Kill and restart the app.
12. Check that a bottom sheet appears about the update.
13. Check that the IN_APP_UPDATE_SHOWN event is tracked
14. Check that the update bottom sheet appears.
15. Tap "Update" button.
16. Check that the IN_APP_UPDATE_ACCEPTED event is tracked.
17. The update is being downloaded in the background.
18. When the update is downloaded and our app is in the foreground:
19.Check that a snackbar appears that informs the user and asking for a restart.
20. Tap on the restart action.
**21. Check that the IN_APP_UPDATE_COMPLETED_WITH_APP_RESTART_BY_USER event is tracked.**
 22. Check that the update is installed and the app is restarted.

Attention: If the app is in the background when the update is downloaded, the update is installed silently without notifying the user.
-----