### PR TITLE
[Build] Migrate Build Scan to Develocity APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,4 +259,3 @@ dependencies {
 }
 
 apply from: './config/gradle/code_coverage.gradle'
-apply from: './config/gradle/gradle_build_scan.gradle'

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,11 +1,13 @@
 
 // Only run build scan on CI builds.
 if (System.getenv('CI')) {
-    buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        tag 'CI'
-        publishAlways()
-        uploadInBackground = false
+    develocity {
+        buildScan {
+            termsOfUseUrl = 'https://gradle.com/terms-of-service'
+            termsOfUseAgree = 'yes'
+            tag 'CI'
+            publishing.onlyIf { true }
+            uploadInBackground = false
+        }
     }
 }

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -10,4 +10,10 @@ if (System.getenv('CI')) {
             uploadInBackground = false
         }
     }
+} else {
+    develocity {
+        buildScan {
+            publishing.onlyIf { false }
+        }
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,3 +65,4 @@ include ':libs:mocks'
 
 apply from: './config/gradle/included_builds.gradle'
 apply from: './config/gradle/gradle_build_cache.gradle'
+apply from: './config/gradle/gradle_build_scan.gradle'


### PR DESCRIPTION
Relates To: #21164

## Description:

In our previous attempt to upgrade `com.gradle.enterprise` from `3.15` to `3.18` we had to also upgrade to the plugin id to `com.gradle.develocity` (#21164). Although testing CI didn't show anything fishy about this migration, and build scans continue to work as expected, when running any task locally it now started to asking for a build scan license agreement:

`Publishing a build scan to scans.gradle.com requires accepting the Gradle Terms of Use defined at https://gradle.com/help/legal-terms-of-use. Do you accept these terms? [yes, no]`

After researching quickly on the matter, it seems that `Develocity` is now publishing every build by default (see [Publishing every build](https://docs.gradle.com/develocity/gradle-plugin/current/#controlling_when_build_scans_are_published)). Previously, we only accepted the build scan agreement on CI and ignored any local configuration, it defaulting to NOT publishing on every build.

FYI: Also, as part of this change, the `buildScan` APIs were migrated to the new `develocity` ones, which are being accessible from the including `develocity { ... }` block, and then, the whole script got applied on the `settings.gradle` level, just like it is already done for `buildCache`.

-----

Additionally, you would notice the below (related) warning:

```
WARNING: The following functionality has been deprecated and will be removed in the next major release 
of the Develocity Gradle plugin. Run with '-Ddevelocity.deprecation.captureOrigin=true' to see where the 
deprecated functionality is being used. For assistance with migration, see https://gradle.com/help/
gradle-plugin-develocity-migration.
- The deprecated "gradleEnterprise.buildScan.buildScanPublished" API has been replaced by 
"develocity.buildScan.buildScanPublished"
```

After running with the `-Ddevelocity.deprecation.captureOrigin=true` parameter further information reveals that this is related to the [com.automattic.android.measure-builds](https://github.com/Automattic/measure-builds-gradle-plugin), so maybe, it is worth updating this plugin to `Develocity` at some point as well:

```
WARNING: The following functionality ... replaced by "develocity.buildScan.buildScanPublished"
  Origin:
    com.automattic.android.measure.BuildTimePlugin.prepareBuildScanListener(BuildTimePlugin.kt:83)
    com.automattic.android.measure.BuildTimePlugin.apply(BuildTimePlugin.kt:60)
    com.automattic.android.measure.BuildTimePlugin.apply(BuildTimePlugin.kt:24)
```

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Local:
    - Run `./gradlew assembleJetpackJalapenoDebug` and make sure that the build is not blocked by the license agreement at the end.
    - Run `./gradlew assembleJetpackJalapenoDebug --scan` and make sure that issuing a build scan on demand still works as expected.
2. CI:
    - Look at the `Prototype Build` job, any of the two, or any job for that matter, and make sure that at the end of that job a build scan is being publishing as expected.

-----

## Regression Notes: `N/A`

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`