### PR TITLE
Feedback form support note

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -107,7 +107,7 @@ private fun MessageSection(
         focusRequester.requestFocus()
     }
 
-    Box(
+    Column(
         modifier = Modifier
             .padding(
                 vertical = V_PADDING.dp,
@@ -130,6 +130,13 @@ private fun MessageSection(
                 .fillMaxWidth()
                 .defaultMinSize(minHeight = 180.dp)
                 .focusRequester(focusRequester),
+        )
+        Text(
+            text = stringResource(id = R.string.feedback_form_note),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier
+                .padding(top = V_PADDING.dp)
+
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -71,7 +71,7 @@ fun FeedbackFormScreen(
         )
         MediaUriPager(
             mediaUris = attachments.value.map { it.uri },
-            onButtonClick =  { uri -> onRemoveMediaClick(uri) },
+            onButtonClick = { uri -> onRemoveMediaClick(uri) },
             modifier = Modifier
                 .padding(
                     vertical = V_PADDING.dp,
@@ -134,6 +134,7 @@ private fun MessageSection(
         Text(
             text = stringResource(id = R.string.feedback_form_note),
             style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
                 .padding(top = V_PADDING.dp)
 

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -259,7 +259,7 @@
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
                     style="@style/MeListRowTextView"
-                    android:text="@string/me_btn_help" />
+                    android:text="@string/me_btn_help_and_support" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1142,6 +1142,7 @@
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>
+    <string name="feedback_form_note">If you need support, please get in touch using the \"Help\" screen</string>
     <string name="media_pager_remove_item_content_description">Remove item %1$d</string>
 
     <!-- activity log -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1142,7 +1142,7 @@
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>
-    <string name="feedback_form_note">If you need support, please get in touch using the \"Help\" screen</string>
+    <string name="feedback_form_note">If you need support, please get in touch using the &quot;Help &amp; Support&quot; screen</string>
     <string name="media_pager_remove_item_content_description">Remove item %1$d</string>
 
     <!-- activity log -->
@@ -2575,7 +2575,7 @@
     <!--Me-->
     <string name="me_profile_photo">Profile Photo</string>
     <string name="me_btn_app_settings">App Settings</string>
-    <string name="me_btn_help">Help</string>
+    <string name="me_btn_help_and_support">Help &amp; Support</string>
     <string name="me_btn_feedback">Send feedback</string>
     <string name="me_btn_share">Share WordPress with a friend</string>
     <string name="me_btn_about">About WordPress</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1142,7 +1142,7 @@
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>
-    <string name="feedback_form_note">If you need support, please get in touch using the &quot;Help &amp; Support&quot; screen</string>
+    <string name="feedback_form_note">If you need support, please get in touch using the \"Help &amp; Support\" screen</string>
     <string name="media_pager_remove_item_content_description">Remove item %1$d</string>
 
     <!-- activity log -->


### PR DESCRIPTION
Fixes #21350

This PR adds a note to the feedback form instructing the user to use "Help & Support" for support, to match iOS. I also changed the "Help" row on the Me tab to "Help & Support," again to match iOS.

![light](https://github.com/user-attachments/assets/cb492bc2-1428-4227-a7ea-1006a79c96bc)


