### PR TITLE
Jetpack overlay Material3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/WPJetpackIndividualPluginFragment.kt
@@ -18,7 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.ui.ActivityLauncherWrapper
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.ActionEvent
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginViewModel.UiState
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.compose.WPJetpackIndividualPluginOverlayScreen
@@ -39,7 +39,7 @@ class WPJetpackIndividualPluginFragment : BottomSheetDialogFragment() {
         savedInstanceState: Bundle?
     ): View = ComposeView(requireContext()).apply {
         setContent {
-            AppThemeM2 {
+            AppThemeM3 {
                 val uiState by viewModel.uiState.collectAsState()
                 when (val state = uiState) {
                     is UiState.Loaded -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/MultipleSitesContent.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/SingleSiteContent.kt
@@ -2,7 +2,7 @@ package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -13,10 +13,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -35,10 +35,10 @@ import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MainTopAppBar
 import org.wordpress.android.ui.compose.components.NavigationIcons
 import org.wordpress.android.ui.compose.components.buttons.ButtonSize
-import org.wordpress.android.ui.compose.components.buttons.PrimaryButton
-import org.wordpress.android.ui.compose.components.buttons.SecondaryButton
+import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
+import org.wordpress.android.ui.compose.components.buttons.SecondaryButtonM3
 import org.wordpress.android.ui.compose.theme.AppColor
-import org.wordpress.android.ui.compose.theme.AppThemeM2
+import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.theme.JpColorPalette
 import org.wordpress.android.ui.jetpackoverlay.individualplugin.SiteWithIndividualJetpackPlugins
 import org.wordpress.android.ui.jetpackplugininstall.fullplugin.onboarding.compose.component.JPInstallFullPluginAnimation
@@ -64,7 +64,7 @@ private val ContentTextStyle
 private val ContentMargin = 20.dp
 
 @Composable
-@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter", "UnusedMaterial3ScaffoldPaddingParameter")
 fun WPJetpackIndividualPluginOverlayScreen(
     sites: List<SiteWithIndividualJetpackPlugins>,
     onCloseClick: () -> Unit,
@@ -141,23 +141,23 @@ fun WPJetpackIndividualPluginOverlayScreen(
                     .padding(horizontal = ContentMargin),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                PrimaryButton(
+                PrimaryButtonM3(
                     text = stringResource(R.string.wp_jetpack_individual_plugin_overlay_primary_button),
                     onClick = onPrimaryButtonClick,
                     buttonSize = ButtonSize.LARGE,
                     padding = PaddingValues(0.dp),
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = JpColorPalette().primary,
+                        containerColor = JpColorPalette().primary,
                         contentColor = AppColor.White,
                     ),
                 )
-                SecondaryButton(
+                SecondaryButtonM3(
                     text = stringResource(R.string.wp_jetpack_continue_without_jetpack),
                     onClick = onSecondaryButtonClick,
                     buttonSize = ButtonSize.LARGE,
                     padding = PaddingValues(0.dp),
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = Color.Transparent,
+                        containerColor = Color.Transparent,
                         contentColor = JpColorPalette().primary,
                     ),
                 )
@@ -179,7 +179,7 @@ private fun getTitle(siteCount: Int): String = if (siteCount > 1) {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(
@@ -200,7 +200,7 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteSinglePluginPreview() {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(
@@ -222,7 +222,7 @@ fun WPJetpackIndividualPluginOverlayScreenSingleSiteMultiplePluginsPreview() {
 @Preview(widthDp = 720, heightDp = 360)
 @Composable
 fun WPJetpackIndividualPluginOverlayScreenMultipleSitesPreview() {
-    AppThemeM2 {
+    AppThemeM3 {
         WPJetpackIndividualPluginOverlayScreen(
             sites = listOf(
                 SiteWithIndividualJetpackPlugins(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.jetpackoverlay.individualplugin.compose
 
-import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.Arrangement
@@ -71,7 +70,6 @@ private val ContentMargin = 20.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@SuppressLint("UnusedMaterialScaffoldPaddingParameter", "UnusedMaterial3ScaffoldPaddingParameter")
 fun WPJetpackIndividualPluginOverlayScreen(
     sites: List<SiteWithIndividualJetpackPlugins>,
     onCloseClick: () -> Unit,
@@ -94,29 +92,21 @@ fun WPJetpackIndividualPluginOverlayScreen(
                 },
             )
         }
-    ) {
+    ) { contentPadding ->
         val orientation = LocalConfiguration.current.orientation
         val isLandscape = remember(orientation) { orientation == Configuration.ORIENTATION_LANDSCAPE }
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .let {
-                    if (isLandscape) it.verticalScroll(rememberScrollState()) else it
-                }
+                .verticalScroll(rememberScrollState())
+                .padding(contentPadding),
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .let {
-                        if (!isLandscape) {
-                            it
-                                .weight(1f)
-                                .verticalScroll(rememberScrollState())
-                        } else {
-                            it
-                        }
-                    }
+                    .verticalScroll(rememberScrollState())
+                    .weight(1f)
                     .padding(ContentMargin),
                 verticalArrangement = Arrangement.Center,
             ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackoverlay/individualplugin/compose/WPJetpackIndividualPluginOverlayScreen.kt
@@ -13,10 +13,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -63,6 +69,7 @@ private val ContentTextStyle
 
 private val ContentMargin = 20.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter", "UnusedMaterial3ScaffoldPaddingParameter")
 fun WPJetpackIndividualPluginOverlayScreen(
@@ -77,6 +84,14 @@ fun WPJetpackIndividualPluginOverlayScreen(
                 title = null,
                 navigationIcon = NavigationIcons.CloseIcon,
                 onNavigationIconClick = onCloseClick
+            )
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onCloseClick) {
+                        Icon(Icons.Filled.Close, stringResource(R.string.close))
+                    }
+                },
             )
         }
     ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -97,6 +97,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
+import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginFragment;
 import org.wordpress.android.ui.main.MainActionListItem.ActionType;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
@@ -509,6 +510,9 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
+
+        // TODO remove before merging
+        WPJetpackIndividualPluginFragment.show(getSupportFragmentManager());
     }
 
     private void initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -97,7 +97,6 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFr
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper;
-import org.wordpress.android.ui.jetpackoverlay.individualplugin.WPJetpackIndividualPluginFragment;
 import org.wordpress.android.ui.main.MainActionListItem.ActionType;
 import org.wordpress.android.ui.main.WPMainNavigationView.OnPageListener;
 import org.wordpress.android.ui.main.WPMainNavigationView.PageType;
@@ -510,9 +509,6 @@ public class WPMainActivity extends LocaleAwareActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
-
-        // TODO remove before merging
-        WPJetpackIndividualPluginFragment.show(getSupportFragmentManager());
     }
 
     private void initBackPressHandler() {


### PR DESCRIPTION
This PR converts `WPJetpackIndividualPluginOverlayScreen` to Material3. To make testing easier, I've modified the main activity to show this screen at startup. I'll remove that before merging.

You can also rely on screen previews for testing.

![1](https://github.com/user-attachments/assets/5bf6fbf1-d951-443e-b52f-082d469ca8c8)
![2](https://github.com/user-attachments/assets/3207ad0d-15b2-428a-bf66-9ed6d7c651f6)
![3](https://github.com/user-attachments/assets/8f8d2984-bbb1-4640-94fd-9a6cc8f9e91d)
![4](https://github.com/user-attachments/assets/670b7dc8-b264-4a9a-857c-296f662e4392)
