### PR TITLE
[Gutenberg] - Remove Gallery V1 and experimental flags 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2531,17 +2531,6 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
             )
         }
 
-    /**
-     * Checks if the theme supports the new gallery block with image blocks.
-     * Note that if the editor theme has not been initialized (usually on the first app run)
-     * the value returned is null and the `unstable_gallery_with_image_blocks` analytics property will not be reported.
-     * @return true if the the supports the new gallery block with image blocks or null if the theme is not initialized.
-     */
-    private fun themeSupportsGalleryWithImageBlocks(): Boolean? {
-        val editorTheme = editorThemeStore.getEditorThemeForSite(siteModel) ?: return null
-        return editorTheme.themeSupport.galleryWithImageBlocks
-    }
-
     private var mediaCapturePath: String? = ""
     private fun getUploadErrorHtml(mediaId: String, path: String): String {
         return String.format(
@@ -3508,7 +3497,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         if (showAztecEditor && editorFragment is AztecEditorFragment) {
             val entryPoint =
                 intent.getSerializableExtra(EditPostActivityConstants.EXTRA_ENTRY_POINT) as PostUtils.EntryPoint?
-            postEditorAnalyticsSession?.start(null, themeSupportsGalleryWithImageBlocks(), entryPoint)
+            postEditorAnalyticsSession?.start(null, entryPoint)
         }
     }
 
@@ -3523,7 +3512,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
         // It assumes this is being called when the editor has finished loading
         // If you need to refactor this, please ensure that the startup_time_ms property
         // is still reflecting the actual startup time of the editor
-        postEditorAnalyticsSession?.start(unsupportedBlocksList, themeSupportsGalleryWithImageBlocks(), entryPoint)
+        postEditorAnalyticsSession?.start(unsupportedBlocksList, entryPoint)
         presentNewPageNoticeIfNeeded()
 
         // Start VM, load prompt and populate Editor with content after edit IS ready.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -26,7 +26,6 @@ public class PostEditorAnalyticsSession implements Serializable {
     private static final String KEY_EDITOR = "editor";
     private static final String KEY_HAS_UNSUPPORTED_BLOCKS = "has_unsupported_blocks";
     private static final String KEY_UNSUPPORTED_BLOCKS = "unsupported_blocks";
-    private static final String KEY_GALLERY_WITH_IMAGE_BLOCKS = "unstable_gallery_with_image_blocks";
     private static final String KEY_POST_TYPE = "post_type";
     private static final String KEY_OUTCOME = "outcome";
     private static final String KEY_SESSION_ID = "session_id";
@@ -115,16 +114,12 @@ public class PostEditorAnalyticsSession implements Serializable {
     }
 
     public void start(ArrayList<Object> unsupportedBlocksList,
-                      Boolean galleryWithImageBlocks,
                       final EntryPoint entryPoint) {
         if (!mStarted) {
             mHasUnsupportedBlocks = unsupportedBlocksList != null && unsupportedBlocksList.size() > 0;
             Map<String, Object> properties = getCommonProperties();
             properties.put(KEY_UNSUPPORTED_BLOCKS,
                     unsupportedBlocksList != null ? unsupportedBlocksList : new ArrayList<>());
-            if (galleryWithImageBlocks != null) {
-                properties.put(KEY_GALLERY_WITH_IMAGE_BLOCKS, galleryWithImageBlocks);
-            }
             // Note that start time only counts when the analytics session was created and not when the editor
             // activity started. We are mostly interested in measuring the loading times for the block editor,
             // where the main bottleneck seems to be initializing React Native and doing the initial load of Gutenberg.

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostEditorAnalyticsSessionTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/editor/PostEditorAnalyticsSessionTest.kt
@@ -24,7 +24,7 @@ class PostEditorAnalyticsSessionTest {
         val postEditorAnalyticsSession = createPostEditorAnalyticsSessionTracker(analyticsTracker)
 
         // trigger all the editor_session events
-        postEditorAnalyticsSession.start(null, true, null)
+        postEditorAnalyticsSession.start(null, null)
         postEditorAnalyticsSession.end()
         postEditorAnalyticsSession.switchEditor(GUTENBERG)
         postEditorAnalyticsSession.applyTemplate("Just a template name")

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6973-0239a7b2494802dfff1e9d8faa486efdf0885631'
+    gutenbergMobileVersion = '6978-f65a69019e6634e8277fb0861b7cd7d2f4442d73'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6973-80c9f88a26f89804fbec0e929f24ac240dca38d4'
+    gutenbergMobileVersion = '6973-0239a7b2494802dfff1e9d8faa486efdf0885631'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6978-f65a69019e6634e8277fb0861b7cd7d2f4442d73'
+    gutenbergMobileVersion = '6978-25a28edbafe8bb8895436c9cc3df48c51367465d'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.121.0-alpha1'
+    gutenbergMobileVersion = '6973-80c9f88a26f89804fbec0e929f24ac240dca38d4'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6978-25a28edbafe8bb8895436c9cc3df48c51367465d'
+    gutenbergMobileVersion = 'v1.121.0-alpha2'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6973
- https://github.com/WordPress/gutenberg/pull/63285

-----

## To Test:

- Test adding a Gallery block to a post

-----

## Regression Notes

1. Potential unintended areas of impact

    - It affects only the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing and existing automated tests for the Gallery block.

3. What automated tests I added (or what prevented me from doing so)

    - No tests were added since this is only removing the old Gallery block format and a few experimental flags.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
