### PR TITLE
[Tooling] Fix `update_appstore_strings` backmerge PR creation

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -134,7 +134,7 @@ platform :android do
 
     push_to_git_remote(tags: false)
 
-    create_backmerge_pr
+    create_backmerge_pr(source_branch: git_branch, target_branch: "release/#{version}")
   end
 
   # Updates the metadata in the Play Store (Main store listing) from the content of `fastlane/{metadata|jetpack_metadata}/android/*/*.txt` files

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -577,8 +577,8 @@ platform :android do
 
       #{e.message}
 
-      If this is not the first time you are running the release task, the backmerge PR for the version `#{current_release_version}` might have already been previously created.
-      Please close any previous backmerge PR for `#{current_release_version}`, delete the previous merge branch, then run the release task again.
+      If this is not the first time you are running the automation that creates a backmerge, the backmerge PR for the `#{source_branch}` branch might have already been previously created.
+      Please close any previous backmerge PR for the `#{source_branch}` branch, delete the previous merge branch, then run the release task again.
     MESSAGE
 
     buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -563,12 +563,11 @@ platform :android do
     buildkite_annotate(style: 'info', context: 'trigger-release-build', message: message) if is_ci
   end
 
-  def create_backmerge_pr
-    version = current_release_version
-
+  def create_backmerge_pr(source_branch: "release/#{current_release_version}", target_branch: nil)
     pr_url = create_release_backmerge_pull_request(
       repository: GHHELPER_REPO,
-      source_branch: "release/#{version}",
+      source_branch: source_branch,
+      target_branches: Array(target_branch),
       labels: ['Releases'],
       milestone_title: next_release_version
     )
@@ -578,8 +577,8 @@ platform :android do
 
       #{e.message}
 
-      If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
-      Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+      If this is not the first time you are running the release task, the backmerge PR for the version `#{current_release_version}` might have already been previously created.
+      Please close any previous backmerge PR for `#{current_release_version}`, delete the previous merge branch, then run the release task again.
     MESSAGE
 
     buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci


### PR DESCRIPTION
This PR should fix the issue highlighted by @oguzkocer on [this change](https://github.com/wordpress-mobile/WordPress-Android/pull/21229/files#r1800099465), where `update_appstore_strings` wouldn't properly create the PR to merge the `release_notes/{version}` branch to `release/{version}`.

iOS counterpart: https://github.com/wordpress-mobile/WordPress-iOS/pull/23758

-----

## To Test:

This will be fully tested during the regular release cycle.

It is possible to simulate a similar scenario following the steps below:
1. Create a dummy local branch
2. Create and push a dummy release branch with a number far in the future (e.g. `release/500.0`)
3. Go back to the initial local dummy branch
4. Run the lane with `bundle exec fastlane update_appstore_strings version:"500.0"`
5. A PR from the local branch (which, in a real world scenario, will be the release note branch) should be created.
