### PR TITLE
[Voice to Content] Clear recorder resources

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/RecordingUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/RecordingUseCase.kt
@@ -14,7 +14,6 @@ class RecordingUseCase @Inject constructor(
         audioRecorder.startRecording(onRecordingFinished)
     }
 
-    @Suppress("ReturnCount")
     fun stopRecording() {
        audioRecorder.stopRecording()
     }
@@ -22,5 +21,8 @@ class RecordingUseCase @Inject constructor(
     fun recordingUpdates(): Flow<RecordingUpdate> {
         return audioRecorder.recordingUpdates()
     }
-}
 
+    fun endRecordingSession() {
+        audioRecorder.endRecordingSession()
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.voicetocontent
 
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -18,6 +19,7 @@ import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.R
 import org.wordpress.android.util.audio.IAudioRecorder.Companion.REQUIRED_RECORDING_PERMISSIONS
 import android.provider.Settings
+import android.util.Log
 import android.widget.FrameLayout
 import androidx.compose.material.ExperimentalMaterialApi
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -68,15 +70,10 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
                 @SuppressLint("SwitchIntDef")
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
                     when (newState) {
-                        BottomSheetBehavior.STATE_HIDDEN -> {
-                            // Bottom sheet is hidden, you can listen for this event here
-                            viewModel.onBottomSheetClosed()
-                        }
+                        BottomSheetBehavior.STATE_HIDDEN,
                         BottomSheetBehavior.STATE_COLLAPSED -> {
-                            // Bottom sheet is collapsed, you can listen for this event here
-                            viewModel.onBottomSheetClosed()
+                            onBottomSheetClosed()
                         }
-                        // Handle other states if necessary
                     }
                 }
 
@@ -88,7 +85,23 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
             // Disable touch interception by the bottom sheet to allow nested scrolling
             bottomSheet.setOnTouchListener { _, _ -> false }
         }
+
+        // Observe the ViewModel to update the cancelable state of closing on outside touch
+        viewModel.isCancelableOutsideTouch.observe(this) { cancelable ->
+            Log.i(javaClass.simpleName, "***=> disable outside touch")
+            dialog.setCanceledOnTouchOutside(cancelable)
+        }
+
         return dialog
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        viewModel.onBottomSheetClosed()
+    }
+
+    private fun onBottomSheetClosed() {
+        dismiss()
     }
 
     private fun observeViewModel() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -64,6 +64,27 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
             behavior.skipCollapsed = true
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
+            behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+                @SuppressLint("SwitchIntDef")
+                override fun onStateChanged(bottomSheet: View, newState: Int) {
+                    when (newState) {
+                        BottomSheetBehavior.STATE_HIDDEN -> {
+                            // Bottom sheet is hidden, you can listen for this event here
+                            viewModel.onBottomSheetClosed()
+                        }
+                        BottomSheetBehavior.STATE_COLLAPSED -> {
+                            // Bottom sheet is collapsed, you can listen for this event here
+                            viewModel.onBottomSheetClosed()
+                        }
+                        // Handle other states if necessary
+                    }
+                }
+
+                override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                    // Handle the slide offset if needed
+                }
+            })
+
             // Disable touch interception by the bottom sheet to allow nested scrolling
             bottomSheet.setOnTouchListener { _, _ -> false }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -104,6 +104,10 @@ class VoiceToContentViewModel @Inject constructor(
         isStarted = true
     }
 
+    fun onBottomSheetClosed() {
+        recordingUseCase.endRecordingSession()
+    }
+
     // Recording
     private fun updateRecordingData(recordingUpdate: RecordingUpdate) {
         _recordingUpdate.value = recordingUpdate
@@ -206,6 +210,7 @@ class VoiceToContentViewModel @Inject constructor(
 
     private fun onClose() {
         logger.track(Stat.VOICE_TO_CONTENT_BUTTON_CLOSE_TAPPED)
+        recordingUseCase.endRecordingSession()
         _dismiss.postValue(Unit)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -56,6 +56,9 @@ class VoiceToContentViewModel @Inject constructor(
     private val _onIneligibleForVoiceToContent = MutableLiveData<String>()
     val onIneligibleForVoiceToContent = _onIneligibleForVoiceToContent as LiveData<String>
 
+    private val _isCancelableOutsideTouch = MutableLiveData(true)
+    val isCancelableOutsideTouch: LiveData<Boolean> get() = _isCancelableOutsideTouch
+
     private var isStarted = false
 
     private val _state = MutableStateFlow(VoiceToContentUiState(
@@ -129,6 +132,7 @@ class VoiceToContentViewModel @Inject constructor(
 
     private fun startRecording() {
         transitionToRecording()
+        disableDialogCancelableOutsideTouch()
         recordingUseCase.startRecording { audioRecorderResult ->
             when (audioRecorderResult) {
                 is Success -> {
@@ -145,6 +149,10 @@ class VoiceToContentViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun disableDialogCancelableOutsideTouch() {
+        _isCancelableOutsideTouch.value = false
     }
 
     @Suppress("ReturnCount")

--- a/WordPress/src/main/java/org/wordpress/android/util/audio/AudioRecorder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/audio/AudioRecorder.kt
@@ -90,7 +90,7 @@ class AudioRecorder(
         }
     }
 
-    override fun stopRecording() {
+    private fun clearResources() {
         try {
             recorder?.apply {
                 stop()
@@ -104,7 +104,11 @@ class AudioRecorder(
             _isPaused.value = false
             _isRecording.value = false
         }
-        // return filePath
+    }
+
+    override fun stopRecording() {
+        clearResources()
+        // return the filePath
         onRecordingFinished(Success(filePath))
     }
 
@@ -134,6 +138,10 @@ class AudioRecorder(
                 }
             }
         }
+    }
+
+    override fun endRecordingSession() {
+        clearResources()
     }
 
     override fun recordingUpdates(): Flow<RecordingUpdate> = recordingUpdates

--- a/WordPress/src/main/java/org/wordpress/android/util/audio/IAudioRecorder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/audio/IAudioRecorder.kt
@@ -9,6 +9,7 @@ interface IAudioRecorder {
     fun pauseRecording()
     fun resumeRecording()
     fun recordingUpdates(): Flow<RecordingUpdate>
+    fun endRecordingSession()
 
     sealed class AudioRecorderResult {
         data class Success(val recordingPath: String) : AudioRecorderResult()


### PR DESCRIPTION
This PR addresses an issue with the AudioRecorder not clearing it's resources. With this implementation the process now captures the bottom sheet close event, the close tap and sends the endRecordingSession event to the usecase. This is turn will release the resources of the recorder.


> [!NOTE]
> The following have not yet been implemented
> recording timer
> orientation changes
> Overall polishing of the UI
> Launching Edit Post

-----

## To Test:
There is not much to test 
- Install and launch the app
- Navigate to Me > Debug Settings and enable the voice_to_content flag (restart the app)
- Navigate to My Site and tap the FAB
- Select the Post with Audio option
- Start the recording session by tapping on the mic icon
- Tap the close button or swipe down to close the bottom sheet
- ✅ Verify the app doesn't crash or do anything weird

-----

## Regression Notes

1. Potential unintended areas of impact
The resources are not released

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A

