### PR TITLE
Bump rmagick to 5.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
 
 ### Gems needed only for generating Promo Screenshots
 group :screenshots, optional: true do
-  gem 'rmagick', '~> 4.1'
+  gem 'rmagick', '~> 5.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    observer (0.1.2)
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -260,6 +261,7 @@ GEM
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
+    pkg-config (1.5.6)
     plist (3.7.1)
     progress_bar (1.3.4)
       highline (>= 1.6)
@@ -279,7 +281,9 @@ GEM
     retriable (3.1.2)
     rexml (3.2.9)
       strscan
-    rmagick (4.3.0)
+    rmagick (5.5.0)
+      observer (~> 0.1)
+      pkg-config (~> 1.4)
     rouge (2.0.7)
     rubocop (1.64.1)
       json (~> 2.3)
@@ -344,7 +348,7 @@ DEPENDENCIES
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit (~> 11.0)
   nokogiri
-  rmagick (~> 4.1)
+  rmagick (~> 5.3)
 
 BUNDLED WITH
    2.4.21


### PR DESCRIPTION
Update rmagick to address https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/24

### Testing

I've tried to test it with `fastlane android screenshots app:wordpress` but the operation fails with `junit.framework.AssertionFailedError: Unable to continue – expectation wasn't satisfied quickly enough`. It's not related to rmagick (this fails also on `trunk`).

So I don't know how to test it, do you have an idea?