### PR TITLE
Feedback form: anonymous identity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -88,10 +88,10 @@ class ZendeskHelper(
     }
 
     /**
-     * If there is no identity set yet, create an anonymous one.
-     * warning: This method should only be used for interactions with Zendesk
-     * that doesn't require a confirmed identity and/or a response from support,
-     * such as sending feedback about the app.
+     * Create an anonymous identity if one hasn't been previously set.
+     * Warning: This method should only be used for interactions with
+     * Zendesk that don't require a confirmed identity or a response
+     * from support, such as sending feedback about the app.
      */
     fun createAnonymousIdentityIfNeeded() {
         if (!isIdentitySet()) {

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskHelper.kt
@@ -52,7 +52,7 @@ class ZendeskHelper(
     private val accountStore: AccountStore,
     private val siteStore: SiteStore,
     private val supportHelper: SupportHelper,
-    private val buildConfigWrapper: BuildConfigWrapper
+    private val buildConfigWrapper: BuildConfigWrapper,
 ) {
     private val zendeskInstance: Zendesk
         get() = Zendesk.INSTANCE
@@ -85,6 +85,19 @@ class ZendeskHelper(
         val identityEmail = (zendeskInstance.identity as? AnonymousIdentity)?.email
         val hasIdentityWithValidEmail = identityEmail?.let { validateEmail(it) } ?: false
         return hasValidEmail && hasIdentityWithValidEmail
+    }
+
+    /**
+     * If there is no identity set yet, create an anonymous one.
+     * warning: This method should only be used for interactions with Zendesk
+     * that doesn't require a confirmed identity and/or a response from support,
+     * such as sending feedback about the app.
+     */
+    fun createAnonymousIdentityIfNeeded() {
+        if (!isIdentitySet()) {
+            AppLog.i(T.SUPPORT, "Creating anonymous Zendesk identity")
+            zendeskInstance.setIdentity(AnonymousIdentity())
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -41,22 +41,24 @@ class FeedbackFormViewModel @Inject constructor(
             return
         }
 
-        zendeskHelper.requireIdentity(context, selectedSiteRepository.getSelectedSite()) {
-            _isProgressShowing.value = true
-            createZendeskFeedbackRequest(
-                context = context,
-                callback = object : ZendeskHelper.CreateRequestCallback() {
-                    override fun onSuccess() {
-                        _isProgressShowing.value = false
-                        onSuccess(context)
-                    }
+        //  we don't want to prompt the user for their name & email so create an anonymous
+        //  identity if it hasn't been previously set
+        zendeskHelper.createAnonymousIdentityIfNeeded()
 
-                    override fun onError(errorMessage: String?) {
-                        _isProgressShowing.value = false
-                        onFailure(context, errorMessage)
-                    }
-                })
-        }
+        _isProgressShowing.value = true
+        createZendeskFeedbackRequest(
+            context = context,
+            callback = object : ZendeskHelper.CreateRequestCallback() {
+                override fun onSuccess() {
+                    _isProgressShowing.value = false
+                    onSuccess(context)
+                }
+
+                override fun onError(errorMessage: String?) {
+                    _isProgressShowing.value = false
+                    onFailure(context, errorMessage)
+                }
+            })
     }
 
     private fun createZendeskFeedbackRequest(


### PR DESCRIPTION
This PR updates the feedback form to use an anonymous Zendesk identity if an identity hasn't been previously set.