### PR TITLE
Match iOS Feedback Form Tracks Events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1314,8 +1314,7 @@ public class ActivityLauncher {
 
     public static void viewFeedbackForm(@NonNull Context context) {
         warnIfIdentityA8C(context);
-        // TODO verify tracks event with iOS
-        AnalyticsTracker.track(Stat.FEEDBACK_FORM_OPENED);
+        AnalyticsTracker.track(Stat.APP_REVIEWS_FEEDBACK_SCREEN_OPENED);
         Intent intent = new Intent(context, FeedbackFormActivity.class);
         context.startActivity(intent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.wordpress.android.R
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_FEEDBACK_SENT
+import org.wordpress.android.analytics.AnalyticsTracker.Stat.APP_REVIEWS_FEEDBACK_SCREEN_CANCELED
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.support.ZendeskHelper
@@ -28,6 +30,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.ToastUtilsWrapper
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.extensions.copyToTempFile
 import org.wordpress.android.util.extensions.fileSize
 import org.wordpress.android.util.extensions.mimeType
@@ -47,6 +50,7 @@ class FeedbackFormViewModel @Inject constructor(
     private val toastUtilsWrapper: ToastUtilsWrapper,
     private val feedbackFormUtils: FeedbackFormUtils,
     private val mediaPickerLauncher: MediaPickerLauncher,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
 ) : ScopedViewModel(mainDispatcher) {
     private val _messageText = MutableStateFlow("")
     val messageText = _messageText.asStateFlow()
@@ -172,6 +176,7 @@ class FeedbackFormViewModel @Inject constructor(
     fun onCloseClick(context: Context) {
         (context as? Activity)?.let { activity ->
             if (_messageText.value.isEmpty() && _attachments.value.isEmpty()) {
+                analyticsTrackerWrapper.track(APP_REVIEWS_FEEDBACK_SCREEN_CANCELED)
                 activity.finish()
             } else {
                 confirmDiscard(activity)
@@ -183,6 +188,7 @@ class FeedbackFormViewModel @Inject constructor(
         MaterialAlertDialogBuilder(activity).also { builder ->
             builder.setTitle(R.string.feedback_form_discard)
             builder.setPositiveButton(R.string.discard) { _, _ ->
+                analyticsTrackerWrapper.track(APP_REVIEWS_FEEDBACK_SCREEN_CANCELED)
                 activity.finish()
             }
             builder.setNegativeButton(R.string.cancel) { _, _ ->
@@ -192,6 +198,7 @@ class FeedbackFormViewModel @Inject constructor(
     }
 
     private fun onSuccess(context: Context) {
+        analyticsTrackerWrapper.track(APP_REVIEWS_FEEDBACK_SENT)
         showToast(R.string.feedback_form_success)
         (context as? Activity)?.finish()
     }

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -654,7 +654,13 @@ public final class AnalyticsTracker {
         SUPPORT_CHATBOT_TICKET_SUCCESS,
         SUPPORT_CHATBOT_TICKET_FAILURE,
         SUPPORT_CHATBOT_ENDED,
-        FEEDBACK_FORM_OPENED,
+
+        // these events are for the feedback form, which on iOS was originally part of the
+        // in-app review feature.
+        APP_REVIEWS_FEEDBACK_SCREEN_OPENED,
+        APP_REVIEWS_FEEDBACK_SENT,
+        APP_REVIEWS_FEEDBACK_SCREEN_CANCELED,
+
         QUICK_START_STARTED,
         QUICK_START_CARD_SHOWN,
         QUICK_START_TAPPED,


### PR DESCRIPTION
Fixes #21348

Previously on Android we tracked when the feedback form was opened using `FEEDBACK_FORM_OPENED`, but on iOS this is `APP_REVIEWS_FEEDBACK_SCREEN_OPENED`. This is because initially the feedback form was part of the in-app reviews feature.

This PR updates that event to match iOS, and to match iOS it also adds these two events:

* APP_REVIEWS_FEEDBACK_SENT
* APP_REVIEWS_FEEDBACK_SCREEN_CANCELED

To test:

* Make sure to enable "Collect information" in the app's Privacy section
* Filter Logcat for "Tracked"
* Verify that events are being tracked correctly when the form is opened, cancelled, and submitted