### PR TITLE
Catch ZipException when inflating

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.kt
@@ -26,6 +26,7 @@ import java.util.Date
 import java.util.EnumSet
 import java.util.zip.DataFormatException
 import java.util.zip.Inflater
+import java.util.zip.ZipException
 
 class Note {
     val id: String
@@ -416,6 +417,9 @@ class Note {
                 length
             } catch (e: DataFormatException) {
                 AppLog.e(AppLog.T.NOTIFS, "Can't decompress the PN BlockListPayload. It could be > 4K", e)
+                0
+            } catch (e: ZipException) {
+                AppLog.e(AppLog.T.NOTIFS, "Can't decompress the PN BlockListPayload. Possible zip traversal exploit", e)
                 0
             }
             val out: String? = try {

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.kt
@@ -419,7 +419,7 @@ class Note {
                 AppLog.e(AppLog.T.NOTIFS, "Can't decompress the PN BlockListPayload. It could be > 4K", e)
                 0
             } catch (e: ZipException) {
-                AppLog.e(AppLog.T.NOTIFS, "Can't decompress the PN BlockListPayload. Possible zip traversal exploit", e)
+                AppLog.e(AppLog.T.NOTIFS, "Can't decompress the PN BlockListPayload.", e)
                 0
             }
             val out: String? = try {


### PR DESCRIPTION
Fixes #21040 

One change in Android 14 is that a `ZipException` may be thrown during ZIP inflation due to the [ZIP traversal exploit](https://developer.android.com/about/versions/14/behavior-changes-14#zip-path-traversal). 

Scanning our code base I found only a single instance of ZIP inflation, so this small PR addresses this one situation. Note that since the ZIP is opened via `setInput` with a `ByteArray` as opposed to from a file, this exploit may not even be a possibility. However, I felt the exception handling should still be added for safety.