### PR TITLE
Fix QuickPress shortcut not opening Edit post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -638,7 +638,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         val hasQuickPressBlogId = extras.containsKey(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID)
 
         // QuickPress might want to use a different blog than the current blog
-        return if (!isActionSendOrNewMedia && !hasQuickPressFlag && hasQuickPressBlogId) {
+        return if ((isActionSendOrNewMedia || hasQuickPressFlag) && hasQuickPressBlogId) {
             val localSiteId = intent.getIntExtra(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID, -1)
             siteStore.getSiteByLocalId(localSiteId)
         } else {


### PR DESCRIPTION
Fixes #20912 

The PR address an issue with setting the site when launching Edit Post from a QuickPress shortcut.

-----

## To Test:
**Reproduce the issue** 
- Install a JP app version other than the one in this PR
- Log in and select a site
- Go back to the device's home screen and long tap on the app icon.
- Select Widgets.
- Add the QuickPress shortcut to the home screen (be sure to select a site when prompted)
- Tap on the shortcut.
- ✅ Verify you see the following error message "An error occurred when accessing this blog, and not opening the posting screen."

**Test the fix**
- Install JP from this PR
- Log in and select a site
- Go back to the device's home screen and long tap on the app icon.
- Select Widgets.
- Add the QuickPress shortcut to the home screen (be sure to select a site when prompted)
- Tap on the shortcut.
- ✅ Verify you the app launches and you are taken to the Edit Post view

Note: If you attempt to launch a site connected to QuickPress without being logged into an account with the necessary access, you will see the above error message.

-----

## Regression Notes
1. Potential unintended areas of impact
The quickpress shortcut does not work as expected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Relied upon existing tests

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A

