### PR TITLE
Feedback form: suspend cancel upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -19,15 +19,15 @@ import kotlin.coroutines.resumeWithException
  */
 class ZendeskUploadHelper @Inject constructor() {
     /**
-     * Uploads multiple attachments to Zendesk and returns a list of their tokens when completed
+     * Uploads multiple file attachments to Zendesk and returns a list of their tokens when
+     * all uploads have completed
      */
     suspend fun uploadFileAttachments(
-        files: List<File>,
+        files: List<File>
     ) = suspendCancellableCoroutine { continuation ->
         val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
         if (uploadProvider == null) {
-            AppLog.e(T.SUPPORT, "Upload provider is null")
-            continuation.resumeWithException(IOException("Unable to upload attachments"))
+            continuation.resumeWithException(IOException("Unable to upload attachments (null provider)"))
             return@suspendCancellableCoroutine
         }
 
@@ -48,9 +48,8 @@ class ZendeskUploadHelper @Inject constructor() {
             }
 
             override fun onError(errorResponse: ErrorResponse?) {
-                AppLog.e(T.SUPPORT, "Uploading to Zendesk failed with ${errorResponse?.reason}")
                 if (continuation.isActive) {
-                    continuation.resumeWithException(IOException("Uploading to Zendesk failed"))
+                    continuation.resumeWithException(IOException("Uploading to Zendesk failed with ${errorResponse?.reason}"))
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -49,7 +49,9 @@ class ZendeskUploadHelper @Inject constructor() {
 
             override fun onError(errorResponse: ErrorResponse?) {
                 if (continuation.isActive) {
-                    continuation.resumeWithException(IOException("Uploading to Zendesk failed with ${errorResponse?.reason}"))
+                    continuation.resumeWithException(
+                        IOException("Uploading to Zendesk failed with ${errorResponse?.reason}")
+                    )
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/support/ZendeskUploadHelper.kt
@@ -9,8 +9,10 @@ import org.wordpress.android.util.extensions.mimeType
 import zendesk.support.Support
 import zendesk.support.UploadResponse
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * https://zendesk.github.io/mobile_sdk_javadocs/supportv2/v301/index.html?zendesk/support/UploadProvider.html
@@ -25,33 +27,31 @@ class ZendeskUploadHelper @Inject constructor() {
         val uploadProvider = Support.INSTANCE.provider()?.uploadProvider()
         if (uploadProvider == null) {
             AppLog.e(T.SUPPORT, "Upload provider is null")
-            continuation.resume(null)
+            continuation.resumeWithException(IOException("Unable to upload attachments"))
             return@suspendCancellableCoroutine
         }
 
         val tokens = ArrayList<String>()
         var numAttachments = files.size
 
-        fun decAttachments() {
-            numAttachments--
-            if (numAttachments <= 0) {
-                continuation.resume(tokens)
-            }
-        }
-
         val callback = object : ZendeskCallback<UploadResponse>() {
             override fun onSuccess(result: UploadResponse) {
-                result.token?.let {
-                    tokens.add(it)
+                if (continuation.isActive) {
+                    result.token?.let {
+                        tokens.add(it)
+                    }
+                    numAttachments--
+                    if (numAttachments <= 0) {
+                        continuation.resume(tokens)
+                    }
                 }
-                decAttachments()
             }
 
             override fun onError(errorResponse: ErrorResponse?) {
-                AppLog.e(
-                    T.SUPPORT, "Uploading to Zendesk failed with ${errorResponse?.reason}"
-                )
-                decAttachments()
+                AppLog.e(T.SUPPORT, "Uploading to Zendesk failed with ${errorResponse?.reason}")
+                if (continuation.isActive) {
+                    continuation.resumeWithException(IOException("Uploading to Zendesk failed"))
+                }
             }
         }
         for (file in files) {
@@ -79,8 +79,8 @@ class ZendeskUploadHelper @Inject constructor() {
                 AppLog.i(T.SUPPORT, "Successfully deleted Zendesk attachment")
             }
 
-            override fun onError(error: ErrorResponse?) {
-                AppLog.e(T.SUPPORT, "Unable to delete Zendesk attachment")
+            override fun onError(errorResponse: ErrorResponse?) {
+                AppLog.e(T.SUPPORT, "Unable to delete Zendesk attachment: ${errorResponse?.reason}")
             }
         })
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -76,11 +76,13 @@ fun FeedbackFormScreen(
         }
         SubmitButton(
             isEnabled = message.isNotEmpty(),
-            progressDialogState = progressDialogState?.value,
             onClick = {
                 onSubmitClick(context)
             }
         )
+        progressDialogState?.value?.let {
+            ProgressDialog(it)
+        }
     }
     Screen(
         content = content,
@@ -120,7 +122,6 @@ private fun MessageSection(
 private fun SubmitButton(
     onClick: () -> Unit,
     isEnabled: Boolean,
-    progressDialogState: ProgressDialogState? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -131,9 +132,6 @@ private fun SubmitButton(
                 horizontal = H_PADDING.dp
             ),
     ) {
-        if (progressDialogState != null) {
-            ProgressDialog(progressDialogState)
-        }
         Button(
             enabled = isEnabled,
             onClick = onClick,
@@ -273,7 +271,7 @@ private fun Screen(
 )
 @Composable
 private fun FeedbackFormScreenPreview() {
-    val attachment = FeedbackFormAttachment(
+    val attachment1 = FeedbackFormAttachment(
         uri = Uri.parse("https://via.placeholder.com/150"),
         attachmentType = FeedbackFormAttachmentType.IMAGE,
         size = 123456789,
@@ -281,13 +279,22 @@ private fun FeedbackFormScreenPreview() {
         mimeType = "image/jpeg",
         tempFile = File("/tmp/attachment.jpg")
     )
-    val attachments = MutableStateFlow(listOf(attachment))
+    val attachment2 = FeedbackFormAttachment(
+        uri = Uri.parse("https://via.placeholder.com/150"),
+        attachmentType = FeedbackFormAttachmentType.VIDEO,
+        size = 123456789,
+        displayName = "attachment.mp4 (12.4 MB)",
+        mimeType = "video/mp4",
+        tempFile = File("/tmp/attachment.mp4")
+    )
+    val attachments = MutableStateFlow(listOf(attachment1, attachment2))
     val messageText = MutableStateFlow("I love this app!")
     val progressDialogState = MutableStateFlow<ProgressDialogState?>(
         ProgressDialogState(
             message = R.string.uploading,
             showCancel = false,
             progress = 50f / 100f,
+            dismissible = false,
         )
     )
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -275,7 +275,7 @@ private fun FeedbackFormScreenPreview() {
         uri = Uri.parse("https://via.placeholder.com/150"),
         attachmentType = FeedbackFormAttachmentType.IMAGE,
         size = 123456789,
-        displayName = "attachment.jpg (1.2 MB)",
+        displayName = "IMAGE_1 (1.2 MB)",
         mimeType = "image/jpeg",
         tempFile = File("/tmp/attachment.jpg")
     )
@@ -283,7 +283,7 @@ private fun FeedbackFormScreenPreview() {
         uri = Uri.parse("https://via.placeholder.com/150"),
         attachmentType = FeedbackFormAttachmentType.VIDEO,
         size = 123456789,
-        displayName = "attachment.mp4 (12.4 MB)",
+        displayName = "VIDEO_1 (12.4 MB)",
         mimeType = "video/mp4",
         tempFile = File("/tmp/attachment.mp4")
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -201,10 +201,8 @@ class FeedbackFormViewModel @Inject constructor(
             showToast(R.string.feedback_form_max_attachments_reached)
         } else if (newList.any { it.uri == uri }) {
             showToast(R.string.feedback_form_attachment_already_added)
-        } else if (size > MAX_SINGLE_ATTACHMENT_SIZE) {
+        } else if (size > MAX_ATTACHMENT_SIZE) {
             showToast(R.string.feedback_form_attachment_too_large)
-        } else if (totalAttachmentSize() + size > MAX_TOTAL_ATTACHMENT_SIZE) {
-            showToast(R.string.feedback_form_total_attachments_too_large)
         } else if (file == null) {
             showToast(R.string.feedback_form_unable_to_create_tempfile)
         } else if (!feedbackFormUtils.isSupportedMimeType(mimeType)) {
@@ -244,11 +242,6 @@ class FeedbackFormViewModel @Inject constructor(
         }
     }
 
-    private fun totalAttachmentSize(): Long {
-        val list = _attachments.value
-        return list.sumOf { it.size }
-    }
-
     private fun showToast(@StringRes msgId: Int) {
         viewModelScope.launch {
             toastUtilsWrapper.showToast(msgId)
@@ -256,8 +249,7 @@ class FeedbackFormViewModel @Inject constructor(
     }
 
     companion object {
-        private const val MAX_SINGLE_ATTACHMENT_SIZE = 32_000_000
-        private const val MAX_TOTAL_ATTACHMENT_SIZE = MAX_SINGLE_ATTACHMENT_SIZE * 3
+        private const val MAX_ATTACHMENT_SIZE = 32_000_000
         private const val MAX_ATTACHMENTS = 15
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -250,7 +250,7 @@ class FeedbackFormViewModel @Inject constructor(
 
     companion object {
         private const val MAX_ATTACHMENT_SIZE = 32_000_000
-        private const val MAX_ATTACHMENTS = 15
+        private const val MAX_ATTACHMENTS = 5
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -202,7 +202,7 @@ class FeedbackFormViewModel @Inject constructor(
         } else if (newList.any { it.uri == uri }) {
             showToast(R.string.feedback_form_attachment_already_added)
         } else if (size > MAX_ATTACHMENT_SIZE) {
-            showToast(R.string.feedback_form_attachment_too_large)
+            showToast(context.getString(R.string.feedback_form_attachment_too_large, MAX_ATTACHMENT_SIZE_FMT))
         } else if (file == null) {
             showToast(R.string.feedback_form_unable_to_create_tempfile)
         } else if (!feedbackFormUtils.isSupportedMimeType(mimeType)) {
@@ -248,8 +248,16 @@ class FeedbackFormViewModel @Inject constructor(
         }
     }
 
+    private fun showToast(msg: String) {
+        viewModelScope.launch {
+            toastUtilsWrapper.showToast(msg)
+        }
+    }
+
     companion object {
+        // these match iOS
         private const val MAX_ATTACHMENT_SIZE = 32_000_000
+        private const val MAX_ATTACHMENT_SIZE_FMT = "32MB"
         private const val MAX_ATTACHMENTS = 5
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -202,7 +202,7 @@ class FeedbackFormViewModel @Inject constructor(
         } else if (newList.any { it.uri == uri }) {
             showToast(R.string.feedback_form_attachment_already_added)
         } else if (size > MAX_ATTACHMENT_SIZE) {
-            showToast(context.getString(R.string.feedback_form_attachment_too_large, MAX_ATTACHMENT_SIZE_FMT))
+            showToast(R.string.feedback_form_attachment_too_large)
         } else if (file == null) {
             showToast(R.string.feedback_form_unable_to_create_tempfile)
         } else if (!feedbackFormUtils.isSupportedMimeType(mimeType)) {
@@ -248,16 +248,9 @@ class FeedbackFormViewModel @Inject constructor(
         }
     }
 
-    private fun showToast(msg: String) {
-        viewModelScope.launch {
-            toastUtilsWrapper.showToast(msg)
-        }
-    }
-
     companion object {
         // these match iOS
         private const val MAX_ATTACHMENT_SIZE = 32_000_000
-        private const val MAX_ATTACHMENT_SIZE_FMT = "32MB"
         private const val MAX_ATTACHMENTS = 5
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -256,7 +256,7 @@ class FeedbackFormViewModel @Inject constructor(
     }
 
     companion object {
-        private const val MAX_SINGLE_ATTACHMENT_SIZE = 50000000
+        private const val MAX_SINGLE_ATTACHMENT_SIZE = 32_000_000
         private const val MAX_TOTAL_ATTACHMENT_SIZE = MAX_SINGLE_ATTACHMENT_SIZE * 3
         private const val MAX_ATTACHMENTS = 15
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -77,7 +77,7 @@ class FeedbackFormViewModel @Inject constructor(
         if (_attachments.value.isNotEmpty()) {
             showProgressDialog(R.string.uploading)
             launch {
-                val files =  _attachments.value.map { it.tempFile }
+                val files = _attachments.value.map { it.tempFile }
                 try {
                     val tokens = zendeskUploadHelper.uploadFileAttachments(files)
                     withContext(Dispatchers.Main) {
@@ -182,12 +182,15 @@ class FeedbackFormViewModel @Inject constructor(
         if (data.hasExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)) {
             val stringArray = data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
             stringArray?.forEach { stringUri ->
-                addAttachment(context, Uri.parse(stringUri))
+                // don't add additional attachments if one fails
+                if (!addAttachment(context, Uri.parse(stringUri))) {
+                    return
+                }
             }
         }
     }
 
-    private fun addAttachment(context: Context, uri: Uri) {
+    private fun addAttachment(context: Context, uri: Uri): Boolean {
         val list = _attachments.value
         val newList = list.toMutableList()
         val size = uri.fileSize(context)
@@ -227,7 +230,10 @@ class FeedbackFormViewModel @Inject constructor(
                 )
             )
             _attachments.value = newList.toList()
+            return true
         }
+
+        return false
     }
 
     fun onRemoveMediaClick(uri: Uri) {

--- a/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
@@ -9,4 +9,6 @@ import javax.inject.Inject
 class ToastUtilsWrapper @Inject constructor() {
     fun showToast(@StringRes messageRes: Int) =
         ToastUtils.showToast(WordPress.getContext(), messageRes)
+    fun showToast(message: String) =
+        ToastUtils.showToast(WordPress.getContext(), message)
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/ToastUtilsWrapper.kt
@@ -9,6 +9,4 @@ import javax.inject.Inject
 class ToastUtilsWrapper @Inject constructor() {
     fun showToast(@StringRes messageRes: Int) =
         ToastUtils.showToast(WordPress.getContext(), messageRes)
-    fun showToast(message: String) =
-        ToastUtils.showToast(WordPress.getContext(), message)
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1137,7 +1137,7 @@
     <string name="feedback_form_failure">We were unable to submit your feedback</string>
     <string name="feedback_form_max_attachments_reached">Maximum number of attachments reached</string>
     <string name="feedback_form_unsupported_attachment">This file type is not supported</string>
-    <string name="feedback_form_attachment_too_large">Attachments must be %s or smaller</string>
+    <string name="feedback_form_attachment_too_large">Attachments must be 32MB or smaller</string>
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1137,7 +1137,7 @@
     <string name="feedback_form_failure">We were unable to submit your feedback</string>
     <string name="feedback_form_max_attachments_reached">Maximum number of attachments reached</string>
     <string name="feedback_form_unsupported_attachment">This file type is not supported</string>
-    <string name="feedback_form_attachment_too_large">Attachments must be 32MB or smaller</string>
+    <string name="feedback_form_attachment_too_large">Attachments must be %s or smaller</string>
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1137,8 +1137,7 @@
     <string name="feedback_form_failure">We were unable to submit your feedback</string>
     <string name="feedback_form_max_attachments_reached">Maximum number of attachments reached</string>
     <string name="feedback_form_unsupported_attachment">This file type is not supported</string>
-    <string name="feedback_form_attachment_too_large">Attachments must be 50MB or smaller</string>
-    <string name="feedback_form_total_attachments_too_large">The total size of the attachments must be 150MB or smaller</string>
+    <string name="feedback_form_attachment_too_large">Attachments must be 32MB or smaller</string>
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>


### PR DESCRIPTION
As part of #21105, this PR updates the Zendesk file uploading to use a `suspendCancellableCoroutine` that throws an exception on failure. Previously we would continue to upload attachments even after an error occurred. I also added a few unrelated changes to match iOS.