### PR TITLE
Move "Send feedback" to HelpActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -112,7 +112,7 @@ class HelpActivity : LocaleAwareActivity() {
                 showContactUs()
             }
 
-            if(BuildConfig.DEBUG && BuildConfig.ENABLE_DEBUG_SETTINGS) {
+            if (BuildConfig.DEBUG && BuildConfig.ENABLE_DEBUG_SETTINGS) {
                 enableDebugSettings()
             }
 
@@ -120,6 +120,10 @@ class HelpActivity : LocaleAwareActivity() {
             applicationVersion.text = getString(R.string.version_with_name_param, WordPress.versionName)
             logsButton.setOnClickListener { v ->
                 startActivity(Intent(v.context, AppLogViewerActivity::class.java))
+            }
+
+            feedbackButton.setOnClickListener {
+                ActivityLauncher.viewFeedbackForm(this@HelpActivity)
             }
 
             if (originFromExtras == Origin.JETPACK_MIGRATION_HELP) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -207,9 +207,6 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         rowSupport.setOnClickListener {
             ActivityLauncher.viewHelp(requireContext(), ME_SCREEN_HELP, viewModel.getSite(), null)
         }
-        rowFeedback.setOnClickListener {
-            ActivityLauncher.viewFeedbackForm(requireContext())
-        }
         learnMoreAtGravatar.setOnClickListener {
             ActivityLauncher.openUrlExternal(activity, GRAVATAR_URL)
         }

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -130,6 +130,11 @@
                     style="@style/HelpActivitySingleText"
                     android:text="@string/contact_support" />
 
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/feedbackButton"
+                    style="@style/HelpActivitySingleText"
+                    android:text="@string/send_feedback" />
+
                 <LinearLayout
                     android:id="@+id/forumContainer"
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -266,24 +266,6 @@
             <View style="@style/MeListSectionDividerView" />
 
             <LinearLayout
-                android:id="@+id/row_feedback"
-                style="@style/MeListRowLayout">
-
-                <ImageView
-                    android:id="@+id/me_feedback_icon"
-                    style="@style/MeListRowIcon"
-                    android:contentDescription="@null"
-                    android:src="@drawable/ic_pencil_white_24dp" />
-
-                <org.wordpress.android.util.widgets.AutoResizeTextView
-                    style="@style/MeListRowTextView"
-                    android:text="@string/me_btn_feedback" />
-
-            </LinearLayout>
-
-            <View style="@style/MeListSectionDividerView" />
-
-            <LinearLayout
                 android:id="@+id/recommend_the_app_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2577,7 +2577,6 @@
     <string name="me_profile_photo">Profile Photo</string>
     <string name="me_btn_app_settings">App Settings</string>
     <string name="me_btn_help_and_support">Help &amp; Support</string>
-    <string name="me_btn_feedback">Send feedback</string>
     <string name="me_btn_share">Share WordPress with a friend</string>
     <string name="me_btn_about">About WordPress</string>
     <string name="me_btn_login_logout">Login/Logout</string>
@@ -2959,6 +2958,7 @@
     <string name="let_us_help">Let Us Help</string>
     <string name="start_over_text">If you want a site but don\'t want any of the posts and pages you have now, our support team can delete your posts, pages, media and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.</string>
     <string name="contact_support">Contact Support</string>
+    <string name="send_feedback">Send feedback</string>
     <string name="confirm_delete_site">Confirm Delete Site</string>
     <string name="confirm_delete_site_prompt">Please type in %1$s in the field below to confirm. Your site will then be gone forever.</string>
     <string name="site_settings_export_content_title">Export content</string>


### PR DESCRIPTION
Fixes #21380

As [discussed on Slack](p1730125385198439/1730124391.538659-slack-C0180B5PRJ4), we're getting a lot of support requests and spam through the feedback form. This PR hopes to alleviate that by moving "Send feedback" to the "Help & support" screen.

To test:

* Verify that "Send feedback" is no longer on the Me screen
* Tap "Help & Support" on the Me screen
* Verify that "Send feedback" appears on the Help screen and tapping it opens the feedback form

![feedback](https://github.com/user-attachments/assets/8c5e1205-b132-4f00-8620-42c7da91020b)
