### PR TITLE
Fix Jetpack poster line spacing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -99,7 +99,11 @@ fun JetpackStaticPoster(
                             R.string.wp_jp_static_poster_title_plural else R.string.wp_jp_static_poster_title,
                         uiStringText(featureName)
                     ),
-                    style = MaterialTheme.typography.h1.copy(fontSize = 34.sp, fontWeight = FontWeight.Bold),
+                    style = MaterialTheme.typography.h1.copy(
+                        fontSize = 34.sp,
+                        fontWeight = FontWeight.Bold,
+                        lineHeight = 48.sp
+                    ),
                 )
                 Text(
                     stringResource(R.string.wp_jp_static_poster_message),


### PR DESCRIPTION
Fixes #21294 

Prior to this PR, the spacing between lines in the headline on the "Jetpack Poster" screen was far too large. This tiny PR resolves this by setting the `lineHeight` of the headline.

To test, you can simply view the preview of the `JetpackStaticPoster` screen, or run the WordPress app and verify the spacing issue is resolved when trying to view stats, the reader, or notifications.

**BEFORE**

![before](https://github.com/user-attachments/assets/ad4bd28e-6055-4c45-b327-00d526b95412)

**AFTER**

![after](https://github.com/user-attachments/assets/8f77d8e4-3b52-4e01-a905-362fc5110c5d)
