### PR TITLE
Revert exclude com.automattic:Automattic-Tracks-Android 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -611,8 +611,6 @@ dependencyAnalysis {
         onUnusedDependencies {
             // This dependency is actually needed because otherwise UI tests fail to run (but do compile).
             exclude("org.mockito:mockito-android")
-            // This dependency is used by the libs:analytics module, which wasn't converted to adhere to included builds
-            exclude("com.automattic:Automattic-Tracks-Android")
         }
     }
 }


### PR DESCRIPTION
In #21237 we removed unused dependencies, and as part of that we excluded the Tracks library from the dependency analysis. But as @ParaskP7 noted [here](https://github.com/wordpress-mobile/WordPress-Android/pull/21238#issuecomment-2362960791), ignoring that library simply hides the problem, making it less likely we'll resolve it. So this PR reverts that change.