### PR TITLE
[Buildkite] Add Agent Attribute with Queue Android to Every YML File

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -7,6 +7,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   #################
   # Gradle Wrapper Validation

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for beta builds
 

--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Code Freeze"
     plugins: *common_plugins

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Complete Code Freeze"
     plugins: *common_plugins

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Finalize release"
     plugins: *common_plugins

--- a/.buildkite/new-beta-release.yml
+++ b/.buildkite/new-beta-release.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/new-beta-release.yml
+++ b/.buildkite/new-beta-release.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   - label: "New Beta Release"
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for release builds
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -7,6 +7,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   #################
   # Gradle Wrapper Validation

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -9,9 +9,7 @@ agents:
 
 steps:
   - label: "dependency analysis"
-    # The meta-data added is used by Apps Metrics Prometheus collector to find the build.
     command: |
-      buildkite-agent meta-data set "scheduled-build" "dependency-analysis"
       echo "--- 📊 Analyzing"
       cp gradle.properties-example gradle.properties
       ./gradlew buildHealth

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -4,6 +4,9 @@ common_params:
   - &common_plugins
     - automattic/a8c-ci-toolkit#3.4.2
 
+agents:
+  queue: "android"
+
 steps:
   - label: "Update release notes"
     plugins: *common_plugins


### PR DESCRIPTION
This PR adds the `agent` attribute with `queue android` to every YML file missing it, and also, removes the custom meta-data on the scheduled build for dependency analysis ([context](https://github.com/Automattic/buildkite-ci/pull/459#issuecomment-2199589109)).

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Make sure CI is green (🟢).

-----

## Regression Notes

1. Potential unintended areas of impact: (`N/A`)

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): (`N/A`)