### PR TITLE
Feedback form temporary files

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormAttachment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormAttachment.kt
@@ -1,11 +1,9 @@
 package org.wordpress.android.ui.main.feedbackform
 
 import android.net.Uri
-import java.io.File
 
 data class FeedbackFormAttachment(
     val uri: Uri,
-    val tempFile: File,
     val mimeType: String,
     val attachmentType: FeedbackFormAttachmentType,
     val size: Long,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -44,11 +44,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.components.MediaUriPager
 import org.wordpress.android.ui.compose.components.ProgressDialog
 import org.wordpress.android.ui.compose.components.ProgressDialogState
-import org.wordpress.android.ui.compose.components.MediaUriPager
 import org.wordpress.android.ui.compose.theme.M3Theme
-import java.io.File
 
 @Composable
 fun FeedbackFormScreen(
@@ -243,14 +242,12 @@ private fun FeedbackFormScreenPreview() {
         attachmentType = FeedbackFormAttachmentType.IMAGE,
         size = 123456789,
         mimeType = "image/jpeg",
-        tempFile = File("/tmp/attachment.jpg")
     )
     val attachment2 = FeedbackFormAttachment(
         uri = Uri.parse("https://via.placeholder.com/150"),
         attachmentType = FeedbackFormAttachmentType.VIDEO,
         size = 123456789,
         mimeType = "video/mp4",
-        tempFile = File("/tmp/attachment.mp4")
     )
     val attachments = MutableStateFlow(listOf(attachment1, attachment2))
     val messageText = MutableStateFlow("I love this app!")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -77,7 +77,7 @@ class FeedbackFormViewModel @Inject constructor(
         if (_attachments.value.isNotEmpty()) {
             showProgressDialog(R.string.uploading)
             launch {
-                val tempFiles = createTempFiles(context)
+                val tempFiles = createAttachmentTempFiles(context)
                 try {
                     try {
                         val tokens = zendeskUploadHelper.uploadFileAttachments(tempFiles)
@@ -104,13 +104,13 @@ class FeedbackFormViewModel @Inject constructor(
     /**
      * Creates temporary files for each attachment and returns a list of their paths
      */
-    private fun createTempFiles(context: Context): List<File> {
+    private fun createAttachmentTempFiles(context: Context): List<File> {
         val tempFiles = ArrayList<File>()
         val uris = _attachments.value.map { it.uri }
         for (uri in uris) {
             uri.copyToTempFile(context)?.let {
                 tempFiles.add(it)
-            }
+            } ?: appLogWrapper.e(T.SUPPORT, "Failed to copy attachment to temp file: $uri")
         }
         return tempFiles
     }


### PR DESCRIPTION
Fixes #21132

When I coded the feedback form, I neglected to delete the temporary files created when uploading attachments. This PR corrects this oversight. Also, previously the temporary files were being created as soon as an attachment was added, but now they're created as part of the upload process.

To test, simply verify that uploading attachments from the feedback form still works as expected, and be sure to close any tickets by visiting `https://a8c.zendesk.com/agent/tickets/[TICKET-NUMBER]`.

**Note:** The [SonarCloud warning](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&pullRequest=21133&id=wordpress-mobile_WordPress-Android) about the "delete" function can be ignored.