### PR TITLE
Merge JUnit unit tests report

### DIFF
--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -4,15 +4,18 @@ echo "--- 🧪 Testing"
 set +e
 if [ "$1" == "wordpress" ]; then
     test_suite="testWordpressVanillaRelease koverXmlReportWordpressVanillaRelease"
-    test_log_dir="WordPress/build/test-results/*/*.xml"
+    test_results_dir="WordPress/build/test-results"
+    test_log_dir="${test_results_dir}/*/*.xml"
     code_coverage_report="WordPress/build/reports/kover/reportWordpressVanillaRelease.xml"
 elif [ "$1" == "processors" ]; then
     test_suite=":libs:processors:test :libs:processors:koverXmlReport"
-    test_log_dir="libs/processors/build/test-results/test/*.xml"
+    test_results_dir="libs/processors/build/test-results"
+    test_log_dir="${test_results_dir}/test/*.xml"
     code_coverage_report="libs/processors/build/reports/kover/report.xml"
 elif [ "$1" == "image-editor" ]; then
     test_suite=":libs:image-editor:testReleaseUnitTest :libs:image-editor:koverXmlReportRelease"
-    test_log_dir="libs/image-editor/build/test-results/testReleaseUnitTest/*.xml"
+    test_results_dir="libs/processors/build/test-results"
+    test_log_dir="${test_results_dir}/testReleaseUnitTest/*.xml"
     code_coverage_report="libs/image-editor/build/reports/kover/reportRelease.xml"
 else
     echo "Invalid Test Suite! Expected 'wordpress', 'processors', or 'image-editor', received '$1' instead"
@@ -31,7 +34,6 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
 fi
 
 echo "--- 🚦 Report Tests Status"
-test_results_dir=$(echo "$test_log_dir" | sed 's|\(.*test-results\)/.*|\1|')
 results_file="$test_results_dir/merged-test-results.xml"
 
 # Merge JUnit results into a single file (for performance reasons with reporting)

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -37,7 +37,7 @@ echo "--- 🚦 Report Tests Status"
 results_file="$test_results_dir/merged-test-results.xml"
 
 # Merge JUnit results into a single file (for performance reasons with reporting)
-merge_junit -d ${test_log_dir%/*} -o $results_file
+merge_junit_reports -d ${test_log_dir%/*} -o $results_file
 
 if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
   annotate_test_failures "$results_file" --slack "build-and-ship"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -31,7 +31,8 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
 fi
 
 echo "--- 🚦 Report Tests Status"
-results_file="WooCommerce/build/test-results/merged-test-results.xml"
+test_results_dir=$(echo "$test_log_dir" | sed 's|\(.*test-results\)/.*|\1|')
+results_file="$test_results_dir/merged-test-results.xml"
 
 # Merge JUnit results into a single file (for performance reasons with reporting)
 merge_junit -d ${test_log_dir%/*} -o $results_file

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -14,7 +14,7 @@ elif [ "$1" == "processors" ]; then
     code_coverage_report="libs/processors/build/reports/kover/report.xml"
 elif [ "$1" == "image-editor" ]; then
     test_suite=":libs:image-editor:testReleaseUnitTest :libs:image-editor:koverXmlReportRelease"
-    test_results_dir="libs/processors/build/test-results"
+    test_results_dir="libs/image-editor/build/test-results"
     test_log_dir="${test_results_dir}/testReleaseUnitTest/*.xml"
     code_coverage_report="libs/image-editor/build/reports/kover/reportRelease.xml"
 else

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@ steps:
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_WORDPRESS"
         artifact_paths:
-          - "**/build/test-results/*/*.xml"
+          - "**/build/test-results/merged-test-results.xml"
 
       - label: "🔬 Unit Test Processors"
         command: ".buildkite/commands/run-unit-tests.sh processors"
@@ -95,7 +95,7 @@ steps:
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_PROCESSORS"
         artifact_paths:
-          - "**/build/test-results/*/*.xml"
+          - "**/build/test-results/merged-test-results.xml"
 
       - label: "🔬 Unit Test Image Editor"
         command: ".buildkite/commands/run-unit-tests.sh image-editor"
@@ -105,7 +105,7 @@ steps:
               <<: *test_collector_common_params
               api-token-env-name: "BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS_IMAGE_EDITOR"
         artifact_paths:
-          - "**/build/test-results/*/*.xml"
+          - "**/build/test-results/merged-test-results.xml"
 
   #################
   # Instrumented (aka UI) Tests

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.4.2"
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#36a662c095092f5198cea98cc05d1d36a30a8551"
  export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#496c3c15d3daa81661ac502d1b3640ca288e918a"
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.0"
  export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#36a662c095092f5198cea98cc05d1d36a30a8551"
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#9cef1fa0d0766fcc1c445918ff4f803651690e50"
  export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#9cef1fa0d0766fcc1c445918ff4f803651690e50"
+ export CI_TOOLKIT="automattic/a8c-ci-toolkit#496c3c15d3daa81661ac502d1b3640ca288e918a"
  export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/WordPress/src/test/java/org/wordpress/android/util/UnifiedCommentLevelerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/UnifiedCommentLevelerTest.kt
@@ -64,7 +64,7 @@ class UnifiedCommentLevelerTest {
     fun `createLevelList creates list of comments with correct level variable`() {
         val leveledCommentList = commentLeveler.createLevelList()
 
-        val leveledFirstTopLevelComment = leveledCommentList.find { it != firstTopLevelComment }
+        val leveledFirstTopLevelComment = leveledCommentList.find { it == firstTopLevelComment }
         Assert.assertNotNull(leveledFirstTopLevelComment)
         Assert.assertEquals(0, leveledFirstTopLevelComment!!.level)
 

--- a/WordPress/src/test/java/org/wordpress/android/util/UnifiedCommentLevelerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/util/UnifiedCommentLevelerTest.kt
@@ -64,7 +64,7 @@ class UnifiedCommentLevelerTest {
     fun `createLevelList creates list of comments with correct level variable`() {
         val leveledCommentList = commentLeveler.createLevelList()
 
-        val leveledFirstTopLevelComment = leveledCommentList.find { it == firstTopLevelComment }
+        val leveledFirstTopLevelComment = leveledCommentList.find { it != firstTopLevelComment }
         Assert.assertNotNull(leveledFirstTopLevelComment)
         Assert.assertEquals(0, leveledFirstTopLevelComment!!.level)
 


### PR DESCRIPTION
Wait with merge for this PR:
- https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/103

### Description

This PR adds behavior of merging reports of unit tests into a single file before requesting Buildkite annotations or copying them for Buildkite Test Collector.

This way, these operations is far more performant. See **Impact**

### Impact

#### Buildkite annotations

| | `WordPress` | 
| -- | -- |
| Before (2069f5709555311539c94b1a3bb56670b954e072) | 4m33s |
| After | 1s |
| Diff | -99.6% 😅 |

#### Collecting artifacts

| | `WordPress` | 
| -- | -- |
| Before (2069f5709555311539c94b1a3bb56670b954e072) | 8m49s |
| After | 1s |
| Diff | -99.8% 😅 |

### Testing

Verify if the number of tests reported by Buildkite test collector (`View in Test Analytics` button on Buildkite) is the same before and after this PR.
