### PR TITLE
Migrated `PostSettingsInputDialogFragment` to ViewBinding

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -94,31 +94,32 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
                 new MaterialAlertDialogBuilder(new ContextThemeWrapper(getActivity(), R.style.PostSettingsTheme));
         LayoutInflater layoutInflater = requireActivity().getLayoutInflater();
         //noinspection InflateParams
-        PostSettingsInputDialogBinding mBinding =
+        PostSettingsInputDialogBinding binding =
                 PostSettingsInputDialogBinding.inflate(layoutInflater, null, false);
-        builder.setView(mBinding.getRoot());
+        builder.setView(binding.getRoot());
         if (mIsMultilineInput) {
-            mBinding.postSettingsInputDialogEditText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+            binding.postSettingsInputDialogEditText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
         } else {
-            mBinding.postSettingsInputDialogEditText.setInputType(InputType.TYPE_CLASS_TEXT);
+            binding.postSettingsInputDialogEditText.setInputType(InputType.TYPE_CLASS_TEXT);
         }
         if (!TextUtils.isEmpty(mCurrentInput)) {
-            mBinding.postSettingsInputDialogEditText.setText(mCurrentInput);
+            binding.postSettingsInputDialogEditText.setText(mCurrentInput);
             // move the cursor to the end
-            mBinding.postSettingsInputDialogEditText.setSelection(mCurrentInput.length());
+            binding.postSettingsInputDialogEditText.setSelection(mCurrentInput.length());
         }
-        mBinding.postSettingsInputDialogEditText.addTextChangedListener(this);
+        binding.postSettingsInputDialogEditText.addTextChangedListener(this);
 
-        mBinding.postSettingsInputDialogInputLayout.setHint(mTitle);
+        binding.postSettingsInputDialogInputLayout.setHint(mTitle);
 
-        mBinding.postSettingsInputDialogHint.setText(mHint);
+        binding.postSettingsInputDialogHint.setText(mHint);
 
         builder.setNegativeButton(R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                mCurrentInput = mBinding.postSettingsInputDialogEditText.getText().toString();
-                if (mListener != null) {
+                Editable text = binding.postSettingsInputDialogEditText.getText();
+                if (mListener != null && text != null) {
+                    mCurrentInput = text.toString();
                     mListener.onInputUpdated(mCurrentInput);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -8,9 +8,6 @@ import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.widget.EditText;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -18,10 +15,11 @@ import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.fragment.app.DialogFragment;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-import com.google.android.material.textfield.TextInputLayout;
 
 import org.wordpress.android.R;
+import org.wordpress.android.databinding.PostSettingsInputDialogBinding;
 import org.wordpress.android.util.ActivityUtils;
+
 
 public class PostSettingsInputDialogFragment extends DialogFragment implements TextWatcher {
     public static final String TAG = "post_settings_input_dialog_fragment";
@@ -35,6 +33,7 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
     private static final String HINT_TAG = "hint";
     private static final String DISABLE_EMPTY_INPUT_TAG = "disable_empty_input";
     private static final String MULTILINE_INPUT_TAG = "is_multiline_input";
+
     private String mCurrentInput;
     private String mTitle;
     private String mHint;
@@ -94,34 +93,32 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder =
                 new MaterialAlertDialogBuilder(new ContextThemeWrapper(getActivity(), R.style.PostSettingsTheme));
-        LayoutInflater layoutInflater = getActivity().getLayoutInflater();
+        LayoutInflater layoutInflater = requireActivity().getLayoutInflater();
         //noinspection InflateParams
-        View dialogView = layoutInflater.inflate(R.layout.post_settings_input_dialog, null);
-        builder.setView(dialogView);
-        final EditText editText = dialogView.findViewById(R.id.post_settings_input_dialog_edit_text);
+        PostSettingsInputDialogBinding mBinding =
+                PostSettingsInputDialogBinding.inflate(layoutInflater, null, false);
+        builder.setView(mBinding.getRoot());
         if (mIsMultilineInput) {
-            editText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+            mBinding.postSettingsInputDialogEditText.setRawInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
         } else {
-            editText.setInputType(InputType.TYPE_CLASS_TEXT);
+            mBinding.postSettingsInputDialogEditText.setInputType(InputType.TYPE_CLASS_TEXT);
         }
         if (!TextUtils.isEmpty(mCurrentInput)) {
-            editText.setText(mCurrentInput);
+            mBinding.postSettingsInputDialogEditText.setText(mCurrentInput);
             // move the cursor to the end
-            editText.setSelection(mCurrentInput.length());
+            mBinding.postSettingsInputDialogEditText.setSelection(mCurrentInput.length());
         }
-        editText.addTextChangedListener(this);
+        mBinding.postSettingsInputDialogEditText.addTextChangedListener(this);
 
-        TextInputLayout textInputLayout = dialogView.findViewById(R.id.post_settings_input_dialog_input_layout);
-        textInputLayout.setHint(mTitle);
+        mBinding.postSettingsInputDialogInputLayout.setHint(mTitle);
 
-        TextView hintTextView = dialogView.findViewById(R.id.post_settings_input_dialog_hint);
-        hintTextView.setText(mHint);
+        mBinding.postSettingsInputDialogHint.setText(mHint);
 
         builder.setNegativeButton(R.string.cancel, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                mCurrentInput = editText.getText().toString();
+                mCurrentInput = mBinding.postSettingsInputDialogEditText.getText().toString();
                 if (mListener != null) {
                     mListener.onInputUpdated(mCurrentInput);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -20,7 +20,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.databinding.PostSettingsInputDialogBinding;
 import org.wordpress.android.util.ActivityUtils;
 
-
 public class PostSettingsInputDialogFragment extends DialogFragment implements TextWatcher {
     public static final String TAG = "post_settings_input_dialog_fragment";
 


### PR DESCRIPTION
## Description 

This pull request migrates the `AddCategoryFragment`  to use ViewBinding, improving type safety and eliminating the need for findViewById calls. 

## Fixes 
* #19180

## Screenshots/ Video

[PostSettingsInputDialogFragment.webm](https://github.com/wordpress-mobile/WordPress-Android/assets/60827173/30bd16be-4c67-484b-93a5-87c823c70c3f)

## Steps to reproduce 


## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [X] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [X] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)

