### PR TITLE
Fix NPE in EditPostActivty onPostUploaded 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3813,7 +3813,10 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onPostUploaded(event: OnPostUploaded) {
         val post: PostModel? = event.post
-        val editPostId = editPostRepository.getPost()?.id
+
+        // Check if editPostRepository is initialized
+        val editPostRepositoryInitialized = this::editPostRepository.isInitialized
+        val editPostId = if (editPostRepositoryInitialized) editPostRepository.getPost()?.id else null
 
         if (post != null && post.id == editPostId) {
             if (!isRemotePreviewingFromEditor) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3813,7 +3813,9 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onPostUploaded(event: OnPostUploaded) {
         val post: PostModel? = event.post
-        if (post != null && post.id == editPostRepository.id) {
+        val editPostId = editPostRepository.getPost()?.id
+
+        if (post != null && post.id == editPostId) {
             if (!isRemotePreviewingFromEditor) {
                 // We are not remote previewing a post: show snackbar and update post status if needed
                 val snackbarAttachView = findViewById<View>(R.id.editor_activity)


### PR DESCRIPTION
Fixes #20953 

This PR addresses a potential NullPointerException in the `onPostUploaded` event handler by ensuring that the `editPostRepository.id` is safely accessed. In `EditPostActivity`, the EventBus is registered before `EditPostRepository` is fully initialized. As such, there is a risk that an onPostUploaded event might be posted before the EditPostRepository has completed its initialization process, thus causing an NPE when "id" is accessed.

Changes:
- Updated the onPostUploaded method to use val editPostId = editPostRepository.getPost()?.id.
This ensures that the check post.id == editPostId will fail if editPostRepository.getPost() returns null, preventing a NullPointerException.


-----

## To Test:
As I was unable to recreate the issue, please validate that the Create/Edit post flow works as expected.

-----

## Regression Notes

1. Potential unintended areas of impact
The crash still occurs

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
