### PR TITLE
Updated bell icon

### DIFF
--- a/WordPress/src/main/res/drawable/ic_notifications_selected.xml
+++ b/WordPress/src/main/res/drawable/ic_notifications_selected.xml
@@ -1,11 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportHeight="24"
-    android:viewportWidth="24">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
-        android:fillColor="#00000000"
-        android:pathData="M12,20.5c-0.7,0 -1.3,-0.5 -1.4,-1.2h2.8c-0.1,0.7 -0.7,1.2 -1.4,1.2ZM17,8.5v3c0,1 0,2 0.5,3 0.2,0.5 0.7,1 1.2,1.3L5.3,15.8c0.5,-0.4 1,-0.8 1.2,-1.4 0.5,-0.9 0.5,-2 0.5,-3L7,8.5c0,-2.8 2.2,-5 5,-5s5,2.2 5,5Z"
-        android:strokeColor="#C3C4C7"
-        android:strokeWidth="1.8" />
+        android:pathData="M17,11.5c0,1.4 0.2,2.4 1,3l1,0.5v1H5v-1a3,3 0,0 0,1 -0.5c0.8,-0.6 1,-1.6 1,-3V9a5,5 0,0 1,5 -5,5 5,0 0,1 5,5v2.5ZM15.5,9v2.5a6.6,6.6 0,0 0,0.6 3H7.9v-0.1c0.5,-1 0.6,-2 0.6,-2.9V9c0,-2 1.5,-3.5 3.5,-3.5S15.5,7 15.5,9ZM10,18v-0.5h4a2,2 0,1 1,-4 0.5Z"
+        android:fillColor="#000"
+        android:fillType="evenOdd"/>
 </vector>


### PR DESCRIPTION
Fixes #21235 

This tiny PR updates the notification bell icon in the navigation bar to match the one in [this Gutenberg PR](https://github.com/WordPress/gutenberg/pull/65324).

Note that the differences between the current icon and this new one are very subtle, as shown below:

**CURRENT**

![current](https://github.com/user-attachments/assets/e019cbfe-bf46-4ce5-93c2-cdaed4a818e4)

**NEW**

![new](https://github.com/user-attachments/assets/a444d2b8-40d4-4f50-92cb-44c7ab025176)
