### PR TITLE
Rename M3Theme to AppThemeM3

### DIFF
--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -35,7 +35,7 @@ import org.wordpress.android.ui.accounts.login.components.TopLinearGradient
 import org.wordpress.android.ui.accounts.login.components.WordpressJetpackLogo
 import org.wordpress.android.ui.compose.TestTags
 import org.wordpress.android.ui.compose.components.ColumnWithFrostedGlassBackground
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 
 val LocalPosition = compositionLocalOf { 0f }
@@ -51,7 +51,7 @@ class LoginPrologueRevampedFragment : Fragment() {
         savedInstanceState: Bundle?
     ) = ComposeView(requireContext()).apply {
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 PositionProvider(viewModel) {
                     LoginScreenRevamped(
                         onWpComLoginClicked = {
@@ -151,7 +151,7 @@ private fun LoginScreenRevamped(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewLoginScreenRevamped() {
-    M3Theme {
+    AppThemeM3 {
         LoginScreenRevamped(
             onWpComLoginClicked = {},
             onSiteAddressLoginClicked = {}

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingText.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingText.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.accounts.login.LocalPosition
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.util.extensions.isOdd
 
 private const val FIXED_FONT_SIZE = 40
@@ -72,7 +72,7 @@ fun LoopingText(modifier: Modifier = Modifier) {
 @Preview(showBackground = true, device = Devices.PIXEL_4, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewLoopingText() {
-    M3Theme {
+    AppThemeM3 {
         LoopingText()
     }
 }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/LoopingTextWithBackground.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun LoopingTextWithBackground(
@@ -46,7 +46,7 @@ fun LoopingTextWithBackground(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewLoopingTextWithBackground() {
-    M3Theme {
+    AppThemeM3 {
         LoopingTextWithBackground()
     }
 }

--- a/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/TopLinearGradient.kt
+++ b/WordPress/src/jetpack/java/org/wordpress/android/ui/accounts/login/components/TopLinearGradient.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun TopLinearGradient(modifier: Modifier = Modifier) {
@@ -29,7 +29,7 @@ fun TopLinearGradient(modifier: Modifier = Modifier) {
 @Preview(device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PreviewTopLinearGradient() {
-    M3Theme {
+    AppThemeM3 {
         TopLinearGradient()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/ProgressDialog.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import kotlinx.coroutines.flow.Flow
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun ProgressDialog(progressDialogState: Flow<ProgressDialogState?>) {
@@ -37,7 +37,7 @@ fun ProgressDialog(progressDialogState: Flow<ProgressDialogState?>) {
 
 @Composable
 fun ProgressDialog(progressDialogState: ProgressDialogState) {
-    M3Theme {
+    AppThemeM3 {
         val dialogProps = DialogProperties(
             dismissOnBackPress = progressDialogState.dismissible,
             dismissOnClickOutside = progressDialogState.dismissible,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButtonM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButtonM3.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun PrimaryButtonM3(
@@ -86,7 +86,7 @@ fun PrimaryButtonM3(
 )
 @Composable
 private fun PrimaryButtonPreview() {
-    M3Theme {
+    AppThemeM3 {
         PrimaryButtonM3(text = "Continue", onClick = {})
     }
 }
@@ -98,7 +98,7 @@ private fun PrimaryButtonPreview() {
 )
 @Composable
 private fun PrimaryButtonInProgressPreview() {
-    M3Theme {
+    AppThemeM3 {
         PrimaryButtonM3(text = "", onClick = {}, isInProgress = true)
     }
 }
@@ -110,7 +110,7 @@ private fun PrimaryButtonInProgressPreview() {
 )
 @Composable
 private fun PrimaryButtonLargePreview() {
-    M3Theme {
+    AppThemeM3 {
         PrimaryButtonM3(text = "Continue", onClick = {}, buttonSize = ButtonSize.LARGE)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM3.kt
@@ -17,17 +17,17 @@ import org.wordpress.android.BuildConfig
 private val localColors = staticCompositionLocalOf { extraPaletteJPLight }
 
 @Composable
-fun M3Theme(
+fun AppThemeM3(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    M3ThemeWithoutBackground(isDarkTheme) {
+    AppThemeM3WithoutBackground(isDarkTheme) {
         ContentInSurfaceM3(content)
     }
 }
 
 @Composable
-fun M3ThemeWithoutBackground(
+fun AppThemeM3WithoutBackground(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsActivity.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
@@ -16,7 +16,7 @@ class DebugSharedPreferenceFlagsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 val uiState by viewModel.uiStateFlow.collectAsState()
                 DebugSharedPreferenceFlagsScreen(
                     flags = uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/preferences/DebugSharedPreferenceFlagsScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun DebugSharedPreferenceFlagsScreen(
@@ -79,7 +79,7 @@ fun DebugFlagRow(
 @Preview
 @Composable
 fun DebugFlagsScreenPreview() {
-    M3Theme {
+    AppThemeM3 {
         DebugSharedPreferenceFlagsScreen(
             flags = mapOf(
                 "EXAMPLE_FEATURE_FLAG" to true,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainManagementActivity.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.ActionEvent
 import org.wordpress.android.ui.domains.management.details.DomainManagementDetailsActivity
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
@@ -21,7 +21,7 @@ class DomainManagementActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 val uiState by viewModel.uiStateFlow.collectAsState()
 
                 MyDomainsScreen(

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainStatusRow.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainStatusRow.kt
@@ -31,7 +31,7 @@ import org.wordpress.android.R
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType
 import org.wordpress.android.ui.domains.management.composable.PendingGhostStrip
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -111,7 +111,7 @@ class PreviewStatusProvider: PreviewParameterProvider<Pair<DomainStatus, LocalDa
 fun DomainStatusRowPreview(
     @PreviewParameter(PreviewStatusProvider::class) status: Pair<DomainStatus, LocalDate?>?,
 ) {
-    M3Theme {
+    AppThemeM3 {
         Column (Modifier.padding(8.dp)) {
             StatusRow(
                 uiState = status?.let { (domainStatus, expiry) ->

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainsListCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/DomainsListCard.kt
@@ -27,7 +27,7 @@ import org.wordpress.android.fluxc.network.rest.wpcom.site.AllDomainsDomain
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainStatus
 import org.wordpress.android.fluxc.network.rest.wpcom.site.StatusType
 import org.wordpress.android.ui.domains.management.composable.PendingGhostStrip
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
@@ -109,7 +109,7 @@ fun DomainListCard(
 fun DomainListCardPreview() {
     val expiry = LocalDate.of(2024,8,15).asLegacyDate()
 
-    M3Theme {
+    AppThemeM3 {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier.padding(16.dp),

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/MyDomainsScreen.kt
@@ -42,7 +42,7 @@ import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiS
 import org.wordpress.android.ui.domains.management.DomainManagementViewModel.UiState.PopulatedList
 import org.wordpress.android.ui.domains.management.composable.DomainsSearchTextField
 import org.wordpress.android.ui.domains.management.composable.PrimaryButton
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun MyDomainsScreen(
@@ -198,7 +198,7 @@ fun MyDomainsList(
 @Preview(device = Devices.PIXEL_3A, uiMode = UI_MODE_NIGHT_YES, group = "Initial")
 @Composable
 fun PreviewMyDomainsScreen() {
-    M3Theme {
+    AppThemeM3 {
         MyDomainsScreen(
             uiState = PopulatedList.Initial,
             onSearchQueryChanged = {},
@@ -214,7 +214,7 @@ fun PreviewMyDomainsScreen() {
 @Preview(device = Devices.PIXEL_3A, uiMode = UI_MODE_NIGHT_YES, group = "Error / Offline")
 @Composable
 fun PreviewMyDomainsScreenError() {
-    M3Theme {
+    AppThemeM3 {
         MyDomainsScreen(
             uiState = Error,
             onSearchQueryChanged = {},
@@ -230,7 +230,7 @@ fun PreviewMyDomainsScreenError() {
 @Preview(device = Devices.PIXEL_3A, uiMode = UI_MODE_NIGHT_YES, group = "Empty")
 @Composable
 fun PreviewMyDomainsScreenEmpty() {
-    M3Theme {
+    AppThemeM3 {
         MyDomainsScreen(
             uiState = Empty,
             onSearchQueryChanged = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/DomainsSearchTextField.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/DomainsSearchTextField.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun DomainsSearchTextField(
@@ -71,7 +71,7 @@ fun DomainsSearchTextField(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, group = "Empty")
 @Composable
 fun PreviewDomainsSearchTextFieldEmpty() {
-    M3Theme {
+    AppThemeM3 {
         DomainsSearchTextField(
             value = "",
             onValueChange = {},
@@ -84,7 +84,7 @@ fun PreviewDomainsSearchTextFieldEmpty() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, group = "Populated")
 @Composable
 fun PreviewDomainsSearchTextFieldPopulated() {
-    M3Theme {
+    AppThemeM3 {
         DomainsSearchTextField(
             value = "Cool domain",
             onValueChange = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/composable/PrimaryButton.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun PrimaryButton(
@@ -52,7 +52,7 @@ fun PrimaryButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrimaryButtonPreview() {
-    M3Theme {
+    AppThemeM3 {
         PrimaryButton(text = "Continue", onClick = {})
     }
 }
@@ -61,7 +61,7 @@ private fun PrimaryButtonPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrimaryButtonInProgressPreview() {
-    M3Theme {
+    AppThemeM3 {
         PrimaryButton(text = "Continue", onClick = {}, isInProgress = true)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/newdomainsearch/NewDomainSearchActivity.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityNavigator
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.domains.management.newdomainsearch.composable.NewDomainSearchScreen
 import javax.inject.Inject
 
@@ -25,7 +25,7 @@ class NewDomainSearchActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 val uiState by viewModel.uiStateFlow.collectAsState()
                 NewDomainSearchScreen(
                     uiState = uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/PurchaseDomainActivity.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.domains.DomainRegistrationCheckoutWebViewActivity
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoBack
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoToDomainPurchasing
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.ActionEvent.GoToSitePicker
@@ -64,7 +64,7 @@ class PurchaseDomainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 val uiState by viewModel.uiStateFlow.collectAsState()
                 PurchaseDomainScreen(
                     uiState = uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/domains/management/purchasedomain/composable/PurchaseDomainScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.domains.management.composable.PrimaryButton
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState
 import org.wordpress.android.ui.domains.management.purchasedomain.PurchaseDomainViewModel.UiState.Initial
@@ -275,7 +275,7 @@ private val isPortrait: Boolean @Composable get() = LocalConfiguration.current.o
 @Preview(name = "Landscape orientation", device = Devices.AUTOMOTIVE_1024p)
 @Composable
 fun PurchaseDomainScreenPreview() {
-    M3Theme {
+    AppThemeM3 {
         PurchaseDomainScreen(Initial, {}, {}, {}, {})
     }
 }
@@ -284,7 +284,7 @@ fun PurchaseDomainScreenPreview() {
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PurchaseDomainScreenErrorPreview() {
-    M3Theme {
+    AppThemeM3 {
         PurchaseDomainScreen(UiState.ErrorSubmittingCart, {}, {}, {}, {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -47,7 +47,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MediaUriPager
 import org.wordpress.android.ui.compose.components.ProgressDialog
 import org.wordpress.android.ui.compose.components.ProgressDialogState
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun FeedbackFormScreen(
@@ -200,7 +200,7 @@ private fun Screen(
     content: @Composable () -> Unit,
     onCloseClick: () -> Unit
 ) {
-    M3Theme {
+    AppThemeM3 {
         Scaffold(
             topBar = {
                 TopAppBar(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/JetpackStaticPosterFragment.kt
@@ -15,7 +15,7 @@ import org.wordpress.android.ui.ActivityLauncherWrapper
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.CAMPAIGN_STATIC_POSTER
 import org.wordpress.android.ui.ActivityLauncherWrapper.Companion.JETPACK_PACKAGE_NAME
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.main.jetpack.staticposter.compose.JetpackStaticPoster
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.extensions.getParcelableCompat
@@ -34,7 +34,7 @@ class JetpackStaticPosterFragment : Fragment() {
         savedInstanceState: Bundle?
     ) = ComposeView(requireContext()).apply {
         setContent {
-            M3Theme {
+            AppThemeM3 {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Content -> JetpackStaticPoster(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/staticposter/compose/JetpackStaticPoster.kt
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
 import org.wordpress.android.ui.compose.theme.AppColor
 import org.wordpress.android.ui.compose.theme.JpColorPalette
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.staticposter.UiData
 import org.wordpress.android.ui.main.jetpack.staticposter.UiState
@@ -164,7 +164,7 @@ fun JetpackStaticPoster(
 )
 @Composable
 private fun PreviewJetpackStaticPoster() {
-    M3Theme {
+    AppThemeM3 {
         val uiState = UiData.STATS.toContentUiState()
         JetpackStaticPoster(uiState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/AccountClosureDialog.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun AccountClosureDialog(
@@ -21,7 +21,7 @@ fun AccountClosureDialog(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val padding = 10.dp
-    M3Theme {
+    AppThemeM3 {
         Dialog(
             onDismissRequest = onDismissRequest,
             properties = DialogProperties(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/CloseAccountButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/CloseAccountButton.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3ThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM3WithoutBackground
 
 @Composable
 fun CloseAccountButton(onClick: () -> Unit = {}): Unit = Button(
@@ -45,7 +45,7 @@ fun CloseAccountButton(onClick: () -> Unit = {}): Unit = Button(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewCloseAccountButton() {
-    M3ThemeWithoutBackground {
+    AppThemeM3WithoutBackground {
         CloseAccountButton()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/components/FlatButtons.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.wordpress.android.ui.compose.theme.M3ThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM3WithoutBackground
 
 @Composable
 fun FlatButton(
@@ -69,7 +69,7 @@ fun FlatOutlinedButton(
 @Preview(name = "Dark Mode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewFlatButton() {
-    M3ThemeWithoutBackground {
+    AppThemeM3WithoutBackground {
         FlatButton(
             text = "Flat",
             onClick = {},
@@ -81,7 +81,7 @@ fun PreviewFlatButton() {
 @Preview(name = "Dark Mode", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewOutlinedButton() {
-    M3ThemeWithoutBackground {
+    AppThemeM3WithoutBackground {
         FlatOutlinedButton(
             text = "Outlined",
             onClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/selfhostedusers/SelfHostedUserComposables.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.M3Theme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 /**
  * These composables were created for the self-hosted users feature but were written to be reusable
@@ -178,7 +178,7 @@ fun ScreenWithTopBar(
     closeIcon: ImageVector = Icons.Default.Close,
     content: @Composable () -> Unit,
 ) {
-    M3Theme {
+    AppThemeM3 {
         Scaffold(
             topBar = {
                 TopAppBar(


### PR DESCRIPTION
This PR renames `M3Theme` to `AppThemeM3` to make it more consistent with the existing `AppTheme`. There's really nothing to test - it's just a simple rename.