### PR TITLE
Integrate gutenberg-mobile release v1.121.0

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,8 @@
 25.2
 -----
 * [*] Fix ability to update a published post's date [https://github.com/wordpress-mobile/WordPress-Android/pull/21036]
-
+* [**] Block editor: Fixed an issue preventing some users from editing or creating content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967]
+* [*] Block editor: Added partial prefix support for creating Headings, List, and Quote blocks [https://github.com/WordPress/gutenberg/pull/62576]
 
 25.1
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = 'v1.121.0-alpha2'
+    gutenbergMobileVersion = '6992-2ec1f526f28da566370a7b705176f6e9c0054c30'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-2d90f9a8abbb862ebc1689553006d76e44a0d3c8'
     wordPressLoginVersion = '1.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
     automatticAboutVersion = '1.4.0'
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
-    gutenbergMobileVersion = '6992-2ec1f526f28da566370a7b705176f6e9c0054c30'
+    gutenbergMobileVersion = 'v1.121.0'
     wordPressAztecVersion = 'v2.1.3'
     wordPressFluxCVersion = 'trunk-2d90f9a8abbb862ebc1689553006d76e44a0d3c8'
     wordPressLoginVersion = '1.16.0'


### PR DESCRIPTION
## Description
This PR incorporates the 1.121.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6992

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.