### PR TITLE
Integrate gutenberg-mobile release v1.120.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6916-704b68e56a293b56ec4bfc9673fb76a918ceb2d8'
+    gutenbergMobileVersion = 'v1.120.0'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.83.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.120.0-alpha1'
+    gutenbergMobileVersion = '6916-704b68e56a293b56ec4bfc9673fb76a918ceb2d8'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.83.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.120.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6916

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.