### PR TITLE
Address WireMock transitive dependencies vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,8 @@ updates:
       - dependency-name: "org.wordpress.aztec:picasso-loader"
       - dependency-name: "com.automattic:about"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
+      # Ignore dependencies that were added only to address security vulnerabilities of transitive WireMock dependencies
+      - dependency-name: "org.eclipse.jetty:jetty-webapp"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      - dependency-name: "com.jayway.jsonpath:json-path"
+      - dependency-name: "commons-fileupload:commons-fileupload"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -512,13 +512,6 @@ dependencies {
             strictly androidxTestEspressoVersion
         }
     }
-    androidTestImplementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
-        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-        exclude group: 'org.apache.commons', module: 'commons-lang3'
-        exclude group: 'asm', module: 'asm'
-        exclude group: 'org.json', module: 'json'
-    }
-    androidTestImplementation "org.apache.httpcomponents:httpclient-android:$wiremockHttpClientVersion"
     androidTestImplementation "androidx.test:runner:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test:rules:$androidxTestCoreVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxTestExtJunitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,6 @@ ext {
     screengrabVersion = '2.1.1'
     squareupMockWebServerVersion = '4.12.0'
     wiremockVersion = '2.26.3'
-    wiremockHttpClientVersion = '4.3.5.1'
 
     // other
     androidDesugarVersion = '2.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ ext {
     screengrabVersion = '2.1.1'
     squareupMockWebServerVersion = '4.12.0'
     wiremockVersion = '2.26.3'
+    wiremockHttpClientVersion = '4.3.5.1'
 
     // other
     androidDesugarVersion = '2.0.4'

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -30,17 +30,20 @@ dependencies {
         implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
             because("newer versions of WireMock use Java APIs not available on Android")
         }
+
+        def wireMockSecurity = "version shipped with WireMock 2.26.3 contains security vulnerabilities"
+
         implementation('org.eclipse.jetty:jetty-webapp:9.4.51.v20230217') {
-            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+            because(wireMockSecurity)
         }
         implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') {
-            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+            because(wireMockSecurity)
         }
         implementation('com.jayway.jsonpath:json-path:2.9.0') {
-            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+            because(wireMockSecurity)
         }
         implementation('commons-fileupload:commons-fileupload:1.5') {
-            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+            because(wireMockSecurity)
         }
     }
 }

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -18,11 +18,29 @@ android {
 }
 
 dependencies {
-    implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
+    implementation("com.github.tomakehurst:wiremock") {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
+   }
+
+    constraints {
+        implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
+            because("newer versions of WireMock use Java APIs not available on Android")
+        }
+        implementation('org.eclipse.jetty:jetty-webapp:9.4.51.v20230217') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.12.7.1') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        implementation('com.jayway.jsonpath:json-path:2.9.0') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        implementation('commons-fileupload:commons-fileupload:1.5') {
+            because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
+        }
+        implementation('org.apache.httpcomponents:httpclient-android:4.3.5.1')
     }
-    implementation "org.apache.httpcomponents:httpclient-android:$wiremockHttpClientVersion"
 }

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -18,12 +18,13 @@ android {
 }
 
 dependencies {
-    implementation("com.github.tomakehurst:wiremock") {
+    api("com.github.tomakehurst:wiremock") {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
-   }
+    }
+    runtimeOnly('org.apache.httpcomponents:httpclient-android:4.3.5.1')
 
     constraints {
         implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {
@@ -41,6 +42,5 @@ dependencies {
         implementation('commons-fileupload:commons-fileupload:1.5') {
             because("version shipped with WireMock 2.26.3 contains security vulnerabilities")
         }
-        implementation('org.apache.httpcomponents:httpclient-android:4.3.5.1')
     }
 }

--- a/libs/mocks/build.gradle
+++ b/libs/mocks/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         exclude group: 'asm', module: 'asm'
         exclude group: 'org.json', module: 'json'
     }
-    runtimeOnly('org.apache.httpcomponents:httpclient-android:4.3.5.1')
+    runtimeOnly("org.apache.httpcomponents:httpclient-android:$wiremockHttpClientVersion")
 
     constraints {
         implementation("com.github.tomakehurst:wiremock:$wiremockVersion") {


### PR DESCRIPTION
This PR addresses security vulnerabilities added by transitive dependencies of WireMock.

## To Test:

Green light on CI should be enough.