### PR TITLE
Fix crash in PluginBrowserViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -396,7 +396,9 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     }
 
     fun requestBookmarkTab() {
-        viewModel.bookmarkTabRequested()
+        if (::viewModel.isInitialized) {
+            viewModel.bookmarkTabRequested()
+        }
     }
 
     private fun showReaderInterests() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -396,9 +396,10 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
     }
 
     fun requestBookmarkTab() {
-        if (::viewModel.isInitialized) {
-            viewModel.bookmarkTabRequested()
+        if (!::viewModel.isInitialized) {
+            viewModel = ViewModelProvider(this@ReaderFragment, viewModelFactory)[ReaderViewModel::class.java]
         }
+        viewModel.bookmarkTabRequested()
     }
 
     private fun showReaderInterests() {


### PR DESCRIPTION
Fixes #20859


This PR addresses a crash in `PluginBrowserViewModel` where the `viewModel` has not been initialized.

-----

## To Test:
I have been unable to reproduce this issue, so code check.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - None

3. What automated tests I added (or what prevented me from doing so)

    - None

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~