### PR TITLE
[Voice to Content\ Implement elapsed time indicator

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -200,7 +200,7 @@ fun formatTime(remainingTimeInSeconds: Int, maxDurationInSeconds: Int): String {
     val seconds = remainingTimeInSeconds % 60
 
     val value = if (minutes == 1) default
-        else return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+        else String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
 
     return value
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -53,6 +53,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.Drawable
 import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.util.audio.RecordingUpdate
+import java.util.Locale
 
 @Composable
 fun VoiceToContentScreen(
@@ -100,7 +101,7 @@ fun VoiceToContentView(state: VoiceToContentUiState, recordingUpdate: RecordingU
             VoiceToContentUIStateType.ERROR -> ErrorView(state)
             else -> {
                 Header(state.header)
-                SecondaryHeader(state.secondaryHeader)
+                SecondaryHeader(state.secondaryHeader, recordingUpdate)
                 RecordingPanel(state, recordingUpdate)
             }
         }
@@ -159,14 +160,16 @@ fun Header(model: HeaderUIModel) {
 }
 
 @Composable
-fun SecondaryHeader(model: SecondaryHeaderUIModel?) {
+fun SecondaryHeader(model: SecondaryHeaderUIModel?, recordingUpdate: RecordingUpdate) {
     model?.let {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(text = stringResource(id = model.label), style = secondaryHeaderStyle)
-            Spacer(modifier = Modifier.width(8.dp)) // Add space between text and progress
+            if (model.isLabelVisible) {
+                Text(text = stringResource(id = model.label), style = secondaryHeaderStyle)
+                Spacer(modifier = Modifier.width(8.dp)) // Add space between text and progress
+            }
             if (model.isProgressIndicatorVisible) {
                 Box(
                     modifier = Modifier.size(20.dp) // size the progress indicator
@@ -176,12 +179,46 @@ fun SecondaryHeader(model: SecondaryHeaderUIModel?) {
                     )
                 }
             } else {
-                Text(text = model.requestsAvailable, style = secondaryHeaderStyle)
+                Text(
+                    text = if (model.isTimeElapsedVisible)
+                        formatTime(recordingUpdate.remainingTimeInSeconds, model.timeMaxDurationInSeconds)
+                    else model.requestsAvailable,
+                    style = secondaryHeaderStyle
+                )
             }
             Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }
+
+@Composable
+fun formatTime(remainingTimeInSeconds: Int, maxDurationInSeconds: Int): String {
+    val default = getDefaultTimeString(maxDurationInSeconds)
+    if (remainingTimeInSeconds == -1) return default
+
+    val minutes = remainingTimeInSeconds / 60
+    val seconds = remainingTimeInSeconds % 60
+
+    val value = if (minutes == 1) default
+        else return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+
+    return value
+}
+
+@Composable
+fun getDefaultTimeString(maxDurationInSeconds: Int): String {
+    if (maxDurationInSeconds <= 0) {
+        return "00:00"
+    }
+
+    // Calculate minutes and seconds
+    val minutes = (maxDurationInSeconds - 1) / 60
+    val seconds = (maxDurationInSeconds - 1) % 60
+
+    // Format and return the default time string
+    return String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+}
+
 
 @Composable
 fun RecordingPanel(model: VoiceToContentUiState, recordingUpdate: RecordingUpdate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentUiState.kt
@@ -13,7 +13,7 @@ data class SecondaryHeaderUIModel(
     val isLabelVisible: Boolean = true,
     val isProgressIndicatorVisible: Boolean = false,
     val requestsAvailable: String = "0",
-    val timeElapsed: String = "00:00:00",
+    val timeMaxDurationInSeconds: Int = 0,
     val isTimeElapsedVisible: Boolean = false
 )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.voicetocontent.VoiceToContentUIStateType.RECORDI
 import org.wordpress.android.util.audio.IAudioRecorder
 import org.wordpress.android.util.audio.IAudioRecorder.AudioRecorderResult.Error
 import org.wordpress.android.util.audio.IAudioRecorder.AudioRecorderResult.Success
+import org.wordpress.android.util.audio.RecordingStrategy
 import org.wordpress.android.util.audio.RecordingUpdate
 import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
@@ -132,6 +133,7 @@ class VoiceToContentViewModel @Inject constructor(
         recordingUseCase.startRecording { audioRecorderResult ->
             when (audioRecorderResult) {
                 is Success -> {
+                    transitionToProcessing()
                     val file = getRecordingFile(audioRecorderResult.recordingPath)
                     file?.let {
                         executeVoiceToContent(it)
@@ -276,8 +278,9 @@ class VoiceToContentViewModel @Inject constructor(
             uiStateType = RECORDING,
             header = currentState.header.copy(label = R.string.voice_to_content_recording_label),
             secondaryHeader = currentState.secondaryHeader?.copy(
-                timeElapsed = "00:00:00",
-                isTimeElapsedVisible = true
+                isTimeElapsedVisible = true,
+                timeMaxDurationInSeconds = MAX_DURATION,
+                isLabelVisible = false
             ),
             recordingPanel = currentState.recordingPanel?.copy(
                 onStopTap = ::onStopTap,
@@ -330,6 +333,7 @@ class VoiceToContentViewModel @Inject constructor(
         private val NetworkUnavailableMsg = R.string.error_network_connection
         private val GenericFailureMsg = R.string.voice_to_content_generic_error
         private const val VOICE_TO_CONTENT = "Voice to content"
+        private val MAX_DURATION = RecordingStrategy.VoiceToContentRecordingStrategy().maxDuration
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/audio/RecordingUpdate.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/audio/RecordingUpdate.kt
@@ -1,7 +1,7 @@
 package org.wordpress.android.util.audio
 
 data class RecordingUpdate(
-    val elapsedTime: Int = 0, // in seconds
+    val remainingTimeInSeconds: Int = -1,
     val fileSize: Long = 0L, // in bytes
     val fileSizeLimitExceeded: Boolean = false,
     val amplitudes: List<Float> = emptyList()


### PR DESCRIPTION
Closes https://github.com/Automattic/wordpress-mobile/issues/82

### UPDATE:  The elapsed timer logic has been updated and simplified in #20955 

This PR implements the time elapsed visual indicator in the recorder view.

<img width="250" height="500" alt="Alt desc" src="https://github.com/wordpress-mobile/WordPress-Android/assets/506707/e1cb9420-7005-450d-8d65-780e984637c7">



> [!IMPORTANT]
> **Merge Instructions**
> - Make sure #20983 has been merged to trunk (this branch builds off of that branch)
> - Remove the Not Ready for Merge Label
> - Merge as normal

> [!NOTE]
> The following have not yet been implemented:
>  - Orientation changes
>  - Overall polishing of the UI
> - Launching Edit Post
> - Remove debug log lines and comments
> - Unit tests

-----
## To Test:
- Install and launch the app
- Login with an account that has access to AI credits (Any a8c P2 will have this - other free sites have 20 requests)
- Navigate to Me > Debug Settings and enable the voice_to_content flag (restart the app)
- Navigate to My Site and tap the FAB
- Select the Post with Audio option
- Start the recording session by tapping on the mic icon
- ✅ Verify the elapsed time is showing under the Recording header 

-----

## Regression Notes

1. Potential unintended areas of impact
The elapsed time is not showing

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A

