### PR TITLE
[Fix] IllegalArgumentException: in ReaderPostRenderer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -48,6 +48,7 @@ import java.util.regex.Pattern;
  */
 public class ReaderPostRenderer {
     private static final String JAVASCRIPT_MESSAGE_HANDLER = "wvHandler";
+    private static final String JS_OBJECT_ADDED_TAG = "jsObjectAdded";
     private final ReaderResourceVars mResourceVars;
     private final ReaderPost mPost;
     private final int mMinFullSizeWidthDp;
@@ -645,6 +646,11 @@ public class ReaderPostRenderer {
     }
 
     private void setWebViewMessageHandler(@NonNull WebView webView) {
+        Object tag = webView.getTag(JS_OBJECT_ADDED_TAG.hashCode());
+        if (tag != null && (boolean) tag) {
+            return; // Exit if the object has already been added
+        }
+
         Set<String> allowedOrigins = new HashSet<>();
         allowedOrigins.add("*");
 
@@ -665,6 +671,9 @@ public class ReaderPostRenderer {
                     }
                     return null;
                 });
+
+        // Set the tag that the JS object has been added, so we can check before adding it again
+        webView.setTag(JS_OBJECT_ADDED_TAG.hashCode(), true);
     }
 
     void setPostMessageListener(@Nullable ReaderPostMessageListener listener) {


### PR DESCRIPTION
Fixes #20996 

This PR is an attempt to fix IllegalArgumentException: jsObjectName wvHandler was already added.

The exception we are encountering indicates that the wvHandler JavaScript object name is being added multiple times to the WebView, which is not allowed. This can happen if setWebViewMessageHandler is called more than once for the same WebView instance without removing or properly handling the previously added JavaScript object.

To avoid this issue, this PR sets a tag on the webview and checks for the instance of that tag before the jsObject is added again.

Note: I was unable to recreate the issue, so please feel free to block this fix. 

## To Test:
As the issue can't be recreated, please test that the existing functionality works as expected. These test instructions were taken from #20895, as this is when the code was added.

- Open Jetpack
- Make sure data collection is enabled in App Settings -> Privacy
- Go to Reader
- Go to any post
- Select some text
- Verify the reader_article_text_highlighted event is tracked (use logcat)
- Tap on Copy in the context menu
- Verify the reader_article_text_copied event is tracked



-----

## Regression Notes

1. Potential unintended areas of impact
The crash still happens

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

-----

## PR Submission Checklist:
- [X] I have completed the Regression Notes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A
 
