### PR TITLE
Material 3 bar code & QR code scanners

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/barcodescanner/BarcodeScannerScreen.kt
@@ -4,10 +4,10 @@ import android.content.res.Configuration
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 
 @Composable
 fun BarcodeScannerScreen(
@@ -91,7 +91,7 @@ private fun AlertDialog(
             ) {
                 Text(
                     ctaLabel,
-                    color = MaterialTheme.colors.secondary,
+                    color = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.padding(8.dp)
                 )
             }
@@ -104,7 +104,7 @@ private fun AlertDialog(
             ) {
                 Text(
                     dismissCtaLabel,
-                    color = MaterialTheme.colors.secondary,
+                    color = MaterialTheme.colorScheme.secondary,
                     modifier = Modifier.padding(8.dp)
                 )
             }
@@ -116,7 +116,7 @@ private fun AlertDialog(
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeniedOnceAlertDialog() {
-    AppThemeM2 {
+    AppThemeM3 {
         AlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_rationale_message),
@@ -132,7 +132,7 @@ fun DeniedOnceAlertDialog() {
 @Preview(name = "Dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun DeniedPermanentlyAlertDialog() {
-    AppThemeM2 {
+    AppThemeM3 {
         AlertDialog(
             title = stringResource(id = R.string.barcode_scanning_alert_dialog_title),
             message = stringResource(id = R.string.barcode_scanning_alert_dialog_permanently_denied_message),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -127,7 +127,6 @@ import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.prefs.privacy.banner.PrivacyBannerFragment;
-import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActivity;
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts;
 import org.wordpress.android.ui.quickstart.QuickStartTracker;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
@@ -510,9 +509,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
-
-        // TODO remove this before merging
-        QRCodeAuthActivity.start(this);
     }
 
     private void initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -127,6 +127,7 @@ import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.prefs.privacy.banner.PrivacyBannerFragment;
+import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActivity;
 import org.wordpress.android.ui.quickstart.QuickStartMySitePrompts;
 import org.wordpress.android.ui.quickstart.QuickStartTracker;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
@@ -509,6 +510,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
+
+        // TODO remove this before merging
+        QRCodeAuthActivity.start(this);
     }
 
     private void initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/QRCodeAuthFragment.kt
@@ -29,7 +29,7 @@ import org.wordpress.android.ui.barcodescanner.BarcodeScanningFragment.Companion
 import org.wordpress.android.ui.barcodescanner.BarcodeScanningFragment.Companion.KEY_BARCODE_SCANNING_SCAN_STATUS
 import org.wordpress.android.ui.barcodescanner.CodeScannerStatus
 import org.wordpress.android.ui.compose.components.VerticalScrollBox
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.posts.BasicDialogViewModel
 import org.wordpress.android.ui.posts.BasicDialogViewModel.BasicDialogModel
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthActionEvent.FinishActivity
@@ -69,7 +69,7 @@ class QRCodeAuthFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppThemeM2 {
+            AppThemeM3 {
                 QRCodeAuthScreen()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/PrimaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/PrimaryButton.kt
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.qrcodeauth.compose.components
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.wordpress.android.ui.compose.unit.Margin

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/SecondaryButton.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/SecondaryButton.kt
@@ -1,10 +1,10 @@
 package org.wordpress.android.ui.qrcodeauth.compose.components
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -20,10 +20,10 @@ fun SecondaryButton(
     Button(
         onClick = onClick,
         enabled = enabled,
-        elevation = ButtonDefaults.elevation(0.dp),
+        elevation = ButtonDefaults.buttonElevation(0.dp),
         colors = ButtonDefaults.buttonColors(
-            backgroundColor = MaterialTheme.colors.background,
-            disabledBackgroundColor = MaterialTheme.colors.background,
+            containerColor = MaterialTheme.colorScheme.background,
+            disabledContainerColor = MaterialTheme.colorScheme.background,
         ),
         modifier = modifier.padding(
             vertical = Margin.Small.value,

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Subtitle.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Subtitle.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.qrcodeauth.compose.components
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Title.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/components/Title.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.qrcodeauth.compose.components
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ContentState.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState
@@ -53,7 +53,7 @@ fun ContentState(uiState: QRCodeAuthUiState.Content): Unit = with(uiState) {
             Title(text = uiStringText(it))
         }
         subtitle?.let {
-            Subtitle(text = uiStringText(it), color = MaterialTheme.colors.onBackground)
+            Subtitle(text = uiStringText(it), color = MaterialTheme.colorScheme.onBackground)
         }
         primaryActionButton?.let { actionButton ->
             if (actionButton.isVisible) {
@@ -91,7 +91,7 @@ fun ContentState(uiState: QRCodeAuthUiState.Content): Unit = with(uiState) {
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun ContentStatePreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         val state = QRCodeAuthUiState.Content.Validated(
             browser = "{browser}",
             location = "{location}",

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/ErrorState.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,7 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.qrcodeauth.QRCodeAuthUiState
@@ -44,7 +44,7 @@ fun ErrorState(uiState: QRCodeAuthUiState.Error): Unit = with(uiState) {
                 .wrapContentSize()
         )
         Title(text = uiStringText(title))
-        Subtitle(text = uiStringText(subtitle), color = MaterialTheme.colors.error)
+        Subtitle(text = uiStringText(subtitle), color = MaterialTheme.colorScheme.error)
         primaryActionButton?.let { actionButton ->
             if (actionButton.isVisible) {
                 PrimaryButton(
@@ -69,7 +69,7 @@ fun ErrorState(uiState: QRCodeAuthUiState.Error): Unit = with(uiState) {
 @Preview(showBackground = true)
 @Composable
 private fun ErrorStatePreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         val state = QRCodeAuthUiState.Error.InvalidData(
             primaryActionButton = ErrorPrimaryActionButton {},
             secondaryActionButton = ErrorSecondaryActionButton {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/LoadingState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/qrcodeauth/compose/state/LoadingState.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.qrcodeauth.compose.state
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
Fixes #21329

This PR converts the QR code & bar code scanners to Material3. To test:

* Sign into the app with an account that doesn't have 2FA enabled (QR login isn't supported when 2FA is enabled)
* Me > Scan Login Code
* On your desktop/laptop, visit https://wordpress.com/log-in
* Choose "Login via App"
* Verify the various screens appear correctly
