### PR TITLE
[Gutenberg] Improve List block onSplit to avoid hiding the keyboard on enter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.120.0'
+    gutenbergMobileVersion = '6922-11a3a4525496b6c0fbd6a67de380a0c3575e41a5'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.83.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
Fixes #

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
