### PR TITLE
Update camerax to 1.3.4 and fix the API change, which deprecates setTargetSolution

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanner.kt
@@ -6,6 +6,9 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST
 import androidx.camera.core.ImageProxy
+import androidx.camera.core.resolutionselector.AspectRatioStrategy
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Column
@@ -41,12 +44,18 @@ fun BarcodeScanner(
                 val preview = CameraPreview.Builder().build()
                 preview.setSurfaceProvider(previewView.surfaceProvider)
                 val selector = CameraSelector.Builder().requireLensFacing(CameraSelector.LENS_FACING_BACK).build()
-                val imageAnalysis = ImageAnalysis.Builder().setTargetResolution(
-                    Size(
-                        previewView.width,
-                        previewView.height
-                    )
-                )
+                val imageAnalysis = ImageAnalysis.Builder()
+                    .setResolutionSelector(ResolutionSelector.Builder()
+                        .setAspectRatioStrategy(AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY)
+                        .setResolutionStrategy(
+                        ResolutionStrategy(
+                            Size(
+                                previewView.width,
+                                previewView.height
+                            ),
+                            ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER
+                        )
+                    ).build())
                     .setBackpressureStrategy(STRATEGY_KEEP_ONLY_LATEST)
                     .build()
                 imageAnalysis.setAnalyzer(ContextCompat.getMainExecutor(context)) { imageProxy ->

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     androidxAnnotationVersion = '1.6.0'
     androidxAppcompatVersion = '1.6.1'
     androidxArchCoreVersion = '2.2.0'
-    androidxCameraVersion = '1.2.3'
+    androidxCameraVersion = '1.3.4'
     androidxComposeBomVersion = '2023.10.00'
     androidxComposeCompilerVersion = '1.5.9'
     androidxComposeNavigationVersion = '2.7.6'


### PR DESCRIPTION
Reference: https://github.com/wordpress-mobile/WordPress-Android/pull/20998

This PR updates the camerax library from 1.2.3 to [1.3.4](https://developer.android.com/jetpack/androidx/releases/camera#1.3.4). Unfortunately there was a small breaking change. `setTargetSolution` is being deprecated. This PR makes the update to use `setResolutionSelector`, which was introduced in the 1.3. I set reasonable defaults that make the scanning QR code to login with the app work.

## To Test:

In order to test, you need an account that does not have 2FA.

- [ ] Login with that non-2fa account on mobile.
- [ ] On web, while logged out, select "Login via app".
- [ ] On your phone go to: Me -> ScanLogin Code
- [ ] Scanning the QR code should work and allow you to login on web without entering your email or password.

-----

## Regression Notes

1. Potential unintended areas of impact

    Using the camera

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    Manual test

3. What automated tests I added (or what prevented me from doing so)

    N/A

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
