### PR TITLE
build: Update FluxC reference to trunk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     automatticTracksVersion = '5.1.0'
     gutenbergMobileVersion = 'v1.121.0-alpha1'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = '3045-5fc175e4780dec098cfd04bf5eb9da7f3cce4076'
+    wordPressFluxCVersion = 'trunk-c670e916346bdaa2379936dd8dbb6750766ca319'
     wordPressLoginVersion = '1.16.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
Avoid references that do not belong to the trunk branch as customary for the project.

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

N/A, covered in https://github.com/wordpress-mobile/WordPress-Android/pull/21036.

## Regression Notes

1. Potential unintended areas of impact
    N/A, covered in https://github.com/wordpress-mobile/WordPress-Android/pull/21036.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A, covered in https://github.com/wordpress-mobile/WordPress-Android/pull/21036.
3. What automated tests I added (or what prevented me from doing so)
    N/A, covered in https://github.com/wordpress-mobile/WordPress-Android/pull/21036.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] ~WordPress.com sites and self-hosted Jetpack sites.~
- [ ] ~Portrait and landscape orientations.~
- [ ] ~Light and dark modes.~
- [ ] ~Fonts: Larger, smaller and bold text.~
- [ ] ~High contrast.~
- [ ] ~Talkback.~
- [ ] ~Languages with large words or with letters/accents not frequently used in English.~
- [ ] ~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
- [ ] ~Large and small screen sizes. (Tablet and smaller phones)~
- [ ] ~Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)~
