### PR TITLE
[Deps] Migrate EventBus to Version Catalogs

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -605,7 +605,7 @@ dependencyAnalysis {
     issues {
         onUnusedDependencies {
             // This dependency is actually needed otherwise the app will crash with a runtime exception.
-            exclude("org.greenrobot:eventbus")
+            exclude(libs.greenrobot.eventbus.main.get().module.toString())
             // This dependency is actually needed because otherwise UI tests fail to run (but do compile).
             exclude(libs.mockito.android.get().module.toString())
         }


### PR DESCRIPTION
## Description

This PR finalizes migration of `EventBus` to [Version Catalogs](https://docs.gradle.org/current/userguide/platforms.html). 

PS: Note that this was a left-over from #21252 and #21262 combined.

-----

## To Test (Optional):

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

You could also run the `./gradlew buildHealth` task locally and verify that everything is working as expected, no unused dependency related to `EventBus`, or any dependency for that matter.

-----

## Regression Notes: `N/A`

-----

## PR Submission Checklist: `N/A`

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`