### PR TITLE
Bump Sentry Gradle Plugin to 4.11.0

### DIFF
--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,9 +1,5 @@
 name: Submit dependencies to GitHub Dependency Graph
-on:
-  push:
-    branches:
-      - trunk
-      - release/*
+on: [push, pull_request]
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,5 +1,9 @@
 name: Submit dependencies to GitHub Dependency Graph
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - trunk
+      - release/*
 permissions:
   contents: write
 jobs:

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     gradle.ext.agpVersion = '8.5.1'
     gradle.ext.googleServicesVersion = '4.3.15'
     gradle.ext.navigationVersion = '2.7.7'
-    gradle.ext.sentryVersion = '4.3.1'
+    gradle.ext.sentryVersion = '4.11.0'
     gradle.ext.daggerVersion = "2.50"
     gradle.ext.detektVersion = '1.23.0'
     gradle.ext.violationCommentsVersion = '1.70.0'


### PR DESCRIPTION
To address:
- https://github.com/wordpress-mobile/WordPress-Android/security/dependabot/77

Sentry Gradle Plugin in version 4.3.1 [bundled Gradle API](https://mvnrepository.com/artifact/io.sentry/sentry-android-gradle-plugin/4.3.1), which included old transitive dependencies with some security vulnerabilities.

### Testing
Not needed: the green light on CI is fine, locally I run the upload of mapping files, and it all worked well:

<img width="1505" alt="Screenshot 2024-08-09 at 12 58 02" src="https://github.com/user-attachments/assets/2b1216f6-b841-4368-b5cb-107d498fff5c">

