### PR TITLE
[Hack Week] A generic solution for resolving the ANRs caused by accessing local database

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/AsyncTaskHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AsyncTaskHandler.kt
@@ -1,0 +1,32 @@
+package org.wordpress.android.datasets
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Helper class to handle async tasks by using coroutines
+ */
+object AsyncTaskHandler {
+    /**
+     * Load data in the background and handle the result on the main thread
+     */
+    @JvmStatic
+    fun <T> load(backgroundTask: () -> T, callback: AsyncTaskCallback<T>) {
+        CoroutineScope(Dispatchers.IO).launch {
+            // handle the background task
+            val result = backgroundTask()
+
+            withContext(Dispatchers.Main) {
+                // handle the result on the main thread
+                callback.onTaskFinished(result)
+            }
+        }
+    }
+
+    interface AsyncTaskCallback<T> {
+        fun onTaskFinished(result: T)
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AsyncTaskHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AsyncTaskHandler.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.withContext
 
 /**
  * Helper class to handle async tasks by using coroutines
+ * @see <a href="https://github.com/wordpress-mobile/WordPress-Android/pull/20937">Introduction</a>
  */
 object AsyncTaskHandler {
     /**


### PR DESCRIPTION
This is a Hack Week project, this PR also fixes #20850 for demonstrating how to use the helper to update the current codebase.

## Why

There are a number of Android ANR errors reported on Sentry, and some of these ANRs are caused by local database access. The likely cause is that some code is accessing the local database without switching to the background thread, which can lead to ANRs in certain situations.

To address this issue, I have created a generic helper that can be used to easily handle thread switching. This helper can be used by anyone who encounters a similar situation in the future.

P.S. This helper is not limited to accessing the database; this helper can also be used for any requirement that needs to be executed on a IO thread and then switched back to the main thread.


## Use with Caution

This helper looks convenient, but the goal is not to use it extensively. Good code should have a well-designed architecture and proper implementations, which wouldn't require this helper. It's meant for quick fixes in the code's incorrect implementations. However, in the long run, we should aim for a complete refactor.

## Note
While working on #20851, I found that the solution to modify the original blocking operation to thread switching introduced a race condition that caused UI errors. The culprit was a piece of code operating on another thread. This means that the original code needs to be refactored further to avoid this issue. It's crucial to carefully check for potential race conditions when dealing with similar problems.

-----

## To Test:

1. Sign in JP app.
2. Go to the `Reader` tab.
3. Click on a post.
4. Click on a tag in that post.
5. Click Subscribe/unsubscribe button on the tag header.
6. It should work as usual.
7. Done, thank you!

| Post | Tag Header |
|--|--|
| ![Screenshot_20240604-174237](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/022f5fee-2b24-4b3d-8fbb-284a6f9cb19b) | ![Screenshot_20240604-174247](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/8a8a18f4-447b-4b11-9b6f-74b63faade27) |



-----

## Regression Notes

1. Potential unintended areas of impact

    - reader

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

10. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

skipped
