### PR TITLE
[Tooling] Use a shared Buildkite pipeline vars file

### DIFF
--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -1,18 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
 steps:
   - label: "Code Freeze"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-git-for-release-management.sh
 

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -1,18 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
 steps:
   - label: "Complete Code Freeze"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -1,18 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
 steps:
   - label: "Finalize release"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-release-branch.sh

--- a/.buildkite/new-beta-release.yml
+++ b/.buildkite/new-beta-release.yml
@@ -1,18 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
 steps:
   - label: "New Beta Release"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-git-for-release-management.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,11 +3,6 @@
 
 # Nodes with values to reuse in the pipeline.
 common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &ci_toolkit
-    automattic/a8c-ci-toolkit#3.4.2
-  - &test_collector
-    test-collector#v1.8.0
   - &test_collector_common_params
       files: "buildkite-test-analytics/*.xml"
       format: "junit"
@@ -22,7 +17,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: [*ci_toolkit]
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -46,7 +41,7 @@ steps:
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew checkstyle
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/checkstyle/checkstyle.*"
 
@@ -54,7 +49,7 @@ steps:
         command: |
           cp gradle.properties-example gradle.properties
           ./gradlew detekt
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/detekt/detekt.html"
 
@@ -73,7 +68,7 @@ steps:
       cp gradle.properties-example gradle.properties
       .buildkite/commands/dependency-tree-diff.sh
     if: build.pull_request.id != null
-    plugins: [*ci_toolkit]
+    plugins: [$CI_TOOLKIT]
 
   #################
   # Unit Tests
@@ -83,8 +78,8 @@ steps:
       - label: "🔬 Unit Test WordPress"
         command: ".buildkite/commands/run-unit-tests.sh wordpress"
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
         artifact_paths:
@@ -93,8 +88,8 @@ steps:
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"
         artifact_paths:
@@ -103,8 +98,8 @@ steps:
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"
         artifact_paths:
@@ -118,8 +113,8 @@ steps:
       - label: ":wordpress: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh wordpress"
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_WORDPRESS"
         artifact_paths:
@@ -128,8 +123,8 @@ steps:
       - label: ":jetpack: 🔬 Instrumented tests"
         command: ".buildkite/commands/run-instrumented-tests.sh jetpack"
         plugins:
-          - *ci_toolkit
-          - *test_collector :
+          - $CI_TOOLKIT
+          - $TEST_COLLECTOR :
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_INSTRUMENTED_TESTS_JETPACK"
         artifact_paths:
@@ -143,9 +138,9 @@ steps:
       - label: ":wordpress: :android: Prototype Build"
         command: ".buildkite/commands/prototype-build.sh wordpress"
         if: build.pull_request.id != null
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]
 
       - label: ":jetpack: :android: Prototype Build"
         command: ".buildkite/commands/prototype-build.sh jetpack"
         if: build.pull_request.id != null
-        plugins: [*ci_toolkit]
+        plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,12 +4,6 @@
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -21,7 +15,7 @@ steps:
     command: |
       validate_gradle_wrapper
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -57,7 +51,7 @@ steps:
         command: ".buildkite/commands/release-build.sh wordpress"
         priority: 1
         depends_on: wplint
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
 
@@ -66,7 +60,7 @@ steps:
         command: ".buildkite/commands/release-build.sh jetpack"
         priority: 1
         depends_on: jplint
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
 
@@ -79,4 +73,4 @@ steps:
       - jpbuild
     command: ".buildkite/commands/create-github-release.sh"
     priority: 1
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,12 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &ci_toolkit
-      automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -16,7 +10,7 @@ steps:
       echo "--- 📊 Analyzing"
       cp gradle.properties-example gradle.properties
       ./gradlew buildHealth
-    plugins: [*ci_toolkit]
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "build/reports/dependency-analysis/build-health-report.*"
     notify:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+ # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+ # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+ export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -1,18 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
 steps:
   - label: "Update release notes"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-editorial-branch.sh


### PR DESCRIPTION
## References

This PR requires https://github.com/Automattic/buildkite-ci/pull/459 to be deployed first.
The "pipeline upload" CI step will fail on this PR until then.

See also: https://wp.me/paaHJt-5Rr

## What it does

This PR introduces the pipeline variables `CI_TOOLKIT` and `TEST_COLLECTOR`, both defined in `./buildkite/shared-pipeline-vars`, and replaces them across all pipelines.

### How to test

 - Deploy https://github.com/Automattic/buildkite-ci/pull/459
 - Re-run CI on this PR and make sure it is 🟢 