### PR TITLE
Add enhanced lint security checks. Bump CI toolkit to 3.7.1. 

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
- export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.7.0"
- export TEST_COLLECTOR="test-collector#v1.10.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.7.1"
+export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -604,6 +604,7 @@ dependencies {
     implementation "me.saket.cascade:cascade-compose:2.3.0"
 
     implementation "com.automattic.tracks:crashlogging:$automatticTracksVersion"
+    lintChecks 'com.android.security.lint:lint:1.0.1'
 }
 
 dependencyAnalysis {

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -39,6 +39,10 @@
         <!-- EDITOR -->
         <ignore path="**/org.jsoup/**" /> <!-- jsoup -->
     </issue>
+    <issue id="MissingAutoVerifyAttribute" severity="warning" />
+    <issue id="SensitiveExternalPath" severity="warning" />
+    <issue id="WeakPrng" severity="warning" />
+    <issue id="TapjackingVulnerable" severity="warning" />
     <!-- PERFORMANCE -->
     <issue id="UnusedResources">
         <!-- EDITOR -->

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -43,6 +43,7 @@
     <issue id="SensitiveExternalPath" severity="warning" />
     <issue id="WeakPrng" severity="warning" />
     <issue id="TapjackingVulnerable" severity="warning" />
+    <issue id="InsecurePermissionProtectionLevel" severity="warning" />
     <!-- PERFORMANCE -->
     <issue id="UnusedResources">
         <!-- EDITOR -->

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -39,6 +39,7 @@
         <!-- EDITOR -->
         <ignore path="**/org.jsoup/**" /> <!-- jsoup -->
     </issue>
+    <!--  After addressing them, remove the below set of security issues from this list  -->
     <issue id="MissingAutoVerifyAttribute" severity="warning" />
     <issue id="SensitiveExternalPath" severity="warning" />
     <issue id="WeakPrng" severity="warning" />


### PR DESCRIPTION
### Description

This PR integrates enhanced security Android lint checks: https://github.com/google/android-security-lints. 

Additionally, it fixes not working Android SARIF file upload on main branch.

### Testing

One can compare lint report before and after this PR. The report from this PR reports more lint issues in `Security` category.
