### PR TITLE
Fix the crashes in UploadUtilsWrapper caused by null snackbarAttachView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1394,10 +1394,11 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     break;
                 }
 
-                if (site != null && post != null) {
+                View snackbarAttachView = findViewById(R.id.coordinator);
+                if (site != null && post != null && snackbarAttachView != null) {
                     mUploadUtilsWrapper.handleEditPostResultSnackbars(
                             this,
-                            findViewById(R.id.coordinator),
+                            snackbarAttachView,
                             data,
                             post,
                             site,
@@ -1805,21 +1806,24 @@ public class WPMainActivity extends LocaleAwareActivity implements
                     }
                 }
 
-                mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
-                        this,
-                        findViewById(R.id.coordinator),
-                        event.isError(),
-                        event.isFirstTimePublish,
-                        event.post,
-                        null,
-                        targetSite,
-                        isFirstTimePublishing -> {
-                            mBloggingRemindersViewModel.onPublishingPost(targetSite.getId(), isFirstTimePublishing);
-                            if (isFirstTimePublishing) {
-                                AppReviewManager.INSTANCE.onPostPublished();
+                View snackbarAttachView = findViewById(R.id.coordinator);
+                if (snackbarAttachView != null) {
+                    mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
+                            this,
+                            snackbarAttachView,
+                            event.isError(),
+                            event.isFirstTimePublish,
+                            event.post,
+                            null,
+                            targetSite,
+                            isFirstTimePublishing -> {
+                                mBloggingRemindersViewModel.onPublishingPost(targetSite.getId(), isFirstTimePublishing);
+                                if (isFirstTimePublishing) {
+                                    AppReviewManager.INSTANCE.onPostPublished();
+                                }
                             }
-                        }
-                );
+                    );
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1203,10 +1203,11 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(UploadService.UploadErrorEvent event) {
         EventBus.getDefault().removeStickyEvent(event);
-        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+        View snackbarAttachView = findViewById(R.id.tab_layout);
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty() && snackbarAttachView != null) {
             mUploadUtilsWrapper.onMediaUploadedSnackbarHandler(
                     this,
-                    findViewById(R.id.tab_layout),
+                    snackbarAttachView,
                     true,
                     !TextUtils.isEmpty(event.errorMessage)
                     && event.errorMessage.contains(getString(R.string.error_media_quota_exceeded))
@@ -1223,10 +1224,10 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
         EventBus.getDefault().removeStickyEvent(event);
-        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
-            mUploadUtilsWrapper.onMediaUploadedSnackbarHandler(this,
-                    findViewById(R.id.tab_layout), false,
-                    event.mediaModelList, mSite, event.successMessage);
+        View snackbarAttachView = findViewById(R.id.tab_layout);
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty() && snackbarAttachView != null) {
+            mUploadUtilsWrapper.onMediaUploadedSnackbarHandler(this, snackbarAttachView, false, event.mediaModelList,
+                    mSite, event.successMessage);
             updateMediaGridForTheseMedia(event.mediaModelList);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -328,10 +328,11 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
                         return;
                     }
 
-                    if (site != null && post != null) {
+                    View snackbarAttachView = findViewById(R.id.coordinator);
+                    if (site != null && post != null && snackbarAttachView != null) {
                         mUploadUtilsWrapper.handleEditPostResultSnackbars(
                                 this,
-                                findViewById(R.id.coordinator),
+                                snackbarAttachView,
                                 data,
                                 post,
                                 site,
@@ -357,10 +358,11 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
         SiteModel site = mSiteStore.getSiteByLocalId(mSelectedSiteRepository.getSelectedSiteLocalId());
-        if (site != null && event.post != null) {
+        View snackbarAttachView = findViewById(R.id.coordinator);
+        if (site != null && event.post != null && snackbarAttachView != null) {
             mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
                     this,
-                    findViewById(R.id.coordinator),
+                    snackbarAttachView,
                     event.isError(),
                     event.isFirstTimePublish,
                     event.post,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -337,17 +337,12 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
                                 post,
                                 site,
                                 mUploadActionUseCase.getUploadAction(post),
-                                new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View v) {
-                                        UploadUtils.publishPost(
-                                                ReaderPostListActivity.this,
-                                                post,
-                                                site,
-                                                mDispatcher
-                                        );
-                                    }
-                                });
+                                v -> UploadUtils.publishPost(
+                                        ReaderPostListActivity.this,
+                                        post,
+                                        site,
+                                        mDispatcher
+                                ));
                     }
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1091,10 +1091,11 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
                     break;
                 }
 
-                if (site != null && post != null) {
+                View snackbarAttachView = findViewById(R.id.coordinator);
+                if (site != null && post != null && snackbarAttachView != null) {
                     mUploadUtilsWrapper.handleEditPostResultSnackbars(
                             this,
-                            findViewById(R.id.coordinator),
+                            snackbarAttachView,
                             data,
                             post,
                             site,
@@ -1119,10 +1120,11 @@ public class ReaderPostPagerActivity extends LocaleAwareActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPostUploaded(OnPostUploaded event) {
         SiteModel site = mSiteStore.getSiteByLocalId(mSelectedSiteRepository.getSelectedSiteLocalId());
-        if (site != null && event.post != null) {
+        View snackbarAttachView = findViewById(R.id.coordinator);
+        if (site != null && event.post != null && snackbarAttachView != null) {
             mUploadUtilsWrapper.onPostUploadedSnackbarHandler(
                     this,
-                    findViewById(R.id.coordinator),
+                    snackbarAttachView,
                     event.isError(),
                     event.isFirstTimePublish,
                     event.post,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -53,7 +53,7 @@ class UploadUtilsWrapper @Inject constructor(
     @Suppress("LongParameterList")
     fun onPostUploadedSnackbarHandler(
         activity: Activity?,
-        snackbarAttachView: View?,
+        snackbarAttachView: View,
         isError: Boolean,
         isFirstTimePublish: Boolean,
         post: PostModel?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtilsWrapper.kt
@@ -34,7 +34,7 @@ class UploadUtilsWrapper @Inject constructor(
     @Suppress("LongParameterList")
     fun onMediaUploadedSnackbarHandler(
         activity: Activity?,
-        snackbarAttachView: View?,
+        snackbarAttachView: View,
         isError: Boolean,
         mediaList: List<MediaModel?>?,
         site: SiteModel?,


### PR DESCRIPTION
Fixes #21010
I can't reproduce the crash, but it occurs when the activity is stopped while the snackbar is being invoked in a separate thread, such as in `onActivityResult` or EventBus functions. Therefore, I added a check before showing snackbars.

There are different crashes on Sentry related to `UploadUtilsWrapper`. If the `snackbarAttachView` is null, it's pointless to call functions showing snackbars. I made all `snackbarAttachView` parameters non-null and checked their nullability in the Java classes where these `UploadUtilsWrapper`' functions are being called.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Since I can't reproduce it, it's not testable.

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - Since I can't reproduce it, I didn't add a test.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
