### PR TITLE
Fix - EditPostActivity - Update fetching for the block editor's settings logic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3874,8 +3874,11 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     private fun refreshEditorTheme() {
-        val payload = FetchEditorThemePayload(siteModel, globalStyleSupportFeatureConfig.isEnabled())
-        dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(payload))
+        val shouldLoadBlockEditorThemeData = siteModel.isWPCom || siteModel.isWPComAtomic || isJetpackSsoEnabled
+        if (shouldLoadBlockEditorThemeData) {
+            val payload = FetchEditorThemePayload(siteModel, globalStyleSupportFeatureConfig.isEnabled())
+            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(payload))
+        }
     }
 
     @Suppress("unused")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/21005

It appears the `/wp/v2/themes?status=active` endpoint is not returning any data for self-hosted sites, from my debugging the API call it's returning is `Sorry, you are not allowed to view the active theme`.

This endpoint is available [in WordPress core](https://developer.wordpress.org/rest-api/reference/themes/) so there must be something wrong with the authentication of this call.

As a workaround, this PR disables calling the following endpoints within the editor:

- `wp-block-editor/v1/settings?context=mobile`
- `/wp/v2/themes?status=active`

The first one is only available for Dotcom or Jetpack-connected sites with the Gutenberg plugin activated.

If the first one is unavailable, it fetches the current active theme to get its colors. This one is currently failing and blocking the Editor's UI and functionality.

Disabling these calls for self-hosted sites won't affect the editor's functionality.

-----

## To Test:

## Self-hosted site (**without** Jetpack and the Gutenberg plugin)

- Install the app (Fresh install)
- Log in using a self-hosted site (**without** Jetpack and the Gutenberg plugin)
- Open the editor
- **Expect** to be able to set a title and content, try adding different blocks: Paragraphs, Headings, Gallery
- **Expect** **to not see** your theme's background and text color in the editor's canvas.

## Self-hosted site (**with** Jetpack and the Gutenberg plugin)

- Install the app (Fresh install)
- Log in using a self-hosted site (**with** Jetpack and the Gutenberg plugin)
- Open the editor
- **Expect** to be able to set a title and content, try adding different blocks: Paragraphs, Headings, Gallery
- **Expect** **to see** your theme's background and text color in the editor's canvas.

## Simple sites

- Install the app (Fresh install)
- Log in using a simple site
- Open the editor
- **Expect** to be able to set a title and content, try adding different blocks: Paragraphs, Headings, Gallery
- **Expect** **to see** your theme's background and text color in the editor's canvas.

## Atomic sites

- Install the app (Fresh install)
- Log in using an Atomic site
- Open the editor
- **Expect** to be able to set a title and content, try adding different blocks: Paragraphs, Headings, Gallery
- **Expect** **to see** your theme's background and text color in the editor's canvas.

Before|After
-|-
<video src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/0a534e5d-ec2c-4945-840f-f95871583374" width=250 />|<video src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/65f320bb-b1a8-4801-a27e-196b9ec92946" width=250 />

-----

## Regression Notes

1. Potential unintended areas of impact

    - It only affects the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing.

3. What automated tests I added (or what prevented me from doing so)

    - No new tests added, relied on manual testing to fix the current bug.

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
