### PR TITLE
[Deps] Add Back EventBus Android Dependency

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -483,6 +483,7 @@ dependencies {
 
     implementation "com.android.installreferrer:installreferrer:$androidInstallReferrerVersion"
     implementation "com.github.chrisbanes:PhotoView:$chrisbanesPhotoviewVersion"
+    implementation "org.greenrobot:eventbus:$eventBusVersion"
     implementation "org.greenrobot:eventbus-java:$eventBusVersion"
     implementation "com.squareup.retrofit2:retrofit:$squareupRetrofitVersion"
     implementation "org.apache.commons:commons-text:$apacheCommonsTextVersion"
@@ -609,6 +610,8 @@ dependencies {
 dependencyAnalysis {
     issues {
         onUnusedDependencies {
+            // This dependency is actually needed otherwise the app will crash with a runtime exception.
+            exclude("org.greenrobot:eventbus")
             // This dependency is actually needed because otherwise UI tests fail to run (but do compile).
             exclude("org.mockito:mockito-android")
         }


### PR DESCRIPTION
## Description

This PR adds back the main `EventBus` dependency, which is `Android` related.

This dependency was incorrectly removed and replaced by its corresponding `eventbus-java` transitive dependency, assuming that is not required. However, after further testing it was revealed that this parent `eventbus` dependency, which is actually `android` specific is indeed necessary. If it is not provided on the classpath then an app will crash with the below runtime exception:

```
java.lang.RuntimeException: Unable to create application xyz: java.lang .RuntimeException:
It looks like you are using EventBus on Android, make sure to add the "eventbus" Android
library to your dependencies.
```

For more info see:
- [EventBus.register(...)](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/EventBus.java#L143-L147)
- [!AndroidDependenciesDetector.areAndroidComponentsAvailable()](https://github.com/greenrobot/EventBus/blob/0194926b3bcf70cc0d7bfd3c5da16708dd5ab876/EventBus/src/org/greenrobot/eventbus/android/AndroidDependenciesDetector.java#L25-L36)

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise related to `eventbus`.
2. Testing:
    - Smoke test both, the `Jetpack` and `WordPress`  apps, and verify everything is working as expected.

-----

## Regression Notes (`N/A`)

-----

## PR Submission Checklist: (`N/A`)

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): (`N/A`)
