### PR TITLE
[Tooling] Move locales validation to the main lint task

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -28,12 +28,14 @@ steps:
       - label: "🕵️ Lint WordPress"
         key: wplint
         command: ".buildkite/commands/lint.sh wordpress"
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
       - label: "🕵️ Lint Jetpack"
         key: jplint
         command: ".buildkite/commands/lint.sh jetpack"
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -eu
 
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :globe_with_meridians: Localization check"
+bundle exec fastlane check_locales_consistency app:$1
+
 echo "--- :microscope: Linting"
 cp gradle.properties-example gradle.properties
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -4,7 +4,7 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :globe_with_meridians: Localization check"
-bundle exec fastlane check_locales_consistency app:$1
+bundle exec fastlane check_declared_locales_consistency app:$1
 
 echo "--- :microscope: Linting"
 cp gradle.properties-example gradle.properties

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -3,11 +3,13 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :globe_with_meridians: Localization check"
-bundle exec fastlane check_declared_locales_consistency app:$1
+echo "--- : clipboard: Copying gradle.properties"
+cp gradle.properties-example gradle.properties
+
+echo "--- :globe_with_meridians: Check Locales Declaration Consistency"
+bundle exec fastlane check_declared_locales_consistency app:"$1"
 
 echo "--- :microscope: Linting"
-cp gradle.properties-example gradle.properties
 
 if [ "$1" = "wordpress" ]; then
 	./gradlew lintWordpressVanillaRelease

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -3,7 +3,7 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- : clipboard: Copying gradle.properties"
+echo "--- :clipboard: Copying gradle.properties"
 cp gradle.properties-example gradle.properties
 
 echo "--- :globe_with_meridians: Check Locales Declaration Consistency"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,11 +55,13 @@ steps:
 
       - label: "🕵️ Lint WordPress"
         command: ".buildkite/commands/lint.sh wordpress"
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
       - label: "🕵️ Lint Jetpack"
         command: ".buildkite/commands/lint.sh jetpack"
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -30,6 +30,7 @@ steps:
         key: wplint
         command: ".buildkite/commands/lint.sh wordpress"
         priority: 1
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
@@ -37,6 +38,7 @@ steps:
         key: jplint
         command: ".buildkite/commands/lint.sh jetpack"
         priority: 1
+        plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -41,9 +41,9 @@ steps:
           - "**/build/reports/lint-results*.*"
 
   #################
-  # Beta Builds
+  # Release Builds
   #################
-  - group: "🚀 Beta Builds"
+  - group: "🚀 Release Builds"
     steps:
 
       - label: ":wordpress: :android: Release Build"

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -378,7 +378,7 @@ platform :android do
     resource_configs = output.match(/^#{app}: \[(.*)\]$/)&.captures&.first&.gsub(' ', '')&.split(',')&.sort
     if resource_configs.nil? || resource_configs.empty?
       UI.message("No `resourceConfigurations` field set in `build.gradle` for the `#{app}` flavor. Nothing to check.")
-      return
+      next
     end
 
     locales_list = { 'wordpress' => WP_APP_LOCALES, 'jetpack' => JP_APP_LOCALES }.fetch(app, nil)

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -337,7 +337,6 @@ platform :android do
   #####################################################################################
   lane :download_translations do
     # WordPress strings
-    check_declared_locales_consistency(app_flavor: 'wordpress', locales_list: WP_APP_LOCALES)
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'main', 'res'),
       glotpress_url: APP_SPECIFIC_VALUES[:wordpress][:glotpress_appstrings_project],
@@ -345,12 +344,19 @@ platform :android do
     )
 
     # Jetpack strings
-    check_declared_locales_consistency(app_flavor: 'jetpack', locales_list: JP_APP_LOCALES)
     android_download_translations(
       res_dir: File.join('WordPress', 'src', 'jetpack', 'res'),
       glotpress_url: APP_SPECIFIC_VALUES[:jetpack][:glotpress_appstrings_project],
       locales: JP_APP_LOCALES
     )
+  end
+
+  lane :check_locales_consistency do |app:|
+    validate_app_name!(app)
+
+    app_locales = { 'wordpress' => WP_APP_LOCALES, 'jetpack' => JP_APP_LOCALES }.fetch(app, nil)
+
+    check_declared_locales_consistency(app_flavor: app, locales_list: app_locales)
   end
 
   # Updates the `.po` file at the given `po_path` using the content of the `sources` files, interpolating `release_version` where appropriate.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -374,8 +374,6 @@ platform :android do
   lane :check_declared_locales_consistency do |app:|
     validate_app_name!(app)
 
-    locales_list = { 'wordpress' => WP_APP_LOCALES, 'jetpack' => JP_APP_LOCALES }.fetch(app, nil)
-
     output = gradle(task: 'printResourceConfigurations', flags: '--quiet')
     resource_configs = output.match(/^#{app}: \[(.*)\]$/)&.captures&.first&.gsub(' ', '')&.split(',')&.sort
     if resource_configs.nil? || resource_configs.empty?
@@ -383,6 +381,7 @@ platform :android do
       return
     end
 
+    locales_list = { 'wordpress' => WP_APP_LOCALES, 'jetpack' => JP_APP_LOCALES }.fetch(app, nil)
     expected_locales = locales_list.map { |l| l[:android] }
     # Support for legacy locale codes
     expected_locales << 'in' if expected_locales.include?('id')

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -482,9 +482,13 @@ platform :android do
   #####################################################################################
   def get_app_name_option!(options)
     app = options[:app]&.downcase
+    validate_app_name!(app)
+    app
+  end
+
+  def validate_app_name!(app)
     UI.user_error!("Missing 'app' parameter. Expected 'app:wordpress' or 'app:jetpack'") if app.nil?
     UI.user_error!("Invalid 'app' parameter #{app.inspect}. Expected 'wordpress' or 'jetpack'") unless %i[wordpress jetpack].include?(app.to_sym)
-    app
   end
 
   def release_notes_path(app)


### PR DESCRIPTION
The goal of this PR is to avoid Gradle tasks running during release-on-CI lanes, namely `new_beta_release` and `finalize_release`.

Those two lanes called `download_translations`, which ran a `check_declared_locales_consistency` validation before downloading the new strings.
`check_declared_locales_consistency` triggered a Gradle task, which won't run successfully in the trusted agents now being used for the release.

This PR extracts the validation to the main lint task.

-----

## Testing:

You can test the new validation lane by running `bundle exec fastlane check_locales_consistency app:jetpack`, for example.

The full flow for `new_beta_release` / `finalize_release` needs to be tested in the context of a release (it could run locally if the calls generating side effects are commented out).