### PR TITLE
Bump `checkstyle` to `10.17.0` 

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
@@ -9,12 +9,12 @@ import org.wordpress.android.fluxc.network.UserAgent;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
-
-import dagger.hilt.android.testing.HiltAndroidRule;
-import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class UserAgentTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/AuthenticatorRequestTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/AuthenticatorRequestTest.java
@@ -7,10 +7,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.wordpress.android.FactoryUtils;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class AuthenticatorRequestTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/WPNetworkImageViewTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/WPNetworkImageViewTest.java
@@ -17,10 +17,10 @@ import org.wordpress.android.util.AppLog.T;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.TestCase.assertTrue;
-
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
+
+import static junit.framework.TestCase.assertTrue;
 
 @HiltAndroidTest
 public class WPNetworkImageViewTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/support/BaseTest.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import dagger.hilt.android.testing.HiltAndroidRule;
+
 import static androidx.compose.ui.test.junit4.AndroidComposeTestRule_androidKt.createComposeRule;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesTypes;
@@ -55,8 +57,6 @@ import static org.wordpress.android.BuildConfig.E2E_SELF_HOSTED_USER_SITE_ADDRES
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_EMAIL;
 import static org.wordpress.android.BuildConfig.E2E_WP_COM_USER_PASSWORD;
 import static org.wordpress.android.support.WPSupportUtils.isElementDisplayed;
-
-import dagger.hilt.android.testing.HiltAndroidRule;
 
 public class BaseTest {
     static final String TAG = BaseTest.class.getSimpleName();

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/NotesParseTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/NotesParseTest.java
@@ -5,11 +5,11 @@ import android.text.Spanned;
 import org.junit.Test;
 import org.wordpress.android.util.HtmlUtils;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class NotesParseTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
@@ -2,11 +2,11 @@ package org.wordpress.android.ui.posts;
 
 import org.junit.Test;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class PostUtilsTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/JPScreenshotTest.java
@@ -26,6 +26,11 @@ import org.wordpress.android.util.image.ImageType;
 
 import java.util.Locale;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+import tools.fastlane.screengrab.locale.LocaleTestRule;
+
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -53,11 +58,6 @@ import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElem
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 import static org.wordpress.android.support.WPSupportUtils.waitForImagesOfTypeWithPlaceholder;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
-import tools.fastlane.screengrab.Screengrab;
-import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
-import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 @LargeTest
 @HiltAndroidTest

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/screenshots/WPScreenshotTest.java
@@ -23,6 +23,11 @@ import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.UiTestingUtils;
 import org.wordpress.android.util.image.ImageType;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+import tools.fastlane.screengrab.locale.LocaleTestRule;
+
 import static org.wordpress.android.support.WPSupportUtils.clickOn;
 import static org.wordpress.android.support.WPSupportUtils.clickOnViewWithTag;
 import static org.wordpress.android.support.WPSupportUtils.getCurrentActivity;
@@ -37,11 +42,6 @@ import static org.wordpress.android.support.WPSupportUtils.waitForAtLeastOneElem
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayed;
 import static org.wordpress.android.support.WPSupportUtils.waitForElementToBeDisplayedWithoutFailure;
 import static org.wordpress.android.support.WPSupportUtils.waitForImagesOfTypeWithPlaceholder;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
-import tools.fastlane.screengrab.Screengrab;
-import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
-import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 @LargeTest
 @HiltAndroidTest

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/AutolinkUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/AutolinkUtilsTest.java
@@ -4,10 +4,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertEquals;
-
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
+
+import static junit.framework.TestCase.assertEquals;
 
 @HiltAndroidTest
 public class AutolinkUtilsTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
@@ -2,9 +2,9 @@ package org.wordpress.android.util;
 
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertEquals;
-
 import dagger.hilt.android.testing.HiltAndroidTest;
+
+import static junit.framework.TestCase.assertEquals;
 
 @HiltAndroidTest
 public class UrlUtilsTest {

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
@@ -7,10 +7,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import dagger.hilt.android.testing.HiltAndroidTest;
+
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-
-import dagger.hilt.android.testing.HiltAndroidTest;
 
 @HiltAndroidTest
 public class WPUrlUtilsTest {

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -49,6 +49,7 @@ import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import dagger.hilt.components.SingletonComponent;
 import kotlinx.coroutines.CoroutineScope;
+
 import static org.wordpress.android.modules.ThreadModuleKt.APPLICATION_SCOPE;
 
 @InstallIn(SingletonComponent.class)

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -20,9 +20,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.push.GCMMessageHandler.PUSH_TYPE_ZENDESK;
-
 import dagger.hilt.android.AndroidEntryPoint;
+
+import static org.wordpress.android.push.GCMMessageHandler.PUSH_TYPE_ZENDESK;
 
 @AndroidEntryPoint
 public class GCMMessageService extends FirebaseMessagingService {

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -55,10 +55,10 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.push.NotificationPushIds.GROUP_NOTIFICATION_ID;
 import static org.wordpress.android.push.NotificationPushIds.QUICK_START_REMINDER_NOTIFICATION_ID;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * service which makes it possible to process Notifications quick actions in the background,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -85,12 +85,12 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.util.ActivityUtils.hideKeyboard;
-
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
 import dagger.hilt.android.AndroidEntryPoint;
+
+import static org.wordpress.android.util.ActivityUtils.hideKeyboard;
 
 @AndroidEntryPoint
 public class LoginActivity extends LocaleAwareActivity implements ConnectionCallbacks, OnConnectionFailedListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -43,9 +43,9 @@ import org.wordpress.android.widgets.WPViewPagerTransformer;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.comments.unified.CommentConstants.COMMENTS_PER_PAGE;
-
 import dagger.hilt.android.AndroidEntryPoint;
+
+import static org.wordpress.android.ui.comments.unified.CommentConstants.COMMENTS_PER_PAGE;
 
 /**
  * @deprecated

--- a/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/deeplinks/DeepLinkingIntentReceiverActivity.java
@@ -27,10 +27,10 @@ import org.wordpress.android.util.extensions.CompatExtensionsKt;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.WordPress.getContext;
 import static org.wordpress.android.ui.main.WPMainActivity.ARG_BYPASS_MIGRATION;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * An activity to handle deep linking and intercepting links like:

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -185,17 +185,17 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function3;
+
 import static androidx.lifecycle.Lifecycle.State.STARTED;
 import static org.wordpress.android.WordPress.SITE;
 import static org.wordpress.android.fluxc.store.SiteStore.CompleteQuickStartVariant.NEXT_STEPS;
 import static org.wordpress.android.login.LoginAnalyticsListener.CreatedAccountSource.EMAIL;
 import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 import static org.wordpress.android.ui.JetpackConnectionSource.NOTIFICATIONS;
-
-import dagger.hilt.android.AndroidEntryPoint;
-import kotlin.Unit;
-import kotlin.jvm.functions.Function0;
-import kotlin.jvm.functions.Function3;
 
 /**
  * Main activity which hosts sites, reader, me and notifications pages

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -53,9 +53,9 @@ import java.util.Locale;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import static org.wordpress.android.modules.ThreadModuleKt.APPLICATION_SCOPE;
-
 import kotlinx.coroutines.CoroutineScope;
+
+import static org.wordpress.android.modules.ThreadModuleKt.APPLICATION_SCOPE;
 
 /**
  * An adapter for the media gallery grid.

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -76,13 +76,13 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
 import static org.wordpress.android.models.Note.NOTE_COMMENT_TYPE;
 import static org.wordpress.android.models.Note.NOTE_FOLLOW_TYPE;
 import static org.wordpress.android.models.Note.NOTE_LIKE_TYPE;
 import static org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter.IS_TAPPED_ON_NOTIFICATION;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 @SuppressWarnings("deprecation")

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -62,10 +62,10 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import kotlin.Unit;
+
 import static com.google.android.material.textfield.TextInputLayout.END_ICON_DROPDOWN_MENU;
 import static com.google.android.material.textfield.TextInputLayout.END_ICON_NONE;
-
-import kotlin.Unit;
 
 public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFragment.OnRoleSelectListener,
         PeopleManagementActivity.InvitationSender {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -113,9 +113,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.prefs.WPComSiteSettings.supportsJetpackSiteAcceleratorSettings;
-
 import kotlin.Triple;
+
+import static org.wordpress.android.ui.prefs.WPComSiteSettings.supportsJetpackSiteAcceleratorSettings;
 
 /**
  * Allows interfacing with WordPress site settings. Works with WP.com and WP.org v4.5+ (pending).

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -26,9 +26,9 @@ import org.wordpress.android.util.ToastUtils;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeConstantsKt.TWITTER_DEPRECATION_FIND_OUT_MORE_URL;
-
 import kotlin.Unit;
+
+import static org.wordpress.android.ui.publicize.PublicizeTwitterDeprecationNoticeConstantsKt.TWITTER_DEPRECATION_FIND_OUT_MORE_URL;
 
 public class PublicizeDetailFragment extends PublicizeBaseFragment
         implements PublicizeConnectionAdapter.OnAdapterLoadedListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -56,10 +56,10 @@ import org.wordpress.android.util.image.ImageType;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.ENABLE_POST_SHARING;
-
 import dagger.hilt.android.AndroidEntryPoint;
 import kotlin.Unit;
+
+import static org.wordpress.android.fluxc.store.QuickStartStore.QuickStartNewSiteTask.ENABLE_POST_SHARING;
 
 @AndroidEntryPoint
 public class PublicizeListFragment extends PublicizeBaseFragment {

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -26,9 +26,9 @@ import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
-
 import dagger.hilt.android.AndroidEntryPoint;
+
+import static org.wordpress.android.push.NotificationsProcessingService.ARG_NOTIFICATION_TYPE;
 
 @AndroidEntryPoint
 public class QuickStartReminderReceiver extends BroadcastReceiver {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -96,14 +96,14 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+import kotlin.Unit;
+
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_REPLY;
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_SELECTION_END;
 import static org.wordpress.android.ui.CommentFullScreenDialogFragment.RESULT_SELECTION_START;
 import static org.wordpress.android.ui.reader.FollowConversationUiStateKt.FOLLOW_CONVERSATION_UI_STATE_FLAGS_KEY;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
-
-import dagger.hilt.android.AndroidEntryPoint;
-import kotlin.Unit;
 
 @AndroidEntryPoint
 public class ReaderCommentListActivity extends LocaleAwareActivity implements OnConfirmListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -153,11 +153,11 @@ import java.util.Stack;
 
 import javax.inject.Inject;
 
+import kotlin.Unit;
+
 import static androidx.lifecycle.LifecycleOwnerKt.getLifecycleScope;
 import static org.wordpress.android.fluxc.generated.AccountActionBuilder.newUpdateSubscriptionNotificationPostAction;
 import static org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType.INTERNAL;
-
-import kotlin.Unit;
 
 public class ReaderPostListFragment extends ViewPagerFragment
         implements ReaderInterfaces.OnPostSelectedListener,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -98,10 +98,10 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.ui.main.WPMainActivity.ARG_OPEN_PAGE;
 import static org.wordpress.android.ui.main.WPMainActivity.ARG_READER;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 /*
  * shows reader post detail fragments in a ViewPager - primarily used for easy swiping between

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -13,6 +13,8 @@ import org.wordpress.android.util.AppLog;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_FEED_ID;
@@ -22,8 +24,6 @@ import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceSta
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_TAGTYPE;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_TITLE;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * service which updates posts with specific tags or in specific blogs/feeds - relies on

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -12,13 +12,13 @@ import org.wordpress.android.util.AppLog;
 
 import javax.inject.Inject;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_FEED_ID;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG;
 import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
-
-import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * service which updates posts with specific tags or in specific blogs/feeds - relies on

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ allprojects {
     }
 
     checkstyle {
-        toolVersion = '8.29'
+        toolVersion = '10.17.0'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -165,7 +165,7 @@ allprojects {
     }
 
     checkstyle {
-        toolVersion = '8.3'
+        toolVersion = '8.29'
         configFile file("${project.rootDir}/config/checkstyle.xml")
     }
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -119,6 +119,17 @@
       <property name="severity" value="error"/>
     </module>
 
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <!-- what is a good max value? -->
+        <property name="max" value="120"/>
+        <!-- ignore lines like "$File: //depot/... $" -->
+        <property name="ignorePattern" value="\$File.*\$"/>
+        <property name="severity" value="error"/>
+    </module>
+
     <module name="TreeWalker">
 
         <!-- Checks for Naming Conventions.                  -->
@@ -173,13 +184,6 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-          <!-- what is a good max value? -->
-          <property name="max" value="120"/>
-          <!-- ignore lines like "$File: //depot/... $" -->
-          <property name="ignorePattern" value="\$File.*\$"/>
-          <property name="severity" value="error"/>
-        </module>
         <module name="MethodLength">
           <property name="tokens" value="METHOD_DEF"/>
           <!-- TODO: We should set this value around 40 or 50 -->

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -125,8 +125,8 @@
         <property name="fileExtensions" value="java"/>
         <!-- what is a good max value? -->
         <property name="max" value="120"/>
-        <!-- ignore lines like "$File: //depot/... $" -->
-        <property name="ignorePattern" value="\$File.*\$"/>
+        <!-- ignore lines like "$File: //depot/... $ and package or import statements" -->
+        <property name="ignorePattern" value="\$File.*\$|^(package|import) .*"/>
         <property name="severity" value="error"/>
     </module>
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -119,8 +119,6 @@
       <property name="severity" value="error"/>
     </module>
 
-    <!-- Checks for Size Violations.                    -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
         <!-- what is a good max value? -->


### PR DESCRIPTION
This PR bumps `checkstyle` to the newest stable version to address

- https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/90
- https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/28

Since this is a significant upgrade (2 major versions), additional configuration update was necessary. It's documented on PR comments.

## To Test:
Green light from CI should be just fine.
