### PR TITLE
Constraint `gson` in build classpath

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -2,23 +2,6 @@ import io.sentry.android.gradle.extensions.InstrumentationFeature
 import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
 import se.bjurr.violations.lib.model.SEVERITY
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("se.bjurr.violations:violation-comments-to-github-gradle-plugin:$gradle.ext.violationCommentsVersion") {
-            //noinspection ForeignDelegate
-            constraints {
-                //noinspection ForeignDelegate
-                classpath("com.google.code.gson:gson:$googleGsonVersion") {
-                    because 'GSON used in this plugin contains a security vulnerability'
-                }
-            }
-        }
-    }
-}
-
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -2,6 +2,23 @@ import io.sentry.android.gradle.extensions.InstrumentationFeature
 import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
 import se.bjurr.violations.lib.model.SEVERITY
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("se.bjurr.violations:violation-comments-to-github-gradle-plugin:$gradle.ext.violationCommentsVersion") {
+            //noinspection ForeignDelegate
+            constraints {
+                //noinspection ForeignDelegate
+                classpath("com.google.code.gson:gson:$googleGsonVersion") {
+                    because 'GSON used in this plugin contains a security vulnerability'
+                }
+            }
+        }
+    }
+}
+
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -421,7 +421,7 @@ dependencies {
     implementation "com.google.android.flexbox:flexbox:$googleFlexboxlayoutVersion"
     implementation "androidx.percentlayout:percentlayout:$androidxPercentlayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
-    implementation "androidx.preference:preference:$androidxPreferenceVersion"
+    implementation "androidx.preference:preference-ktx:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
     implementation "androidx.webkit:webkit:$androidxWebkitVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -421,7 +421,7 @@ dependencies {
     implementation "com.google.android.flexbox:flexbox:$googleFlexboxlayoutVersion"
     implementation "androidx.percentlayout:percentlayout:$androidxPercentlayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
-    implementation "androidx.preference:preference-ktx:$androidxPreferenceVersion"
+    implementation "androidx.preference:preference:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
     implementation "androidx.webkit:webkit:$androidxWebkitVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -438,7 +438,7 @@ dependencies {
     implementation "com.google.android.flexbox:flexbox:$googleFlexboxlayoutVersion"
     implementation "androidx.percentlayout:percentlayout:$androidxPercentlayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
-    implementation "androidx.preference:preference-ktx:$androidxPreferenceVersion"
+    implementation "androidx.preference:preference:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
     implementation "androidx.webkit:webkit:$androidxWebkitVersion"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -438,7 +438,7 @@ dependencies {
     implementation "com.google.android.flexbox:flexbox:$googleFlexboxlayoutVersion"
     implementation "androidx.percentlayout:percentlayout:$androidxPercentlayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$androidxSwipeToRefreshVersion"
-    implementation "androidx.preference:preference:$androidxPreferenceVersion"
+    implementation "androidx.preference:preference-ktx:$androidxPreferenceVersion"
     implementation "androidx.work:work-runtime:$androidxWorkManagerVersion"
     implementation "androidx.work:work-runtime-ktx:$androidxWorkManagerVersion"
     implementation "androidx.webkit:webkit:$androidxWebkitVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.automattic.android.measure-builds'
     id "org.jetbrains.kotlinx.kover"
     id "com.autonomousapps.dependency-analysis"
+    id "se.bjurr.violations.violation-comments-to-github-gradle-plugin" apply false
     id "androidx.navigation.safeargs.kotlin" apply false
     id "com.android.library" apply false
     id 'com.google.gms.google-services' apply false


### PR DESCRIPTION
Because version shipped with `violation-comments-to-github-gradle-plugin` reports a security vulnerability:

- https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/32

Anyway, we should probably consider dropping support for this plugin (it's no longer maintained). I've added an item: https://github.com/orgs/Automattic/projects/841/views/6?pane=issue&itemId=74192621

### Testing

Not needed - I've added a temporary commit with dependencies change and the comment was added as expected:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/de148c06-2bfd-46fb-86d3-c47f75d74852">
