### PR TITLE
Update FluxC Hash

### DIFF
--- a/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUIModelMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingUIModelMapperTest.kt
@@ -4,9 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -17,7 +15,6 @@ import org.wordpress.android.ui.stats.refresh.utils.StatsUtils
 import org.wordpress.android.ui.utils.UiString
 
 @ExperimentalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
 class CampaignListingUIModelMapperTest : BaseUnitTest() {
     @Mock
     lateinit var statsUtils: StatsUtils
@@ -41,6 +38,7 @@ class CampaignListingUIModelMapperTest : BaseUnitTest() {
         targetUrn = null,
         totalBudget = 1.0,
         spentBudget = 0.0,
+        isEndlessCampaign = false,
     )
 
     @Test
@@ -71,6 +69,7 @@ class CampaignListingUIModelMapperTest : BaseUnitTest() {
         targetUrn = null,
         totalBudget = 0.0,
         spentBudget = 0.0,
+        isEndlessCampaign = false,
     )
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/blaze/BlazeCardBuilderTest.kt
@@ -35,6 +35,7 @@ val campaign = BlazeCampaignModel(
     targetUrn = null,
     totalBudget = 0.0,
     spentBudget = 0.0,
+    isEndlessCampaign = false,
 )
 
 val onCreateCampaignClick = { }

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     automatticTracksVersion = '5.1.0'
     gutenbergMobileVersion = 'v1.121.0'
     wordPressAztecVersion = 'v2.1.4'
-    wordPressFluxCVersion = 'trunk-94d25d35fb4bf58a2e90741a6a5d56b8c6c3ce42'
+    wordPressFluxCVersion = 'trunk-a77c116b8bd00247c8c0551b4497629ff84ca023'
     wordPressLoginVersion = '1.16.0'
     wordPressPersistentEditTextVersion = '1.0.2'
     wordPressRsVersion = 'trunk-50f703a7f677084157d02f05d4d477d7eaf960b1'


### PR DESCRIPTION
This PR updates the FluxC hash to include changes added in [this PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3090). To test, select a blog with a large number of posts and verify scrolling through the post list works as expected.