### PR TITLE
[Gutenberg] Disable calling the `themes` endpoint

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3891,11 +3891,8 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     }
 
     private fun refreshEditorTheme() {
-        val shouldLoadBlockEditorThemeData = siteModel.isWPCom || siteModel.isWPComAtomic || isJetpackSsoEnabled
-        if (shouldLoadBlockEditorThemeData) {
-            val payload = FetchEditorThemePayload(siteModel, globalStyleSupportFeatureConfig.isEnabled())
-            dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(payload))
-        }
+        val payload = FetchEditorThemePayload(siteModel, globalStyleSupportFeatureConfig.isEnabled())
+        dispatcher.dispatch(EditorThemeActionBuilder.newFetchEditorThemeAction(payload))
     }
 
     @Suppress("unused")

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.120.1'
+    gutenbergMobileVersion = 'v1.121.0-alpha1-test'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.121.0-alpha1-test'
+    gutenbergMobileVersion = 'v1.121.0-alpha1'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/21005

**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967
- https://github.com/WordPress/gutenberg/pull/63183

-----

## To Test:

Check the Gutenberg PR's description.

-----

## Regression Notes

1. Potential unintended areas of impact

    - It should only affect the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - Relied in the current testing suite.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
