### PR TITLE
Enable non-final resource IDs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -147,20 +147,22 @@ public class AppLogViewerActivity extends LocaleAwareActivity {
     }
 
     @Override
-    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.app_log_share:
-                shareAppLog();
-                return true;
-            case R.id.app_log_copy_to_clipboard:
-                copyAppLogToClipboard();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
         }
+
+        if (item.getItemId() == R.id.app_log_share) {
+            shareAppLog();
+            return true;
+        }
+
+        if (item.getItemId() == R.id.app_log_copy_to_clipboard) {
+            copyAppLogToClipboard();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrainOfAvatarsItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/avatars/TrainOfAvatarsItem.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.avatars
 
-import android.annotation.SuppressLint
 import androidx.annotation.DimenRes
 import org.wordpress.android.R
 import org.wordpress.android.ui.avatars.TrainOfAvatarsViewType.AVATAR
@@ -8,12 +7,10 @@ import org.wordpress.android.ui.avatars.TrainOfAvatarsViewType.TRAILING_LABEL
 import org.wordpress.android.ui.utils.UiString
 
 @DimenRes
-@SuppressLint("NonConstantResourceId")
-const val AVATAR_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
+var AVATAR_LEFT_OFFSET_DIMEN = R.dimen.margin_small_medium
 
 @DimenRes
-@SuppressLint("NonConstantResourceId")
-const val AVATAR_SIZE_DIMEN = R.dimen.avatar_sz_small
+var AVATAR_SIZE_DIMEN = R.dimen.avatar_sz_small
 
 sealed class TrainOfAvatarsItem(val type: TrainOfAvatarsViewType) {
     data class AvatarItem(val userAvatarUrl: String) : TrainOfAvatarsItem(AVATAR)

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackBrandingUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/JetpackBrandingUiState.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.jetpackoverlay
 
-import android.annotation.SuppressLint
 import org.wordpress.android.R
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -13,36 +12,31 @@ sealed class JetpackBrandingUiState {
         val otherRes: Int
 
         companion object {
-            @SuppressLint("NonConstantResourceId")
-            const val RES_ARE_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_are_moving_in
-            @SuppressLint("NonConstantResourceId")
-            const val RES_IS_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_is_moving_in
+            var RES_ARE_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_are_moving_in
+            var RES_IS_MOVING_IN = R.string.wp_jetpack_powered_phase_3_feature_is_moving_in
         }
     }
 
     object Soon : JetpackBrandingUiState(), Indeterminate {
-        @SuppressLint("NonConstantResourceId")
-        const val RES_ARE_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_are_moving_soon
-        @SuppressLint("NonConstantResourceId")
-        const val RES_IS_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_is_moving_soon
+        var RES_ARE_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_are_moving_soon
+        var RES_IS_MOVING_SOON = R.string.wp_jetpack_powered_phase_3_feature_is_moving_soon
     }
 
     data class Weeks(override val number: Long) : JetpackBrandingUiState(), Pluralisable {
-        override val oneRes = R.string.weeks_quantity_one
-        override val otherRes = R.string.weeks_quantity_other
+        override var oneRes = R.string.weeks_quantity_one
+        override var otherRes = R.string.weeks_quantity_other
     }
 
     data class Days(override val number: Long) : JetpackBrandingUiState(), Pluralisable {
-        override val oneRes = R.string.days_quantity_one
-        override val otherRes = R.string.days_quantity_other
+        override var oneRes = R.string.days_quantity_one
+        override var otherRes = R.string.days_quantity_other
     }
 
     object Unknown : JetpackBrandingUiState(), Indeterminate
-    object Passed : JetpackBrandingUiState()
+    data object Passed : JetpackBrandingUiState()
 
     companion object {
-        @SuppressLint("NonConstantResourceId")
-        const val RES_JP_POWERED = R.string.wp_jetpack_powered
+        var RES_JP_POWERED = R.string.wp_jetpack_powered
 
         fun between(startDate: LocalDate, endDate: LocalDate): JetpackBrandingUiState {
             val days = ChronoUnit.DAYS.between(startDate, endDate)

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -662,29 +661,31 @@ public class MediaBrowserActivity extends LocaleAwareActivity implements MediaGr
     }
 
     @Override
-    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                getOnBackPressedDispatcher().onBackPressed();
-                return true;
-            case R.id.menu_new_media:
-                // Do Nothing (handled in action view click listener)
-                return true;
-            case R.id.menu_search:
-                mSearchMenuItem = item;
-                mSearchMenuItem.setOnActionExpandListener(this);
-                mSearchMenuItem.expandActionView();
+        if (item.getItemId() == android.R.id.home) {
+            getOnBackPressedDispatcher().onBackPressed();
+            return true;
+        }
 
-                mSearchView = (SearchView) item.getActionView();
-                mSearchView.setOnQueryTextListener(this);
+        if (item.getItemId() == R.id.menu_new_media) {
+            // Do Nothing (handled in action view click listener)
+            return true;
+        }
 
-                // load last saved query
-                if (!TextUtils.isEmpty(mQuery)) {
-                    onQueryTextSubmit(mQuery);
-                    mSearchView.setQuery(mQuery, true);
-                }
-                return true;
+        if (item.getItemId() == R.id.menu_search) {
+            mSearchMenuItem = item;
+            mSearchMenuItem.setOnActionExpandListener(this);
+            mSearchMenuItem.expandActionView();
+
+            mSearchView = (SearchView) item.getActionView();
+            mSearchView.setOnQueryTextListener(this);
+
+            // load last saved query
+            if (!TextUtils.isEmpty(mQuery)) {
+                onQueryTextSubmit(mQuery);
+                mSearchView.setQuery(mQuery, true);
+            }
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -130,23 +130,19 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
                 @Override
                 public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
                     GalleryType galleryType;
-                    switch (checkedId) {
-                        case R.id.radio_circles:
-                            galleryType = GalleryType.CIRCLES;
-                            break;
-                        case R.id.radio_slideshow:
-                            galleryType = GalleryType.SLIDESHOW;
-                            break;
-                        case R.id.radio_squares:
-                            galleryType = GalleryType.SQUARES;
-                            break;
-                        case R.id.radio_tiled:
-                            galleryType = GalleryType.TILED;
-                            break;
-                        default:
-                            galleryType = GalleryType.DEFAULT;
-                            break;
+
+                    if (checkedId == R.id.radio_circles) {
+                        galleryType = GalleryType.CIRCLES;
+                    } else if (checkedId == R.id.radio_slideshow) {
+                        galleryType = GalleryType.SLIDESHOW;
+                    } else if (checkedId == R.id.radio_squares) {
+                        galleryType = GalleryType.SQUARES;
+                    } else if (checkedId == R.id.radio_tiled) {
+                        galleryType = GalleryType.SQUARES;
+                    } else {
+                        galleryType = GalleryType.DEFAULT;
                     }
+
                     setGalleryType(galleryType);
                 }
             });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -2232,38 +2232,38 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private final class ActionModeCallback implements ActionMode.Callback {
         @Override
-        @SuppressLint("NonConstantResourceId")
         public boolean onActionItemClicked(@NonNull ActionMode mode, @NonNull MenuItem item) {
-            switch (item.getItemId()) {
-                case R.id.menu_delete:
-                    SparseBooleanArray checkedItems = getAdapter().getItemsSelected();
+            if (item.getItemId() == R.id.menu_delete) {
+                SparseBooleanArray checkedItems = getAdapter().getItemsSelected();
 
-                    HashMap<String, Object> properties = new HashMap<>();
-                    properties.put("num_items_deleted", checkedItems.size());
-                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_DELETED_LIST_ITEMS,
-                            mSite, properties);
+                HashMap<String, Object> properties = new HashMap<>();
+                properties.put("num_items_deleted", checkedItems.size());
+                AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_DELETED_LIST_ITEMS,
+                        mSite, properties);
 
-                    for (int i = checkedItems.size() - 1; i >= 0; i--) {
-                        final int index = checkedItems.keyAt(i);
+                for (int i = checkedItems.size() - 1; i >= 0; i--) {
+                    final int index = checkedItems.keyAt(i);
 
-                        if (checkedItems.get(index)) {
-                            mEditingList.remove(index);
-                        }
+                    if (checkedItems.get(index)) {
+                        mEditingList.remove(index);
                     }
+                }
 
-                    mSiteSettings.saveSettings();
-                    mActionMode.finish();
-                    return true;
-                case R.id.menu_select_all:
-                    for (int i = 0; i < getAdapter().getItemCount(); i++) {
-                        getAdapter().setItemSelected(i);
-                    }
-
-                    mActionMode.invalidate();
-                    return true;
-                default:
-                    return false;
+                mSiteSettings.saveSettings();
+                mActionMode.finish();
+                return true;
             }
+
+            if (item.getItemId() == R.id.menu_select_all) {
+                for (int i = 0; i < getAdapter().getItemCount(); i++) {
+                    getAdapter().setItemSelected(i);
+                }
+
+                mActionMode.invalidate();
+                return true;
+            }
+
+            return false;
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.reader;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
@@ -206,15 +205,15 @@ public class ReaderPostListActivity extends LocaleAwareActivity {
     }
 
     @Override
-    @SuppressLint("NonConstantResourceId")
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                getOnBackPressedDispatcher().onBackPressed();
-                return true;
-            case R.id.menu_share:
-                shareSite();
-                return true;
+        if (item.getItemId() == android.R.id.home) {
+            getOnBackPressedDispatcher().onBackPressed();
+            return true;
+        }
+
+        if (item.getItemId() == R.id.menu_share) {
+            shareSite();
+            return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceNotification.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/services/SiteCreationServiceNotification.kt
@@ -1,18 +1,14 @@
 package org.wordpress.android.ui.sitecreation.services
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.content.Context
 import org.wordpress.android.R
 import org.wordpress.android.util.AutoForegroundNotification
 
 object SiteCreationServiceNotification {
-    @SuppressLint("NonConstantResourceId")
-    private const val channelResId = R.string.notification_channel_normal_id
-    @SuppressLint("NonConstantResourceId")
-    private const val colorResId = R.color.primary_50
-    @SuppressLint("NonConstantResourceId")
-    private const val drawableResId = R.drawable.ic_app_white_24dp
+    private var channelResId = R.string.notification_channel_normal_id
+    private var colorResId = R.color.primary_50
+    private var drawableResId = R.drawable.ic_app_white_24dp
 
     fun createCreatingSiteNotification(context: Context): Notification {
         return AutoForegroundNotification.progressIndeterminate(

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/pages/PostPageListLabelColorUseCase.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.viewmodel.pages
 
-import android.annotation.SuppressLint
 import androidx.annotation.ColorRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.PostModel
@@ -15,12 +14,9 @@ import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostU
 import org.wordpress.android.viewmodel.pages.PostModelUploadUiStateUseCase.PostUploadUiState.UploadingPost
 import javax.inject.Inject
 
-@SuppressLint("NonConstantResourceId")
-const val ERROR_COLOR = R.color.error
-@SuppressLint("NonConstantResourceId")
-const val PROGRESS_INFO_COLOR = R.color.neutral_50
-@SuppressLint("NonConstantResourceId")
-const val STATE_INFO_COLOR = R.color.warning_dark
+var ERROR_COLOR = R.color.error
+var PROGRESS_INFO_COLOR = R.color.neutral_50
+var STATE_INFO_COLOR = R.color.warning_dark
 
 class PostPageListLabelColorUseCase @Inject constructor() {
     @ColorRes

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -13,7 +13,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
+android.nonFinalResIds=true
 android.enableR8.fullMode=false
 
 # For more details on what these properties do visit


### PR DESCRIPTION
Mostly just curious if this will work – Android Studio says it'll speed up build times

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - TODO

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

3. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
