### PR TITLE
Configure dependabot to only observe version catalog file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gradle"
     open-pull-requests-limit: 6
-    directory: "/"
+    directory: "gradle/"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
### Description

The recent FluxC merge caused Dependabot to create PRs for merged submodules, particularly `login` module.

To reduce unnecessary noise as we'll be moving to version catalogs for `login` module as well, let's configure Dependabot to check for dependencies only in version catalog file. Relevant comment: https://github.com/wordpress-mobile/WordPress-Android/pull/21337#issuecomment-2434543581