### PR TITLE
Bump fluxc to a trunk hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     automatticTracksVersion = '5.1.0'
     gutenbergMobileVersion = 'v1.121.0'
     wordPressAztecVersion = 'v2.1.3'
-    wordPressFluxCVersion = '3067-eb4f1dd16a21b577efb727561f025d865ec5f88f'
+    wordPressFluxCVersion = 'trunk-94d25d35fb4bf58a2e90741a6a5d56b8c6c3ce42'
     wordPressLoginVersion = '1.16.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressUtilsVersion = '3.14.0'


### PR DESCRIPTION
The FluxC was updated in the PR https://github.com/wordpress-mobile/WordPress-Android/pull/21088, but it was still targeting a PR hash, to avoid any conflicts with other FluxC changes, this PR updates it to a trunk hash that includes the same changes.