### PR TITLE
[Localization] Fix Remote Libraries Strings Paths

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -248,14 +248,14 @@ platform :android do
   REMOTE_LIBRARIES_STRINGS_PATHS = [
     {
       name: 'Gutenberg Native',
-      import_key: 'gutenbergMobileVersion',
+      import_key: 'gutenberg-mobile',
       repository: 'wordpress-mobile/gutenberg-mobile',
       strings_file_path: 'bundle/android/strings.xml',
       source_id: 'gutenberg'
     },
     {
       name: 'Login Library',
-      import_key: 'wordPressLoginVersion',
+      import_key: 'wordpress-login',
       repository: 'wordpress-mobile/WordPress-Login-Flow-Android',
       strings_file_path: 'WordPressLoginFlow/src/main/res/values/strings.xml',
       exclusions: ['default_web_client_id'],
@@ -263,7 +263,7 @@ platform :android do
     },
     {
       name: 'About Library',
-      import_key: 'automatticAboutVersion',
+      import_key: 'automattic-about',
       repository: 'Automattic/about-automattic-android',
       strings_file_path: 'library/src/main/res/values/strings.xml',
       source_id: 'about'
@@ -295,7 +295,7 @@ platform :android do
         import_key: lib[:import_key],
         repository: lib[:repository],
         file_path: lib[:strings_file_path],
-        build_gradle_path: File.join(PROJECT_ROOT_FOLDER, 'build.gradle')
+        build_gradle_path: File.join(PROJECT_ROOT_FOLDER, 'gradle/libs.versions.toml')
       )
 
       if download_path.nil?


### PR DESCRIPTION
Similar to this [WCAndroid PR](https://github.com/woocommerce/woocommerce-android/pull/12799), this PR updates the `android_download_file_by_version(...)` Fastfile action and import keys to fix a localization related issues related to versioning.

This is a leftover from the `Version Catalogs` migration work ([PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21262)).

FYI: During a WCAndroid release, the `complete_code_freeze` workflow failed due to the fact that the old, non-version-catalogs related versions couldn't be referenced any more. The same will apply for this project when a new release will commence. This change addresses that. Apologies for any inconvenience. 🙏 

-----

## To Test:

This is going to be tested live via the newest WCAndroid release ([reference](https://github.com/woocommerce/woocommerce-android/pull/12799)). If everything goes well there we can assume that this change is going to work on this project as well.

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

-----

## Regression Notes

1. Potential unintended areas of impact

    - Localization is still failing during release code freeze.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist: `N/A`

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`