### PR TITLE
Convert Bloganuary screen to Material3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
@@ -150,7 +150,7 @@ fun BloganuaryNudgeLearnMoreOverlay(
                     modifier = Modifier.align(Alignment.CenterHorizontally),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.bodySmall,
-                    color = LocalContentColor.current.copy(alpha = 0.4f),
+                    color = LocalContentColor.current.copy(alpha = contentTextEmphasis()),
                 )
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
@@ -65,7 +65,7 @@ private fun contentIconBackgroundColor(isDarkTheme: Boolean = isSystemInDarkThem
 @Composable
 private fun contentTextEmphasis(isDarkTheme: Boolean = isSystemInDarkTheme()): Float {
     return if (isDarkTheme) {
-        0.7f
+        0.6f
     } else {
         1f
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.bloganuary.learnmore
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,17 +21,16 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,24 +50,27 @@ import org.wordpress.android.ui.compose.theme.AppThemeM2
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString.UiStringRes
-import androidx.compose.material.MaterialTheme as Material2Theme
 
 private val contentIconForegroundColor: Color
     get() = AppColor.White
 
-private val contentIconBackgroundColor: Color
-    @Composable get() = if (Material2Theme.colors.isLight) {
+@Composable
+private fun contentIconBackgroundColor(isDarkTheme: Boolean = isSystemInDarkTheme()): Color {
+    return if (isDarkTheme) {
         AppColor.Black
     } else {
         AppColor.White.copy(alpha = 0.18f)
     }
+}
 
-private val contentTextEmphasis: Float
-    @Composable get() = if (Material2Theme.colors.isLight) {
-        1f
+@Composable
+private fun contentTextEmphasis(isDarkTheme: Boolean = isSystemInDarkTheme()): Float {
+    return if (isDarkTheme) {
+        0.4f // TODO verify this is correct
     } else {
-        ContentAlpha.medium
+        1f
     }
+}
 
 @Composable
 fun BloganuaryNudgeLearnMoreOverlay(
@@ -111,7 +114,7 @@ fun BloganuaryNudgeLearnMoreOverlay(
             ) {
                 Image(
                     painter = painterResource(R.drawable.logo_bloganuary),
-                    colorFilter = ColorFilter.tint(Material2Theme.colors.onSurface),
+                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
                     modifier = Modifier.width(180.dp),
                     contentScale = ContentScale.Inside,
                     contentDescription = stringResource(
@@ -148,12 +151,12 @@ fun BloganuaryNudgeLearnMoreOverlay(
                     modifier = Modifier.align(Alignment.CenterHorizontally),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.bodySmall,
-                    color = LocalContentColor.current.copy(alpha = ContentAlpha.medium),
+                    color = LocalContentColor.current.copy(alpha = 0.4f),
                 )
             }
         }
 
-        Divider()
+        HorizontalDivider()
 
         Button(
             onClick = { onActionClick(model.action) },
@@ -163,8 +166,8 @@ fun BloganuaryNudgeLearnMoreOverlay(
             elevation = null,
             contentPadding = PaddingValues(vertical = Margin.Large.value),
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = Material2Theme.colors.onSurface,
-                contentColor = Material2Theme.colors.surface,
+                containerColor = MaterialTheme.colorScheme.onSurface,
+                contentColor = MaterialTheme.colorScheme.surface,
             ),
         ) {
             Text(stringResource(model.action.textRes))
@@ -211,7 +214,7 @@ private fun OverlayContentItem(
             modifier = Modifier
                 .size(48.dp)
                 .background(
-                    color = contentIconBackgroundColor,
+                    color = contentIconBackgroundColor(),
                     shape = CircleShape,
                 ),
         ) {
@@ -227,7 +230,7 @@ private fun OverlayContentItem(
 
         Spacer(Modifier.width(Margin.ExtraLarge.value))
 
-        ContentAlphaProvider(contentTextEmphasis) {
+        ContentAlphaProvider(contentTextEmphasis()) {
             Text(
                 stringResource(textRes),
                 style = MaterialTheme.typography.titleMedium,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlay.kt
@@ -44,9 +44,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
-import org.wordpress.android.ui.compose.components.ContentAlphaProvider
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.compose.utils.uiStringText
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -57,16 +56,16 @@ private val contentIconForegroundColor: Color
 @Composable
 private fun contentIconBackgroundColor(isDarkTheme: Boolean = isSystemInDarkTheme()): Color {
     return if (isDarkTheme) {
-        AppColor.Black
-    } else {
         AppColor.White.copy(alpha = 0.18f)
+    } else {
+        AppColor.Black
     }
 }
 
 @Composable
 private fun contentTextEmphasis(isDarkTheme: Boolean = isSystemInDarkTheme()): Float {
     return if (isDarkTheme) {
-        0.4f // TODO verify this is correct
+        0.7f
     } else {
         1f
     }
@@ -230,12 +229,11 @@ private fun OverlayContentItem(
 
         Spacer(Modifier.width(Margin.ExtraLarge.value))
 
-        ContentAlphaProvider(contentTextEmphasis()) {
-            Text(
-                stringResource(textRes),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
+        Text(
+            text = stringResource(textRes),
+            style = MaterialTheme.typography.titleMedium,
+            color = LocalContentColor.current.copy(alpha = contentTextEmphasis()),
+        )
     }
 }
 
@@ -244,7 +242,7 @@ private fun OverlayContentItem(
 @Preview(name = "Dark Mode", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun BloganuaryNudgeLearnMoreOverlayPreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         BloganuaryNudgeLearnMoreOverlay(
             model = BloganuaryNudgeLearnMoreOverlayUiState(
                 noteText = UiStringRes(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloganuary/learnmore/BloganuaryNudgeLearnMoreOverlayFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.util.extensions.fillScreen
 import org.wordpress.android.viewmodel.main.WPMainActivityViewModel
 import javax.inject.Inject
@@ -40,7 +40,7 @@ class BloganuaryNudgeLearnMoreOverlayFragment : BottomSheetDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                AppThemeM2 {
+                AppThemeM3 {
                     BloganuaryNudgeLearnMoreOverlay(
                         model = viewModel.getUiState(isPromptsEnabled),
                         onActionClick = viewModel::onActionClick,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -161,6 +161,8 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             setupContentViews(savedInstanceState)
             setupObservers()
         }
+        // TODO remove this
+        openBloganuaryNudgeOverlay(true)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -725,15 +727,19 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
         )
 
         is SiteNavigationAction.OpenBloganuaryNudgeOverlay -> {
-            BloganuaryNudgeLearnMoreOverlayFragment
-                .newInstance(action.isPromptsEnabled)
-                .show(requireActivity().supportFragmentManager, BloganuaryNudgeLearnMoreOverlayFragment.TAG)
+            openBloganuaryNudgeOverlay(action.isPromptsEnabled)
         }
 
         is SiteNavigationAction.OpenSiteMonitoring -> activityNavigator.navigateToSiteMonitoring(
             requireActivity(),
             action.site
         )
+    }
+
+    private fun openBloganuaryNudgeOverlay(isPromptsEnabled: Boolean) {
+        BloganuaryNudgeLearnMoreOverlayFragment
+            .newInstance(isPromptsEnabled)
+            .show(requireActivity().supportFragmentManager, BloganuaryNudgeLearnMoreOverlayFragment.TAG)
     }
 
     private fun handleNavigation(action: BloggingPromptCardNavigationAction) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -161,8 +161,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             setupContentViews(savedInstanceState)
             setupObservers()
         }
-        // TODO remove this
-        openBloganuaryNudgeOverlay(true)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
This small PR updates the Bloganuary screen to Material3. To make it easy to test, I changed the "My Site" fragment to automatically show the Bloganuary screen when it's created. I'll remove this before merging.

**BEFORE**

![bloganuary-before](https://github.com/user-attachments/assets/52dad0c0-713d-4b6a-bf15-d80857c27538)

**AFTER**

![after](https://github.com/user-attachments/assets/c3aa0608-f318-4b3a-a904-c0f99e81bf82)
