### PR TITLE
Bump Aztec to `2.1.4`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     automatticRestVersion = '1.0.8'
     automatticTracksVersion = '5.1.0'
     gutenbergMobileVersion = 'v1.121.0'
-    wordPressAztecVersion = 'v2.1.3'
+    wordPressAztecVersion = 'v2.1.4'
     wordPressFluxCVersion = 'trunk-94d25d35fb4bf58a2e90741a6a5d56b8c6c3ce42'
     wordPressLoginVersion = '1.16.0'
     wordPressPersistentEditTextVersion = '1.0.2'


### PR DESCRIPTION
This tiny PR bumps Aztec to `2.1.4` to address

- https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/91