### PR TITLE
Link Day One attribution to dayoneapp.com when tapped

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -110,7 +110,7 @@ class MySiteAdapter(
                 bloggingPromptsCardAnalyticsTracker,
                 htmlCompatWrapper,
                 learnMoreClicked,
-                containerClicked,
+                containerClicked
             )
 
             MySiteCardAndItem.Type.BLOGANUARY_NUDGE_CARD.ordinal -> BloganuaryNudgeCardViewHolder(parent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteAdapter.kt
@@ -73,7 +73,8 @@ class MySiteAdapter(
     val gravatarLoader: MeGravatarLoader,
     val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker,
     val htmlCompatWrapper: HtmlCompatWrapper,
-    val learnMoreClicked: () -> Unit
+    val learnMoreClicked: () -> Unit,
+    val containerClicked: () -> Unit
 ) : ListAdapter<MySiteCardAndItem, MySiteCardAndItemViewHolder<*>>(MySiteAdapterDiffCallback) {
     private var nestedScrollStates = Bundle()
 
@@ -108,7 +109,8 @@ class MySiteAdapter(
                 uiHelpers,
                 bloggingPromptsCardAnalyticsTracker,
                 htmlCompatWrapper,
-                learnMoreClicked
+                learnMoreClicked,
+                containerClicked,
             )
 
             MySiteCardAndItem.Type.BLOGANUARY_NUDGE_CARD.ordinal -> BloganuaryNudgeCardViewHolder(parent)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -349,8 +349,10 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             accountStore,
             meGravatarLoader,
             bloggingPromptsCardAnalyticsTracker,
-            htmlCompatWrapper
-        ) { viewModel.onBloggingPromptsLearnMoreClicked() }
+            htmlCompatWrapper,
+            { viewModel.onBloggingPromptsLearnMoreClicked() },
+            { viewModel.onBloggingPromptsAttributionClicked() }
+        )
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -417,6 +417,11 @@ class MySiteViewModel @Inject constructor(
         _onNavigation.postValue(Event(BloggingPromptCardNavigationAction.LearnMore))
     }
 
+    fun onBloggingPromptsAttributionClicked() {
+        _onNavigation.value = Event(
+            SiteNavigationAction.OpenExternalUrl(DAY_ONE_EXTERNAL_URL)
+        )
+    }
 
     // FluxC events
     @Subscribe(threadMode = MAIN)
@@ -458,5 +463,6 @@ class MySiteViewModel @Inject constructor(
         const val ARG_QUICK_START_TASK = "ARG_QUICK_START_TASK"
         const val HIDE_WP_ADMIN_GMT_TIME_ZONE = "GMT"
         private const val DELAY_BEFORE_SHOWING_JETPACK_INDIVIDUAL_PLUGIN_OVERLAY = 500L
+        private const val DAY_ONE_EXTERNAL_URL = "https://dayoneapp.com/?utm_source=jetpack&utm_medium=prompts"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
@@ -9,17 +10,23 @@ enum class BloggingPromptAttribution(
     val value: String,
     @StringRes val contentRes: Int,
     @DrawableRes val iconRes: Int,
+    @LayoutRes val containerRes: Int,
+    @DrawableRes val externalLinkIconRes: Int
 ) {
-    NO_ATTRIBUTION("", -1, -1),
+    NO_ATTRIBUTION("", -1, -1, -1, -1),
     DAY_ONE(
         "dayone",
         R.string.my_site_blogging_prompt_card_attribution_day_one,
         R.drawable.ic_dayone_24dp,
+        R.id.attribution_container,
+        R.id.attribution_external_link_icon
     ),
     BLOGANUARY(
         "bloganuary",
         R.string.my_site_blogging_prompt_card_attribution_bloganuary,
         R.drawable.ic_bloganuary_24dp,
+        -1,
+        -1
     );
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
@@ -9,22 +9,19 @@ enum class BloggingPromptAttribution(
     val value: String,
     @StringRes val contentRes: Int,
     @DrawableRes val iconRes: Int,
-    @DrawableRes val externalLinkIconRes: Int,
     val isContainerClickable: Boolean
 ) {
-    NO_ATTRIBUTION("", -1, -1, -1, false),
+    NO_ATTRIBUTION("", -1, -1, false),
     DAY_ONE(
         "dayone",
         R.string.my_site_blogging_prompt_card_attribution_day_one,
         R.drawable.ic_dayone_24dp,
-        R.id.attribution_container,
         true
     ),
     BLOGANUARY(
         "bloganuary",
         R.string.my_site_blogging_prompt_card_attribution_bloganuary,
         R.drawable.ic_bloganuary_24dp,
-        -1,
         false
     );
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptAttribution.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts
 
 import androidx.annotation.DrawableRes
-import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
@@ -10,23 +9,23 @@ enum class BloggingPromptAttribution(
     val value: String,
     @StringRes val contentRes: Int,
     @DrawableRes val iconRes: Int,
-    @LayoutRes val containerRes: Int,
-    @DrawableRes val externalLinkIconRes: Int
+    @DrawableRes val externalLinkIconRes: Int,
+    val isContainerClickable: Boolean
 ) {
-    NO_ATTRIBUTION("", -1, -1, -1, -1),
+    NO_ATTRIBUTION("", -1, -1, -1, false),
     DAY_ONE(
         "dayone",
         R.string.my_site_blogging_prompt_card_attribution_day_one,
         R.drawable.ic_dayone_24dp,
         R.id.attribution_container,
-        R.id.attribution_external_link_icon
+        true
     ),
     BLOGANUARY(
         "bloganuary",
         R.string.my_site_blogging_prompt_card_attribution_bloganuary,
         R.drawable.ic_bloganuary_24dp,
         -1,
-        -1
+        false
     );
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -78,7 +78,7 @@ class BloggingPromptCardViewHolder(
             }
 
         attribution.isContainerClickable
-            .takeIf { true }
+            .takeIf { it }
             ?.let {
                 attributionContainer.setOnClickListener { containerClicked() }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -81,11 +81,6 @@ class BloggingPromptCardViewHolder(
             .takeIf { it }
             ?.let {
                 attributionContainer.setOnClickListener { containerClicked() }
-            }
-
-        attribution.externalLinkIconRes
-            .takeIf { it != -1 }
-            ?.let {
                 attributionExternalLinkIcon.setVisible(true)
             }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.ui.mysite.cards.dashboard.bloggingprompts.BloggingP
 import org.wordpress.android.ui.utils.UiHelpers
 import org.wordpress.android.util.HtmlCompatWrapper
 import org.wordpress.android.util.extensions.getColorStateListFromAttributeOrRes
+import org.wordpress.android.util.extensions.setVisible
 import org.wordpress.android.util.extensions.viewBinding
 
 class BloggingPromptCardViewHolder(
@@ -20,7 +21,8 @@ class BloggingPromptCardViewHolder(
     private val uiHelpers: UiHelpers,
     private val bloggingPromptsCardAnalyticsTracker: BloggingPromptsCardAnalyticsTracker,
     private val htmlCompatWrapper: HtmlCompatWrapper,
-    private val learnMoreClicked: () -> Unit
+    private val learnMoreClicked: () -> Unit,
+    private val containerClicked: () -> Unit,
 ) : MySiteCardAndItemViewHolder<MySiteBloggingPromptCardBinding>(
     parent.viewBinding(MySiteBloggingPromptCardBinding::inflate)
 ) {
@@ -73,6 +75,18 @@ class BloggingPromptCardViewHolder(
             .takeIf { it != -1 }
             ?.let { iconRes ->
                 attributionIcon.setImageResource(iconRes)
+            }
+
+        attribution.containerRes
+            .takeIf { it != -1 }
+            ?.let {
+                attributionContainer.setOnClickListener { containerClicked() }
+            }
+
+        attribution.externalLinkIconRes
+            .takeIf { it != -1 }
+            ?.let {
+                attributionExternalLinkIcon.setVisible(true)
             }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -77,8 +77,8 @@ class BloggingPromptCardViewHolder(
                 attributionIcon.setImageResource(iconRes)
             }
 
-        attribution.containerRes
-            .takeIf { it != -1 }
+        attribution.isContainerClickable
+            .takeIf { true }
             ?.let {
                 attributionContainer.setOnClickListener { containerClicked() }
             }

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -53,13 +53,17 @@
 
         <LinearLayout
             android:id="@+id/attribution_container"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal|center_vertical"
+            android:background="?attr/selectableItemBackground"
             android:orientation="horizontal"
             android:paddingTop="@dimen/margin_medium"
+            android:paddingBottom="@dimen/margin_medium"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@+id/prompt_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             tools:visibility="visible">
 
             <ImageView
@@ -93,7 +97,7 @@
             android:id="@+id/answered_users_avatars"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
+            android:layout_marginTop="@dimen/margin_small"
             app:iconSize="@dimen/avatar_sz_extra_small"
             app:placeholder="@drawable/bg_oval_placeholder_user_32dp"
             app:chainUseRtl="true"

--- a/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
+++ b/WordPress/src/main/res/layout/my_site_blogging_prompt_card.xml
@@ -77,6 +77,16 @@
                 android:textAppearance="?attr/textAppearanceCaption"
                 tools:text="@string/my_site_blogging_prompt_card_attribution_day_one" />
 
+            <ImageView
+                android:id="@+id/attribution_external_link_icon"
+                style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/margin_small"
+                android:visibility="gone"
+                android:contentDescription="@string/open_external_link_desc"
+                android:src="@drawable/ic_external_white_24dp"
+                app:tint="?attr/colorPrimary" />
+
         </LinearLayout>
 
         <org.wordpress.android.ui.compose.views.TrainOfAvatarsView


### PR DESCRIPTION
This is the Android version of https://github.com/wordpress-mobile/WordPress-iOS/pull/23586

In this PR we are opening dayoneapp.com when a user taps on the "Day One" attribution in the blogging prompt. There's an "external link" icon added as well.

<img width="361" alt="Screenshot 2024-09-16 at 1 14 40 PM" src="https://github.com/user-attachments/assets/5a7917e4-e15c-4dfd-9b35-9ded2624be15">

-----

## To Test:

* Sign into Jetpack
* On the `My Site` tab, if you have a Day One prompt, you should see the external link icon next to it.
* Tap it!
* You should be at dayoneapp.com
* Bonus, change the `BloggingPromptAttribution` class to use these values for `DAY_ONE`:

```
DAY_ONE(
        "dayone",
        R.string.my_site_blogging_prompt_card_attribution_day_one,
        R.drawable.ic_dayone_24dp,
        false
    ),
```

In this case you should _not_ see the external icon and tapping on it should do nothing. This simulates the behavior for bloganuary prompts that we don't want to show the icon for or make tappable. (I never saw any of these in my testing)

-----

## PR Submission Checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
