### PR TITLE
Issue/21283 no connection message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
@@ -39,8 +39,7 @@ class GifMediaDataSource
 
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
+                UiStringRes(R.string.no_network_message),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = items
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSource.kt
@@ -40,7 +40,7 @@ class GifMediaDataSource
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
                 UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = items
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
@@ -59,8 +59,7 @@ class MediaLibraryDataSource(
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
+                UiStringRes(R.string.no_network_message),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
@@ -60,7 +60,7 @@ class MediaLibraryDataSource(
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
                 UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get(mediaTypes, filter) else listOf()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
@@ -32,8 +32,7 @@ class StockMediaDataSource
     ): MediaLoadingResult {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
-                UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
+                UiStringRes(R.string.no_network_message),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get() else listOf()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSource.kt
@@ -33,7 +33,7 @@ class StockMediaDataSource
         if (!networkUtilsWrapper.isNetworkAvailable()) {
             return Failure(
                 UiStringRes(R.string.no_network_title),
-                htmlSubtitle = UiStringRes(R.string.no_network_message),
+                htmlSubtitle = UiStringRes(R.string.no_network_subtitle),
                 image = R.drawable.img_illustration_cloud_off_152dp,
                 data = if (loadMore) get() else listOf()
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -118,7 +118,7 @@ fun OfflineView() {
     MessageView(
         R.drawable.ic_wifi_off_24px,
         R.string.no_network_title,
-        R.string.no_network_message,
+        R.string.no_network_subtitle,
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -143,15 +144,14 @@ fun MessageView(
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(imageRes),
+            tint = colorResource(R.color.neutral_30),
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier
-                .size(85.dp)
         )
         Text(
             text = stringResource(messageRes),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(top = 16.dp),
         )
         if (buttonRes != null && onButtonClick != null) {
             Button(

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -121,22 +120,20 @@ fun OfflineView(
     onRetryClick: (() -> Unit)? = null,
 ) {
     MessageView(
-        R.drawable.img_illustration_cloud_off_152dp,
-        R.string.no_network_message,
-        R.string.retry,
+       imageRes =  R.drawable.img_illustration_cloud_off_152dp,
+        messageRes = R.string.no_network_message,
+        buttonRes = R.string.retry,
         onButtonClick = onRetryClick
     )
 }
 
 /**
- * A composable that displays a title with an icon above it and an optional subtitle below it and an
- * optional button below that
+ * A composable that displays a message with an image above it and an optional button below it
  */
 @Composable
 fun MessageView(
-    @DrawableRes iconRes: Int,
-    @StringRes titleRes: Int,
-    @StringRes subtitleRes: Int? = null,
+    @DrawableRes imageRes: Int,
+    @StringRes messageRes: Int,
     @StringRes buttonRes: Int? = null,
     onButtonClick: (() -> Unit)? = null,
 ) {
@@ -146,37 +143,24 @@ fun MessageView(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(
-            imageVector = ImageVector.vectorResource(iconRes),
+            imageVector = ImageVector.vectorResource(imageRes),
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .size(85.dp)
         )
         Text(
-            text = stringResource(titleRes),
+            text = stringResource(messageRes),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        if (subtitleRes != null) {
-            Text(
-                text = stringResource(subtitleRes),
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-        }
         if (buttonRes != null && onButtonClick != null) {
             Box(
                 contentAlignment = Alignment.Center,
+                modifier = Modifier.padding(top = 16.dp)
             ) {
                 Button(
-                    modifier = Modifier.padding(
-                        top = 48.dp
-                    ),
                     onClick = onButtonClick,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.secondary,
-                    ),
                 ) {
                     Text(
                         text = stringResource(R.string.retry).uppercase(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
@@ -16,6 +17,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -114,21 +117,28 @@ fun LargeAvatar(avatarUrl: String) {
  * A composable that displays a message when there is no network connection
  */
 @Composable
-fun OfflineView() {
+fun OfflineView(
+    onRetryClick: (() -> Unit)? = null,
+) {
     MessageView(
         R.drawable.img_illustration_cloud_off_152dp,
         R.string.no_network_message,
+        R.string.retry,
+        onButtonClick = onRetryClick
     )
 }
 
 /**
- * A composable that displays a title with an icon above it and an optional subtitle below it
+ * A composable that displays a title with an icon above it and an optional subtitle below it and an
+ * optional button below that
  */
 @Composable
 fun MessageView(
     @DrawableRes iconRes: Int,
     @StringRes titleRes: Int,
     @StringRes subtitleRes: Int? = null,
+    @StringRes buttonRes: Int? = null,
+    onButtonClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -153,6 +163,26 @@ fun MessageView(
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+        }
+        if (buttonRes != null && onButtonClick != null) {
+            Box(
+                contentAlignment = Alignment.Center,
+            ) {
+                Button(
+                    modifier = Modifier.padding(
+                        top = 48.dp
+                    ),
+                    onClick = onButtonClick,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.secondary,
+                    ),
+                ) {
+                    Text(
+                        text = stringResource(R.string.retry).uppercase(),
+                    )
+                }
+            }
         }
     }
 }
@@ -213,12 +243,14 @@ fun ScreenWithTopBar(
 )
 private fun OfflineScreenPreview() {
     val content: @Composable () -> Unit = @Composable {
-        OfflineView()
+        OfflineView(
+            onRetryClick = {}
+        )
     }
     ScreenWithTopBar(
         title = "Title",
         content = content,
         onCloseClick = {},
-        isScrollable = false
+        isScrollable = false,
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -116,9 +116,8 @@ fun LargeAvatar(avatarUrl: String) {
 @Composable
 fun OfflineView() {
     MessageView(
-        R.drawable.ic_wifi_off_24px,
-        R.string.no_network_title,
-        R.string.no_network_subtitle,
+        R.drawable.img_illustration_cloud_off_152dp,
+        R.string.no_network_message,
     )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -156,6 +157,7 @@ fun MessageView(
         if (buttonRes != null && onButtonClick != null) {
             Button(
                 modifier = Modifier.padding(top = 16.dp),
+                shape = RoundedCornerShape(2.dp),
                 onClick = onButtonClick,
             ) {
                 Text(

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -6,7 +6,6 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
@@ -120,7 +119,7 @@ fun OfflineView(
     onRetryClick: (() -> Unit)? = null,
 ) {
     MessageView(
-       imageRes =  R.drawable.img_illustration_cloud_off_152dp,
+        imageRes = R.drawable.img_illustration_cloud_off_152dp,
         messageRes = R.string.no_network_message,
         buttonRes = R.string.retry,
         onButtonClick = onRetryClick
@@ -155,17 +154,13 @@ fun MessageView(
             color = MaterialTheme.colorScheme.onSurface,
         )
         if (buttonRes != null && onButtonClick != null) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.padding(top = 16.dp)
+            Button(
+                modifier = Modifier.padding(top = 16.dp),
+                onClick = onButtonClick,
             ) {
-                Button(
-                    onClick = onButtonClick,
-                ) {
-                    Text(
-                        text = stringResource(R.string.retry).uppercase(),
-                    )
-                }
+                Text(
+                    text = stringResource(R.string.retry).uppercase(),
+                )
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersActivity.kt
@@ -50,6 +50,9 @@ class SelfHostedUsersActivity : LocaleAwareActivity() {
                         },
                         onUserAvatarClick = { avatarUrl ->
                             viewModel.onUserAvatarClick(avatarUrl)
+                        },
+                        onRetryClick = {
+                            viewModel.onRetryClick()
                         }
                     )
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -39,6 +39,7 @@ fun SelfHostedUsersScreen(
     onCloseClick: () -> Unit = {},
     onUserClick: (UserWithEditContext) -> Unit = {},
     onUserAvatarClick: (avatarUrl: String?) -> Unit = {},
+    onRetryClick: () -> Unit = {},
 ) {
     val state = uiState.collectAsState().value
 
@@ -106,7 +107,9 @@ fun SelfHostedUsersScreen(
                 }
 
                 is SelfHostedUserState.Offline -> {
-                    OfflineView()
+                    OfflineView(
+                        onRetryClick = onRetryClick
+                    )
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -90,8 +90,8 @@ fun SelfHostedUsersScreen(
 
                 is SelfHostedUserState.EmptyUserList -> {
                     MessageView(
-                        R.drawable.ic_people_white_24dp,
-                        R.string.no_users,
+                        imageRes = R.drawable.ic_people_white_24dp,
+                        messageRes = R.string.no_users,
                     )
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersViewModel.kt
@@ -87,6 +87,14 @@ class SelfHostedUsersViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Called when the retry button is clicked
+     */
+    fun onRetryClick() {
+        _uiState.value = SelfHostedUserState.Loading
+        fetchUsers()
+    }
+
     sealed class SelfHostedUserState {
         data object Loading : SelfHostedUserState()
         data object Offline : SelfHostedUserState()

--- a/WordPress/src/main/res/layout/actionable_empty_view.xml
+++ b/WordPress/src/main/res/layout/actionable_empty_view.xml
@@ -62,7 +62,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:adjustViewBounds="true"
-                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:contentDescription="@null"
                 android:visibility="gone" />
 
             <ProgressBar

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
         site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
         this problem.</string>
     <string name="no_network_title">No network available</string>
+    <string name="no_network_subtitle">Try again after reconnecting</string>
     <string name="no_network_message">There is no network available</string>
     <string name="request_failed_message">There was a problem handling the request. Please try again later.</string>
     <string name="sign_out_wpcom_confirm_with_changes">You have changes to posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -11,7 +11,6 @@
         site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve
         this problem.</string>
     <string name="no_network_title">No network available</string>
-    <string name="no_network_subtitle">Try again after reconnecting</string>
     <string name="no_network_message">There is no network available</string>
     <string name="request_failed_message">There was a problem handling the request. Please try again later.</string>
     <string name="sign_out_wpcom_confirm_with_changes">You have changes to posts that haven’t been uploaded to your site. Logging out now will delete those changes from your device. Log out anyway?</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/GifMediaDataSourceTest.kt
@@ -110,8 +110,7 @@ class GifMediaDataSourceTest : BaseUnitTest() {
         val result = gifMediaDataSource.load(forced = false, loadMore = false, filter = filter)
 
         (result as MediaLoadingResult.Failure).apply {
-            Assertions.assertThat((this.title as UiStringRes).stringRes).isEqualTo(R.string.no_network_title)
-            Assertions.assertThat(this.htmlSubtitle).isEqualTo(UiStringRes(R.string.no_network_message))
+            Assertions.assertThat((this.title as UiStringRes).stringRes).isEqualTo(R.string.no_network_message)
             Assertions.assertThat(this.image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
         }
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSourceTest.kt
@@ -80,8 +80,7 @@ class MediaLibraryDataSourceTest : BaseUnitTest() {
 
         val result = dataSource.load(forced = false, loadMore = false, filter = null) as Failure
 
-        assertThat(result.title).isEqualTo(UiStringRes(R.string.no_network_title))
-        assertThat(result.htmlSubtitle).isEqualTo(UiStringRes(R.string.no_network_message))
+        assertThat(result.title).isEqualTo(UiStringRes(R.string.no_network_message))
         assertThat(result.image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
         assertThat(result.data).isEmpty()
     }
@@ -96,8 +95,7 @@ class MediaLibraryDataSourceTest : BaseUnitTest() {
 
         val result = dataSource.load(forced = false, loadMore = true, filter = null) as Failure
 
-        assertThat(result.title).isEqualTo(UiStringRes(R.string.no_network_title))
-        assertThat(result.htmlSubtitle).isEqualTo(UiStringRes(R.string.no_network_message))
+        assertThat(result.title).isEqualTo(UiStringRes(R.string.no_network_message))
         assertThat(result.image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
         assertThat(result.data).hasSize(1)
         result.data.assertContains(mediaModel, 0)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/loader/StockMediaDataSourceTest.kt
@@ -138,8 +138,7 @@ class StockMediaDataSourceTest : BaseUnitTest() {
         val result = stockMediaDataSource.load(forced = false, loadMore = false, filter = filter)
 
         (result as MediaLoadingResult.Failure).apply {
-            assertThat((this.title as UiStringRes).stringRes).isEqualTo(R.string.no_network_title)
-            assertThat(this.htmlSubtitle).isEqualTo(UiStringRes(R.string.no_network_message))
+            assertThat((this.title as UiStringRes).stringRes).isEqualTo(R.string.no_network_message)
             assertThat(this.image).isEqualTo(R.drawable.img_illustration_cloud_off_152dp)
         }
         verifyNoInteractions(stockMediaStore)


### PR DESCRIPTION
Fixes #21283 

Prior to this PR, there were a few places in the app where the user would see both "No network available" and "There is no network available" when there's no network connection. This PR changes this so only the second message appears, and a Retry button was added to the self-hosted user list for consistency.

The following four areas contain this change:

* SelfHostedUserComposables - self-hosted user list
* GifMediaDataSource - adding to media library from Tenor
* StockMediaDataSource - adding to media library from free photo library
* MediaLibraryDataSource - adding media to a post from WP media library

![media-library](https://github.com/user-attachments/assets/7a23ee9f-5a65-4553-923e-4e7b153a211c)
