### PR TITLE
[Reader] Show custom lists directly if there are 2 or fewer items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelper.kt
@@ -55,21 +55,27 @@ class ReaderTopBarMenuHelper @Inject constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.let { customListsArray ->
                     add(MenuElementData.Divider)
-                    if (customListsArray.size() > 2) {
-                        // If custom lists has more than 2 items, we add a submenu called "Lists"
-                        add(createCustomListsItem(customListsArray))
-                    } else {
-                        // If the custom lists has 2 or less items, we add the items directly without submenu
-                        customListsArray.forEach { index, readerTag ->
-                            add(
-                                MenuElementData.Item.Single(
-                                    id = getMenuItemIdFromReaderTagIndex(index),
-                                    text = UiString.UiStringText(readerTag.tagTitle),
-                                )
-                            )
-                        }
-                    }
+                    createCustomListsItems(customListsArray)
                 }
+        }
+    }
+
+    private fun MutableList<MenuElementData>.createCustomListsItems(
+        customListsArray: SparseArrayCompat<ReaderTag>
+    ) {
+        if (customListsArray.size() > 2) {
+            // If custom lists has more than 2 items, we add a submenu called "Lists"
+            add(createCustomListsItem(customListsArray))
+        } else {
+            // If the custom lists has 2 or less items, we add the items directly without submenu
+            customListsArray.forEach { index, readerTag ->
+                add(
+                    MenuElementData.Item.Single(
+                        id = getMenuItemIdFromReaderTagIndex(index),
+                        text = UiString.UiStringText(readerTag.tagTitle),
+                    )
+                )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelper.kt
@@ -55,7 +55,20 @@ class ReaderTopBarMenuHelper @Inject constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.let { customListsArray ->
                     add(MenuElementData.Divider)
-                    add(createCustomListsItem(customListsArray))
+                    if (customListsArray.size() > 2) {
+                        // If custom lists has more than 2 items, we add a submenu called "Lists"
+                        add(createCustomListsItem(customListsArray))
+                    } else {
+                        // If the custom lists has 2 or less items, we add the items directly without submenu
+                        customListsArray.forEach { index, readerTag ->
+                            add(
+                                MenuElementData.Item.Single(
+                                    id = getMenuItemIdFromReaderTagIndex(index),
+                                    text = UiString.UiStringText(readerTag.tagTitle),
+                                )
+                            )
+                        }
+                    }
                 }
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/reader/utils/ReaderTopBarMenuHelperTest.kt
@@ -73,6 +73,27 @@ class ReaderTopBarMenuHelperTest {
     }
 
     @Test
+    fun `GIVEN custom lists has 2 items or less WHEN createMenu THEN custom lists items are shown outside a submenu`() {
+        val tags = ReaderTagList().apply {
+            add(mockFollowingTag()) // item 0
+            add(mockDiscoverTag()) // item 1
+            add(mockSavedTag()) // item 2
+            add(mockLikedTag()) // item 3
+            add(mockA8CTag()) // item 4
+            add(mockFollowedP2sTag()) // item 5
+            add(createCustomListTag("custom-list-1")) // item 6
+            add(createCustomListTag("custom-list-2")) // item 7
+        }
+        val menu = helper.createMenu(tags)
+
+        val customListItem1 = menu.findSingleItem { it.id == "6" }!!
+        assertThat(customListItem1.text).isEqualTo(UiStringText("custom-list-1"))
+
+        val customListItem2 = menu.findSingleItem { it.id == "7" }!!
+        assertThat(customListItem2.text).isEqualTo(UiStringText("custom-list-2"))
+    }
+
+    @Test
     fun `GIVEN all tags are available and tags FF enabled WHEN createMenu THEN all items are created correctly`() {
         whenever(readerTagsFeedFeatureConfig.isEnabled()).thenReturn(true)
 


### PR DESCRIPTION
Fixes #20033 

-----

## To Test:
- Make sure you have more than 2 custom reading lists (you can see your lists [here](https://wordpress.com/read)).
- Install JP and sign in.
- Open Reader.
- 🔍 Expand the dropdown menu: you should see the "Lists" submenu item, and when tapping on it you should see the names of your lists.
<img width="300" alt="Screenshot 2024-06-05 at 1 34 29 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/9de6514a-5454-4542-897f-c492417c09f7">

- Make sure you have 2 or less custom reading lists.
- Reload the Reader.
- 🔍 Expand the dropdown menu: instead of seeing the "Lists" submenu, you should see the custom lists items directly in the main menu.
<img width="300" alt="Screenshot 2024-06-05 at 1 33 33 PM" src="https://github.com/wordpress-mobile/WordPress-Android/assets/14964993/f808a071-b158-40ac-8f0c-5efa06c8c648">
-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and updated unit tests

3. What automated tests I added (or what prevented me from doing so)

    - Updated `ReaderTopBarMenuHelperTest.kt`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
