### PR TITLE
[Android 14 PR] Set remaining foreground service types

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,11 +2,12 @@
 
 25.4
 -----
+* [**] [internal] Set remaining foreground service types for Android 14 [https://github.com/wordpress-mobile/WordPress-Android/pull/21047]
 
 
 25.2
 -----
-* [**] [internal] Set remaining foreground service types for Android 14 [https://github.com/wordpress-mobile/WordPress-Android/pull/21047]
+
 
 25.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,12 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
-25.2
+25.4
 -----
 
+
+25.2
+-----
+* [**] [internal] Set remaining foreground service types for Android 14 [https://github.com/wordpress-mobile/WordPress-Android/pull/21047]
 
 25.1
 -----

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -833,7 +833,7 @@
         <service
             android:name=".ui.uploads.UploadService"
             android:label="Upload Service"
-            android:foregroundServiceType="dataSync"/>
+            android:foregroundServiceType="dataSync" />
         <service
             android:name=".ui.media.services.MediaDeleteService"
             android:label="Media Delete Service"
@@ -920,12 +920,14 @@
         <service
             android:name=".login.LoginWpcomService"
             android:exported="false"
-            android:label="Login to WPCOM Service" />
+            android:label="Login to WPCOM Service"
+            android:foregroundServiceType="dataSync" />
 
         <service
             android:name=".ui.sitecreation.services.SiteCreationService"
             android:exported="false"
-            android:label="Site Creation Service" />
+            android:label="Site Creation Service"
+            android:foregroundServiceType="dataSync" />
 
         <!-- Samsung multiwindow support -->
         <uses-library

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -921,7 +921,7 @@
             android:name=".login.LoginWpcomService"
             android:exported="false"
             android:label="Login to WPCOM Service"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="shortService" />
 
         <service
             android:name=".ui.sitecreation.services.SiteCreationService"

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     gutenbergMobileVersion = 'v1.121.0-alpha1'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
-    wordPressLoginVersion = '1.16.0'
+    wordPressLoginVersion = '150-e84accf2781a1a354478cbe3b6567e87571de730'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'
     indexosMediaForMobileVersion = '43a9026f0973a2f0a74fa813132f6a16f7499c3a'


### PR DESCRIPTION
Fixes #21039

This PR targets the `feature/android-14` branch and updates the following services to specify their foreground service type as part of our Android 14 update:

* SiteCreationService
* LoginWpcomService

The following services already have this change:

* UploadService 
* MediaDeleteService

-----

## To Test:

* Test site creation and login on an Android 34+ device and verify there are no issues
* Do the same on a pre-Android 34 device

-----

## Notes:

* Even though LoginWpcomService is part of our login library, we declare the foreground service type for that service in WPAndroid's manifest so no changes are needed in the service itself (which already targets SDK 34). Also see [this related login PR](https://github.com/wordpress-mobile/WordPress-Login-Flow-Android/pull/150) and [this related WooCommerce PR](https://github.com/woocommerce/woocommerce-android/pull/11970).


-----

## Regression Notes

1. Potential unintended areas of impact

    - Failures in SiteCreationService and LoginWpcomService

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing

3. What automated tests I added (or what prevented me from doing so)

    - I have not added tests under the assumption that existing tests would suffice

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
~~- [ ] Portrait and landscape orientations.~~
~~- [ ] Light and dark modes.~~
~~- [ ] Fonts: Larger, smaller and bold text.~~
~~- [ ] High contrast.~~
~~- [ ] Talkback.~~
~~- [ ] Languages with large words or with letters/accents not frequently used in English.~~
~~- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~~
~~- [ ] Large and small screen sizes. (Tablet and smaller phones)~~
~~- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~~
