### PR TITLE
Revert "Merge pull request #20854 from wordpress-mobile/andy/target-s…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 ext {
     minSdkVersion = 24
     compileSdkVersion = 34
-    targetSdkVersion = 34
+    targetSdkVersion = 33
 }
 
 ext {


### PR DESCRIPTION
This PR reverts targeting SDK 34 ([20854](https://github.com/wordpress-mobile/WordPress-Android/pull/20854)) while we investigate the play store declaration blocker.

-----

## To Test:

- [x] 🚬 test the app. Ensure you can login, post, use the reader, read comments.

-----

## Regression Notes

1. Potential unintended areas of impact

   I don't expect this to be an issue. It worked prior.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test.

3. What automated tests I added (or what prevented me from doing so)

    N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

