### PR TITLE
Reduce size of Lint report by disabling `UnknownNullness` check

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -79,4 +79,6 @@
 
     <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/issues/21065 -->
     <issue id="UsingMaterialAndMaterial3Libraries" severity="warning" />
+    <!--  We rely on more granural checks from WordPress-Lint-Android  -->
+    <issue id="UnknownNullness" severity="ignore" />
 </lint>

--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -39,7 +39,7 @@
         <!-- EDITOR -->
         <ignore path="**/org.jsoup/**" /> <!-- jsoup -->
     </issue>
-    <!--  After addressing them, remove the below set of security issues from this list  -->
+    <!--  TODO: After addressing them, remove the below set of security issues from this list  -->
     <issue id="MissingAutoVerifyAttribute" severity="warning" />
     <issue id="SensitiveExternalPath" severity="warning" />
     <issue id="WeakPrng" severity="warning" />


### PR DESCRIPTION
### Description

This PR disables `UnknownNullness` Lint rule, as it duplicates rules introduced via https://github.com/wordpress-mobile/WordPress-Lint-Android.

Internal reference: p1727182042410479-slack-C030U03RC8Y