### PR TITLE
Remove `violations-comments-to-github-gradle-plugin`

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,6 +1,4 @@
 import io.sentry.android.gradle.extensions.InstrumentationFeature
-import se.bjurr.violations.comments.github.plugin.gradle.ViolationCommentsToGitHubTask
-import se.bjurr.violations.lib.model.SEVERITY
 
 plugins {
     alias(libs.plugins.android.application)
@@ -8,7 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.allopen)
     alias(libs.plugins.sentry)
-    alias(libs.plugins.violation.comments)
     alias(libs.plugins.google.services)
     alias(libs.plugins.google.dagger.hilt)
     alias(libs.plugins.kotlinx.kover)
@@ -591,32 +588,6 @@ if (!file("google-services.json").exists()) {
 // Print warning message if example Google services file is used.
 if ((file('google-services.json').text) == (file('google-services.json-example').text)) {
     println("WARNING: You're using the example google-services.json file. Google login will fail.")
-}
-
-tasks.register("violationCommentsToGitHub", ViolationCommentsToGitHubTask) {
-    repositoryOwner = "wordpress-mobile"
-    repositoryName = "WordPress-Android"
-    pullRequestId = System.properties['GITHUB_PULLREQUESTID']
-    username = System.properties['GITHUB_USERNAME']
-    password = System.properties['GITHUB_PASSWORD']
-    oAuth2Token = System.properties['GITHUB_OAUTH2TOKEN']
-    gitHubUrl = "https://api.github.com/"
-    createCommentWithAllSingleFileComments = false
-    createSingleFileComments = true
-    commentOnlyChangedContent = true
-    minSeverity = SEVERITY.INFO //ERROR, INFO, WARN
-    commentTemplate = """
-**Reporter**: {{violation.reporter}}{{#violation.rule}}\n
-**Rule**: {{violation.rule}}{{/violation.rule}}
-**Severity**: {{violation.severity}}
-**File**: {{violation.file}}:{{violation.startLine}}{{#violation.source}}
-**Source**: {{violation.source}}{{/violation.source}}
-{{violation.message}}
-"""
-    violations = [
-            ["CHECKSTYLE", ".", ".*/build/.*/checkstyle/.*\\.xml\$", "CheckStyle"],
-            ["CHECKSTYLE", ".", ".*/build/.*/detekt/.*\\.xml\$", "Detekt"]
-    ]
 }
 
 tasks.register("printVersionName") {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.automattic.measure.builds)
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.dependency.analysis)
-    alias(libs.plugins.violation.comments).apply(false)
     alias(libs.plugins.androidx.navigation.safeargs).apply(false)
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.android.library).apply(false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,6 @@ squareup-java-poet = '1.13.0'
 squareup-kotlin-poet = '1.18.1'
 squareup-okhttp3 = '4.12.0'
 squareup-retrofit = '2.11.0'
-violation-comments = '1.70.0'
 wellsql = '2.0.0'
 wiremock = '2.26.3'
 wordpress-aztec = 'v2.1.4'
@@ -281,4 +280,3 @@ kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kov
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentry" }
 room = { id = "androidx.room", version.ref = "androidx-room" }
-violation-comments = { id = "se.bjurr.violations.violation-comments-to-github-gradle-plugin", version.ref = "violation-comments" }


### PR DESCRIPTION
### Description

The reasons to remove this plugin from the project are:
- the plugin is not configuration-cache compatible and is archived/deprecated
- we don't use this plugin on CI for years now: it seems was forgotten when we were migrating from CircleCI
- we already support a tool that comments on PRs: GitHub Code scanning. For now we only comment with Android Lint, but if it's needed, we can add support for Detekt and Checkstyle as well.

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

As this is build-only dependency, testing is not needed. The green light from CI is completely fine.
