### PR TITLE
Hotfix: Disable the app rating dialog (25.2.1)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/AppReviewManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AppReviewManager.kt
@@ -168,11 +168,13 @@ object AppReviewManager {
      * @return true if the dialog should be shown
      */
     private fun shouldShowRateDialog(): Boolean {
-        return if (optOut or (launchTimes < CRITERIA_LAUNCH_TIMES) or (interactions < CRITERIA_INTERACTIONS)) {
+        // as of 25.2.1 we no longer want to ever show the rating dialog
+        return false
+        /*return if (optOut or (launchTimes < CRITERIA_LAUNCH_TIMES) or (interactions < CRITERIA_INTERACTIONS)) {
             false
         } else {
             Date().time - installDate.time >= criteriaInstallMs && Date().time - askLaterDate.time >= criteriaInstallMs
-        }
+        }*/
     }
 
     private fun showRateDialog(fragmentManger: FragmentManager) {


### PR DESCRIPTION
In #21102 we dropped our custom app rating dialog, then we decided the rating dialog was causing enough problems to warrant a hotfix, so this is it!

Here we simply prevent the dialog from ever being shown. Merged PR #22102 contains a more thorough implementation which removes the old rating code entirely.