### PR TITLE
WPMediaUtils - Set normal orientation for the exif data

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -18,6 +18,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.FileProvider;
+import androidx.exifinterface.media.ExifInterface;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -84,6 +85,9 @@ public class WPMediaUtils {
             AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");
             AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZE_ERROR);
         } else {
+            // Set the default orientation tag for the EXIF data
+            exifData.put("Orientation", String.valueOf(ExifInterface.ORIENTATION_NORMAL));
+
             // Write EXIF data to the new image
             ExifUtils.writeExifData(exifData, optimizedPath);
 


### PR DESCRIPTION
Fixes a regression introduced after https://github.com/wordpress-mobile/WordPress-Android/pull/20955

There is an issue when uploading portrait images where they get rotated 90 degrees, this does not affect landscape orientations.

I've tested this PR with different images: `landscape`, `portrait`, and an edited portrait photo into landscape.

-----

## To Test:

- Open the editor
- Add an Image block
- Select an image with portrait orientation
- **Expect** the image to not change its original orientation

**Note:** It'd be good to test landscape orientations as well.

Before|After
-|-
<video src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/6564bdff-c03d-44d3-a5a4-5728d3f3da39" width=250 />|<video src="https://github.com/wordpress-mobile/WordPress-Android/assets/4885740/60c81290-927e-4a0d-beb7-1510ac5fdf9e" width=250 />

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
