### PR TITLE
[Tooling] Use a trusted CI agent for pipelines that require push access

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -4,12 +4,6 @@
 # This pipeline is meant to be run via the Buildkite API, and is
 # only used for beta builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.4.2
-
 agents:
   queue: "android"
 
@@ -20,7 +14,7 @@ steps:
   - label: "Gradle Wrapper Validation"
     command: |
       validate_gradle_wrapper
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
@@ -53,7 +47,7 @@ steps:
         key: wpbuild
         command: ".buildkite/commands/beta-build.sh wordpress"
         depends_on: wplint
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
 
@@ -61,7 +55,7 @@ steps:
         key: jpbuild
         command: ".buildkite/commands/beta-build.sh jetpack"
         depends_on: jplint
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
 
@@ -73,4 +67,4 @@ steps:
       - wpbuild
       - jpbuild
     command: ".buildkite/commands/create-github-release.sh"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]

--- a/.buildkite/code-freeze.yml
+++ b/.buildkite/code-freeze.yml
@@ -1,15 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
 
 steps:
   - label: "Code Freeze"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-git-for-release-management.sh
+      source .buildkite/commands/configure-git-for-release-management.sh
 
       install_gems
 
       bundle exec fastlane code_freeze skip_confirm:true
+    agents:
+       queue: "tumblr-metal"

--- a/.buildkite/commands/configure-git-for-release-management.sh
+++ b/.buildkite/commands/configure-git-for-release-management.sh
@@ -1,10 +1,11 @@
 #!/bin/bash -eu
 
-# Git command line client is not configured in Buildkite. Temporarily, we configure it in each step.
-# Later on, we should be able to configure the agent instead.
-curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
-git config --global user.email "mobile+wpmobilebot@automattic.com"
-git config --global user.name "Automattic Release Bot"
+# This script needs to be source'd as use-bot-for-git exports a variable and this needs to be visible outside
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "This script must be 'source'd (instead of being called directly as an executable) to work properly"
+  exit 1
+fi
 
-# Buildkite is currently using the https url to checkout. We need to override it to be able to use the deploy key.
-git remote set-url origin git@github.com:wordpress-mobile/WordPress-Android.git
+echo '--- :robot_face: Use bot for git operations'
+# shellcheck disable=SC1091
+source use-bot-for-git

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -1,16 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
 
 steps:
   - label: "Complete Code Freeze"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-git-for-release-management.sh
+      source .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-release-branch.sh
 
       install_gems
 
       bundle exec fastlane complete_code_freeze skip_confirm:true
+    agents:
+       queue: "tumblr-metal"

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -1,14 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
 
 steps:
   - label: "Finalize release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-git-for-release-management.sh
+      source .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-release-branch.sh
 
       install_gems
@@ -16,3 +14,5 @@ steps:
       cp gradle.properties-example gradle.properties
 
       bundle exec fastlane finalize_release skip_confirm:true
+    agents:
+       queue: "tumblr-metal"

--- a/.buildkite/new-beta-release.yml
+++ b/.buildkite/new-beta-release.yml
@@ -1,17 +1,17 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
 
 steps:
   - label: "New Beta Release"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-git-for-release-management.sh
+      source .buildkite/commands/configure-git-for-release-management.sh
 
       install_gems
 
       cp gradle.properties-example gradle.properties
 
       bundle exec fastlane new_beta_release skip_confirm:true
+    agents:
+       queue: "tumblr-metal"

--- a/.buildkite/test-git-push.yml
+++ b/.buildkite/test-git-push.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+
+steps:
+  - label: "Test Git Push 👀"
+    plugins: [$CI_TOOLKIT]
+    command: |
+      install_gems
+
+      bundle exec fastlane test_git_push
+    agents:
+       queue: "tumblr-metal"

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -1,16 +1,16 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
-agents:
-  queue: "android"
 
 steps:
   - label: "Update release notes"
     plugins: [$CI_TOOLKIT]
     command: |
-      .buildkite/commands/configure-git-for-release-management.sh
+      source .buildkite/commands/configure-git-for-release-management.sh
       .buildkite/commands/checkout-editorial-branch.sh
 
       install_gems
 
       bundle exec fastlane update_appstore_strings version:${RELEASE_VERSION}
+    agents:
+       queue: "tumblr-metal"

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -121,6 +121,19 @@ platform :android do
     create_release_management_pull_request('trunk', "Merge #{new_version} code freeze into trunk")
   end
 
+  lane :test_git_push do |options|
+    UI.message 'Bumping beta version and build code...'
+    VERSION_FILE.write_version(
+      version_name: code_freeze_beta_version,
+      version_code: next_build_code
+    )
+    commit_version_bump
+    push_to_git_remote(
+      local_branch: 'iangmaia/iangmaia/trusted-agent-for-push-access',
+      tags: false
+    )
+  end
+
   #####################################################################################
   # new_beta_release
   # -----------------------------------------------------------------------------------


### PR DESCRIPTION
### Description
This PR uses the trusted agent helper script `use-bot-for-git` to use the GitHub bot for performing git push operations on CI.

### Testing Steps
- This PR will need to be tested during the next release cycle of the project, when the affected pipelines should still be able to finish successfully.
- You can trigger one of the builds manually on Buildkite using the `PIPELINE` env var creating a new build on this branch, as long as any side effect is avoided or reversed.

### Follow-up
Once this PR is merged and making to a code freeze, we will need to revoke and replace in our setup the current deploy key with the new read-only one.