### PR TITLE
Comment details trash moderation redesign

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -14,6 +14,7 @@ import androidx.annotation.OptIn;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.gravatar.AvatarQueryOptions;
 import com.gravatar.AvatarUrl;
@@ -138,6 +139,8 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
 
     @Nullable protected CommentDetailFragmentBinding mBinding = null;
 
+    private CommentDetailViewModel mViewModel;
+
     private final OnActionClickListener mOnActionClickListener = new OnActionClickListener() {
         @Override public void onEditCommentClicked() {
             editComment();
@@ -168,7 +171,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) requireActivity().getApplication()).component().inject(this);
-
+        mViewModel = new ViewModelProvider(this).get(CommentDetailViewModel.class);
         mCommentSource = (CommentSource) requireArguments().getSerializable(KEY_MODE);
         setHasOptionsMenu(true);
     }
@@ -687,30 +690,11 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
         // Fire the appropriate listener if we have one
         if (note != null && mOnNoteCommentActionListener != null) {
             mOnNoteCommentActionListener.onModerateCommentForNote(note, newStatus);
-            dispatchModerationAction(site, comment, newStatus);
+            mViewModel.dispatchModerationAction(site, comment, newStatus);
         } else if (mOnCommentActionListener != null) {
             mOnCommentActionListener.onModerateComment(comment, newStatus);
             // Sad, but onModerateComment does the moderation itself (due to the undo bar), this should be refactored,
             // That's why we don't call dispatchModerationAction() here.
-        }
-    }
-
-    private void dispatchModerationAction(
-            @NonNull SiteModel site,
-            @NonNull CommentModel comment,
-            CommentStatus newStatus
-    ) {
-        if (newStatus == CommentStatus.DELETED) {
-            // For deletion, we need to dispatch a specific action.
-            mCommentsStoreAdapter.dispatch(
-                    CommentActionBuilder.newDeleteCommentAction(new RemoteCommentPayload(site, comment))
-            );
-        } else {
-            // Actual moderation (push the modified comment).
-            comment.setStatus(newStatus.toString());
-            mCommentsStoreAdapter.dispatch(
-                    CommentActionBuilder.newPushCommentAction(new RemoteCommentPayload(site, comment))
-            );
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -655,7 +655,7 @@ public abstract class CommentDetailFragment extends ViewPagerFragment implements
     /*
      * approve, disapprove, spam, or trash the current comment
      */
-    private void moderateComment(
+    protected void moderateComment(
             @NonNull SiteModel site,
             @NonNull CommentModel comment,
             @Nullable Note note,

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -63,8 +63,10 @@ class CommentDetailViewModel @Inject constructor(
         comment.apply { this.status = status.toString() }
         commentsStoreAdapter.dispatch(
             if (status == CommentStatus.DELETED) {
+                // For deletion, we need to dispatch a specific action.
                 CommentActionBuilder.newDeleteCommentAction(CommentStore.RemoteCommentPayload(site, comment))
             } else {
+                // Actual moderation (push the modified comment).
                 CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
             }
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -61,11 +61,13 @@ class CommentDetailViewModel @Inject constructor(
      */
     fun dispatchModerationAction(site: SiteModel, comment: CommentModel, status: CommentStatus) {
         comment.apply { this.status = status.toString() }
-        if (status == CommentStatus.DELETED) {
-            CommentActionBuilder.newDeleteCommentAction(CommentStore.RemoteCommentPayload(site, comment))
-        } else {
-            CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
-        }
+        commentsStoreAdapter.dispatch(
+            if (status == CommentStatus.DELETED) {
+                CommentActionBuilder.newDeleteCommentAction(CommentStore.RemoteCommentPayload(site, comment))
+            } else {
+                CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
+            }
+        )
 
         _updatedComment.postValue(comment)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailViewModel.kt
@@ -57,15 +57,17 @@ class CommentDetailViewModel @Inject constructor(
     }
 
     /**
-     * Dispatch a moderation action to the server, it does not include [CommentStatus.DELETED] status
+     * Dispatch a moderation action to the server
      */
     fun dispatchModerationAction(site: SiteModel, comment: CommentModel, status: CommentStatus) {
-        commentsStoreAdapter.dispatch(
-            CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
-        )
-
         comment.apply { this.status = status.toString() }
-            .let { _updatedComment.postValue(it) }
+        if (status == CommentStatus.DELETED) {
+            CommentActionBuilder.newDeleteCommentAction(CommentStore.RemoteCommentPayload(site, comment))
+        } else {
+            CommentActionBuilder.newPushCommentAction(CommentStore.RemoteCommentPayload(site, comment))
+        }
+
+        _updatedComment.postValue(comment)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.databinding.CommentApprovedBinding
 import org.wordpress.android.databinding.CommentPendingBinding
+import org.wordpress.android.databinding.CommentTrashBinding
 import org.wordpress.android.fluxc.model.CommentModel
 import org.wordpress.android.fluxc.model.CommentStatus
 import org.wordpress.android.fluxc.model.SiteModel
@@ -79,18 +80,30 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
         // reset visibilities
         mBinding?.layoutCommentPending?.root?.isVisible = false
         mBinding?.layoutCommentApproved?.root?.isVisible = false
+        mBinding?.layoutCommentTrash?.root?.isVisible = false
 
         val commentStatus = CommentStatus.fromString(comment.status)
         when (commentStatus) {
             CommentStatus.APPROVED -> mBinding?.layoutCommentApproved?.bindApprovedView()
             CommentStatus.UNAPPROVED -> mBinding?.layoutCommentPending?.bindPendingView()
             CommentStatus.SPAM -> {}
-            CommentStatus.TRASH -> {}
+            CommentStatus.TRASH -> mBinding?.layoutCommentTrash?.bindTrashView()
             CommentStatus.DELETED -> {}
             CommentStatus.ALL -> {}
             CommentStatus.UNREPLIED -> {}
             CommentStatus.UNSPAM -> {}
             CommentStatus.UNTRASH -> {}
+        }
+    }
+
+    private fun CommentTrashBinding.bindTrashView() {
+        root.isVisible = true
+        buttonDeleteTrash.setOnClickListener {
+            viewModel.dispatchModerationAction(
+                site,
+                comment,
+                CommentStatus.DELETED
+            )
         }
     }
 
@@ -169,6 +182,8 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
             )
         ).apply {
             onApprovedClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.APPROVED) }
+            onPendingClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.UNAPPROVED) }
+            onTrashClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.TRASH) }
         }.show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.gravatar.AvatarQueryOptions
 import com.gravatar.AvatarUrl
 import com.gravatar.types.Email
@@ -99,22 +100,25 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
     private fun CommentTrashBinding.bindTrashView() {
         root.isVisible = true
         buttonDeleteTrash.setOnClickListener {
-            viewModel.dispatchModerationAction(
-                site,
-                comment,
-                CommentStatus.DELETED
-            )
+            showDeleteCommentDialog()
         }
+    }
+
+    private fun showDeleteCommentDialog() {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.delete)
+            .setMessage(R.string.dlg_sure_to_delete_comment)
+            .setPositiveButton(R.string.yes) { _, _ ->
+                moderateComment(site, comment, mNote, CommentStatus.DELETED)
+            }
+            .setNegativeButton(R.string.no) { _, _ -> }
+            .show()
     }
 
     private fun CommentPendingBinding.bindPendingView() {
         root.isVisible = true
         buttonApproveComment.setOnClickListener {
-            viewModel.dispatchModerationAction(
-                site,
-                comment,
-                CommentStatus.APPROVED
-            )
+            moderateComment(site, comment, mNote, CommentStatus.APPROVED)
         }
         textMoreOptions.setOnClickListener { showModerationBottomSheet() }
     }
@@ -181,9 +185,9 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
                 canTrash = enabledActions.canTrash(),
             )
         ).apply {
-            onApprovedClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.APPROVED) }
-            onPendingClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.UNAPPROVED) }
-            onTrashClicked = { viewModel.dispatchModerationAction(site, comment, CommentStatus.TRASH) }
+            onApprovedClicked = { moderateComment(site, comment, mNote, CommentStatus.APPROVED) }
+            onPendingClicked = { moderateComment(site, comment, mNote, CommentStatus.UNAPPROVED) }
+            onTrashClicked = { moderateComment(site, comment, mNote, CommentStatus.TRASH) }
         }.show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/SharedCommentDetailFragment.kt
@@ -87,19 +87,20 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
         when (commentStatus) {
             CommentStatus.APPROVED -> mBinding?.layoutCommentApproved?.bindApprovedView()
             CommentStatus.UNAPPROVED -> mBinding?.layoutCommentPending?.bindPendingView()
-            CommentStatus.SPAM -> {}
-            CommentStatus.TRASH -> mBinding?.layoutCommentTrash?.bindTrashView()
-            CommentStatus.DELETED -> {}
-            CommentStatus.ALL -> {}
-            CommentStatus.UNREPLIED -> {}
-            CommentStatus.UNSPAM -> {}
-            CommentStatus.UNTRASH -> {}
+            CommentStatus.SPAM, CommentStatus.TRASH -> mBinding?.layoutCommentTrash?.bindTrashView()
+            CommentStatus.DELETED,
+            CommentStatus.ALL,
+            CommentStatus.UNREPLIED,
+            CommentStatus.UNSPAM,
+            CommentStatus.UNTRASH -> {
+                // do nothing
+            }
         }
     }
 
     private fun CommentTrashBinding.bindTrashView() {
         root.isVisible = true
-        buttonDeleteTrash.setOnClickListener {
+        buttonDeleteComment.setOnClickListener {
             showDeleteCommentDialog()
         }
     }
@@ -188,6 +189,7 @@ abstract class SharedCommentDetailFragment : CommentDetailFragment() {
             onApprovedClicked = { moderateComment(site, comment, mNote, CommentStatus.APPROVED) }
             onPendingClicked = { moderateComment(site, comment, mNote, CommentStatus.UNAPPROVED) }
             onTrashClicked = { moderateComment(site, comment, mNote, CommentStatus.TRASH) }
+            onSpamClicked = { moderateComment(site, comment, mNote, CommentStatus.SPAM) }
         }.show(childFragmentManager, ModerationBottomSheetDialogFragment.TAG)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -568,7 +568,10 @@ public class NotificationsDetailActivity extends LocaleAwareActivity implements
         resultIntent.putExtra(NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA, newStatus.toString());
 
         setResult(RESULT_OK, resultIntent);
-        finish();
+
+        if (newStatus == CommentStatus.DELETED) {
+            finish();
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/res/drawable/trash_24.xml
+++ b/WordPress/src/main/res/drawable/trash_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.5,5H14.8C14.8,3.7 13.8,2.7 12.5,2.7C11.2,2.7 10.2,3.7 10.2,5H4.5V7H6V7.3L7.7,18.4C7.8,19.4 8.7,20.1 9.7,20.1H15.4C16.4,20.1 17.2,19.4 17.4,18.4L19.1,7.3V7H20.5V5ZM17.3,7L15.6,18.1C15.6,18.2 15.5,18.3 15.3,18.3H9.6C9.5,18.3 9.3,18.2 9.3,18.1L7.7,7H17.3Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -31,6 +31,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone"/>
+
+        <include
+            android:id="@+id/layout_comment_trash"
+            layout="@layout/comment_trash"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
     </FrameLayout>
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/comment_trash.xml
+++ b/WordPress/src/main/res/layout/comment_trash.xml
@@ -24,7 +24,7 @@
         android:textSize="@dimen/text_sz_small" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/button_delete_trash"
+        android:id="@+id/button_delete_comment"
         style="@style/Widget.ShareButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/comment_trash.xml
+++ b/WordPress/src/main/res/layout/comment_trash.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1px"
+        android:background="@color/divider_likes" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:drawablePadding="@dimen/margin_small"
+        android:gravity="center_vertical"
+        android:includeFontPadding="false"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/comment_moderation_trash"
+        android:textColor="@color/menu_more"
+        android:textSize="@dimen/text_sz_small" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_delete_trash"
+        style="@style/Widget.ShareButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:layout_marginBottom="@dimen/margin_extra_extra_medium_large"
+        android:text="@string/comment_moderation_delete"
+        app:icon="@drawable/trash_24"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorSurface" />
+</LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -465,8 +465,10 @@
     <string name="comment_action_change_status">Change status</string>
 
     <string name="comment_moderation_pending">Comment pending moderation</string>
+    <string name="comment_moderation_trash">Comment in Trash</string>
     <string name="comment_moderation_approved">Comment Approved</string>
     <string name="comment_moderation_approve">Approve comment</string>
+    <string name="comment_moderation_delete">Delete permanently</string>
     <string name="comment_moderation_more">More options</string>
     <string name="comment_moderation_status_title">Choose status</string>
     <string name="comment_moderation_status_approved">Approved</string>


### PR DESCRIPTION
Implemented
https://github.com/Automattic/wordpress-mobile/issues/41
https://github.com/Automattic/wordpress-mobile/issues/40

This PR contains features related to comment moderation. The changes mostly are in the moderation bottom sheet. Every action button is implemented on the bottom sheet in this PR.

| Screenshot 1 | Screenshot 2 |
|---|---|
| ![Screenshot_20240610-212609](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/c9824917-9f66-4d11-9b05-af1fa59248fc) | ![Screenshot_20240610-212626](https://github.com/wordpress-mobile/WordPress-Android/assets/3839951/7ce9dee4-5c90-45fc-b2ca-5fe09f2e8629) |





-----

## To Test:

1. Sign in JP app
2. Go to `Notifications`
3. Click on a notification with type `Comment`
4. Open the comment menu by clicking the `...` icon
5. Click on Change status
6. Test the functionality of every action
7. They should work correctly, and the UI is as the design on Figma
8. Go to My site -> More -> Comments
9. Click on a comment
10. Repeat step 4 - 7.
11. Done, thank you!

P.S. It will update the moderation status UI directly if the comment is from a notification (not including deletion action). But it will finish the screen if the comment is from the comment list.

-----

## Regression Notes

1. Potential unintended areas of impact

    - notifications, comments

12. What I did to test those areas of impact (or what existing automated tests I relied on)

    - manual

13. What automated tests I added (or what prevented me from doing so)

    - n/a

-----

## PR Submission Checklist:

skipped

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

skipped
