### PR TITLE
[Gutenberg] - Gallery block - Fix getMediaItems 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6973-0239a7b2494802dfff1e9d8faa486efdf0885631'
+    gutenbergMobileVersion = '6978-f65a69019e6634e8277fb0861b7cd7d2f4442d73'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6978-f65a69019e6634e8277fb0861b7cd7d2f4442d73'
+    gutenbergMobileVersion = '6978-25a28edbafe8bb8895436c9cc3df48c51367465d'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-79f2bc35285748c715e00f2a6648ed6831632178'
     wordPressLoginVersion = '1.16.0'


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6978
- https://github.com/WordPress/gutenberg/pull/63426
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23417

Fixes an issue with the Gallery block displaying an invalid type error when adding images.

-----

## To Test:

Check the Gutenberg PR description.

-----

## Regression Notes

1. Potential unintended areas of impact

    - It affects only the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - Manual testing.

3. What automated tests I added (or what prevented me from doing so)

    - No new tests were added.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
