### PR TITLE
Rename AppTheme to AppThemeM2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanner.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanner.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import androidx.camera.core.Preview as CameraPreview
 
 @Composable
@@ -98,7 +98,7 @@ class DummyCodeScanner : CodeScanner {
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun BarcodeScannerScreenPreview() {
-    AppTheme {
+    AppThemeM2 {
         BarcodeScanner(codeScanner = DummyCodeScanner(), onScannedResult = object : CodeScannerCallback {
             override fun run(status: CodeScannerStatus?) {
                 // no-ops

--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun BarcodeScannerScreen(
@@ -116,7 +116,7 @@ private fun AlertDialog(
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeniedOnceAlertDialog() {
-    AppTheme {
+    AppThemeM2 {
         AlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_rationale_message),
@@ -132,7 +132,7 @@ fun DeniedOnceAlertDialog() {
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeniedPermanentlyAlertDialog() {
-    AppTheme {
+    AppThemeM2 {
         AlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_permanently_denied_message),

--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScanningFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.WPPermissionUtils
 import javax.inject.Inject
 
@@ -38,7 +38,7 @@ class BarcodeScanningFragment : Fragment() {
     private fun observeCameraPermissionState(view: ComposeView) {
         viewModel.permissionState.observe(viewLifecycleOwner) { permissionState ->
             view.setContent {
-                AppTheme {
+                AppThemeM2 {
                     BarcodeScannerScreen(
                         codeScanner = codeScanner,
                         permissionState = permissionState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaigndetail/CampaignDetailFragment.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.blaze.BlazeActionEvent
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.extensions.getSerializableCompat
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
@@ -69,7 +69,7 @@ class CampaignDetailFragment : Fragment(), CampaignDetailWebViewClient.CampaignD
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 CampaignDetailPage(
                     navigationUp = requireActivity().onBackPressedDispatcher::onBackPressed
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazecampaigns/campaignlisting/CampaignListingFragment.kt
@@ -54,7 +54,7 @@ import org.wordpress.android.ui.blaze.blazecampaigns.CampaignViewModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.isLightTheme
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
@@ -87,7 +87,7 @@ class CampaignListingFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val campaigns by viewModel.uiState.observeAsState()
                 CampaignListingPage(campaigns ?: CampaignListingUiState.Loading)
             }
@@ -266,7 +266,7 @@ fun CampaignListingError(error: CampaignListingUiState.Error) {
 @Preview
 @Composable
 fun CampaignListingErrorPreview() {
-    AppTheme {
+    AppThemeM2 {
         CampaignListingError(CampaignListingUiState.Error(
             title = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_title),
             description = UiString.UiStringRes(R.string.campaign_listing_page_no_campaigns_message_description),

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazeoverlay/BlazeOverlayFragment.kt
@@ -64,7 +64,7 @@ import org.wordpress.android.ui.compose.components.buttons.ImageButton
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.utils.UiString
@@ -96,7 +96,7 @@ class BlazeOverlayFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val postModel by viewModel.promoteUiState.observeAsState(BlazeUiState.PromoteScreen.Site)
                 BlazeOverlayScreen(postModel)
             }
@@ -361,7 +361,7 @@ class BlazeOverlayFragment : Fragment() {
     @Preview
     @Composable
     private fun PreviewBlazeOverlayScreenPostFlow() {
-        AppTheme {
+        AppThemeM2 {
             BlazeOverlayScreen(
                 content = BlazeUiState.PromoteScreen.PromotePost(
                     PostUIModel(
@@ -381,7 +381,7 @@ class BlazeOverlayFragment : Fragment() {
     @Preview
     @Composable
     private fun PreviewBlazeOverlayScreenSiteFlow() {
-        AppTheme {
+        AppThemeM2 {
             BlazeOverlayScreen(BlazeUiState.PromoteScreen.Site)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.ui.blaze.BlazeWebViewHeaderUiState
 import org.wordpress.android.ui.blaze.OnBlazeWebViewClientListener
 import org.wordpress.android.ui.blaze.blazeoverlay.BlazeViewModel
 import org.wordpress.android.ui.compose.components.MainTopAppBar
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
 import org.wordpress.android.editor.R as EditorR
@@ -73,7 +73,7 @@ class BlazePromoteWebViewFragment: Fragment(), OnBlazeWebViewClientListener,
         savedInstanceState: Bundle?
     ) = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 BlazeWebViewScreen()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ContentAlphaProvider
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -241,7 +241,7 @@ private fun OverlayContentItem(
 @Preview(name = "Dark Mode", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun BloganuaryNudgeLearnMoreOverlayPreview() {
-    AppTheme {
+    AppThemeM2 {
         BloganuaryNudgeLearnMoreOverlay(
             model = BloganuaryNudgeLearnMoreOverlayUiState(
                 noteText = UiStringRes(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.extensions.fillScreen
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
 import javax.inject.Inject
@@ -40,7 +40,7 @@ class BloganuaryNudgeLearnMoreOverlayFragment : BottomSheetDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                AppTheme {
+                AppThemeM2 {
                     BloganuaryNudgeLearnMoreOverlay(
                         model = viewModel.getUiState(isPromptsEnabled),
                         onActionClick = viewModel::onActionClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/BloggingPromptsListActivity.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.bloggingprompts.promptslist.compose.BloggingPromptsListScreen
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.util.extensions.setContent
 
@@ -24,7 +24,7 @@ class BloggingPromptsListActivity : LocaleAwareActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val uiState by viewModel.uiStateFlow.collectAsState()
                 BloggingPromptsListScreen(
                     uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListItem.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPromptsListItemModel
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.asString
@@ -108,7 +108,7 @@ private fun ItemSubtitleDivider() {
 fun BloggingPromptsListItemPreview(
     @PreviewParameter(BloggingPromptsListItemPreviewProvider::class) model: BloggingPromptsListItemModel
 ) {
-    AppTheme {
+    AppThemeM2 {
         BloggingPromptsListItem(model, onClick = {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/promptslist/compose/BloggingPromptsListScreen.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.ui.bloggingprompts.promptslist.model.BloggingPrompt
 import org.wordpress.android.ui.compose.components.EmptyContent
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -125,7 +125,7 @@ private fun NetworkErrorContent() {
 fun BloggingPromptsListScreenPreview(
     @PreviewParameter(provider = BloggingPromptsListScreenPreviewProvider::class) uiState: UiState
 ) {
-    AppTheme {
+    AppThemeM2 {
         BloggingPromptsListScreen(uiState = uiState, onNavigateUp = {}, onItemClick = {})
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/EmptyContent.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActionableEmptyView
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.FontSize
 import org.wordpress.android.ui.compose.unit.Margin
 
@@ -106,7 +106,7 @@ fun EmptyContent(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentPreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             title = "Title",
             subtitle = "Subtitle",
@@ -119,7 +119,7 @@ fun EmptyContentPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentImagePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             image = R.drawable.img_illustration_empty_results_216dp,
         )
@@ -130,7 +130,7 @@ fun EmptyContentImagePreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentImageTitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             title = "Title",
             image = R.drawable.img_illustration_empty_results_216dp,
@@ -142,7 +142,7 @@ fun EmptyContentImageTitlePreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentImageSubtitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             subtitle = "Subtitle",
             image = R.drawable.img_illustration_empty_results_216dp,
@@ -154,7 +154,7 @@ fun EmptyContentImageSubtitlePreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentTitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             title = "Title",
         )
@@ -165,7 +165,7 @@ fun EmptyContentTitlePreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentTitleSubtitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             title = "Title",
             subtitle = "Subtitle",
@@ -177,7 +177,7 @@ fun EmptyContentTitleSubtitlePreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EmptyContentSubtitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         EmptyContent(
             subtitle = "Subtitle",
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/MainTopAppBar.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,7 +22,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.withFullContentAlpha
 
 typealias NavigationIcon = @Composable () -> Unit
@@ -110,7 +109,7 @@ fun MainTopAppBar(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun MainTopAppBarPreview() {
-    AppTheme {
+    AppThemeM2 {
         MainTopAppBar(
             title = "Preview",
             navigationIcon = NavigationIcons.BackIcon,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/TrainOfIcons.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 private const val DEFAULT_ICON_SIZE = 32
 private const val DEFAULT_ICON_BORDER_WIDTH = 2
@@ -114,7 +114,7 @@ fun TrainOfIcons(
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun TrainOfIconsPreview() {
-    AppTheme {
+    AppThemeM2 {
         TrainOfIcons(
             iconModels = listOf(
                 R.drawable.login_prologue_second_asset_three,

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/PrimaryButton.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.modifiers.conditionalThen
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun PrimaryButton(
@@ -81,7 +81,7 @@ fun PrimaryButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrimaryButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         PrimaryButton(text = "Continue", onClick = {})
     }
 }
@@ -90,7 +90,7 @@ private fun PrimaryButtonPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrimaryButtonInProgressPreview() {
-    AppTheme {
+    AppThemeM2 {
         PrimaryButton(text = "Continue", onClick = {}, isInProgress = true)
     }
 }
@@ -99,7 +99,7 @@ private fun PrimaryButtonInProgressPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrimaryButtonLargePreview() {
-    AppTheme {
+    AppThemeM2 {
         PrimaryButton(text = "Continue", onClick = {}, buttonSize = ButtonSize.LARGE)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButton.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun SecondaryButton(
@@ -67,7 +67,7 @@ fun SecondaryButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         SecondaryButton(text = "Continue", onClick = {})
     }
 }
@@ -76,7 +76,7 @@ private fun SecondaryButtonPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonLargePreview() {
-    AppTheme {
+    AppThemeM2 {
         SecondaryButton(text = "Continue", onClick = {}, buttonSize = ButtonSize.LARGE)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButtonM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButtonM3.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun SecondaryButtonM3(
@@ -67,7 +67,7 @@ fun SecondaryButtonM3(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonPreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         SecondaryButtonM3(text = "Continue", onClick = {})
     }
 }
@@ -76,7 +76,7 @@ private fun SecondaryButtonPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonLargePreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         SecondaryButtonM3(text = "Continue", onClick = {}, buttonSize = ButtonSize.LARGE)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButtonM3.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/SecondaryButtonM3.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun SecondaryButtonM3(
@@ -67,7 +67,7 @@ fun SecondaryButtonM3(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         SecondaryButtonM3(text = "Continue", onClick = {})
     }
 }
@@ -76,7 +76,7 @@ private fun SecondaryButtonPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun SecondaryButtonLargePreview() {
-    AppTheme {
+    AppThemeM2 {
         SecondaryButtonM3(text = "Continue", onClick = {}, buttonSize = ButtonSize.LARGE)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/buttons/WPSwitch.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.isLightTheme
 import org.wordpress.android.widgets.WPSwitchCompat
 import com.google.android.material.R as MaterialR
@@ -150,7 +150,7 @@ private fun StatefulWPSwitchWithText(
 @Preview(name = "Dark mode", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun WPSwitchPreview() {
-    AppTheme {
+    AppThemeM2 {
         Column(modifier = Modifier.fillMaxWidth()) {
             val viewModifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/DropdownMenuButton.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData.Item
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString.UiStringText
@@ -98,7 +98,7 @@ fun DropdownMenuButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun JetpackDropdownMenuButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/menu/dropdown/JetpackDropdownMenu.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.unit.dp
 import me.saket.cascade.CascadeColumnScope
 import me.saket.cascade.CascadeDropdownMenu
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString.UiStringText
 
@@ -262,7 +262,7 @@ fun JetpackDropdownMenuPreview() {
     )
     var selectedItem by remember { mutableStateOf(menuItems.first() as MenuElementData.Item.Single) }
 
-    AppTheme {
+    AppThemeM2 {
         Box(
             modifier = Modifier
                 .padding(start = 8.dp, top = 8.dp)

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Message.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Message.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun Message(
@@ -31,7 +31,7 @@ fun Message(
 @Preview
 @Composable
 private fun MessagePreview() {
-    AppTheme {
+    AppThemeM2 {
         Message(text = "This message should be long enough so the preview wraps to more than one line")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Subtitle.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Subtitle.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun Subtitle(
@@ -28,7 +28,7 @@ fun Subtitle(
 @Preview
 @Composable
 private fun SubtitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         Subtitle(text = "This subtitle should be long enough so the preview wraps to more than one line")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Title.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/components/text/Title.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.FontSize
 
 @Composable
@@ -28,7 +28,7 @@ fun Title(
 @Preview
 @Composable
 private fun TitlePreview() {
-    AppTheme {
+    AppThemeM2 {
         Title(text = "This title should be long enough so the preview wraps to more than one line")
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM2.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM2.kt
@@ -9,6 +9,8 @@ import org.wordpress.android.BuildConfig
 /**
  * This theme should be used to support light/dark colors if the root composable does not support
  * [contentColor](https://developer.android.com/jetpack/compose/themes/material#content-color).
+ *
+ * @deprecated New composables should use AppThemeM3 instead.
  */
 @Composable
 fun AppThemeM2(

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM2.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/theme/AppThemeM2.kt
@@ -11,11 +11,11 @@ import org.wordpress.android.BuildConfig
  * [contentColor](https://developer.android.com/jetpack/compose/themes/material#content-color).
  */
 @Composable
-fun AppTheme(
+fun AppThemeM2(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    AppThemeWithoutBackground(isDarkTheme) {
+    AppThemeM2WithoutBackground(isDarkTheme) {
         ContentInSurface(content)
     }
 }
@@ -23,10 +23,10 @@ fun AppTheme(
 /**
  * Use this theme only when the root composable supports
  * [contentColor](https://developer.android.com/jetpack/compose/themes/material#content-color).
- * Otherwise use [AppTheme].
+ * Otherwise use [AppThemeM2].
  */
 @Composable
-fun AppThemeWithoutBackground(
+fun AppThemeM2WithoutBackground(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
@@ -46,7 +46,7 @@ fun AppThemeWithoutBackground(
  * More info: https://github.com/wordpress-mobile/gutenberg-mobile/issues/4889
  */
 @Composable
-fun AppThemeEditor(
+fun AppThemeM2Editor(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/compose/views/TrainOfAvatarsView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/compose/views/TrainOfAvatarsView.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.avatars.TrainOfAvatarsItem.AvatarItem
 import org.wordpress.android.ui.compose.components.TrainOfIcons
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.DisplayUtils
 import org.wordpress.android.util.WPAvatarUtils
 
@@ -92,7 +92,7 @@ class TrainOfAvatarsView @JvmOverloads constructor(
     override fun Content() {
         if (avatarsState.value.isEmpty()) return
 
-        AppTheme {
+        AppThemeM2 {
             TrainOfIcons(
                 iconModels = avatarModels(),
                 iconSize = iconSizeState.value.dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
@@ -18,7 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncherWrapper
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.ActionEvent
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.UiState
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.compose.WPJetpackIndividualPluginOverlayScreen
@@ -39,7 +39,7 @@ class WPJetpackIndividualPluginFragment : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Loaded -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -38,7 +38,7 @@ import org.wordpress.android.ui.compose.components.buttons.ButtonSize
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.theme.JpColorPalette
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.JPInstallFullPluginAnimation
@@ -179,7 +179,7 @@ private fun getTitle(siteCount: Int): String = if (siteCount > 1) {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
-    AppTheme {
+    AppThemeM2 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(
@@ -200,7 +200,7 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
-    AppTheme {
+    AppThemeM2 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(
@@ -222,7 +222,7 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenMultipleSitesPreview() {
-    AppTheme {
+    AppThemeM2 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/install/JetpackFullPluginInstallActivity.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncher
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.compose.JetpackPluginInstallScreen
 import org.wordpress.android.util.extensions.exhaustive
 import org.wordpress.android.util.extensions.setContent
@@ -24,7 +24,7 @@ class JetpackFullPluginInstallActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val uiState by viewModel.uiState.collectAsState()
                 JetpackPluginInstallScreen(
                     uiState = uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/JetpackFullPluginInstallOnboardingDialogFragment.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.install.JetpackFullPluginInstallActivity
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.ActionEvent.ContactSupport
@@ -49,7 +49,7 @@ class JetpackFullPluginInstallOnboardingDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 JetpackFullPluginInstallOnboardingScreen()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/JPInstallFullPluginAnimation.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/JPInstallFullPluginAnimation.kt
@@ -12,7 +12,7 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieComposition
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.extensions.isRtl
 
 @Composable
@@ -38,7 +38,7 @@ fun JPInstallFullPluginAnimation(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewPluginDescriptionMultiplePlugins() {
-    AppTheme {
+    AppThemeM2 {
         JPInstallFullPluginAnimation()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/PluginDescription.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/PluginDescription.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import com.google.android.material.R as MaterialR
 
 @Composable
@@ -101,7 +101,7 @@ private data class PluginDescriptionTextPart(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewPluginDescriptionOnePlugin() {
-    AppTheme {
+    AppThemeM2 {
         PluginDescription(
             siteString = "wordpress.com",
             pluginNames = listOf("Jetpack Search"),
@@ -114,7 +114,7 @@ private fun PreviewPluginDescriptionOnePlugin() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewPluginDescriptionMultiplePlugins() {
-    AppTheme {
+    AppThemeM2 {
         PluginDescription(
             siteString = "wordpress.com",
             pluginNames = listOf("Jetpack Search", "Jetpack Protect"),
@@ -127,7 +127,7 @@ private fun PreviewPluginDescriptionMultiplePlugins() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewPluginDescriptionOnePluginConcise() {
-    AppTheme {
+    AppThemeM2 {
         PluginDescription(
             siteString = "This site",
             pluginNames = listOf("Jetpack Search"),
@@ -141,7 +141,7 @@ private fun PreviewPluginDescriptionOnePluginConcise() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewPluginDescriptionMultiplePluginsConcise() {
-    AppTheme {
+    AppThemeM2 {
         PluginDescription(
             siteString = "This site",
             pluginNames = listOf("Jetpack Search", "Jetpack Protect"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/TermsAndConditions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/component/TermsAndConditions.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun TermsAndConditions(
@@ -63,7 +63,7 @@ fun TermsAndConditions(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewTermsAndConditions() {
-    AppTheme {
+    AppThemeM2 {
         TermsAndConditions {}
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/state/LoadedState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/fullplugin/onboarding/compose/state/LoadedState.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.ui.compose.components.ButtonsColumn
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
 import org.wordpress.android.ui.compose.components.text.Title
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.JetpackFullPluginInstallOnboardingViewModel.UiState
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.JPInstallFullPluginAnimation
@@ -113,7 +113,7 @@ fun LoadedState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewLoadedState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Loaded(
             siteUrl = "wordpress.com",
             pluginNames = listOf("Jetpack Search"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/BaseState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/BaseState.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ContentAlphaProvider
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 import org.wordpress.android.util.extensions.fixWidows
@@ -99,7 +99,7 @@ fun BaseState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewInitialState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Installing
         BaseState(uiState, {})
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/DoneState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/DoneState.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.ButtonSize
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 
 @Composable
@@ -35,7 +35,7 @@ fun DoneState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewDoneState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Done(
             descriptionText = R.string.jetpack_plugin_install_full_plugin_done_description,
             buttonText = R.string.jetpack_plugin_install_full_plugin_done_button,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/ErrorState.kt
@@ -14,7 +14,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.ButtonSize
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 
 @Composable
@@ -47,7 +47,7 @@ fun ErrorState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewErrorState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Error(
             retryButtonText = R.string.jetpack_plugin_install_error_button_retry,
             contactSupportButtonText = R.string.jetpack_plugin_install_error_button_contact_support,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/InitialState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/InitialState.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.ButtonSize
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 
 @Composable
@@ -35,7 +35,7 @@ fun InitialState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewInitialState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Initial(
             buttonText = R.string.jetpack_plugin_install_initial_button,
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/InstallingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/install/compose/state/InstallingState.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.components.buttons.ButtonSize
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 
 @Composable
@@ -31,7 +31,7 @@ fun InstallingState(
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, fontScale = 2f)
 @Composable
 private fun PreviewInstallingState() {
-    AppTheme {
+    AppThemeM2 {
         val uiState = UiState.Installing
         InstallingState(uiState)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/remoteplugin/JetpackRemoteInstallActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackplugininstall/remoteplugin/JetpackRemoteInstallActivity.kt
@@ -19,7 +19,7 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.LoginActivity
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.install.UiState
 import org.wordpress.android.ui.jetpackplugininstall.install.compose.JetpackPluginInstallScreen
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallViewModel.JetpackResultActionData.Action.CONNECT
@@ -38,7 +38,7 @@ class JetpackRemoteInstallActivity : LocaleAwareActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val uiState by viewModel.liveViewState.observeAsState()
                 JetpackPluginInstallScreen(
                     uiState = uiState ?: UiState.Initial(R.string.jetpack_plugin_install_initial_button),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/blaze/BlazeCampaignsCardViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
 import org.wordpress.android.databinding.CampaignsCardBinding
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BlazeCard.BlazeCampaignsCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -14,7 +14,7 @@ class BlazeCampaignsCardViewHolder(parent: ViewGroup) :
     MySiteCardAndItemViewHolder<CampaignsCardBinding>(parent.viewBinding(CampaignsCardBinding::inflate)) {
     fun bind(cardModel: BlazeCampaignsCardModel) = with(binding) {
         blazeCampaignsCard.setContent {
-            AppThemeWithoutBackground {
+            AppThemeM2WithoutBackground {
                 BlazeCampaignsCard(
                     blazeCampaignCardModel = cardModel, modifier = Modifier
                         .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/compose/MySiteCardToolbar.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.styles.DashboardCardTypography
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 /**
  * A toolbar for MySite cards written in Compose, that tries to match behavior and positioning of cards written in XML.
@@ -158,7 +158,7 @@ sealed interface MySiteCardToolbarContextMenuItem {
 )
 @Composable
 private fun MySiteCardToolbarPreview() {
-    AppTheme {
+    AppThemeM2 {
         MySiteCardToolbar(
             onContextMenuClick = {},
             contextMenuItems = listOf(
@@ -191,7 +191,7 @@ private fun MySiteCardToolbarPreview() {
 )
 @Composable
 private fun MySiteCardToolbarInCardPreview() {
-    AppTheme {
+    AppThemeM2 {
         UnelevatedCard(
             modifier = Modifier.padding(8.dp)
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCard.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.styles.DashboardCardTypography
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
@@ -99,7 +99,7 @@ private fun CardToolbar(
 @Preview(name = "Dark Mode", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun BloganuaryNudgeCardPreview() {
-    AppTheme {
+    AppThemeM2 {
         BloganuaryNudgeCard(
             model = BloganuaryNudgeCardModel(
                 UiString.UiStringRes(R.string.bloganuary_dashboard_nudge_title_december),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloganuary/BloganuaryNudgeCardViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import org.wordpress.android.databinding.BloganuaryNudgeCardBinding
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.BloganuaryNudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -16,7 +16,7 @@ class BloganuaryNudgeCardViewHolder(parent: ViewGroup) :
         // Dispose of the Composition when the view's LifecycleOwner is destroyed
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool)
         setContent {
-            AppThemeWithoutBackground {
+            AppThemeM2WithoutBackground {
                 BloganuaryNudgeCard(
                     model = cardModel,
                     modifier = Modifier.fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicCardComposable.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.Dynamic.ActionSource
 import org.wordpress.android.ui.utils.ListItemInteraction
@@ -59,7 +59,7 @@ fun DynamicDashboardCard(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DynamicDashboardCardPreview() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -91,7 +91,7 @@ fun DynamicDashboardCardPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -120,7 +120,7 @@ fun DynamicDashboardCardWithFeatureAndDescriptionPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -149,7 +149,7 @@ fun DynamicDashboardCardWithFeatureAndSubtitleAndDescriptionPreview() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithNoCta() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -176,7 +176,7 @@ fun DynamicDashboardCardWithNoCta() {
 @Preview
 @Composable
 fun DynamicDashboardWithFeatureImageOnly() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",
@@ -196,7 +196,7 @@ fun DynamicDashboardWithFeatureImageOnly() {
 @Preview
 @Composable
 fun DynamicDashboardCardWithTitleAndCompleteRowsPreview() {
-    AppTheme {
+    AppThemeM2 {
         DynamicDashboardCard(
             card = MySiteCardAndItem.Card.Dynamic(
                 id = "id",

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicDashboardCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dynamiccard/DynamicDashboardCardViewHolder.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.mysite.cards.dynamiccard
 
 import android.view.ViewGroup
 import org.wordpress.android.databinding.DynamicDashboardCardBinding
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -11,7 +11,7 @@ class DynamicDashboardCardViewHolder(parent: ViewGroup) :
     MySiteCardAndItemViewHolder<DynamicDashboardCardBinding>(parent.viewBinding(DynamicDashboardCardBinding::inflate)) {
     fun bind(card: MySiteCardAndItem.Card.Dynamic) = with(binding) {
         dynamicCard.setContent {
-            AppThemeWithoutBackground {
+            AppThemeM2WithoutBackground {
                 DynamicDashboardCard(card)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jpfullplugininstall/JetpackInstallFullPluginCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/jpfullplugininstall/JetpackInstallFullPluginCardViewHolder.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.widget.PopupMenu
 import androidx.compose.ui.res.stringResource
 import org.wordpress.android.R
 import org.wordpress.android.databinding.JpInstallFullPluginCardBinding
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.PluginDescription
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.JetpackInstallFullPluginCard
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
@@ -20,7 +20,7 @@ class JetpackInstallFullPluginCardViewHolder(
 ) {
     fun bind(card: JetpackInstallFullPluginCard) = with(binding) {
         jpInstallFullPluginCardContentComposable.setContent {
-            AppTheme {
+            AppThemeM2 {
                 PluginDescription(
                     siteString = stringResource(R.string.jetpack_full_plugin_install_onboarding_description_this_site),
                     pluginNames = card.pluginNames,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/nocards/NoCardsMessageViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/nocards/NoCardsMessageViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
 import org.wordpress.android.databinding.NoCardsMessageBinding
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -14,7 +14,7 @@ class NoCardsMessageViewHolder(parent: ViewGroup) :
     MySiteCardAndItemViewHolder<NoCardsMessageBinding>(parent.viewBinding(NoCardsMessageBinding::inflate)) {
     fun bind(cardModel: MySiteCardAndItem.Card.NoCardsMessage) = with(binding) {
         noCardsMessage.setContent {
-            AppTheme {
+            AppThemeM2 {
                 NoCardsMessage(
                     model = cardModel, modifier = Modifier
                         .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/personalize/PersonalizeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/personalize/PersonalizeCardViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
 import org.wordpress.android.databinding.PersonalizeCardBinding
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -14,7 +14,7 @@ class PersonalizeCardViewHolder(parent: ViewGroup) :
     MySiteCardAndItemViewHolder<PersonalizeCardBinding>(parent.viewBinding(PersonalizeCardBinding::inflate)) {
     fun bind(cardModel: MySiteCardAndItem.Card.PersonalizeCardModel) = with(binding) {
         personalizeCard.setContent {
-            AppThemeWithoutBackground {
+            AppThemeM2WithoutBackground {
                 PersonalizeCard(
                     model = cardModel, modifier = Modifier
                         .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.card.UnelevatedCard
 import org.wordpress.android.ui.compose.styles.DashboardCardTypography
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
@@ -87,7 +87,7 @@ private fun CardToolbar(
 @Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun WpSotw2023NudgeCardPreview() {
-    AppTheme {
+    AppThemeM2 {
         WpSotw2023NudgeCard(
             model = WpSotw2023NudgeCardModel(
                 title = UiStringRes(R.string.wp_sotw_2023_dashboard_nudge_title),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/sotw2023/WpSotw2023NudgeCardViewHolder.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import org.wordpress.android.databinding.WpSotw20223NudgeCardBinding
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.WpSotw2023NudgeCardModel
 import org.wordpress.android.ui.mysite.MySiteCardAndItemViewHolder
 import org.wordpress.android.util.extensions.viewBinding
@@ -16,7 +16,7 @@ class WpSotw2023NudgeCardViewHolder(parent: ViewGroup) :
         // Dispose of the Composition when the view's LifecycleOwner is destroyed
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool)
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 WpSotw2023NudgeCard(
                     model = cardModel,
                     modifier = Modifier.fillMaxWidth(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -56,7 +56,7 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.LocaleAwareComposable
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.SiteNavigationAction
@@ -92,7 +92,7 @@ class MenuActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         initObservers()
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val userLanguage by viewModel.refreshAppLanguage.observeAsState("")
 
                 LocaleAwareComposable(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/personalization/PersonalizationActivity.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.LocaleAwareComposable
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction
@@ -65,7 +65,7 @@ class PersonalizationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val language by viewModel.appLanguage.observeAsState("")
 
                 LocaleAwareComposable(
@@ -351,7 +351,7 @@ fun ShortcutStateRow(
 @Preview
 @Composable
 fun PersonalizationScreenPreview() {
-    AppTheme {
+    AppThemeM2 {
         ShortcutStateRow(
             state = ShortcutState(
                 label = UiString.UiStringRes(R.string.media),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostJetpackSocialConnectionsContainer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostJetpackSocialConnectionsContainer.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.models.PublicizeConnection
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.posts.social.PostSocialConnection
 import org.wordpress.android.ui.posts.social.compose.PostSocialMessageItem
 import org.wordpress.android.usecase.social.JetpackSocialFlow
@@ -41,7 +41,7 @@ fun ColumnScope.EditPostJetpackSocialConnectionsContainer(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EditPostJetpackSocialContainerWithShareLimitPreview() {
-    AppThemeEditor {
+    AppThemeM2Editor {
         Column {
             val connections = mutableListOf<JetpackSocialConnectionData>()
             val connection1 = PublicizeConnection().apply {
@@ -89,7 +89,7 @@ fun EditPostJetpackSocialContainerWithShareLimitPreview() {
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EditPostJetpackSocialContainerWithoutShareLimitPreview() {
-    AppThemeEditor {
+    AppThemeM2Editor {
         Column {
             val connections = mutableListOf<JetpackSocialConnectionData>()
             val connection1 = PublicizeConnection().apply {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostJetpackSocialConnectionsList.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostJetpackSocialConnectionsList.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.models.PublicizeConnection
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.posts.social.PostSocialConnection
 import org.wordpress.android.ui.posts.social.compose.PostSocialConnectionItem
 import org.wordpress.android.usecase.social.JetpackSocialFlow
@@ -43,7 +43,7 @@ data class JetpackSocialConnectionData(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewEditPostJetpackSocialConnectionsList() {
-    AppThemeEditor {
+    AppThemeM2Editor {
         val connections = mutableListOf<JetpackSocialConnectionData>()
         val connection1 = PublicizeConnection().apply {
             connectionId = 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialContainerView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialContainerView.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.AbstractComposeView
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState.Loaded
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState.Loading
@@ -27,7 +27,7 @@ class EditPostSettingsJetpackSocialContainerView @JvmOverloads constructor(
 
     @Composable
     override fun Content() {
-        AppThemeEditor {
+        AppThemeM2Editor {
             with(uiState.value) {
                 when (this) {
                     is Loading -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialNoConnections.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialNoConnections.kt
@@ -23,7 +23,7 @@ import org.wordpress.android.ui.compose.components.TrainOfIcons
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.publicize.PublicizeServiceIcon
 
@@ -103,7 +103,7 @@ fun EditPostSettingsJetpackSocialNoConnections(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EditPostSettingsJetpackSocialNoConnectionsPreview() {
-    AppThemeEditor {
+    AppThemeM2Editor {
         EditPostSettingsJetpackSocialNoConnections(
             trainOfIconsModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
             message = "Increase your traffic by auto-sharing your posts with your friends on social media.",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialSharesContainer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsJetpackSocialSharesContainer.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.posts.social.compose.DescriptionText
 import org.wordpress.android.ui.posts.social.compose.PostSocialSharingModel
@@ -46,7 +46,7 @@ fun EditPostSettingsJetpackSocialSharesContainer(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun EditPostSettingsJetpackSocialSharesContainerPreview() {
-    AppThemeEditor {
+    AppThemeM2Editor {
         EditPostSettingsJetpackSocialSharesContainer(
             postSocialSharingModel = PostSocialSharingModel(
                 title = "Sharing to 2 of 3 accounts",

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostResolutionOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostResolutionOverlay.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ContentAlphaProvider
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString
@@ -270,7 +270,7 @@ private fun OverlayContentItem(
 @Preview(name = "Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PostResolutionOverlayPreview() {
-    AppTheme {
+    AppThemeM2 {
         PostResolutionOverlay(
             uiState = PostResolutionOverlayUiState(
                 titleResId = R.string.dialog_post_conflict_title,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostResolutionOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostResolutionOverlayFragment.kt
@@ -15,7 +15,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.model.PostModel
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.extensions.fillScreen
 import javax.inject.Inject
 
@@ -61,7 +61,7 @@ class PostResolutionOverlayFragment : BottomSheetDialogFragment() {
         initializeViewModelAndStart()
         return ComposeView(requireContext()).apply {
             setContent {
-                AppTheme {
+                AppThemeM2 {
                     val uiState by viewModel.uiState.observeAsState()
                     PostResolutionOverlay(uiState)
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeViewHolder.kt
@@ -20,7 +20,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.withBottomSheetElevation
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ButtonUiState
@@ -128,7 +128,7 @@ sealed class PrepublishingHomeViewHolder(
                     mutableStateOf(uiState)
                 }
 
-                AppTheme {
+                AppThemeM2 {
                     (state as? SocialUiState.Visible)?.let { visibleState ->
                         when (val internalState = visibleState.state) {
                             is JetpackSocialUiState.Loaded -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialNoConnectionsItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/compose/PrepublishingHomeSocialNoConnectionsItem.kt
@@ -25,7 +25,7 @@ import org.wordpress.android.ui.compose.components.TrainOfIcons
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.publicize.PublicizeServiceIcon
 import org.wordpress.android.usecase.social.JetpackSocialFlow
@@ -90,7 +90,7 @@ fun PrepublishingHomeSocialNoConnectionsItem(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PrepublishingHomeSocialNoConnectionsItemPreview() {
-    AppTheme {
+    AppThemeM2 {
         PrepublishingHomeSocialNoConnectionsItem(
             connectionIconModels = PublicizeServiceIcon.values().map { TrainOfIconsModel(it.iconResId) },
             onConnectClick = { /*TODO*/ },

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.PrepublishingSocialFragmentBinding
 import org.wordpress.android.databinding.PrepublishingToolbarBinding
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.withBottomSheetElevation
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.JetpackSocialUiState
@@ -68,7 +68,7 @@ class PrepublishingSocialFragment : Fragment(R.layout.prepublishing_social_fragm
             if (state is JetpackSocialUiState.Loaded) {
                 binding?.apply {
                     prepublishingSocialComposeView.setContent {
-                        AppTheme {
+                        AppThemeM2 {
                             PrepublishingSocialScreen(
                                 state = state,
                                 modifier = Modifier

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/sharemessage/EditJetpackSocialShareMessageActivity.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppThemeEditor
+import org.wordpress.android.ui.compose.theme.AppThemeM2Editor
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageViewModel.ActionEvent
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageViewModel.UiState
@@ -61,7 +61,7 @@ class EditJetpackSocialShareMessageActivity : AppCompatActivity() {
         )
         observeActionEvents()
         setContent {
-            AppThemeEditor {
+            AppThemeM2Editor {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Loaded -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialConnectionItem.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.posts.social.PostSocialConnection
 
@@ -86,7 +86,7 @@ fun PostSocialConnectionItemPreview() {
     )
     var connectionState by remember { mutableStateOf(connection) }
     var disabledState by remember { mutableStateOf(connection.copy(isSharingEnabled = false)) }
-    AppTheme {
+    AppThemeM2 {
         Column {
             // enabled
             PostSocialConnectionItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialMessageItem.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -66,7 +66,7 @@ fun PostSocialMessageItemPreview() {
         messageId = (messageId + 1) % messages.size
     }
 
-    AppTheme {
+    AppThemeM2 {
         Column(
             modifier = Modifier.fillMaxWidth(),
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharesText.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharesText.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -41,7 +41,7 @@ fun PostSocialSharesText(
 @Composable
 fun PostSocialSharesTextPreview() {
     val message = "27/30 Social shares remaining in the next 30 days"
-    AppTheme {
+    AppThemeM2 {
         Column(
             modifier = Modifier.fillMaxWidth(),
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharingItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/social/compose/PostSocialSharingItem.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.TrainOfIcons
 import org.wordpress.android.ui.compose.components.TrainOfIconsModel
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -145,7 +145,7 @@ data class PostSocialSharingModel(
 @Preview(name = "RTL", locale = "ar")
 @Composable
 private fun PostSocialSharingItemPreview() {
-    AppTheme {
+    AppThemeM2 {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/accountsettings/AccountSettingsFragment.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.accounts.HelpActivity
 import org.wordpress.android.ui.accounts.signup.BaseUsernameChangerFullScreenDialogFragment
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.prefs.DetailListPreference
 import org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation
@@ -202,7 +202,7 @@ class AccountSettingsFragment : PreferenceFragmentLifeCycleOwner(),
             listView.addFooterView(ComposeView(context).apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
-                    AppTheme {
+                    AppThemeM2 {
                         AccountClosureUi(viewModel)
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerFragment.kt
@@ -13,7 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.wordpress.android.ui.WPBottomSheetDialogFragment
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.DisplayUtilsWrapper
 import org.wordpress.android.util.extensions.fillScreen
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
@@ -34,7 +34,7 @@ class PrivacyBannerFragment : WPBottomSheetDialogFragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                AppTheme {
+                AppThemeM2 {
                     PrivacyBannerScreen(viewModel)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/privacy/banner/PrivacyBannerScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.WPSwitch
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @Composable
 fun PrivacyBannerScreen(viewModel: PrivacyBannerViewModel) {
@@ -191,7 +191,7 @@ fun PrivacyBannerScreen(
 @Preview(name = "Smaller screen", device = Devices.NEXUS_5)
 @Composable
 private fun PreviewPrivacyBanner() {
-    AppTheme {
+    AppThemeM2 {
         PrivacyBannerScreen(
             state = PrivacyBannerViewModel.UiState(
                 analyticsSwitchEnabled = false,
@@ -206,7 +206,7 @@ private fun PreviewPrivacyBanner() {
 @Preview(name = "With error")
 @Composable
 private fun PreviewError() {
-    AppTheme {
+    AppThemeM2 {
         PrivacyBannerScreen(
             state = PrivacyBannerViewModel.UiState(
                 analyticsSwitchEnabled = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.ui.barcodescanner.BarcodeScanningFragment.Companion
 import org.wordpress.android.ui.barcodescanner.BarcodeScanningFragment.Companion.KEY_BARCODE_SCANNING_SCAN_STATUS
 import org.wordpress.android.ui.barcodescanner.CodeScannerStatus
 import org.wordpress.android.ui.compose.components.VerticalScrollBox
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
@@ -69,7 +69,7 @@ class QRCodeAuthFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 QRCodeAuthScreen()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState
@@ -91,7 +91,7 @@ fun ContentState(uiState: QRCodeAuthUiState.Content): Unit = with(uiState) {
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun ContentStatePreview() {
-    AppTheme {
+    AppThemeM2 {
         val state = QRCodeAuthUiState.Content.Validated(
             browser = "{browser}",
             location = "{location}",

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState
@@ -69,7 +69,7 @@ fun ErrorState(uiState: QRCodeAuthUiState.Error): Unit = with(uiState) {
 @Preview(showBackground = true)
 @Composable
 private fun ErrorStatePreview() {
-    AppTheme {
+    AppThemeM2 {
         val state = QRCodeAuthUiState.Error.InvalidData(
             primaryActionButton = ErrorPrimaryActionButton {},
             secondaryActionButton = ErrorSecondaryActionButton {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderFragment.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.databinding.ReaderFragmentLayoutBinding
 import org.wordpress.android.models.JetpackPoweredScreen
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.ui.ScrollableViewInitializedListener
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureOverlayScreenType
 import org.wordpress.android.ui.main.WPMainActivity.OnScrollToTopListener
@@ -248,7 +248,7 @@ class ReaderFragment : Fragment(R.layout.reader_fragment_layout), ScrollableView
                 val topAppBarState by viewModel.topBarUiState.observeAsState()
                 val state = topAppBarState ?: return@setContent
 
-                AppTheme {
+                AppThemeM2 {
                     ReaderTopAppBar(
                         topBarUiState = state,
                         onMenuItemClick = viewModel::onTopBarMenuItemClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReadingPreferencesDialogFragment.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.R
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.tracker.ReaderReadingPreferencesTracker
 import org.wordpress.android.ui.reader.viewmodels.ReaderPostDetailViewModel
@@ -58,7 +58,7 @@ class ReaderReadingPreferencesDialogFragment : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 val readerPreferences by viewModel.currentReadingPreferences.collectAsState()
                 val isFeedbackEnabled by viewModel.isFeedbackEnabled.collectAsState()
                 ReadingPreferencesScreen(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagsFeedFragment.kt
@@ -26,7 +26,7 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.ReaderTagFeedFragmentLayoutBinding
 import org.wordpress.android.models.ReaderTag
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter
 import org.wordpress.android.ui.reader.discover.ReaderNavigationEvents
@@ -89,7 +89,7 @@ class ReaderTagsFeedFragment : Fragment(R.layout.reader_tag_feed_fragment_layout
         binding = ReaderTagFeedFragmentLayoutBinding.bind(view)
 
         binding.composeView.setContent {
-            AppThemeWithoutBackground {
+            AppThemeM2WithoutBackground {
                 val uiState by viewModel.uiStateFlow.collectAsState()
                 ReaderTagsFeed(uiState)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderAnnouncementCardView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderAnnouncementCardView.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.AbstractComposeView
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.reader.views.compose.ReaderAnnouncementCard
 import org.wordpress.android.ui.reader.views.compose.ReaderAnnouncementCardItemData
 
@@ -21,7 +21,7 @@ class ReaderAnnouncementCardView @JvmOverloads constructor(
 
     @Composable
     override fun Content() {
-        AppTheme {
+        AppThemeM2 {
             ReaderAnnouncementCard(
                 items = items.value,
                 onAnnouncementCardDoneClick = { onDoneClickListener.value?.onDoneClick() }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderAnnouncementCard.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -139,7 +139,7 @@ data class ReaderAnnouncementCardItemData(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedPostListItemPreview() {
-    AppTheme {
+    AppThemeM2 {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/ReaderTopAppBar.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.delay
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.menu.dropdown.JetpackDropdownMenu
 import org.wordpress.android.ui.compose.components.menu.dropdown.MenuElementData
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.horizontalFadingEdges
 import org.wordpress.android.ui.reader.viewmodels.ReaderViewModel
@@ -215,7 +215,7 @@ fun ReaderTopAppBarPreview() {
         )
     }
 
-    AppTheme {
+    AppThemeM2 {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/filter/ReaderFilterChipGroup.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString
@@ -224,7 +224,7 @@ data class ReaderFilterSelectedItem(
 fun ReaderFilterChipGroupPreview() {
     var selectedItem: ReaderFilterSelectedItem? by rememberSaveable { mutableStateOf(null) }
 
-    AppThemeWithoutBackground {
+    AppThemeM2WithoutBackground {
         ReaderFilterChipGroup(
             modifier = Modifier.padding(Margin.Medium.value),
             selectedItem = selectedItem,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesButtons.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesButtons.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.utils.toComposeFontFamily
@@ -183,7 +183,7 @@ fun ReadingPreferencesFontFamilyButton(
 @Preview
 @Composable
 fun ReadingPreferencesThemeButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         var selectedItem: ReaderReadingPreferences.Theme? by remember { mutableStateOf(null) }
 
         Row(
@@ -203,7 +203,7 @@ fun ReadingPreferencesThemeButtonPreview() {
 @Preview
 @Composable
 fun ReadingPreferencesFontFamilyButtonPreview() {
-    AppTheme {
+    AppThemeM2 {
         var selectedItem: ReaderReadingPreferences.FontFamily? by remember { mutableStateOf(null) }
 
         Row(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/readingpreferences/ReadingPreferencesScreen.kt
@@ -48,7 +48,7 @@ import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.reader.models.ReaderReadingPreferences
 import org.wordpress.android.ui.reader.utils.toComposeFontFamily
@@ -334,7 +334,7 @@ private fun getTitleTextStyle(
 @Preview
 @Composable
 private fun ReadingPreferencesScreenPreview() {
-    AppTheme {
+    AppThemeM2 {
         var readingPreferences by remember { mutableStateOf(ReaderReadingPreferences()) }
 
         ReadingPreferencesScreen(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeed.kt
@@ -60,7 +60,7 @@ import org.wordpress.android.R
 import org.wordpress.android.models.ReaderTag
 import org.wordpress.android.models.ReaderTagType
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.ErrorType
 import org.wordpress.android.ui.reader.viewmodels.tagsfeed.ReaderTagsFeedViewModel.PostList
@@ -533,7 +533,7 @@ data class TagsFeedPostItem(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedLoaded() {
-    AppTheme {
+    AppThemeM2 {
         val postListLoaded = PostList.Loaded(
             listOf(
                 TagsFeedPostItem(
@@ -651,7 +651,7 @@ fun ReaderTagsFeedLoaded() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedLoading() {
-    AppTheme {
+    AppThemeM2 {
         ReaderTagsFeed(
             uiState = UiState.Loading
         )
@@ -662,7 +662,7 @@ fun ReaderTagsFeedLoading() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedEmpty() {
-    AppTheme {
+    AppThemeM2 {
         ReaderTagsFeed(
             uiState = UiState.Empty(
                 onOpenTagsListClick = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItem.kt
@@ -57,7 +57,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.util.extensions.getColorResIdFromAttribute
 import org.wordpress.android.util.extensions.getDrawableResIdFromAttribute
@@ -399,7 +399,7 @@ fun PostTextContent(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedPostListItemPreview() {
-    AppTheme {
+    AppThemeM2 {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/compose/tagsfeed/ReaderTagsFeedPostListItemLoading.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 private val ThinLineHeight = 10.dp
@@ -124,7 +124,7 @@ fun ReaderTagsFeedPostListItemLoading() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ReaderTagsFeedPostListItemLoadingPreview() {
-    AppTheme {
+    AppThemeM2 {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainViewHolder.kt
@@ -9,7 +9,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.SiteCreationDomainsItemBinding
 import org.wordpress.android.databinding.SiteCreationDomainsItemV2Binding
 import org.wordpress.android.databinding.SiteCreationSuggestionsErrorItemBinding
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.Old.DomainUiState.AvailableDomain
@@ -66,7 +66,7 @@ sealed class SiteCreationDomainViewHolder<T : ViewBinding>(protected val binding
 
         fun onBind(uiState: New.DomainUiState) = with(binding) {
             composeView.setContent {
-                AppThemeWithoutBackground {
+                AppThemeM2WithoutBackground {
                     DomainItem(uiState)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -21,7 +21,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.SiteCreationDomainsScreenBinding
 import org.wordpress.android.databinding.SiteCreationFormScreenBinding
 import org.wordpress.android.ui.accounts.HelpActivity
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.sitecreation.SiteCreationBaseFormFragment
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.DomainsUiState.DomainsUiContentState
 import org.wordpress.android.ui.sitecreation.domains.compose.SiteExample
@@ -73,7 +73,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
             it.initRecyclerView()
             it.initViewModel()
             it.siteExampleComposeView.setContent {
-                AppTheme {
+                AppThemeM2 {
                     SiteExample()
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.ui.compose.components.SolidCircle
-import org.wordpress.android.ui.compose.theme.AppThemeWithoutBackground
+import org.wordpress.android.ui.compose.theme.AppThemeM2WithoutBackground
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.asString
 import org.wordpress.android.ui.sitecreation.domains.SiteCreationDomainsViewModel.ListItemUiState.New.DomainUiState
@@ -227,7 +227,7 @@ private fun DomainItemPreview() {
             onClick = {}
         )
     }
-    AppThemeWithoutBackground {
+    AppThemeM2WithoutBackground {
         Column {
             uiStates.forEach { DomainItem(it) }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/SiteExample.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/SiteExample.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 private val grayColor @Composable get() = MaterialTheme.colors.onSurface.copy(0.05f)
 private val regularFontSize = 12.sp
@@ -154,7 +154,7 @@ private fun AddressBar(domainText: String) {
 @Preview(widthDp = 900, heightDp = 415, name = "Landscape")
 @Preview(widthDp = 415, heightDp = 900, name = "RTL", locale = "ar")
 private fun SiteExamplePreview() {
-    AppTheme {
+    AppThemeM2 {
         SiteExample()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/plans/SiteCreationPlansFragment.kt
@@ -45,7 +45,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.main.jetpack.migration.compose.state.LoadingState
 import org.wordpress.android.ui.sitecreation.SiteCreationActivity.Companion.ARG_STATE
@@ -62,7 +62,7 @@ class SiteCreationPlansFragment : Fragment(), SiteCreationPlansWebViewClientList
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 SiteCreationPlansPage(
                     navigationUp = requireActivity().onBackPressedDispatcher::onBackPressed
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitemonitor/SiteMonitorParentActivity.kt
@@ -53,7 +53,7 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.WPWebViewActivity
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.util.extensions.getSerializableExtraCompat
 import javax.inject.Inject
@@ -115,7 +115,7 @@ class SiteMonitorParentActivity : AppCompatActivity(), SiteMonitorWebViewClient.
             currentSelectItemId = getInitialTab()
         }
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/MicToStopIcon.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/MicToStopIcon.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 @OptIn(ExperimentalAnimationApi::class)
 @Suppress("DEPRECATION")
@@ -115,7 +115,7 @@ fun MicToStopIcon(model: RecordingPanelUIModel, isRecording: Boolean) {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ExistingLayoutPreview() {
-    AppTheme {
+    AppThemeM2 {
         MicToStopIcon(
             RecordingPanelUIModel(
                 isEligibleForFeature = true,

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentDialogFragment.kt
@@ -28,7 +28,7 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.Dismiss
 import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchEditPost
 import org.wordpress.android.ui.voicetocontent.VoiceToContentActionEvent.LaunchExternalBrowser
@@ -48,7 +48,7 @@ class VoiceToContentDialogFragment : BottomSheetDialogFragment() {
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 VoiceToContentScreen(
                     viewModel = viewModel
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -52,7 +52,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.buttons.Drawable
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.audio.RecordingUpdate
 import java.util.Locale
 
@@ -382,7 +382,7 @@ private val errorUrlLinkCTA: TextStyle
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewInitializingView() {
-    AppTheme {
+    AppThemeM2 {
         val state = VoiceToContentUiState(
             uiStateType = VoiceToContentUIStateType.INITIALIZING,
             header = HeaderUIModel(label = R.string.voice_to_content_base_header_label, onClose = { }),
@@ -404,7 +404,7 @@ fun PreviewInitializingView() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewReadyToRecordView() {
-    AppTheme {
+    AppThemeM2 {
         val state = VoiceToContentUiState(
             uiStateType = VoiceToContentUIStateType.READY_TO_RECORD,
             header = HeaderUIModel(label = R.string.voice_to_content_base_header_label, onClose = { }),
@@ -426,7 +426,7 @@ fun PreviewReadyToRecordView() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewNotEligibleToRecordView() {
-    AppTheme {
+    AppThemeM2 {
         val state = VoiceToContentUiState(
             uiStateType = VoiceToContentUIStateType.INELIGIBLE_FOR_FEATURE,
             header = HeaderUIModel(label = R.string.voice_to_content_base_header_label, onClose = { }),
@@ -447,7 +447,7 @@ fun PreviewNotEligibleToRecordView() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewRecordingView() {
-    AppTheme {
+    AppThemeM2 {
         val state = VoiceToContentUiState(
             uiStateType = VoiceToContentUIStateType.RECORDING,
             header = HeaderUIModel(label = R.string.voice_to_content_recording_label, onClose = { }),
@@ -470,7 +470,7 @@ fun PreviewRecordingView() {
 @Preview(showBackground = true, device = Devices.PIXEL_4_XL, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewProcessingView() {
-    AppTheme {
+    AppThemeM2 {
         val state = VoiceToContentUiState(
             uiStateType = VoiceToContentUIStateType.PROCESSING,
             header = HeaderUIModel(label = R.string.voice_to_content_processing_label, onClose = { })

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/LoginPrologueRevampedFragment.kt
@@ -32,7 +32,7 @@ import org.wordpress.android.ui.accounts.login.compose.components.PrimaryButton
 import org.wordpress.android.ui.accounts.login.compose.components.SecondaryButton
 import org.wordpress.android.ui.accounts.login.compose.components.Tagline
 import org.wordpress.android.ui.compose.TestTags
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.util.extensions.setEdgeToEdgeContentDisplay
 
 class LoginPrologueRevampedFragment : Fragment() {
@@ -44,7 +44,7 @@ class LoginPrologueRevampedFragment : Fragment() {
         savedInstanceState: Bundle?
     ) = ComposeView(requireContext()).apply {
         setContent {
-            AppTheme {
+            AppThemeM2 {
                 LoginScreenRevamped(
                     onWpComLoginClicked = loginPrologueListener::showEmailLoginScreen,
                     onSiteAddressLoginClicked = loginPrologueListener::loginViaSiteAddress,
@@ -123,7 +123,7 @@ fun LoginScreenRevamped(
 @Preview(showBackground = true, device = Devices.PIXEL_3A, uiMode = UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewLoginScreenRevamped() {
-    AppTheme {
+    AppThemeM2 {
         LoginScreenRevamped(onWpComLoginClicked = {}, onSiteAddressLoginClicked = {})
     }
 }

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/PrimaryButton.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/PrimaryButton.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -63,7 +63,7 @@ fun PrimaryButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewPrimaryButton() {
-    AppTheme {
+    AppThemeM2 {
         PrimaryButton("Button", onClick = {})
     }
 }

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/SecondaryButton.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/SecondaryButton.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 
 @Composable
@@ -55,7 +55,7 @@ fun SecondaryButton(
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewSecondaryButton() {
-    AppTheme {
+    AppThemeM2 {
         SecondaryButton("Button", onClick = {})
     }
 }

--- a/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/Tagline.kt
+++ b/WordPress/src/wordpress/java/org/wordpress/android/ui/accounts/login/compose/components/Tagline.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppTheme
+import org.wordpress.android.ui.compose.theme.AppThemeM2
 
 private val fontSize = 22.sp
 private val lineHeight = fontSize * 1.3
@@ -66,7 +66,7 @@ fun ColumnScope.Tagline(text: String, modifier: Modifier = Modifier) {
 @Preview(showBackground = true, heightDp = 200, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun PreviewLoginPrologue() {
-    AppTheme {
+    AppThemeM2 {
         Column(
             Modifier
                 .background(color = colorResource(id = R.color.login_prologue_revamped_background))


### PR DESCRIPTION
Fixes #21322

This PR renames `AppTheme` to `AppThemeM2` to clarify that it's the Material2 theme and deprecates it in favor of using `AppThemeM3` for new composables. Although a large number of files are changed by this PR, there are no changes to logic - it's a simple rename only.