### PR TITLE
[Voice to Content] Launch edit post with AI content

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -953,6 +953,26 @@ public class ActivityLauncher {
         openUrlExternal(context, site.getAdminUrl());
     }
 
+    public static void addNewPostWithContentFromAIForResult(
+            Activity activity,
+            SiteModel site,
+            boolean isPromo,
+            PagePostCreationSourcesDetail source,
+            final String content
+    ) {
+        if (site == null) {
+            return;
+        }
+
+        Intent intent = new Intent(activity, EditPostActivity.class);
+        intent.putExtra(WordPress.SITE, site);
+        intent.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, false);
+        intent.putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, isPromo);
+        intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
+        intent.putExtra(EditPostActivityConstants.EXTRA_CONTENT_FROM_AI, content);
+        activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
+    }
+
     public static void addNewPostForResult(
             Activity activity,
             SiteModel site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -969,7 +969,7 @@ public class ActivityLauncher {
         intent.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, false);
         intent.putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, isPromo);
         intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
-        intent.putExtra(EditPostActivityConstants.EXTRA_CONTENT_FROM_AI, content);
+        intent.putExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT, content);
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -309,6 +309,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     private var postLoadingState: PostLoadingState = PostLoadingState.NONE
     private var isXPostsCapable: Boolean? = null
     private var onGetSuggestionResult: Consumer<String?>? = null
+    private var isVoiceContentSet = false
 
     // For opening the context menu after permissions have been granted
     private var menuView: View? = null
@@ -717,6 +718,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                 }
 
             isNewPost = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, false)
+            isVoiceContentSet = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, false)
             updatePostLoadingAndDialogState(
                 fromInt(
                     state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOADING_STATE, 0)
@@ -1185,6 +1187,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         }
         outState.putInt(EditPostActivityConstants.STATE_KEY_POST_LOADING_STATE, postLoadingState.value)
         outState.putBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, isNewPost)
+        outState.putBoolean(EditPostActivityConstants.STATE_KEY_IS_VOICE_CONTENT_SET, isVoiceContentSet)
         outState.putBoolean(
             EditPostActivityConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE,
             editorPhotoPicker?.isPhotoPickerShowing() ?: false
@@ -3526,6 +3529,25 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         // Start VM, load prompt and populate Editor with content after edit IS ready.
         val promptId: Int = intent.getIntExtra(EditPostActivityConstants.EXTRA_PROMPT_ID, -1)
         editorBloggingPromptsViewModel.start(siteModel, promptId)
+
+        updateVoiceContentIfNeeded()
+    }
+
+    private fun updateVoiceContentIfNeeded() {
+        // Set the voiceToContent content if it exits and this is a GB Editor fragment - do this only once
+        val hasVoiceContent = intent.hasExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
+        if (isNewPost && hasVoiceContent && !isVoiceContentSet) {
+            editorFragment?.let {
+                if (it is GutenbergEditorFragment) {
+                    val gutenbergFragment = editorFragment as GutenbergEditorFragment
+                    val content = intent.getStringExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
+                    content?.let {
+                        isVoiceContentSet = true
+                        gutenbergFragment.updateContent(content)
+                    }
+                }
+            }
+        }
     }
 
     private fun logTemplateSelection() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3534,18 +3534,13 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     private fun updateVoiceContentIfNeeded() {
-        // Set the voiceToContent content if it exits and this is a GB Editor fragment - do this only once
-        val hasVoiceContent = intent.hasExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
-        if (isNewPost && hasVoiceContent && !isVoiceContentSet) {
-            editorFragment?.let {
-                if (it is GutenbergEditorFragment) {
-                    val gutenbergFragment = editorFragment as GutenbergEditorFragment
-                    val content = intent.getStringExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
-                    content?.let {
-                        isVoiceContentSet = true
-                        gutenbergFragment.updateContent(content)
-                    }
-                }
+        // Check if voice content exists and this is a new post for a Gutenberg editor fragment
+        val content = intent.getStringExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
+        if (isNewPost && content != null && !isVoiceContentSet) {
+            val gutenbergFragment = editorFragment as? GutenbergEditorFragment
+            gutenbergFragment?.let {
+                isVoiceContentSet = true
+                it.updateContent(content)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -718,7 +718,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                 }
 
             isNewPost = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, false)
-            isVoiceContentSet = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, false)
+            isVoiceContentSet = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_VOICE_CONTENT_SET, false)
             updatePostLoadingAndDialogState(
                 fromInt(
                     state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOADING_STATE, 0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityConstants.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityConstants.kt
@@ -26,6 +26,7 @@ object EditPostActivityConstants{
     const val EXTRA_PAGE_TEMPLATE = "pageTemplate"
     const val EXTRA_PROMPT_ID = "extraPromptId"
     const val EXTRA_ENTRY_POINT = "extraEntryPoint"
+    const val EXTRA_CONTENT_FROM_AI = "extra_content_from_ai"
     const val STATE_KEY_EDITOR_FRAGMENT = "editorFragment"
     const val STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri"
     const val STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityConstants.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityConstants.kt
@@ -26,7 +26,7 @@ object EditPostActivityConstants{
     const val EXTRA_PAGE_TEMPLATE = "pageTemplate"
     const val EXTRA_PROMPT_ID = "extraPromptId"
     const val EXTRA_ENTRY_POINT = "extraEntryPoint"
-    const val EXTRA_CONTENT_FROM_AI = "extra_content_from_ai"
+    const val EXTRA_VOICE_CONTENT = "extra_voice_content"
     const val STATE_KEY_EDITOR_FRAGMENT = "editorFragment"
     const val STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri"
     const val STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId"
@@ -41,4 +41,5 @@ object EditPostActivityConstants{
     const val STATE_KEY_MEDIA_CAPTURE_PATH = "stateKeyMediaCapturePath"
     const val STATE_KEY_UNDO = "stateKeyUndo"
     const val STATE_KEY_REDO = "stateKeyRedo"
+    const val STATE_KEY_IS_VOICE_CONTENT_SET = "stateKeyIsVoiceContentSet"
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
@@ -7,5 +7,4 @@ sealed class VoiceToContentActionEvent {
     data class LaunchEditPost(val site: SiteModel, val content: String) : VoiceToContentActionEvent()
     data class LaunchExternalBrowser(val url: String) : VoiceToContentActionEvent()
     data object RequestPermission : VoiceToContentActionEvent()
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
@@ -3,5 +3,9 @@ package org.wordpress.android.ui.voicetocontent
 import org.wordpress.android.fluxc.model.SiteModel
 
 sealed class VoiceToContentActionEvent {
+    data object Dismiss: VoiceToContentActionEvent()
     data class LaunchEditPost(val site: SiteModel, val content: String) : VoiceToContentActionEvent()
+    data class LaunchExternalBrowser(val url: String) : VoiceToContentActionEvent()
+    data object RequestPermission : VoiceToContentActionEvent()
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentActionEvent.kt
@@ -1,0 +1,7 @@
+package org.wordpress.android.ui.voicetocontent
+
+import org.wordpress.android.fluxc.model.SiteModel
+
+sealed class VoiceToContentActionEvent {
+    data class LaunchEditPost(val site: SiteModel, val content: String) : VoiceToContentActionEvent()
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -83,6 +83,7 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
                 }
 
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {
+                    // no op
                 }
             })
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -6,27 +6,30 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
-import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.ui.compose.theme.AppTheme
-import org.wordpress.android.R
-import org.wordpress.android.util.audio.IAudioRecorder.Companion.REQUIRED_RECORDING_PERMISSIONS
-import android.provider.Settings
-import android.util.Log
-import android.widget.FrameLayout
-import androidx.compose.material.ExperimentalMaterialApi
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
+import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.Dismiss
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchEditPost
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchExternalBrowser
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.RequestPermission
+import org.wordpress.android.util.audio.IAudioRecorder.Companion.REQUIRED_RECORDING_PERMISSIONS
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -80,17 +83,15 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
                 }
 
                 override fun onSlide(bottomSheet: View, slideOffset: Float) {
-                    // Handle the slide offset if needed
                 }
             })
 
-            // Disable touch interception by the bottom sheet to allow nested scrolling
+            // Disable touch interception by the bottom sheet to allow nested scrolling for landscape and small screens
             bottomSheet.setOnTouchListener { _, _ -> false }
         }
 
         // Observe the ViewModel to update the cancelable state of closing on outside touch
         viewModel.isCancelableOutsideTouch.observe(this) { cancelable ->
-            Log.i(javaClass.simpleName, "***=> disable outside touch")
             dialog.setCanceledOnTouchOutside(cancelable)
         }
 
@@ -107,21 +108,12 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
     }
 
     private fun observeViewModel() {
-        viewModel.requestPermission.observe(viewLifecycleOwner) {
-            requestAllPermissionsForRecording()
-        }
-
-        viewModel.dismiss.observe(viewLifecycleOwner) {
-            dismiss()
-        }
-
-        viewModel.onIneligibleForVoiceToContent.observe(viewLifecycleOwner) { url ->
-            launchIneligibleForVoiceToContent(url)
-        }
-
         viewModel.actionEvent.observe(viewLifecycleOwner) { actionEvent ->
             when(actionEvent) {
-                is VoiceToContentActionEvent.LaunchEditPost -> launchEditPost(actionEvent)
+                is LaunchEditPost -> launchEditPost(actionEvent)
+                is LaunchExternalBrowser -> launchIneligibleForVoiceToContent(actionEvent)
+                is RequestPermission -> requestAllPermissionsForRecording()
+                is Dismiss -> dismiss()
             }
         }
     }
@@ -159,13 +151,13 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
             .show()
     }
 
-    private fun launchIneligibleForVoiceToContent(url: String) {
+    private fun launchIneligibleForVoiceToContent(event: LaunchExternalBrowser) {
         context?.let {
-            activityNavigator.openIneligibleForVoiceToContent(it, url)
+            activityNavigator.openIneligibleForVoiceToContent(it, event.url)
         }
     }
 
-    private fun launchEditPost(event: VoiceToContentActionEvent.LaunchEditPost) {
+    private fun launchEditPost(event: LaunchEditPost) {
         activity?.let {
             ActivityLauncher.addNewPostWithContentFromAIForResult(
                 it,

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -24,7 +24,9 @@ import android.widget.FrameLayout
 import androidx.compose.material.ExperimentalMaterialApi
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityNavigator
+import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -116,6 +118,12 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
         viewModel.onIneligibleForVoiceToContent.observe(viewLifecycleOwner) { url ->
             launchIneligibleForVoiceToContent(url)
         }
+
+        viewModel.actionEvent.observe(viewLifecycleOwner) { actionEvent ->
+            when(actionEvent) {
+                is VoiceToContentActionEvent.LaunchEditPost -> launchEditPost(actionEvent)
+            }
+        }
     }
 
     private val requestMultiplePermissionsLauncher = registerForActivityResult(
@@ -154,6 +162,18 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
     private fun launchIneligibleForVoiceToContent(url: String) {
         context?.let {
             activityNavigator.openIneligibleForVoiceToContent(it, url)
+        }
+    }
+
+    private fun launchEditPost(event: VoiceToContentActionEvent.LaunchEditPost) {
+        activity?.let {
+            ActivityLauncher.addNewPostWithContentFromAIForResult(
+                it,
+                event.site,
+                false,
+                PagePostCreationSourcesDetail.POST_FROM_MY_SITE,
+                event.content
+            )
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -60,6 +60,9 @@ class VoiceToContentViewModel @Inject constructor(
     private val _isCancelableOutsideTouch = MutableLiveData(true)
     val isCancelableOutsideTouch: LiveData<Boolean> get() = _isCancelableOutsideTouch
 
+    private val _actionEvent = MutableLiveData<VoiceToContentActionEvent>()
+    val actionEvent = _actionEvent as LiveData<VoiceToContentActionEvent>
+
     private var isStarted = false
 
     private val _state = MutableStateFlow(VoiceToContentUiState(
@@ -182,7 +185,7 @@ class VoiceToContentViewModel @Inject constructor(
             when (val result = voiceToContentUseCase.execute(site, file)) {
                 is VoiceToContentResult.Failure -> result.transitionToError()
                 is VoiceToContentResult.Success ->
-                    Log.i(javaClass.simpleName, "***=> result is ${result.content}")
+                    _actionEvent.postValue(VoiceToContentActionEvent.LaunchEditPost(site, result.content))
             }
             _dismiss.postValue(Unit)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.voicetocontent
 
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -17,6 +16,10 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.model.jetpackai.JetpackAIAssistantFeature
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.Dismiss
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchEditPost
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchExternalBrowser
+import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.RequestPermission
 import org.wordpress.android.ui.voicetocontent.VoiceToContentUIStateType.ERROR
 import org.wordpress.android.ui.voicetocontent.VoiceToContentUIStateType.INELIGIBLE_FOR_FEATURE
 import org.wordpress.android.ui.voicetocontent.VoiceToContentUIStateType.INITIALIZING
@@ -45,20 +48,11 @@ class VoiceToContentViewModel @Inject constructor(
     private val prepareVoiceToContentUseCase: PrepareVoiceToContentUseCase,
     private val logger: VoiceToContentTelemetry
 ) : ScopedViewModel(mainDispatcher) {
-    private val _requestPermission = MutableLiveData<Unit>()
-    val requestPermission = _requestPermission as LiveData<Unit>
-
-    private val _dismiss = MutableLiveData<Unit>()
-    val dismiss = _dismiss as LiveData<Unit>
-
     private val _recordingUpdate = MutableLiveData<RecordingUpdate>()
-    val recordingUpdate: LiveData<RecordingUpdate> get() = _recordingUpdate
-
-    private val _onIneligibleForVoiceToContent = MutableLiveData<String>()
-    val onIneligibleForVoiceToContent = _onIneligibleForVoiceToContent as LiveData<String>
+    val recordingUpdate = _recordingUpdate as LiveData<RecordingUpdate>
 
     private val _isCancelableOutsideTouch = MutableLiveData(true)
-    val isCancelableOutsideTouch: LiveData<Boolean> get() = _isCancelableOutsideTouch
+    val isCancelableOutsideTouch = _isCancelableOutsideTouch as LiveData<Boolean>
 
     private val _actionEvent = MutableLiveData<VoiceToContentActionEvent>()
     val actionEvent = _actionEvent as LiveData<VoiceToContentActionEvent>
@@ -127,8 +121,6 @@ class VoiceToContentViewModel @Inject constructor(
                     stopRecording()
                 } else {
                     updateRecordingData(update)
-                    // todo: Handle other updates if needed when UI is ready, e.g., elapsed time and file size
-                    Log.d("AudioRecorder", "Recording update: $update")
                 }
             }
         }
@@ -185,16 +177,16 @@ class VoiceToContentViewModel @Inject constructor(
             when (val result = voiceToContentUseCase.execute(site, file)) {
                 is VoiceToContentResult.Failure -> result.transitionToError()
                 is VoiceToContentResult.Success ->
-                    _actionEvent.postValue(VoiceToContentActionEvent.LaunchEditPost(site, result.content))
+                    _actionEvent.postValue(LaunchEditPost(site, result.content))
             }
-            _dismiss.postValue(Unit)
+            _actionEvent.postValue(Dismiss)
         }
     }
 
     // Permissions
     private fun onRequestPermission() {
         logger.track(Stat.VOICE_TO_CONTENT_BUTTON_START_RECORDING_TAPPED)
-        _requestPermission.postValue(Unit)
+        _actionEvent.postValue(RequestPermission)
     }
 
     private fun hasAllPermissionsForRecording(): Boolean {
@@ -224,7 +216,7 @@ class VoiceToContentViewModel @Inject constructor(
     private fun onClose() {
         logger.track(Stat.VOICE_TO_CONTENT_BUTTON_CLOSE_TAPPED)
         recordingUseCase.endRecordingSession()
-        _dismiss.postValue(Unit)
+        _actionEvent.postValue(Dismiss)
     }
 
     private fun onRetryTap() {
@@ -235,7 +227,7 @@ class VoiceToContentViewModel @Inject constructor(
     private fun onLinkTap(url: String?) {
         logger.track(Stat.VOICE_TO_CONTENT_BUTTON_UPGRADE_TAPPED)
         url?.let {
-            _onIneligibleForVoiceToContent.postValue(it)
+            _actionEvent.postValue(LaunchExternalBrowser(it))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentViewModel.kt
@@ -179,7 +179,6 @@ class VoiceToContentViewModel @Inject constructor(
                 is VoiceToContentResult.Success ->
                     _actionEvent.postValue(LaunchEditPost(site, result.content))
             }
-            _actionEvent.postValue(Dismiss)
         }
     }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1690,6 +1690,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override public void onRedoPressed() {
     }
 
+    @Override
+    public void updateContent(@Nullable CharSequence text) {
+        // not implemented for Aztec
+    }
+
     private void onMediaTapped(@NonNull final AztecAttributes attrs, int naturalWidth, int naturalHeight,
                                final MediaType mediaType) {
         if (mediaType == null || !isAdded()) {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -57,6 +57,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void onUndoPressed();
 
     public abstract void onRedoPressed();
+    public abstract void updateContent(CharSequence text);
 
 
     public enum MediaType {

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -1096,6 +1096,17 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
         getGutenbergContainerFragment().setContent(postContent);
     }
 
+    @Override
+    public void updateContent(@Nullable CharSequence text) {
+        if (text == null) {
+            text = "";
+        }
+
+        if (getGutenbergContainerFragment() != null) {
+            getGutenbergContainerFragment().onContentUpdate(text.toString());
+        }
+    }
+
     public void setJetpackSsoEnabled(boolean jetpackSsoEnabled) {
         mIsJetpackSsoEnabled = jetpackSsoEnabled;
     }


### PR DESCRIPTION
Closes https://github.com/Automattic/wordpress-mobile/issues/78

This PR launches the editPost view after successful recording of audio. 

This branch build upon issue/v2c-show-elapsed-time
> [!IMPORTANT]
> **Merge Instructions**
> ~- Make sure #20983 & #20984 have been merged to trunk~
> ~- Remove the Not Ready for Merge Label~
> - Merge as normal

> [!NOTE]
> The following have not yet been implemented:
>  - Orientation changes
>  - Overall polishing of the UI
> - Unit tests

-----
## To Test:
- Install and launch the app
- Login with an account that has access to AI credits (Any a8c P2 will have this - other free sites have 20 requests)
- Navigate to Me > Debug Settings and enable the voice_to_content flag (restart the app)
- Navigate to My Site and tap the FAB
- Select the Post with Audio option
- Start the recording session by tapping on the mic icon
- Record a blog post - a few words, maybe include a list, try it out
- Tap the done icon when finished
- ✅ Verify the processing view is shown
- ✅ Verify the Edit Post view is shown with your recorded content

-----

## Regression Notes

1. Potential unintended areas of impact
The recorded content is not shown

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A