### PR TITLE
Self hosted users accessibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
@@ -74,7 +74,10 @@ object SampleUsers {
     fun getSampleUsers(): ArrayList<UserWithEditContext> {
         fun addWithId(user: UserWithEditContext) {
             sampleUserList.add(
-                user.copy(id = sampleUserList.size)
+                user.copy(
+                    id = sampleUserList.size,
+                    name = "${user.name}${sampleUserList.size}"
+                )
             )
         }
         if (sampleUserList.isEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
@@ -30,10 +30,11 @@ object SampleUsers {
         description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam non quam viverra, viverra est vel, interdum felis. Pellentesque interdum libero quis metus pharetra ullamcorper. Morbi nec libero ligula. Quisque consectetur, purus sit amet lobortis porttitor, ligula ex imperdiet massa, in ullamcorper augue odio sit amet metus. In sollicitudin mauris et risus mollis commodo. Aliquam vel vehicula ante, nec blandit erat. Aenean non turpis porttitor orci fringilla fringilla nec ac nunc. Nulla ultrices urna ut ipsum posuere blandit. Phasellus mauris nulla, tincidunt at leo at, auctor interdum felis. Sed pharetra risus a ullamcorper dictum. Suspendisse pharetra justo molestie risus lobortis facilisis.",
     )
 
+    // TODO remove avatar
     private val sampleUser2 = UserWithEditContext(
         id = 2,
         username = "@sampleUserWithALongUserName",
-        avatarUrls = emptyMap(),
+        avatarUrls = mapOf("sampleUserTwo" to "https://nickbradbury.com/wp-content/uploads/2022/03/1394-2.jpg"),
         capabilities = emptyMap(),
         description = "User description",
         email = "email@exmaple.com",

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SampleUsers.kt
@@ -15,7 +15,7 @@ object SampleUsers {
         username = "@sampleUser",
         avatarUrls = emptyMap(),
         capabilities = emptyMap(),
-        email = "email@exmaple.com",
+        email = "email@example.com",
         extraCapabilities = emptyMap(),
         firstName = "Sample",
         lastName = "User",
@@ -30,14 +30,13 @@ object SampleUsers {
         description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam non quam viverra, viverra est vel, interdum felis. Pellentesque interdum libero quis metus pharetra ullamcorper. Morbi nec libero ligula. Quisque consectetur, purus sit amet lobortis porttitor, ligula ex imperdiet massa, in ullamcorper augue odio sit amet metus. In sollicitudin mauris et risus mollis commodo. Aliquam vel vehicula ante, nec blandit erat. Aenean non turpis porttitor orci fringilla fringilla nec ac nunc. Nulla ultrices urna ut ipsum posuere blandit. Phasellus mauris nulla, tincidunt at leo at, auctor interdum felis. Sed pharetra risus a ullamcorper dictum. Suspendisse pharetra justo molestie risus lobortis facilisis.",
     )
 
-    // TODO remove avatar
     private val sampleUser2 = UserWithEditContext(
         id = 2,
         username = "@sampleUserWithALongUserName",
-        avatarUrls = mapOf("sampleUserTwo" to "https://nickbradbury.com/wp-content/uploads/2022/03/1394-2.jpg"),
+        avatarUrls = emptyMap(),
         capabilities = emptyMap(),
         description = "User description",
-        email = "email@exmaple.com",
+        email = "email@example.com",
         extraCapabilities = emptyMap(),
         firstName = "Sample",
         lastName = "User",
@@ -57,7 +56,7 @@ object SampleUsers {
         avatarUrls = emptyMap(),
         capabilities = emptyMap(),
         description = "User description",
-        email = "email@exmaple.com",
+        email = "email@example.com",
         extraCapabilities = emptyMap(),
         firstName = "Sample",
         lastName = "User",

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -51,6 +51,7 @@ import org.wordpress.android.ui.compose.theme.M3Theme
 @Composable
 fun SmallAvatar(
     avatarUrl: String?,
+    contentDescription: String? = null,
     onAvatarClick: ((String?) -> Unit)? = null,
 ) {
     val extraModifier = if (onAvatarClick != null) {
@@ -80,7 +81,7 @@ fun SmallAvatar(
                 .crossfade(true)
                 .build(),
             contentScale = ContentScale.Fit,
-            contentDescription = null,
+            contentDescription = contentDescription,
             modifier = Modifier
                 .clip(CircleShape)
                 .size(48.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -167,7 +167,7 @@ fun MessageView(
 fun ScreenWithTopBar(
     title: String,
     onCloseClick: () -> Unit,
-    isScrollable: Boolean,
+    isScrollable: Boolean = false,
     closeIcon: ImageVector = Icons.Default.Close,
     content: @Composable () -> Unit,
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -142,7 +142,6 @@ private fun UserLazyRow(
             Column(modifier = Modifier.padding(all = userScreenPaddingDp)) {
                 SmallAvatar(
                     avatarUrl = user.avatarUrls?.values?.firstOrNull(),
-                    contentDescription = stringResource(R.string.user_avatar_content_description, user.name)
                 )
             }
             Column(

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -258,6 +259,7 @@ private fun UserDetailSection(
     Text(
         text = title,
         style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.semantics { heading() }
     )
     Spacer(modifier = Modifier.height(userScreenPaddingDp))
     content()

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -119,13 +119,13 @@ private fun UserList(
     onUserClick: (UserWithEditContext) -> Unit
 ) {
     for (user in users) {
-        UserLazyRow(user, onUserClick)
+        UserListItem(user, onUserClick)
         HorizontalDivider(thickness = 1.dp, modifier = Modifier.padding(start = 80.dp))
     }
 }
 
 @Composable
-private fun UserLazyRow(
+private fun UserListItem(
     user: UserWithEditContext,
     onUserClick: (UserWithEditContext) -> Unit
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -55,7 +53,8 @@ fun SelfHostedUsersScreen(
     }
 
     val isScrollable = when (state) {
-        is SelfHostedUserState.UserDetail -> false
+        is SelfHostedUserState.UserList -> true
+        is SelfHostedUserState.UserDetail -> true
         else -> false
     }
 
@@ -118,14 +117,9 @@ private fun UserList(
     users: List<UserWithEditContext>,
     onUserClick: (UserWithEditContext) -> Unit
 ) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        items(items = users) { user ->
-            UserListItem(user, onUserClick)
-            HorizontalDivider(thickness = 1.dp)
-        }
+    for (user in users) {
+        UserListItem(user, onUserClick)
+        HorizontalDivider(thickness = 1.dp)
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -132,7 +132,11 @@ private fun UserLazyRow(
     LazyRow(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onUserClick(user) }
+            .clickable(
+                onClickLabel = stringResource(R.string.user_row_content_description, user.name)
+            ) {
+                onUserClick(user)
+            }
     ) {
         item {
             Column(modifier = Modifier.padding(all = userScreenPaddingDp)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -10,7 +10,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
@@ -54,8 +55,7 @@ fun SelfHostedUsersScreen(
     }
 
     val isScrollable = when (state) {
-        is SelfHostedUserState.UserList -> true
-        is SelfHostedUserState.UserDetail -> true
+        is SelfHostedUserState.UserDetail -> false
         else -> false
     }
 
@@ -118,9 +118,14 @@ private fun UserList(
     users: List<UserWithEditContext>,
     onUserClick: (UserWithEditContext) -> Unit
 ) {
-    for (user in users) {
-        UserListItem(user, onUserClick)
-        HorizontalDivider(thickness = 1.dp, modifier = Modifier.padding(start = 80.dp))
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        items(items = users) { user ->
+            UserListItem(user, onUserClick)
+            HorizontalDivider(thickness = 1.dp)
+        }
     }
 }
 
@@ -129,7 +134,7 @@ private fun UserListItem(
     user: UserWithEditContext,
     onUserClick: (UserWithEditContext) -> Unit
 ) {
-    LazyRow(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(
@@ -138,37 +143,35 @@ private fun UserListItem(
                 onUserClick(user)
             }
     ) {
-        item {
-            Column(modifier = Modifier.padding(all = userScreenPaddingDp)) {
-                SmallAvatar(
-                    avatarUrl = user.avatarUrls?.values?.firstOrNull(),
+        Column(modifier = Modifier.padding(all = userScreenPaddingDp)) {
+            SmallAvatar(
+                avatarUrl = user.avatarUrls?.values?.firstOrNull(),
+            )
+        }
+        Column(
+            modifier = Modifier
+                .padding(
+                    top = userScreenPaddingDp,
+                    bottom = userScreenPaddingDp,
+                    end = userScreenPaddingDp
                 )
-            }
-            Column(
-                modifier = Modifier
-                    .padding(
-                        top = userScreenPaddingDp,
-                        bottom = userScreenPaddingDp,
-                        end = userScreenPaddingDp
-                    )
-            ) {
-                Text(
-                    text = user.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+        ) {
+            Text(
+                text = user.name,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = user.username,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            if (user.roles.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    text = user.username,
-                    style = MaterialTheme.typography.bodyMedium
+                    text = user.roles.joinToString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline,
                 )
-                if (user.roles.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(2.dp))
-                    Text(
-                        text = user.roles.joinToString(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.outline,
-                    )
-                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -140,11 +140,11 @@ private fun UserLazyRow(
     ) {
         item {
             Column(modifier = Modifier.padding(all = userScreenPaddingDp)) {
-                SmallAvatar(user.avatarUrls?.values?.firstOrNull())
+                SmallAvatar(
+                    avatarUrl = user.avatarUrls?.values?.firstOrNull(),
+                    contentDescription = stringResource(R.string.user_avatar_content_description, user.name)
+                )
             }
-        }
-
-        item {
             Column(
                 modifier = Modifier
                     .padding(
@@ -189,6 +189,7 @@ private fun UserDetail(
             val avatarUrl = user.avatarUrls?.values?.firstOrNull()
             SmallAvatar(
                 avatarUrl = avatarUrl,
+                contentDescription = stringResource(R.string.user_avatar_content_description, user.name),
                 onAvatarClick = if (avatarUrl.isNullOrEmpty()) {
                     null
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUsersScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -199,23 +200,23 @@ private fun UserDetail(
                 .padding(start = userScreenPaddingDp)
         ) {
             UserDetailSection(title = stringResource(R.string.name)) {
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.username),
                     text = user.username,
                 )
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.role),
                     text = user.roles.joinToString(),
                 )
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.first_name),
                     text = user.firstName,
                 )
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.last_name),
                     text = user.lastName,
                 )
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.nickname),
                     text = user.nickname,
                 )
@@ -223,18 +224,18 @@ private fun UserDetail(
             }
 
             UserDetailSection(title = stringResource(R.string.contact_info)) {
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.email),
                     text = user.email,
                 )
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.website),
                     text = user.url,
                 )
             }
 
             UserDetailSection(title = stringResource(R.string.about_the_user)) {
-                UserDetailRow(
+                UserDetailItem(
                     label = stringResource(R.string.biographical_info),
                     text = user.description.ifEmpty {
                         stringResource(R.string.biographical_info_empty)
@@ -262,22 +263,28 @@ private fun UserDetailSection(
 }
 
 @Composable
-private fun UserDetailRow(
+private fun UserDetailItem(
     label: String,
     text: String,
     isMultiline: Boolean = false,
 ) {
-    Text(
-        text = label,
-        style = MaterialTheme.typography.labelLarge,
-    )
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodyLarge,
-        maxLines = if (isMultiline) 10 else 1,
-        overflow = TextOverflow.Ellipsis
-    )
-    Spacer(modifier = Modifier.height(userScreenPaddingDp))
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {}
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = if (isMultiline) 10 else 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Spacer(modifier = Modifier.height(userScreenPaddingDp))
+    }
 }
 
 @Composable

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2989,6 +2989,7 @@
     <string name="about_the_user">About the user</string>
     <string name="biographical_info">Biographical Info</string>
     <string name="biographical_info_empty">None given</string>
+    <string name="user_row_content_description">Show detail for user %s</string>
 
     <!--Account Settings-->
     <string name="account_settings">Account Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2990,6 +2990,7 @@
     <string name="biographical_info">Biographical Info</string>
     <string name="biographical_info_empty">None given</string>
     <string name="user_row_content_description">Show detail for user %s</string>
+    <string name="user_avatar_content_description">Avatar for user %s</string>
 
     <!--Account Settings-->
     <string name="account_settings">Account Settings</string>


### PR DESCRIPTION
Fixes #21284 

This PR reworks the self-hosted user feature to be more accessible for screen readers. To test:

* Enable "Self-hosted users" in debug settings
* Switch to a self-hosted site
* Enable Talkback
* My Site > Users
* Note that tapping a user list item reads the displayed user info
* Double tap to show user detail
* Note that tapping a row reads both the label and the user info (ex: tapping "Username" reads both "Username" and the user's name)
