### PR TITLE
[Deps] Remove Unused Tracks Dependency from Wordpress Module

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -430,12 +430,6 @@ dependencies {
     }
     implementation "$gradle.ext.aboutAutomatticBinaryPath:$automatticAboutVersion"
 
-    implementation("$gradle.ext.tracksBinaryPath:$automatticTracksVersion") {
-        version {
-            strictly automatticTracksVersion
-        }
-    }
-
     implementation ("com.automattic:rest:$automatticRestVersion") {
         exclude group: 'com.mcxiaoke.volley'
     }

--- a/config/gradle/included_builds.gradle
+++ b/config/gradle/included_builds.gradle
@@ -9,7 +9,6 @@ gradle.ext.aztecAndroidWordPressCommentsPath = "org.wordpress.aztec:wordpress-co
 gradle.ext.aztecAndroidGlideLoaderPath = "org.wordpress.aztec:glide-loader"
 gradle.ext.aztecAndroidPicassoLoaderPath = "org.wordpress.aztec:picasso-loader"
 gradle.ext.aboutAutomatticBinaryPath = "com.automattic:about"
-gradle.ext.tracksBinaryPath = "com.automattic:Automattic-Tracks-Android"
 gradle.ext.gravatarBinaryPath = "com.gravatar:gravatar"
 
 def localBuilds = new File("${rootDir}/local-builds.gradle")
@@ -93,15 +92,6 @@ if (localBuilds.exists()) {
             dependencySubstitution {
                 println "Substituting about-automattic with the local build"
                 substitute module("$gradle.ext.aboutAutomatticBinaryPath") using project(':library')
-            }
-        }
-    }
-
-    if (ext.has("localTracksPath")) {
-        includeBuild(ext.localTracksPath) {
-            dependencySubstitution {
-                println "Substituting tracks with the local build"
-                substitute module("$gradle.ext.tracksBinaryPath") using project(':AutomatticTracks')
             }
         }
     }

--- a/local-builds.gradle-example
+++ b/local-builds.gradle-example
@@ -20,6 +20,5 @@ ext {
     //localGutenbergMobilePath = "../gutenberg-mobile"
     //localLoginFlowPath = "../WordPress-Login-Flow-Android"
     //localAztecAndroidPath = "../AztecEditor-Android"
-    //localTracksPath = "../Automattic-Tracks-Android"
     //localGravatarAndroidPath = "../Gravatar-SDK-Android"
 }


### PR DESCRIPTION
## Description

This PR removes the unused `Automattic-Tracks-Android` dependency from the `WordPress` module.

With that change, the `Tracks` related included build configuration is also removed because it anyway hasn't been working as expected since `com.automattic.tracks:crashlogging` got added as an explicit and more focused dependency into the `WordPress` module.

Note that the `Automattic-Tracks-Android` dependency is also being used on the `analytics` module, which means, that this `Tracks` included build wasn't working as expected, not at least to 100%, even when it was initially introduced.

Related PRs:
- [[Gradle] Added tracks to included_builds.gradle #20193](https://github.com/wordpress-mobile/WordPress-Android/pull/20193)
- [Bump Tracks to 5.0.0 #20733](https://github.com/wordpress-mobile/WordPress-Android/pull/20733)

Related Comment:
- [Issue/21237 unused dependencies #21238](https://github.com/wordpress-mobile/WordPress-Android/pull/21238#pullrequestreview-2315615292)

-----

FYI: If anyone tries to use `Tracks` as an included build they will get the below runtime exception when opening the app:

<details>
    <summary>Runtime Exception</summary>

```
E  FATAL EXCEPTION: main
   Process: com.jetpack.android.prealpha, PID: 20182
   java.lang.RuntimeException: Unable to get provider io.sentry.android.core.SentryInitProvider: java.lang.IllegalArgumentException: DSN is required. Use empty string or set enabled to false in SentryOptions to disable SDK.
   	at android.app.ActivityThread.installProvider(ActivityThread.java:8184)
   	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7694)
   	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7383)
   	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
   	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2379)
   	at android.os.Handler.dispatchMessage(Handler.java:107)
   	at android.os.Looper.loopOnce(Looper.java:232)
   	at android.os.Looper.loop(Looper.java:317)
   	at android.app.ActivityThread.main(ActivityThread.java:8592)
   	at java.lang.reflect.Method.invoke(Native Method)
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
   	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
   Caused by: java.lang.IllegalArgumentException: DSN is required. Use empty string or set enabled to false in SentryOptions to disable SDK.
   	at io.sentry.Sentry.initConfigurations(Sentry.java:378)
   	at io.sentry.Sentry.init(Sentry.java:230)
   	at io.sentry.Sentry.init(Sentry.java:167)
   	at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:87)
   	at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:58)
   	at io.sentry.android.core.SentryInitProvider.onCreate(SentryInitProvider.java:25)
   	at android.content.ContentProvider.attachInfo(ContentProvider.java:2644)
   	at android.content.ContentProvider.attachInfo(ContentProvider.java:2613)
   	at io.sentry.android.core.SentryInitProvider.attachInfo(SentryInitProvider.java:43)
   	at android.app.ActivityThread.installProvider(ActivityThread.java:8179)
   	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7694)
   	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7383)
   	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
   	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2379)
   	at android.os.Handler.dispatchMessage(Handler.java:107)
   	at android.os.Looper.loopOnce(Looper.java:232)
   	at android.os.Looper.loop(Looper.java:317)
   	at android.app.ActivityThread.main(ActivityThread.java:8592)
   	at java.lang.reflect.Method.invoke(Native Method)
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
   	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

</details>

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Smoke test both, the `Jetpack` and `WordPress` apps, and verify everything `Tracks` related is working as expected.
- You could also open the `Logcat` and filter for `🔵 Tracked: ` to make sure that all specific app actions are tracked (ie. switching tabs).
    - First, make sure to enabled `Collect information` from within the `Privacy settings` screen of `App Settings`, found on the main `Me` tab.

-----

## Regression Notes

1. Potential unintended areas of impact

    - Tracks is not working as expected, events are not being logged on our `Tracks` platform.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`