### PR TITLE
Coil image loader singleton

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -2,6 +2,8 @@ package org.wordpress.android
 
 import android.app.Application
 import android.content.Context
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
@@ -11,13 +13,19 @@ import org.wordpress.android.modules.AppComponent
  * An abstract class to be extended by {@link WordPressApp} for real application and WordPressTest for UI test
  * application. Containing public static variables and methods to be accessed by other classes.
  */
-abstract class WordPress : Application() {
+abstract class WordPress : Application(), ImageLoaderFactory {
     abstract fun initializer(): AppInitializer
 
     fun component(): AppComponent = EntryPoints.get(this, AppComponent::class.java)
 
     fun wordPressComSignOut() {
         initializer().wordPressComSignOut()
+    }
+
+    override fun newImageLoader(): ImageLoader {
+        return ImageLoader.Builder(this)
+            .crossfade(true)
+            .build()
     }
 
     @Suppress("TooManyFunctions")

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import coil.decode.VideoFrameDecoder
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
@@ -25,6 +26,9 @@ abstract class WordPress : Application(), ImageLoaderFactory {
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
             .crossfade(true)
+            .components {
+                add(VideoFrameDecoder.Factory())
+            }
             .build()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.kt
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.kt
@@ -2,8 +2,6 @@ package org.wordpress.android
 
 import android.app.Application
 import android.content.Context
-import coil.ImageLoader
-import coil.ImageLoaderFactory
 import coil.decode.VideoFrameDecoder
 import com.android.volley.RequestQueue
 import dagger.hilt.EntryPoints
@@ -14,7 +12,7 @@ import org.wordpress.android.modules.AppComponent
  * An abstract class to be extended by {@link WordPressApp} for real application and WordPressTest for UI test
  * application. Containing public static variables and methods to be accessed by other classes.
  */
-abstract class WordPress : Application(), ImageLoaderFactory {
+abstract class WordPress : Application(), coil.ImageLoaderFactory {
     abstract fun initializer(): AppInitializer
 
     fun component(): AppComponent = EntryPoints.get(this, AppComponent::class.java)
@@ -23,8 +21,11 @@ abstract class WordPress : Application(), ImageLoaderFactory {
         initializer().wordPressComSignOut()
     }
 
-    override fun newImageLoader(): ImageLoader {
-        return ImageLoader.Builder(this)
+    /**
+     * This returns a singleton Coil ImageLoader that's accessed with context.imageLoader
+     */
+    override fun newImageLoader(): coil.ImageLoader {
+        return coil.ImageLoader.Builder(this)
             .crossfade(true)
             .components {
                 add(VideoFrameDecoder.Factory())

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MediaUriPager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MediaUriPager.kt
@@ -30,9 +30,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
 import coil.compose.AsyncImage
-import coil.decode.VideoFrameDecoder
+import coil.imageLoader
 import coil.request.ImageRequest
 import org.wordpress.android.R
 
@@ -81,18 +80,13 @@ private fun MediaUriImage(uri: Uri) {
     val context = LocalContext.current
     val mimeType = context.contentResolver.getType(uri)
     if (mimeType?.startsWith("video/") == true) {
-        val imageLoader = ImageLoader.Builder(LocalContext.current)
-            .components {
-                add(VideoFrameDecoder.Factory())
-            }
-            .build()
         Box {
             AsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(uri)
                     .crossfade(true)
                     .build(),
-                imageLoader = imageLoader,
+                imageLoader = context.imageLoader,
                 contentScale = ContentScale.Crop,
                 contentDescription = null,
                 modifier = Modifier


### PR DESCRIPTION
Fixes #21285 

This PR updates our use of the Coil `ImageLoader` to rely on a singleton, as recommended in the [docs](https://coil-kt.github.io/coil/image_loaders/#singleton-vs-dependency-injection). Currently we only use an `ImageLoader` in the `MediaUriPager`, which was added for the feedback form.

To test:

* Me > Send feedback
* Verify attaching an image works
* Verify attaching a video works