### PR TITLE
feat: Toggle editor theme styles via feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -220,6 +220,7 @@ android {
         buildConfigField "boolean", "SYNC_PUBLISHING", "false"
         buildConfigField "boolean", "ENABLE_IN_APP_UPDATES", "false"
         buildConfigField "boolean", "ENABLE_NEW_GUTENBERG", "false"
+        buildConfigField "boolean", "ENABLE_NEW_GUTENBERG_THEME_STYLES", "false"
 
         manifestPlaceholders = [magicLinkScheme:"wordpress"]
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -236,6 +236,7 @@ import org.wordpress.android.util.config.ContactSupportFeatureConfig
 import org.wordpress.android.util.config.GlobalStyleSupportFeatureConfig
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
 import org.wordpress.android.util.config.NewGutenbergFeatureConfig
+import org.wordpress.android.util.config.NewGutenbergThemeStylesFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.util.helpers.MediaGallery
@@ -314,6 +315,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     private var onGetSuggestionResult: Consumer<String?>? = null
     private var isVoiceContentSet = false
     private var isNewGutenbergEditor = false
+    private var isNewGutenbergEditorThemeStyles = false
 
     // For opening the context menu after permissions have been granted
     private var menuView: View? = null
@@ -411,6 +413,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     @Inject lateinit var postConflictResolutionFeatureConfig: PostConflictResolutionFeatureConfig
 
     @Inject lateinit var newGutenbergFeatureConfig: NewGutenbergFeatureConfig
+    @Inject lateinit var newGutenbergThemeStylesConfig: NewGutenbergThemeStylesFeatureConfig
 
     @Inject lateinit var storePostViewModel: StorePostViewModel
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
@@ -2444,7 +2447,8 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
                 "postContent" to editPostRepository.getPost()?.content,
                 "siteApiRoot" to siteApiRoot,
                 "authHeader" to authHeader,
-                "siteApiNamespace" to siteApiNamespace
+                "siteApiNamespace" to siteApiNamespace,
+                "themeStyles" to newGutenbergThemeStylesConfig.isEnabled()
             )
 
             return GutenbergEditorFragment.newInstance(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -315,7 +315,6 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
     private var onGetSuggestionResult: Consumer<String?>? = null
     private var isVoiceContentSet = false
     private var isNewGutenbergEditor = false
-    private var isNewGutenbergEditorThemeStyles = false
 
     // For opening the context menu after permissions have been granted
     private var menuView: View? = null

--- a/WordPress/src/main/java/org/wordpress/android/util/config/NewGutenbergThemeStylesFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/NewGutenbergThemeStylesFeatureConfig.kt
@@ -1,0 +1,16 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.annotation.Feature
+import javax.inject.Inject
+
+private const val NEW_GUTENBERG_THEME_STYLES_FEATURE_REMOTE_FIELD = "experimental_block_editor_theme_styles"
+
+@Feature(NEW_GUTENBERG_THEME_STYLES_FEATURE_REMOTE_FIELD, false)
+class NewGutenbergThemeStylesFeatureConfig @Inject constructor(
+    appConfig: AppConfig
+) : FeatureConfig(
+    appConfig,
+    BuildConfig.ENABLE_NEW_GUTENBERG_THEME_STYLES,
+    NEW_GUTENBERG_THEME_STYLES_FEATURE_REMOTE_FIELD
+)

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergEditorFragment.java
@@ -300,7 +300,7 @@ public class GutenbergEditorFragment extends EditorFragmentAbstract implements
                     (String) mSettings.get("siteApiRoot"),
                     (String) mSettings.get("siteApiNamespace"),
                     (String) mSettings.get("authHeader"),
-                    false, // Set as a FeatureFlag
+                    (Boolean) mSettings.get("themeStyles"),
                     postId,
                     (String) mSettings.get("postType"),
                     (String) mSettings.get("postTitle"),


### PR DESCRIPTION
Provide experimental support for the editor WYSIWYG feature.

Fixes https://github.com/Automattic/dotcom-forge/issues/9450.

## Testing Instructions

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Create a WordPress site that uses block theme, select a style with easily recognizable foreground and background colors (i.e., not black and white).
1. Add the site to the WordPress/Jetpack app.
1. Navigate to _Me_ → _Debug settings_ and enable the following feature flags: 
    - `experimental_block_editor`
    - `experimental_block_editor_theme_styles`
1. Open the editor for the site.
1. Verify the selected theme styles display.
1. Close the editor.
1. Disable the `experimental_block_editor_theme_styles` flag.
1. Open the editor for the site.
1. Verify the default styles display.

## Regression Notes

1. Potential unintended areas of impact
    The existing editor fails.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Briefly tested the existing editor.
4. What automated tests I added (or what prevented me from doing so)
   N/A for this experimental feature.

## PR Submission Checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
