### PR TITLE
ci: Fix Checkstyle configuration

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -27,6 +27,13 @@
     <!--
     <module name="FileLength"/>
     -->
+    <module name="LineLength">
+        <!-- what is a good max value? -->
+        <property name="max" value="120"/>
+        <!-- ignore lines like "$File: //depot/... $" -->
+        <property name="ignorePattern" value="\$File.*\$"/>
+        <property name="severity" value="error"/>
+    </module>
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
@@ -173,13 +180,6 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-          <!-- what is a good max value? -->
-          <property name="max" value="120"/>
-          <!-- ignore lines like "$File: //depot/... $" -->
-          <property name="ignorePattern" value="\$File.*\$"/>
-          <property name="severity" value="error"/>
-        </module>
         <module name="MethodLength">
           <property name="tokens" value="METHOD_DEF"/>
           <!-- TODO: We should set this value around 40 or 50 -->


### PR DESCRIPTION
Update configuration to address the following warning:

```
The Checkstyle rules file could not be parsed. cannot initialize module TreeWalker - TreeWalker is not allowed as a parent of LineLength Please review 'Parent Module' section for this Check in web documentation if Check is standard. The file has been blocked for 60s.
```

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

N/A, no user-facing changes. 

## Regression Notes

1. Potential unintended areas of impact
    CI failures. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verify CI tasks succeed. 
3. What automated tests I added (or what prevented me from doing so)
    N/A, no user-facing changes. 

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
