### PR TITLE
Android 14 broadcast export behavior

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -11,6 +11,7 @@ import android.app.NotificationManager
 import android.app.SyncNotedAppOp
 import android.content.ComponentCallbacks2
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.IntentFilter
 import android.content.res.Configuration
 import android.database.SQLException
@@ -114,7 +115,6 @@ import org.wordpress.android.widgets.AppReviewManager
 import org.wordpress.android.workers.WordPressWorkersFactory
 import java.io.File
 import java.io.IOException
-import java.lang.Exception
 import java.net.CookieManager
 import java.util.Date
 import javax.inject.Inject
@@ -887,10 +887,18 @@ class AppInitializer @Inject constructor(
             // registered with Context.registerReceiver() and that context is still valid.
             if (!connectionReceiverRegistered) {
                 connectionReceiverRegistered = true
-                application.registerReceiver(
-                    ConnectionChangeReceiver.getInstance(),
-                    IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-                )
+                if (Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    application.registerReceiver(
+                        ConnectionChangeReceiver.getInstance(),
+                        IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
+                        RECEIVER_NOT_EXPORTED
+                    )
+                } else {
+                    application.registerReceiver(
+                        ConnectionChangeReceiver.getInstance(),
+                        IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+                    )
+                }
             }
             AnalyticsUtils.refreshMetadata(accountStore, siteStore)
             applicationOpenedDate = Date()

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -11,7 +11,7 @@ import android.app.NotificationManager
 import android.app.SyncNotedAppOp
 import android.content.ComponentCallbacks2
 import android.content.Context
-import android.content.Context.RECEIVER_NOT_EXPORTED
+import android.content.ContextWrapper
 import android.content.IntentFilter
 import android.content.res.Configuration
 import android.database.SQLException
@@ -891,7 +891,7 @@ class AppInitializer @Inject constructor(
                     application.registerReceiver(
                         ConnectionChangeReceiver.getInstance(),
                         IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
-                        RECEIVER_NOT_EXPORTED
+                        ContextWrapper.RECEIVER_NOT_EXPORTED
                     )
                 } else {
                     application.registerReceiver(

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -891,7 +891,7 @@ class AppInitializer @Inject constructor(
                     application.registerReceiver(
                         ConnectionChangeReceiver.getInstance(),
                         IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
-                        ContextWrapper.RECEIVER_NOT_EXPORTED
+                        ContextWrapper.RECEIVER_EXPORTED
                     )
                 } else {
                     application.registerReceiver(

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -12,6 +12,7 @@ import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.text.TextUtils;
@@ -418,7 +419,11 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     @Override
     public void onStart() {
         super.onStart();
-        registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION), RECEIVER_NOT_EXPORTED);
+        } else {
+            registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+        }
         mDispatcher.register(this);
         EventBus.getDefault().register(this);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -420,7 +420,11 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     public void onStart() {
         super.onStart();
         if (Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION), RECEIVER_NOT_EXPORTED);
+            registerReceiver(
+                    mReceiver,
+                    new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
+                    RECEIVER_NOT_EXPORTED
+            );
         } else {
             registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -423,7 +423,7 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
             registerReceiver(
                     mReceiver,
                     new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION),
-                    RECEIVER_NOT_EXPORTED
+                    RECEIVER_EXPORTED
             );
         } else {
             registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/helpers/ConnectionStatusLiveData.kt
@@ -2,9 +2,12 @@ package org.wordpress.android.viewmodel.helpers
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import android.os.Build
+import android.os.Build.VERSION_CODES
 import androidx.lifecycle.LiveData
 import org.wordpress.android.util.distinct
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData.Factory
@@ -28,7 +31,11 @@ class ConnectionStatusLiveData private constructor(private val context: Context)
     override fun onActive() {
         super.onActive()
         val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-        context.registerReceiver(networkReceiver, intentFilter)
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            context.registerReceiver(networkReceiver, intentFilter, ContextWrapper.RECEIVER_EXPORTED)
+        } else {
+            context.registerReceiver(networkReceiver, intentFilter)
+        }
     }
 
     override fun onInactive() {


### PR DESCRIPTION
Fixes #21041 

After reviewing the code it appears that context-registered receivers other than these already declare their export behavior:

* AppInitializer.ConnectionChangeReceiver
* MediaBrowserActivity.mReceiver
* ConnectionStatusLiveData.networkReceiver

This PR updates those items by declaring their export behavior for Android 14 support. I used Gemini to verify the correct export flag (`RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED`).