### PR TITLE
Features in development checkboxes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsItemViewHolder.kt
@@ -51,10 +51,13 @@ sealed class DebugSettingsItemViewHolder(
             }
 
             UiItem.FeatureFlag.State.UNKNOWN -> {
+                // features in development are always unknown until the user taps on them
                 if (item.type == DebugSettingsType.FEATURES_IN_DEVELOPMENT) {
                     featureEnabled.isVisible = true
+                    featureEnabled.isChecked = (item as? UiItem.FeatureFlag.LocalFeatureFlag)?.enabled == true
                     unknownIcon.isVisible = false
                 } else {
+                    featureEnabled.isVisible = false
                     unknownIcon.isVisible = true
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsItemViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/DebugSettingsItemViewHolder.kt
@@ -37,22 +37,26 @@ sealed class DebugSettingsItemViewHolder(
 
     fun DebugSettingsFeatureBinding.showFeatureFlag(item: UiItem.FeatureFlag) {
         featureTitle.text = item.title
-        featureEnabled.visibility = View.GONE
-        unknownIcon.visibility = View.GONE
-        featureEnabled.setOnCheckedChangeListener(null)
         when (item.state) {
             UiItem.FeatureFlag.State.ENABLED -> {
-                featureEnabled.visibility = View.VISIBLE
+                featureEnabled.isVisible = true
                 featureEnabled.isChecked = true
+                unknownIcon.isVisible = false
             }
 
             UiItem.FeatureFlag.State.DISABLED -> {
-                featureEnabled.visibility = View.VISIBLE
+                featureEnabled.isVisible = true
                 featureEnabled.isChecked = false
+                unknownIcon.isVisible = false
             }
 
             UiItem.FeatureFlag.State.UNKNOWN -> {
-                unknownIcon.visibility = View.VISIBLE
+                if (item.type == DebugSettingsType.FEATURES_IN_DEVELOPMENT) {
+                    featureEnabled.isVisible = true
+                    unknownIcon.isVisible = false
+                } else {
+                    unknownIcon.isVisible = true
+                }
             }
         }
         featureEnabled.setOnCheckedChangeListener { _, _ -> item.toggleAction.toggle() }
@@ -66,9 +70,9 @@ sealed class DebugSettingsItemViewHolder(
         R.layout.debug_settings_remote_field
     ) {
         fun bind(item: UiItem.Field) = with(DebugSettingsRemoteFieldBinding.bind(itemView)) {
-            remoteFieldKey.setText(item.remoteFieldKey)
-            remoteFieldValue.setText(item.remoteFieldValue)
-            remoteFieldSource.setText(item.remoteFieldSource)
+            remoteFieldKey.text = item.remoteFieldKey
+            remoteFieldValue.text = item.remoteFieldValue
+            remoteFieldSource.text = item.remoteFieldSource
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/UIState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/UIState.kt
@@ -31,13 +31,7 @@ sealed class UiItem(open val type: DebugSettingsType) {
             state = when (enabled) {
                 true -> State.ENABLED
                 false -> State.DISABLED
-                null -> {
-                    if (debugSettingsType == DebugSettingsType.FEATURES_IN_DEVELOPMENT) {
-                        State.ENABLED
-                    } else {
-                        State.UNKNOWN
-                    }
-                }
+                null -> State.UNKNOWN
             },
             toggleAction = toggleAction,
             type = debugSettingsType

--- a/WordPress/src/main/java/org/wordpress/android/ui/debug/UIState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/debug/UIState.kt
@@ -27,14 +27,20 @@ sealed class UiItem(open val type: DebugSettingsType) {
             toggleAction: ToggleAction,
             debugSettingsType: DebugSettingsType
         ) : this(
-            title,
-            when (enabled) {
+            title = title,
+            state = when (enabled) {
                 true -> State.ENABLED
                 false -> State.DISABLED
-                null -> State.UNKNOWN
+                null -> {
+                    if (debugSettingsType == DebugSettingsType.FEATURES_IN_DEVELOPMENT) {
+                        State.ENABLED
+                    } else {
+                        State.UNKNOWN
+                    }
+                }
             },
-            toggleAction,
-            debugSettingsType
+            toggleAction = toggleAction,
+            type = debugSettingsType
         )
 
         enum class State { ENABLED, DISABLED, UNKNOWN }

--- a/WordPress/src/main/res/layout/debug_settings_feature.xml
+++ b/WordPress/src/main/res/layout/debug_settings_feature.xml
@@ -6,34 +6,28 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/feature_title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:gravity="start"
-        android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textSize="16sp"
-        android:maxLines="2"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/preview_icon"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
+    <CheckBox
+        android:id="@+id/feature_enabled"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_marginEnd="@dimen/margin_medium"
+        app:layout_constraintBottom_toBottomOf="@+id/remote_field_source"
+        app:layout_constraintEnd_toStartOf="@+id/unknown_icon"
+        app:layout_constraintTop_toTopOf="@+id/feature_title"
+        app:layout_constraintVertical_bias="0.0" />
+
+    <ImageView
+        android:id="@+id/unknown_icon"
+        android:layout_width="@dimen/settings_icon_size"
+        android:layout_height="0dp"
+        android:contentDescription="@string/unknown"
+        android:src="@drawable/ic_help_outline_white_24dp"
+        app:layout_constraintBottom_toBottomOf="@+id/remote_field_source"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0"
-        tools:text="Feature Title" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/remote_field_source"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="12sp"
-        android:textAllCaps="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/feature_title"
-        app:layout_constraintVertical_bias="0.0"
-        tools:text="Remote Source" />
+        app:tint="@color/placeholder"
+        tools:visibility="visible" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/preview_icon"
@@ -56,28 +50,33 @@
         app:layout_constraintVertical_bias="0.0"
         tools:visibility="visible" />
 
-    <CheckBox
-        android:id="@+id/feature_enabled"
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/remote_field_source"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginEnd="@dimen/margin_medium"
-        app:layout_constraintBottom_toBottomOf="@+id/remote_field_source"
-        app:layout_constraintEnd_toStartOf="@+id/unknown_icon"
-        app:layout_constraintTop_toTopOf="@+id/feature_title"
+        android:layout_height="wrap_content"
+        android:textAllCaps="true"
+        android:textSize="12sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/feature_title"
         app:layout_constraintVertical_bias="0.0"
-        tools:visibility="visible" />
+        tools:text="Remote Source" />
 
-    <ImageView
-        android:id="@+id/unknown_icon"
-        android:layout_width="@dimen/settings_icon_size"
-        android:layout_height="0dp"
-        android:contentDescription="@string/unknown"
-        android:src="@drawable/ic_help_outline_white_24dp"
-        android:tint="@color/placeholder"
-        app:layout_constraintBottom_toBottomOf="@+id/remote_field_source"
-        app:layout_constraintEnd_toEndOf="parent"
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/feature_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:gravity="start"
+        android:maxLines="2"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/preview_icon"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0"
-        tools:visibility="visible" />
+        tools:text="Feature Title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #21408 

This PR resolves an issue with the "Experimental features" tab in debug settings. Prior to this PR, the checkboxes next to the feature name would be hidden until a row was tapped, like this:

![before](https://github.com/user-attachments/assets/36829aab-d1ff-4e11-acd9-a3e0c178d9f6)

This PR changes that list so the checkboxes are always visible, like this:

![debug](https://github.com/user-attachments/assets/d19967ca-8c6e-40e6-af2d-79045fe86d8a)
