### PR TITLE
feat: Authenticate private resource requests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2528,6 +2528,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 "postType" to postType,
                 "postTitle" to editPostRepository.getPost()?.title,
                 "postContent" to editPostRepository.getPost()?.content,
+                "siteURL" to site.url,
                 "siteApiRoot" to siteApiRoot,
                 "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
                 "authHeader" to authHeader,
@@ -2553,7 +2554,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 isNewPost,
                 gutenbergWebViewAuthorizationData,
                 jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
-                settings
+                settings,
+                site.isPrivate || site.isComingSoon,
+                site.isPrivateWPComAtomic
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2498,8 +2498,23 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 onXpostsSettingsCapability(isXpostsCapable)
             }
 
+            val authorizationData = createGutenbergWebViewAuthorizationData()
+            val settings = createGutenbergSettings()
+
+            return GutenbergKitEditorFragment.newInstance(
+                getContext(),
+                isNewPost,
+                authorizationData,
+                jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
+                settings,
+                site.isPrivate || site.isComingSoon,
+                site.isPrivateWPComAtomic
+            )
+        }
+
+        private fun createGutenbergWebViewAuthorizationData(): GutenbergWebViewAuthorizationData {
             val isWpCom = site.isWPCom || siteModel.isPrivateWPComAtomic || siteModel.isWPComAtomic
-            val gutenbergWebViewAuthorizationData = GutenbergWebViewAuthorizationData(
+            return GutenbergWebViewAuthorizationData(
                 siteModel.url,
                 isWpCom,
                 accountStore.account.userId,
@@ -2513,7 +2528,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 userAgent.toString(),
                 isJetpackSsoEnabled
             )
+        }
 
+        private fun createGutenbergSettings(): Map<String, Any?> {
+            val isWpCom = site.isWPCom || siteModel.isPrivateWPComAtomic || siteModel.isWPComAtomic
             val postType = if (editPostRepository.isPage) "page" else "post"
             val siteApiRoot = if (isWpCom) "https://public-api.wordpress.com/" else ""
             val authToken = accountStore.accessToken
@@ -2523,7 +2541,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             val languageString = perAppLocaleManager.getCurrentLocaleLanguageCode()
             val wpcomLocaleSlug = languageString.replace("_", "-").lowercase()
 
-            val settings = mutableMapOf<String, Any?>(
+            return mutableMapOf(
                 "postId" to editPostRepository.getPost()?.remotePostId?.toInt(),
                 "postType" to postType,
                 "postTitle" to editPostRepository.getPost()?.title,
@@ -2547,16 +2565,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                         }
                     )
                 )
-            )
-
-            return GutenbergKitEditorFragment.newInstance(
-                getContext(),
-                isNewPost,
-                gutenbergWebViewAuthorizationData,
-                jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
-                settings,
-                site.isPrivate || site.isComingSoon,
-                site.isPrivateWPComAtomic
             )
         }
 

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
@@ -16,6 +16,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -44,6 +46,7 @@ import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.IHistoryListener;
+import org.wordpress.gutenberg.GutenbergRequestInterceptor;
 import org.wordpress.gutenberg.GutenbergView;
 import org.wordpress.gutenberg.GutenbergView.HistoryChangeListener;
 import org.wordpress.gutenberg.GutenbergView.LogJsExceptionListener;
@@ -53,11 +56,24 @@ import org.wordpress.gutenberg.GutenbergWebViewPool;
 import org.wordpress.gutenberg.EditorConfiguration;
 import org.wordpress.gutenberg.WebViewGlobal;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import static org.wordpress.gutenberg.Media.createMediaUsingMimeType;
 
@@ -67,7 +83,8 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
         EditorThemeUpdateListener,
         GutenbergDialogPositiveClickInterface,
         GutenbergDialogNegativeClickInterface,
-        GutenbergNetworkConnectionListener {
+        GutenbergNetworkConnectionListener,
+        GutenbergRequestInterceptor {
     @Nullable private GutenbergView mGutenbergView;
     private static final String GUTENBERG_EDITOR_NAME = "gutenberg";
     private static final String KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED";
@@ -93,12 +110,17 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     private View mRootView;
 
     @Nullable private static Map<String, Object> mSettings;
+    private static boolean mIsPrivate = false;
+    private static boolean mIsPrivateAtomic = false;
+    @NonNull OkHttpClient mHttpClient = new OkHttpClient();
 
     public static GutenbergKitEditorFragment newInstance(Context context,
             boolean isNewPost,
             @Nullable GutenbergWebViewAuthorizationData webViewAuthorizationData,
             boolean jetpackFeaturesEnabled,
-            @Nullable Map<String, Object> settings) {
+            @Nullable Map<String, Object> settings,
+            boolean isPrivate,
+            boolean isPrivateAtomic) {
         GutenbergKitEditorFragment fragment = new GutenbergKitEditorFragment();
         Bundle args = new Bundle();
         args.putBoolean(ARG_IS_NEW_POST, isNewPost);
@@ -107,6 +129,8 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
         fragment.setArguments(args);
         SavedInstanceDatabase db = SavedInstanceDatabase.Companion.getDatabase(context);
         mSettings = settings;
+        mIsPrivate = isPrivate;
+        mIsPrivateAtomic = isPrivateAtomic;
         if (db != null) {
             db.addParcel(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, webViewAuthorizationData);
         }
@@ -166,6 +190,7 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
             mEditorFragmentListener.onEditorFragmentContentReady(new ArrayList<>(), false);
             setEditorProgressBarVisibility(false);
         });
+        mGutenbergView.setRequestInterceptor(this);
 
         return mRootView;
     }
@@ -607,5 +632,102 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     @Override
     public void onConnectionStatusChange(boolean isConnected) {
         // Unused, no-op retained for the shared interface with Gutenberg
+    }
+
+    @Override
+    public boolean canIntercept(@NonNull WebResourceRequest request) {
+        Uri url = request.getUrl();
+
+        return mIsPrivate && isSiteHostedMediaFile(url.toString());
+    }
+
+    boolean isSiteHostedMediaFile(@NonNull String urlString) {
+        String siteURL = (String) (mSettings != null ? mSettings.get("siteURL") : "");
+        Set<String> mediaExtensions = new HashSet<>(Arrays.asList(
+                "jpg", "jpeg", "png", "gif", "bmp", "webp",
+                "mp4", "mov", "avi", "mkv",
+                "mp3", "wav", "flac"
+        ));
+
+        try {
+            URL url = new URL(urlString);
+            URL siteUrlObj = new URL(siteURL);
+
+            // Check if the URL is from the same host as the site URL
+            if (!url.getHost().equalsIgnoreCase(siteUrlObj.getHost())) {
+                return false;
+            }
+
+            // Extract the file name and extension
+            String path = url.getPath();
+            int lastDotIndex = path.lastIndexOf('.');
+            if (lastDotIndex == -1) {
+                return false;
+            }
+
+            String extension = path.substring(lastDotIndex + 1).toLowerCase(Locale.ROOT);
+
+            // Check if the extension is in the list of media extensions
+            return mediaExtensions.contains(extension);
+        } catch (MalformedURLException e) {
+            // Handle invalid URLs
+            return false;
+        }
+    }
+
+    @Nullable @Override
+    public WebResourceResponse handleRequest(@NonNull WebResourceRequest request) {
+        Uri url = request.getUrl();
+
+        String proxyUrl = url.toString();
+        if (mIsPrivateAtomic) {
+            proxyUrl = getPrivateResourceProxyUrl(url);
+        }
+
+        try {
+            Request okHttpRequest = new Request.Builder()
+                    .url(proxyUrl)
+                    .headers(Headers.of(request.getRequestHeaders()))
+                    .addHeader("Authorization", mSettings.get("authHeader").toString())
+                    .build();
+
+            Response response = mHttpClient.newCall(okHttpRequest).execute();
+
+            ResponseBody body = response.body();
+            if (body == null) {
+                return null;
+            }
+
+            okhttp3.MediaType contentType = body.contentType();
+            if (contentType == null) {
+                return null;
+            }
+
+            return new WebResourceResponse(
+                    contentType.toString(),
+                    response.header("content-encoding"),
+                    body.byteStream()
+            );
+        } catch (IOException e) {
+            // We don't need to handle this ourselves, just tell the WebView that
+            // we weren't able to fetch the resource
+            return null;
+        }
+    }
+
+    private static @NonNull String getPrivateResourceProxyUrl(@NonNull Uri url) {
+        Uri newUri = new Uri.Builder()
+                .scheme("https")
+                .authority("public-api.wordpress.com")
+                .appendPath("wpcom")
+                .appendPath("v2")
+                .appendPath("sites")
+                .appendPath(url.getAuthority())
+                .appendPath("atomic-auth-proxy")
+                .appendPath("file")
+                .appendEncodedPath(url.getPath().substring(1)) // Remove leading '/'
+                .build();
+
+        return newUri.toString();
     }
 }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
@@ -62,6 +62,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -72,6 +73,7 @@ import java.util.concurrent.CountDownLatch;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.Request.Builder;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
@@ -109,7 +111,7 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     @Nullable
     private View mRootView;
 
-    @Nullable private static Map<String, Object> mSettings;
+    @NonNull private static Map<String, Object> mSettings = Collections.emptyMap();
     private static boolean mIsPrivate = false;
     private static boolean mIsPrivateAtomic = false;
     @NonNull OkHttpClient mHttpClient = new OkHttpClient();
@@ -118,7 +120,7 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
             boolean isNewPost,
             @Nullable GutenbergWebViewAuthorizationData webViewAuthorizationData,
             boolean jetpackFeaturesEnabled,
-            @Nullable Map<String, Object> settings,
+            @NonNull Map<String, Object> settings,
             boolean isPrivate,
             boolean isPrivateAtomic) {
         GutenbergKitEditorFragment fragment = new GutenbergKitEditorFragment();
@@ -642,7 +644,7 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     }
 
     boolean isSiteHostedMediaFile(@NonNull String urlString) {
-        String siteURL = (String) (mSettings != null ? mSettings.get("siteURL") : "");
+        String siteURL = (String) mSettings.get("siteURL");
         Set<String> mediaExtensions = new HashSet<>(Arrays.asList(
                 "jpg", "jpeg", "png", "gif", "bmp", "webp",
                 "mp4", "mov", "avi", "mkv",
@@ -684,15 +686,19 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
             proxyUrl = getPrivateResourceProxyUrl(url);
         }
 
+        String authHeader = (String) mSettings.get("authHeader");
+        if (authHeader == null) {
+            return null;
+        }
+
         try {
-            Request okHttpRequest = new Request.Builder()
+            Request okHttpRequest = new Builder()
                     .url(proxyUrl)
                     .headers(Headers.of(request.getRequestHeaders()))
-                    .addHeader("Authorization", mSettings.get("authHeader").toString())
+                    .addHeader("Authorization", authHeader)
                     .build();
 
             Response response = mHttpClient.newCall(okHttpRequest).execute();
-
             ResponseBody body = response.body();
             if (body == null) {
                 return null;
@@ -716,6 +722,11 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     }
 
     private static @NonNull String getPrivateResourceProxyUrl(@NonNull Uri url) {
+        String path = url.getPath();
+        if (path != null && path.startsWith("/")) {
+            path = path.substring(1); // Remove leading '/'
+        }
+
         Uri newUri = new Uri.Builder()
                 .scheme("https")
                 .authority("public-api.wordpress.com")
@@ -725,7 +736,7 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
                 .appendPath(url.getAuthority())
                 .appendPath("atomic-auth-proxy")
                 .appendPath("file")
-                .appendEncodedPath(url.getPath().substring(1)) // Remove leading '/'
+                .appendEncodedPath(path)
                 .build();
 
         return newUri.toString();

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
@@ -646,10 +646,12 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     boolean isSiteHostedMediaFile(@NonNull String urlString) {
         String siteURL = (String) mSettings.get("siteURL");
         Set<String> mediaExtensions = new HashSet<>(Arrays.asList(
-                "jpg", "jpeg", "png", "gif", "bmp", "webp",
-                "mp4", "mov", "avi", "mkv",
-                "mp3", "wav", "flac"
-        ));
+                // Image formats
+                "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "ico", "tiff", "tif", "heic", "heif",
+                // Video formats
+                "mp4", "mov", "avi", "mkv", "webm", "m4v", "mpeg", "mpg", "3gp", "flv", "wmv", "mts", "m2ts",
+                // Audio formats
+                "mp3", "wav", "flac", "aac", "m4a", "ogg", "wma", "aiff", "mid", "midi"));
 
         try {
             URL url = new URL(urlString);


### PR DESCRIPTION
## Related

- CMM-235-linear-issue
- https://github.com/Automattic/dotcom-forge/issues/9446
- https://github.com/wordpress-mobile/GutenbergKit/pull/34
- https://github.com/wordpress-mobile/GutenbergKit/pull/30

## Description

Authenticate resource requests originating from within the WebView so that
requests to private sites succeed. Ref CMM-235.

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

> [!Important]
> The proposed logic does not work for streamed files (e.g., video and audio). It appears [`shouldInterceptRequest` injects a `Content-Length: 0` header](https://groups.google.com/a/chromium.org/g/net-dev/c/vcglzJAXwaU/m/itqvpU7qHgAJ), which creates duplicate values creating a malformed request that disables streaming. 

See https://github.com/wordpress-mobile/GutenbergKit/pull/34.

## Regression Notes

1. Potential unintended areas of impact
    Gutenberg Mobile or Aztec editors fail. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested both editors. 
3. What automated tests I added (or what prevented me from doing so)
    None, feels unnecessary for this currently experimental editor feature. 

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)