### PR TITLE
Convert Jetpack Migration to Material3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Message.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Message.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
 fun Message(
@@ -24,4 +26,12 @@ fun Message(
             .padding(horizontal = 30.dp)
             .padding(top = 20.dp, bottom = 30.dp)
     )
+}
+
+@Preview
+@Composable
+private fun MessagePreview() {
+    AppTheme {
+        Message(text = "This message should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
@@ -20,7 +20,6 @@ fun MessageM3(
     Text(
         text = text,
         fontSize = 17.sp,
-        style = TextStyle(letterSpacing = (-0.01).sp),
         color = colorResource(R.color.gray_50),
         modifier = modifier
             .padding(horizontal = 30.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.compose.components.text
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.wordpress.android.R
+
+@Composable
+fun MessageM3(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        fontSize = 17.sp,
+        style = TextStyle(letterSpacing = (-0.01).sp),
+        color = colorResource(R.color.gray_50),
+        modifier = modifier
+            .padding(horizontal = 30.dp)
+            .padding(top = 20.dp, bottom = 30.dp)
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/MessageM3.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun MessageM3(
@@ -24,4 +26,12 @@ fun MessageM3(
             .padding(horizontal = 30.dp)
             .padding(top = 20.dp, bottom = 30.dp)
     )
+}
+
+@Preview
+@Composable
+private fun MessageM3Preview() {
+    AppThemeM3 {
+        MessageM3(text = "This message should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Subtitle.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Subtitle.kt
@@ -5,8 +5,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.wordpress.android.ui.compose.theme.AppTheme
 
 @Composable
 fun Subtitle(
@@ -21,4 +23,12 @@ fun Subtitle(
             .padding(horizontal = 30.dp)
             .padding(top = 20.dp)
     )
+}
+
+@Preview
+@Composable
+private fun SubtitlePreview() {
+    AppTheme {
+        Subtitle(text = "This subtitle should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
@@ -18,7 +18,6 @@ fun SubtitleM3(
     Text(
         text = text,
         fontSize = 17.sp,
-        style = TextStyle(letterSpacing = (-0.01).sp),
         modifier = modifier
             .padding(horizontal = 30.dp)
             .padding(top = 20.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.compose.components.text
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SubtitleM3(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        fontSize = 17.sp,
+        style = TextStyle(letterSpacing = (-0.01).sp),
+        modifier = modifier
+            .padding(horizontal = 30.dp)
+            .padding(top = 20.dp)
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/SubtitleM3.kt
@@ -5,8 +5,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun SubtitleM3(
@@ -21,4 +23,12 @@ fun SubtitleM3(
             .padding(horizontal = 30.dp)
             .padding(top = 20.dp)
     )
+}
+
+@Preview
+@Composable
+private fun SubtitleM3Preview() {
+    AppThemeM3 {
+        SubtitleM3(text = "This subtitle should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Title.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Title.kt
@@ -5,7 +5,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.theme.AppTheme
 import org.wordpress.android.ui.compose.unit.FontSize
 
 @Composable
@@ -21,4 +23,12 @@ fun Title(
             .padding(horizontal = 30.dp)
             .padding(top = 30.dp)
     )
+}
+
+@Preview
+@Composable
+private fun TitlePreview() {
+    AppTheme {
+        Title(text = "This title should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
@@ -19,7 +19,7 @@ fun TitleM3(
     Text(
         text = text,
         fontSize = fontSize,
-        lineHeight = fontSize * 1.25,
+        lineHeight = fontSize * 1.1,
         fontWeight = FontWeight.Bold,
         modifier = modifier
             .padding(horizontal = 30.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.FontSize
 
 @Composable
@@ -13,12 +15,22 @@ fun TitleM3(
     text: String,
     modifier: Modifier = Modifier,
 ) {
+    val fontSize = FontSize.ExtraExtraExtraLarge.value
     Text(
         text = text,
-        fontSize = FontSize.ExtraExtraExtraLarge.value,
+        fontSize = fontSize,
+        lineHeight = fontSize * 1.25,
         fontWeight = FontWeight.Bold,
         modifier = modifier
             .padding(horizontal = 30.dp)
             .padding(top = 30.dp)
     )
+}
+
+@Preview
+@Composable
+private fun TitleM3Preview() {
+    AppThemeM3 {
+        TitleM3(text = "This title should be long enough so the preview wraps to more than one line")
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/TitleM3.kt
@@ -1,0 +1,24 @@
+package org.wordpress.android.ui.compose.components.text
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.ui.compose.unit.FontSize
+
+@Composable
+fun TitleM3(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        fontSize = FontSize.ExtraExtraExtraLarge.value,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .padding(horizontal = 30.dp)
+            .padding(top = 30.dp)
+    )
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/JetpackMigrationFragment.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity.Origin.JETPACK_MIGRATION_HELP
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.LocaleAwareComposable
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.JetpackMigrationActionEvent.CompleteFlow
@@ -64,7 +64,7 @@ class JetpackMigrationFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM3 {
                 val userLanguage by viewModel.refreshAppLanguage.observeAsState("")
 
                 LocaleAwareComposable(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -36,6 +38,7 @@ import org.wordpress.android.ui.compose.components.text.SubtitleM3
 import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.modifiers.disableUserScroll
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.SiteListItemUiState
@@ -151,4 +154,21 @@ private fun SiteAddress(url: String) {
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
+}
+
+@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
+@Composable
+private fun PreviewSiteListItem() {
+    val uiState = SiteListItemUiState(
+        id = 1,
+        name = "Site Name",
+        url = "https://www.example.com",
+        iconUrl = "",
+    )
+    AppThemeM3 {
+        SiteListItem(
+            uiState,
+            isDimmed = false
+        )
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -13,17 +13,20 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
@@ -119,19 +122,32 @@ private fun SiteListHeader(uiState: UiState.Content.Welcome): Unit = with(uiStat
 
 @Composable
 private fun SiteIcon(iconUrl: String) {
-    AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(iconUrl)
-            .error(R.drawable.ic_site_icon_placeholder_primary_24)
-            .crossfade(true)
-            .build(),
-        contentDescription = stringResource(R.string.blavatar_desc),
-        modifier = Modifier
-            .padding(vertical = 15.dp)
-            .padding(end = 20.dp)
-            .size(dimensionResource(R.dimen.jp_migration_site_icon_size))
-            .clip(RoundedCornerShape(3.dp))
-    )
+    if (iconUrl.isEmpty()) {
+        Icon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_user_placeholder_primary_24),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+                .padding(vertical = 15.dp)
+                .padding(end = 20.dp)
+                .size(dimensionResource(R.dimen.jp_migration_site_icon_size))
+                .clip(RoundedCornerShape(3.dp))
+        )
+    } else {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(iconUrl)
+                .error(R.drawable.ic_site_icon_placeholder_primary_24)
+                .crossfade(true)
+                .build(),
+            contentDescription = stringResource(R.string.blavatar_desc),
+            modifier = Modifier
+                .padding(vertical = 15.dp)
+                .padding(end = 20.dp)
+                .size(dimensionResource(R.dimen.jp_migration_site_icon_size))
+                .clip(RoundedCornerShape(3.dp))
+        )
+    }
 }
 
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -12,9 +12,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +55,7 @@ fun SiteList(
         state = listState,
         modifier = modifier
             .conditionalThen(!userScrollEnabled, Modifier.disableUserScroll())
-            .background(MaterialTheme.colors.background)
+            .background(MaterialTheme.colorScheme.background)
             .fillMaxHeight()
             .then(blurModifier),
     ) {
@@ -70,7 +70,7 @@ fun SiteList(
                 uiState = site,
                 isDimmed = uiState.isProcessing,
             )
-            Divider(
+            HorizontalDivider(
                 color = colorResource(R.color.gray_10),
                 thickness = 0.5.dp,
                 modifier = Modifier

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -31,9 +31,9 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.components.text.Message
-import org.wordpress.android.ui.compose.components.text.Subtitle
-import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.components.text.MessageM3
+import org.wordpress.android.ui.compose.components.text.SubtitleM3
+import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.modifiers.disableUserScroll
 import org.wordpress.android.ui.compose.unit.FontSize
@@ -108,9 +108,9 @@ private fun SiteListHeader(uiState: UiState.Content.Welcome): Unit = with(uiStat
             .dimmed(uiState.isProcessing)
     ) {
         ScreenIcon(iconRes = screenIconRes)
-        Title(text = uiStringText(title))
-        Subtitle(text = uiStringText(subtitle))
-        Message(text = uiStringText(message))
+        TitleM3(text = uiStringText(title))
+        SubtitleM3(text = uiStringText(subtitle))
+        MessageM3(text = uiStringText(message))
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/SiteList.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -41,7 +39,6 @@ import org.wordpress.android.ui.compose.components.text.SubtitleM3
 import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.modifiers.disableUserScroll
-import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.SiteListItemUiState
@@ -124,7 +121,7 @@ private fun SiteListHeader(uiState: UiState.Content.Welcome): Unit = with(uiStat
 private fun SiteIcon(iconUrl: String) {
     if (iconUrl.isEmpty()) {
         Icon(
-            imageVector = ImageVector.vectorResource(id = R.drawable.ic_user_placeholder_primary_24),
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_site_icon_placeholder_primary_24),
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
@@ -170,21 +167,4 @@ private fun SiteAddress(url: String) {
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
     )
-}
-
-@Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
-@Composable
-private fun PreviewSiteListItem() {
-    val uiState = SiteListItemUiState(
-        id = 1,
-        name = "Site Name",
-        url = "https://www.example.com",
-        iconUrl = "",
-    )
-    AppThemeM3 {
-        SiteListItem(
-            uiState,
-            isDimmed = false
-        )
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/UserAvatarImage.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/components/UserAvatarImage.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,7 +38,7 @@ fun BoxScope.UserAvatarImage(
             .padding(top = MediumLarge.value, end = 30.dp)
             .size(dimensionResource(R.dimen.jp_migration_user_avatar_size))
             .clip(CircleShape)
-            .background(MaterialTheme.colors.surface)
+            .background(MaterialTheme.colorScheme.surface)
             .clickable { onClick() }
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,11 +24,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ButtonsColumn
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
 import org.wordpress.android.ui.compose.components.text.Subtitle
 import org.wordpress.android.ui.compose.components.text.Title
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.DeletePrimaryButton
@@ -74,11 +74,11 @@ fun DeleteStep(uiState: UiState.Content.Delete): Unit = with(uiState) {
             Spacer(modifier = Modifier.weight(0.5f))
         }
         ButtonsColumn {
-            PrimaryButton(
+            PrimaryButtonM3(
                 text = uiStringText(primaryActionButton.text),
                 onClick = primaryActionButton.onClick,
             )
-            SecondaryButton(
+            SecondaryButtonM3(
                 text = uiStringText(secondaryActionButton.text),
                 onClick = secondaryActionButton.onClick,
                 enabled = true
@@ -92,7 +92,7 @@ fun DeleteStep(uiState: UiState.Content.Delete): Unit = with(uiState) {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewDeleteStep() {
-    AppTheme {
+    AppThemeM3 {
         val uiState = UiState.Content.Delete(DeletePrimaryButton {}, DeleteSecondaryButton {})
         DeleteStep(uiState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DeleteStep.kt
@@ -26,8 +26,8 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ButtonsColumn
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
-import org.wordpress.android.ui.compose.components.text.Subtitle
-import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.components.text.SubtitleM3
+import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.compose.utils.uiStringText
@@ -48,8 +48,8 @@ fun DeleteStep(uiState: UiState.Content.Delete): Unit = with(uiState) {
                 .weight(1f)
         ) {
             ScreenIcon(iconRes = screenIconRes)
-            Title(text = uiStringText(title))
-            Subtitle(text = uiStringText(subtitle))
+            TitleM3(text = uiStringText(title))
+            SubtitleM3(text = uiStringText(subtitle))
 
             Spacer(modifier = Modifier.weight(0.5f))
             Image(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,10 +24,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ButtonsColumn
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
 import org.wordpress.android.ui.compose.components.text.Subtitle
 import org.wordpress.android.ui.compose.components.text.Title
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel
@@ -77,7 +77,7 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
             }
         }
         ButtonsColumn {
-            PrimaryButton(
+            PrimaryButtonM3(
                 text = uiStringText(primaryActionButton.text),
                 onClick = primaryActionButton.onClick,
             )
@@ -90,7 +90,7 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewDoneStep() {
-    AppTheme {
+    AppThemeM3 {
         val uiState = UiState.Content.Done(DonePrimaryButton {})
         DoneStep(uiState)
     }
@@ -98,7 +98,7 @@ private fun PreviewDoneStep() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL)
 @Composable
 private fun PreviewDoneStepNoSites() {
-    AppTheme {
+    AppThemeM3 {
         val uiState = UiState.Content.Done(
             JetpackMigrationViewModel.ActionButton.DoneNoSitesFlowPrimaryButton {}, false)
         DoneStep(uiState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/DoneStep.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ButtonsColumn
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
-import org.wordpress.android.ui.compose.components.text.Subtitle
-import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.components.text.SubtitleM3
+import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.htmlToAnnotatedString
 import org.wordpress.android.ui.compose.utils.uiStringText
@@ -47,8 +47,8 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
                 .weight(1f)
         ) {
             ScreenIcon(iconRes = screenIconRes)
-            Title(text = uiStringText(title))
-            Subtitle(text = uiStringText(subtitle))
+            TitleM3(text = uiStringText(title))
+            SubtitleM3(text = uiStringText(subtitle))
 
             if (showDeleteWPApp) {
                 Spacer(modifier = Modifier.weight(0.5f))
@@ -73,7 +73,7 @@ fun DoneStep(uiState: UiState.Content.Done): Unit = with(uiState) {
                 )
                 Spacer(modifier = Modifier.weight(0.5f))
             } else {
-                Subtitle(text = uiStringText(noSitesMessage))
+                SubtitleM3(text = uiStringText(noSitesMessage))
             }
         }
         ButtonsColumn {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.components.ButtonsColumn
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
-import org.wordpress.android.ui.compose.components.text.Message
-import org.wordpress.android.ui.compose.components.text.Subtitle
-import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.components.text.MessageM3
+import org.wordpress.android.ui.compose.components.text.SubtitleM3
+import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.ErrorPrimaryButton
@@ -38,15 +38,15 @@ fun ErrorStep(uiState: UiState.Error): Unit = with(uiState) {
                 iconRes = screenIconRes,
                 modifier = Modifier.dimmed(isProcessing)
             )
-            Title(
+            TitleM3(
                 text = uiStringText(type.title),
                 modifier = Modifier.dimmed(isProcessing)
             )
-            Subtitle(
+            SubtitleM3(
                 text = uiStringText(type.subtitle),
                 modifier = Modifier.dimmed(isProcessing)
             )
-            Message(
+            MessageM3(
                 text = uiStringText(type.message),
                 modifier = Modifier.dimmed(isProcessing)
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/ErrorStep.kt
@@ -10,12 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.components.ButtonsColumn
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
 import org.wordpress.android.ui.compose.components.text.Message
 import org.wordpress.android.ui.compose.components.text.Subtitle
 import org.wordpress.android.ui.compose.components.text.Title
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.ErrorPrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.ErrorSecondaryButton
@@ -52,12 +52,12 @@ fun ErrorStep(uiState: UiState.Error): Unit = with(uiState) {
             )
         }
         ButtonsColumn {
-            PrimaryButton(
+            PrimaryButtonM3(
                 text = uiStringText(primaryActionButton.text),
                 onClick = primaryActionButton.onClick,
                 isInProgress = isProcessing,
             )
-            SecondaryButton(
+            SecondaryButtonM3(
                 text = uiStringText(secondaryActionButton.text),
                 onClick = secondaryActionButton.onClick,
                 enabled = !isProcessing,
@@ -71,7 +71,7 @@ fun ErrorStep(uiState: UiState.Error): Unit = with(uiState) {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PreviewErrorStep() {
-    AppTheme {
+    AppThemeM3 {
         val uiState = UiState.Error(
             primaryActionButton = ErrorPrimaryButton {},
             secondaryActionButton = ErrorSecondaryButton {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/LoadingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/LoadingState.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.main.jetpack.migration.compose.state
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
@@ -10,11 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.components.ButtonsColumn
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
 import org.wordpress.android.ui.compose.components.text.Message
 import org.wordpress.android.ui.compose.components.text.Subtitle
 import org.wordpress.android.ui.compose.components.text.Title
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.UiState
@@ -37,7 +37,7 @@ fun NotificationsStep(uiState: UiState.Content.Notifications): Unit = with(uiSta
             Message(text = uiStringText(message))
         }
         ButtonsColumn {
-            PrimaryButton(
+            PrimaryButtonM3(
                 text = uiStringText(primaryActionButton.text),
                 onClick = primaryActionButton.onClick,
             )
@@ -50,7 +50,7 @@ fun NotificationsStep(uiState: UiState.Content.Notifications): Unit = with(uiSta
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewNotificationsStep() {
-    AppTheme {
+    AppThemeM3 {
         val uiState = UiState.Content.Notifications(NotificationsPrimaryButton {})
         NotificationsStep(uiState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/NotificationsStep.kt
@@ -11,9 +11,9 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.components.ButtonsColumn
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
-import org.wordpress.android.ui.compose.components.text.Message
-import org.wordpress.android.ui.compose.components.text.Subtitle
-import org.wordpress.android.ui.compose.components.text.Title
+import org.wordpress.android.ui.compose.components.text.MessageM3
+import org.wordpress.android.ui.compose.components.text.SubtitleM3
+import org.wordpress.android.ui.compose.components.text.TitleM3
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.NotificationsPrimaryButton
@@ -32,9 +32,9 @@ fun NotificationsStep(uiState: UiState.Content.Notifications): Unit = with(uiSta
                 .weight(1f)
         ) {
             ScreenIcon(iconRes = screenIconRes)
-            Title(text = uiStringText(title))
-            Subtitle(text = uiStringText(subtitle))
-            Message(text = uiStringText(message))
+            TitleM3(text = uiStringText(title))
+            SubtitleM3(text = uiStringText(subtitle))
+            MessageM3(text = uiStringText(message))
         }
         ButtonsColumn {
             PrimaryButtonM3(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ColumnWithTopGlassBorder
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomeSecondaryButton
@@ -208,7 +208,7 @@ private val previewUiState = UiState.Content.Welcome(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PreviewWelcomeStep() {
-    AppTheme {
+    AppThemeM3 {
         Box {
             WelcomeStep(previewUiState)
         }
@@ -220,7 +220,7 @@ private fun PreviewWelcomeStep() {
 @Composable
 private fun PreviewWelcomeStepInProgress() {
     val uiState = previewUiState.copy(isProcessing = true)
-    AppTheme {
+    AppThemeM3 {
         Box {
             WelcomeStep(uiState)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/jetpack/migration/compose/state/WelcomeStep.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ColumnWithTopGlassBorder
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.JetpackMigrationViewModel.ActionButton.WelcomePrimaryButton
@@ -77,12 +77,12 @@ fun WelcomeStep(uiState: UiState.Content.Welcome): Unit = with(uiState) {
                 )
             },
             buttonsColumn = {
-                PrimaryButton(
+                PrimaryButtonM3(
                     text = uiStringText(primaryActionButton.text),
                     onClick = primaryActionButton.onClick,
                     isInProgress = isProcessing,
                 )
-                SecondaryButton(
+                SecondaryButtonM3(
                     text = uiStringText(secondaryActionButton.text),
                     onClick = secondaryActionButton.onClick,
                     enabled = !isProcessing,


### PR DESCRIPTION
This PR converts the Jetpack migration flow to Material3. This is not an easy flow to test so I recommend relying on previewing the various "step" screens under `org.wordpress.android.ui.main.jetpack.migration.compose.state` as shown below.

**DeleteStep**
![delete](https://github.com/user-attachments/assets/7d48571f-ce01-4f30-9eeb-8d8bda861a0f)

**DoneStep**
![done](https://github.com/user-attachments/assets/66009051-c6d3-4d47-98d1-1ecddf3a11a3)

**ErrorStep**
![error](https://github.com/user-attachments/assets/a37fce97-40d1-42d7-aa55-a49ef950a206)

**NotificationsStep**
![notifications](https://github.com/user-attachments/assets/3105ce1c-0948-4065-8878-00b9c76c09f4)

**WelcomeStep**
![welcome](https://github.com/user-attachments/assets/33644a39-36ca-4f3e-af25-8cac2cb01913)



