### PR TITLE
Comment details menu redesign

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -43,7 +43,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.fluxc.tools.FormattableContentMapper;
 import org.wordpress.android.models.Note;
-import org.wordpress.android.models.Note.EnabledActions;
 import org.wordpress.android.models.UserSuggestion;
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateHandler;
 import org.wordpress.android.ui.ActivityId;
@@ -81,7 +80,6 @@ import org.wordpress.android.util.analytics.AnalyticsUtils;
 import org.wordpress.android.util.image.ImageManager;
 import org.wordpress.android.util.image.ImageType;
 
-import java.util.EnumSet;
 import java.util.List;
 
 import javax.inject.Inject;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -47,6 +47,7 @@ import org.wordpress.android.models.Note.EnabledActions;
 import org.wordpress.android.models.UserSuggestion;
 import org.wordpress.android.models.usecases.LocalCommentCacheUpdateHandler;
 import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.CollapseFullScreenDialogFragment;
 import org.wordpress.android.ui.ViewPagerFragment;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
@@ -115,7 +116,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     @Nullable protected Note mNote;
     @Nullable private SuggestionAdapter mSuggestionAdapter;
     @Nullable private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
-    @Nullable private String mRestoredReplyText;
     protected boolean mIsUsersBlog = false;
     protected boolean mShouldFocusReplyField;
     @Nullable private String mPreviousStatus;
@@ -138,13 +138,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     @Nullable private OnNoteCommentActionListener mOnNoteCommentActionListener;
     @NonNull protected CommentSource mCommentSource; // this will be non-null when onCreate()
 
-    /*
-     * these determine which actions (moderation, replying, marking as spam) to enable
-     * for this comment - all actions are enabled when opened from the comment list, only
-     * changed when opened from a notification
-     */
-    @NonNull private EnumSet<EnabledActions> mEnabledActions = EnumSet.allOf(EnabledActions.class);
-
     @Nullable protected CommentDetailFragmentBinding mBinding = null;
 
     private final OnActionClickListener mOnActionClickListener = new OnActionClickListener() {
@@ -154,7 +147,13 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
         @Override public void onUserInfoClicked() {
             UserProfileBottomSheetFragment.newInstance(getUserProfileUiState())
-                    .show(getChildFragmentManager(), UserProfileBottomSheetFragment.TAG);
+                                          .show(getChildFragmentManager(), UserProfileBottomSheetFragment.TAG);
+        }
+
+        @Override public void onShareClicked() {
+            if (getContext() != null) {
+                ActivityLauncher.openShareIntent(getContext(), mComment.getUrl(), null);
+            }
         }
     };
 
@@ -725,15 +724,6 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
         binding.textContent.setVisibility(View.GONE);
 
-        /*
-         * determine which actions to enable for this comment - if the comment is from this user's
-         * blog then all actions will be enabled, but they won't be if it's a reply to a comment
-         * this user made on someone else's blog
-         */
-        if (note != null) {
-            mEnabledActions = note.getEnabledCommentActions();
-        }
-
         if (comment != null) {
             setComment(site, comment);
         } else if (note != null) {
@@ -901,6 +891,9 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
      */
     public interface OnActionClickListener {
         void onEditCommentClicked();
+
         void onUserInfoClicked();
+
+        void onShareClicked();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -155,7 +155,13 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
                 ActivityLauncher.openShareIntent(getContext(), mComment.getUrl(), null);
             }
         }
+
+        @Override public void onChangeStatusClicked() {
+            showModerationBottomSheet();
+        }
     };
+
+    abstract void showModerationBottomSheet();
 
     abstract UserProfileUiState getUserProfileUiState();
 
@@ -895,5 +901,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         void onUserInfoClicked();
 
         void onShareClicked();
+
+        void onChangeStatusClicked();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -60,6 +60,11 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
     @Inject
     lateinit var meGravatarLoader: MeGravatarLoader
 
+    /*
+    * these determine which actions (moderation, replying, marking as spam) to enable
+    * for this comment - all actions are enabled when opened from the comment list, only
+    * changed when opened from a notification
+    */
     abstract val enabledActions: EnumSet<EnabledActions>
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -160,7 +160,7 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
         )
     }
 
-    private fun showModerationBottomSheet() {
+    override fun showModerationBottomSheet() {
         ModerationBottomSheetDialogFragment.newInstance(
             ModerationBottomSheetDialogFragment.CommentState(
                 canModerate = enabledActions.canModerate(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
@@ -32,7 +32,7 @@ object CommentActionPopupHandler {
                     popupWindow.dismiss()
                 }
                 textChangeStatus.setOnClickListener {
-                    ToastUtils.showToast(it.context, "not yet implemented")
+                    listener?.onChangeStatusClicked()
                     popupWindow.dismiss()
                 }
             }.root

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
@@ -24,7 +24,7 @@ object CommentActionPopupHandler {
                     popupWindow.dismiss()
                 }
                 textShare.setOnClickListener {
-                    ToastUtils.showToast(it.context, "not yet implemented")
+                    listener?.onShareClicked()
                     popupWindow.dismiss()
                 }
                 textEditComment.setOnClickListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/unified/CommentActionPopupHandler.kt
@@ -8,7 +8,6 @@ import android.widget.PopupWindow
 import org.wordpress.android.R
 import org.wordpress.android.databinding.CommentActionsBinding
 import org.wordpress.android.ui.comments.CommentDetailFragment
-import org.wordpress.android.util.ToastUtils
 
 object CommentActionPopupHandler {
     @JvmStatic

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -195,7 +195,9 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         this.footerView = footerView
     }
 
-    private val mOnNoteBlockTextClickListener by lazy { NoteBlockTextClickListener(this, notification, onActionClickListener) }
+    private val mOnNoteBlockTextClickListener by lazy {
+        NoteBlockTextClickListener(this, notification, onActionClickListener)
+    }
 
     private val mOnGravatarClickedListener = object : OnGravatarClickedListener {
         override fun onGravatarClicked(siteId: Long, userId: Long, siteUrl: String?) {
@@ -531,7 +533,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         }
     }
 
-    fun setOnEditCommentListener(listener: CommentDetailFragment.OnActionClickListener){
+    fun setOnEditCommentListener(listener: CommentDetailFragment.OnActionClickListener) {
         onActionClickListener = listener
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.kt
@@ -195,7 +195,7 @@ class NotificationsDetailListFragment : ListFragment(), NotificationFragment {
         this.footerView = footerView
     }
 
-    private val mOnNoteBlockTextClickListener = NoteBlockTextClickListener(this, notification, onActionClickListener)
+    private val mOnNoteBlockTextClickListener by lazy { NoteBlockTextClickListener(this, notification, onActionClickListener) }
 
     private val mOnGravatarClickedListener = object : OnGravatarClickedListener {
         override fun onGravatarClicked(siteId: Long, userId: Long, siteUrl: String?) {


### PR DESCRIPTION
Implements https://github.com/Automattic/wordpress-mobile/issues/44

This PR contains the implementations of the `Share` action and `Change Status` action in the comment menu.

<img src="https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/8675d034-68f6-4bcc-a15a-0376887bd6da" width="400"/>

-----

## To Test:

1. Sign in JP app
2. Go to Notifications tab
3. Click on a notification with Comment type
4. Click on the comment menu icon `...`
5. It should display a menu popup as usual
6. Click on the `Share` button
7. It should share the comment's link to other apps
8. Open the comment menu again
9. Click on the `Change status` button
10. It should display the bottom sheet of moderation
11. Go to My site -> More -> Comments
12. Click on a comment
13. Repeat step 4 - 10
14. Done, thank you!

-----

## Regression Notes

1. Potential unintended areas of impact

    - notification, comment

15. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

16. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

skipped

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

skipped
