### PR TITLE
Feedback form progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.compose.components
 
 import android.content.res.Configuration
+import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -60,7 +62,7 @@ fun ProgressDialog(progressDialogState: ProgressDialogState) {
                     }
                     if (progressDialogState.message != null) {
                         Text(
-                            text = progressDialogState.message,
+                            text = LocalContext.current.getString(progressDialogState.message),
                             Modifier.padding(16.dp, 0.dp, 16.dp, 16.dp),
                             color = MaterialTheme.colorScheme.onSurface
                         )
@@ -86,7 +88,7 @@ fun ProgressDialog(progressDialogState: ProgressDialogState) {
 }
 
 data class ProgressDialogState(
-    val message: String? = null,
+    @StringRes val message: Int? = null,
     val progress: Float? = null,
     val showCancel: Boolean = false,
     val dismissible: Boolean = true,
@@ -106,7 +108,7 @@ data class ProgressDialogState(
 fun ProgressDialogPreview() {
     ProgressDialog(
         progressDialogState = ProgressDialogState(
-            message = "Uploading...",
+            message = R.string.uploading,
             showCancel = true,
             progress = 50f / 100f,
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
@@ -1,0 +1,114 @@
+package org.wordpress.android.ui.compose.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.flow.Flow
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.M3Theme
+
+@Composable
+fun ProgressDialog(progressDialogState: Flow<ProgressDialogState?>) {
+    progressDialogState.collectAsState(initial = null).value?.let {
+        ProgressDialog(progressDialogState = it)
+    }
+}
+
+@Composable
+fun ProgressDialog(progressDialogState: ProgressDialogState) {
+    M3Theme {
+        val dialogProps = DialogProperties(
+            dismissOnBackPress = progressDialogState.dismissible,
+            dismissOnClickOutside = progressDialogState.dismissible,
+            usePlatformDefaultWidth = false
+        )
+        Dialog(onDismissRequest = progressDialogState.onDismiss, dialogProps) {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(8.dp))
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.defaultMinSize(100.dp, 100.dp)
+                ) {
+                    if (progressDialogState.progress != null) {
+                        CircularProgressIndicator(progress = {
+                            progressDialogState.progress
+                        }, Modifier.padding(16.dp))
+                    } else {
+                        CircularProgressIndicator(Modifier.padding(16.dp))
+                    }
+                    if (progressDialogState.message != null) {
+                        Text(
+                            text = progressDialogState.message,
+                            Modifier.padding(16.dp, 0.dp, 16.dp, 16.dp),
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    if (progressDialogState.showCancel) {
+                        OutlinedButton(
+                            onClick = progressDialogState.onDismiss,
+                            shape = RoundedCornerShape(20.dp),
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)),
+                            modifier = Modifier.padding(16.dp, 0.dp, 16.dp, 16.dp)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.cancel),
+                                Modifier.padding(2.dp),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class ProgressDialogState(
+    val message: String? = null,
+    val progress: Float? = null,
+    val showCancel: Boolean = false,
+    val dismissible: Boolean = true,
+    val onDismiss: () -> Unit = {}
+)
+
+@Preview(
+    name = "Light Mode",
+    showBackground = true
+)
+@Preview(
+    name = "Dark Mode",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun ProgressDialogPreview() {
+    ProgressDialog(
+        progressDialogState = ProgressDialogState(
+            message = "Uploading...",
+            showCancel = true,
+            progress = 50f / 100f,
+        )
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
@@ -27,7 +27,7 @@ class FeedbackFormActivity : LocaleAwareActivity() {
                 setContent {
                     FeedbackFormScreen(
                         messageText = viewModel.messageText.collectAsState(),
-                        isProgressShowing = viewModel.isProgressShowing.collectAsState(),
+                        progressDialogState = viewModel.progressDialogState.collectAsState(),
                         attachments = viewModel.attachments.collectAsState(),
                         onMessageChanged = {
                             viewModel.updateMessageText(it)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,14 +41,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.ProgressDialog
+import org.wordpress.android.ui.compose.components.ProgressDialogState
 import org.wordpress.android.ui.compose.theme.M3Theme
 import java.io.File
 
 @Composable
 fun FeedbackFormScreen(
     messageText: State<String>?,
-    isProgressShowing: State<Boolean?>,
     attachments: State<List<FeedbackFormAttachment>>,
+    progressDialogState: State<ProgressDialogState?>?,
     onMessageChanged: (String) -> Unit,
     onSubmitClick: (context: Context) -> Unit,
     onCloseClick: (context: Context) -> Unit,
@@ -75,7 +76,7 @@ fun FeedbackFormScreen(
         }
         SubmitButton(
             isEnabled = message.isNotEmpty(),
-            isProgressShowing = isProgressShowing.value,
+            progressDialogState = progressDialogState?.value,
             onClick = {
                 onSubmitClick(context)
             }
@@ -119,7 +120,7 @@ private fun MessageSection(
 private fun SubmitButton(
     onClick: () -> Unit,
     isEnabled: Boolean,
-    isProgressShowing: Boolean?,
+    progressDialogState: ProgressDialogState? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -130,18 +131,17 @@ private fun SubmitButton(
                 horizontal = H_PADDING.dp
             ),
     ) {
-        if (isProgressShowing == true) {
-            CircularProgressIndicator()
-        } else {
-            Button(
-                enabled = isEnabled,
-                onClick = onClick,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(
-                    text = stringResource(R.string.submit).uppercase(),
-                )
-            }
+        if (progressDialogState != null) {
+            ProgressDialog(progressDialogState)
+        }
+        Button(
+            enabled = isEnabled,
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(R.string.submit).uppercase(),
+            )
         }
     }
 }
@@ -282,12 +282,18 @@ private fun FeedbackFormScreenPreview() {
         tempFile = File("/tmp/attachment.jpg")
     )
     val attachments = MutableStateFlow(listOf(attachment))
-    val isProgressShowing = MutableStateFlow<Boolean?>(null)
     val messageText = MutableStateFlow("I love this app!")
+    val progressDialogState = MutableStateFlow<ProgressDialogState?>(
+        ProgressDialogState(
+            message = R.string.uploading,
+            showCancel = false,
+            progress = 50f / 100f,
+        )
+    )
 
     FeedbackFormScreen(
         messageText = messageText.collectAsState(),
-        isProgressShowing = isProgressShowing.collectAsState(),
+        progressDialogState = progressDialogState.collectAsState(),
         attachments = attachments.collectAsState(),
         onMessageChanged = {},
         onSubmitClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -115,7 +115,8 @@ class FeedbackFormViewModel @Inject constructor(
         _progressDialogState.value =
             ProgressDialogState(
                 message = message,
-                showCancel = false
+                showCancel = false,
+                dismissible = false
             )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -223,7 +223,8 @@ class FeedbackFormViewModel @Inject constructor(
     }
 
     /**
-     * Uploads the attachments to Zendesk
+     * Uploads the attachments to Zendesk and builds a list of their tokens. The passed
+     * completion handler will be called once all attachments have been uploaded.
      */
     private fun uploadAttachments(
         completionHandler: () -> Unit

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="status_and_visibility">Status &amp; Visibility</string>
     <string name="free">Free</string>
     <string name="dismiss">Dismiss</string>
+    <string name="sending">Sending</string>
 
     <string name="button_not_now">Not now</string>
     <string name="button_skip">Skip</string>


### PR DESCRIPTION
As part of #21105, this PR replaces the circular progress on the feedback form with a re-usable Compose progress dialog.


https://github.com/user-attachments/assets/6922d74d-b32c-4091-85b9-31f2a91aab2d

