### PR TITLE
Integrate gutenberg-mobile release v1.120.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6938-5177ec9507847f7fe35275e95b5878e6923ce9a1'
+    gutenbergMobileVersion = 'v1.120.1'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.84.0'
     wordPressLoginVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.120.0'
+    gutenbergMobileVersion = '6938-5177ec9507847f7fe35275e95b5878e6923ce9a1'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = '2.84.0'
     wordPressLoginVersion = '1.15.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.120.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6938

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.