### PR TITLE
Feedback form: suspend while uploading

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -35,8 +35,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.support
 
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.extensions.mimeType
@@ -10,24 +11,22 @@ import zendesk.support.UploadResponse
 import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/UploadProvider.html
  */
 class ZendeskUploadHelper @Inject constructor() {
-
     /**
      * Uploads multiple attachments to Zendesk and returns a list of their tokens when completed
      */
     suspend fun uploadFileAttachments(
         files: List<File>,
-    ) = suspendCoroutine { continuation ->
+    ) = suspendCancellableCoroutine { continuation ->
         val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
         if (uploadProvider == null) {
             AppLog.e(T.SUPPORT, "Upload provider is null")
             continuation.resume(null)
-            return@suspendCoroutine
+            return@suspendCancellableCoroutine
         }
 
         val tokens = ArrayList<String>()

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -16,40 +16,6 @@ import kotlin.coroutines.suspendCoroutine
  * https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/UploadProvider.html
  */
 class ZendeskUploadHelper @Inject constructor() {
-    /**
-     * Uploads a single file attachment to Zendesk and returns the token upon completion
-     */
-    @Suppress("unused")
-    suspend fun uploadFileAttachment(
-        file: File,
-        mimeType: String,
-    ) = suspendCoroutine { continuation ->
-        val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
-        if (uploadProvider == null) {
-            AppLog.e(T.SUPPORT, "Upload provider is null")
-            continuation.resume(null)
-            return@suspendCoroutine
-        }
-
-        val callback = object : ZendeskCallback<UploadResponse>() {
-            override fun onSuccess(result: UploadResponse) {
-                continuation.resume(result.token)
-            }
-
-            override fun onError(errorResponse: ErrorResponse?) {
-                AppLog.e(
-                    T.SUPPORT, "Uploading to Zendesk failed with ${errorResponse?.reason}"
-                )
-                continuation.resume(null)
-            }
-        }
-        uploadProvider.uploadAttachment(
-            file.name,
-            file,
-            mimeType,
-            callback
-        )
-    }
 
     /**
      * Uploads multiple attachments to Zendesk and returns a list of their tokens when completed

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -2,12 +2,15 @@ package org.wordpress.android.support
 
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
+import kotlinx.coroutines.DefaultExecutor.enqueue
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import zendesk.support.Support
 import zendesk.support.UploadResponse
 import java.io.File
 import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/UploadProvider.html
@@ -16,7 +19,7 @@ class ZendeskUploadHelper @Inject constructor() {
     /**
      * Uploads an attachment to Zendesk. Note that the UploadResponse will contain the attachment token.
      */
-    fun uploadAttachment(
+    private fun uploadAttachment(
         file: File,
         mimeType: String,
         callback: ZendeskCallback<UploadResponse>,
@@ -27,6 +30,35 @@ class ZendeskUploadHelper @Inject constructor() {
             return
         }
         uploadProvider.uploadAttachment(
+            file.name,
+            file,
+            mimeType,
+            callback
+        )
+    }
+
+    suspend fun uploadAttachment(
+        file: File,
+        mimeType: String,
+    ) = suspendCoroutine<String?> { continuation ->
+        val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
+        if (uploadProvider == null) {
+            AppLog.e(T.SUPPORT, "Upload provider is null")
+            continuation.resume(null)
+        }
+        val callback = object : ZendeskCallback<UploadResponse>() {
+            override fun onSuccess(result: UploadResponse) {
+                continuation.resume(result.token)
+            }
+
+            override fun onError(errorResponse: ErrorResponse?) {
+                AppLog.e(
+                    T.SUPPORT, "Uploading to Zendesk failed with ${errorResponse?.reason}"
+                )
+                continuation.resume(null)
+            }
+        }
+        uploadProvider!!.uploadAttachment(
             file.name,
             file,
             mimeType,

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.support
 
 import com.zendesk.service.ErrorResponse
 import com.zendesk.service.ZendeskCallback
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.extensions.mimeType
@@ -11,6 +10,7 @@ import zendesk.support.UploadResponse
 import java.io.File
 import javax.inject.Inject
 import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 /**
  * https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/UploadProvider.html
@@ -21,12 +21,12 @@ class ZendeskUploadHelper @Inject constructor() {
      */
     suspend fun uploadFileAttachments(
         files: List<File>,
-    ) = suspendCancellableCoroutine { continuation ->
+    ) = suspendCoroutine { continuation ->
         val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
         if (uploadProvider == null) {
             AppLog.e(T.SUPPORT, "Upload provider is null")
             continuation.resume(null)
-            return@suspendCancellableCoroutine
+            return@suspendCoroutine
         }
 
         val tokens = ArrayList<String>()

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/FileExt.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/FileExt.kt
@@ -1,0 +1,11 @@
+package org.wordpress.android.util.extensions
+
+import android.webkit.MimeTypeMap
+import com.google.common.io.Files
+import java.io.File
+
+fun File.mimeType(): String? {
+    @Suppress("UnstableApiUsage") val extension = Files.getFileExtension(this.name)
+    return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+}
+


### PR DESCRIPTION
As part of #21105, this PR redoes the attachment upload to use a `suspend` function with a `continuation` that returns the list of attachment tokens once all uploads completes. This is more reliable than the previous approach, and hopefully gets us closer to making the upload cancellable.