### PR TITLE
[Tooling] Use `buildkite_pipeline_upload` action to inline Buildkite release pipelines

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -13,36 +13,12 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
-      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      echo "RELEASE_VERSION: $RELEASE_VERSION"
       validate_gradle_wrapper
     plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
-
-  #################
-  # Lint
-  #################
-  - group: "🕵️ Lint"
-    steps:
-
-      - label: "🕵️ Lint WordPress"
-        key: wplint
-        command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/lint.sh wordpress
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-      - label: "🕵️ Lint Jetpack"
-        key: jplint
-        command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/lint.sh jetpack
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
 
   #################
   # Beta Builds
@@ -53,9 +29,7 @@ steps:
       - label: ":wordpress: :android: Beta Build"
         key: wpbuild
         command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/beta-build.sh wordpress
-        depends_on: wplint
+          echo "RELEASE_VERSION: $RELEASE_VERSION"
         plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
@@ -67,9 +41,7 @@ steps:
       - label: ":jetpack: :android: Beta Build"
         key: jpbuild
         command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/beta-build.sh jetpack
-        depends_on: jplint
+          echo "RELEASE_VERSION: $RELEASE_VERSION"
         plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
@@ -86,6 +58,5 @@ steps:
       - wpbuild
       - jpbuild
     command: |
-      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-      .buildkite/commands/create-github-release.sh
+      echo "RELEASE_VERSION: $RELEASE_VERSION"
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -13,6 +13,7 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
       validate_gradle_wrapper
     plugins: [$CI_TOOLKIT]
 
@@ -27,14 +28,18 @@ steps:
 
       - label: "🕵️ Lint WordPress"
         key: wplint
-        command: ".buildkite/commands/lint.sh wordpress"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh wordpress
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
       - label: "🕵️ Lint Jetpack"
         key: jplint
-        command: ".buildkite/commands/lint.sh jetpack"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh jetpack
         plugins: [$CI_TOOLKIT]
         artifact_paths:
           - "**/build/reports/lint-results*.*"
@@ -47,7 +52,9 @@ steps:
 
       - label: ":wordpress: :android: Beta Build"
         key: wpbuild
-        command: ".buildkite/commands/beta-build.sh wordpress"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/beta-build.sh wordpress
         depends_on: wplint
         plugins: [$CI_TOOLKIT]
         notify:
@@ -59,7 +66,9 @@ steps:
 
       - label: ":jetpack: :android: Beta Build"
         key: jpbuild
-        command: ".buildkite/commands/beta-build.sh jetpack"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/beta-build.sh jetpack
         depends_on: jplint
         plugins: [$CI_TOOLKIT]
         notify:
@@ -76,5 +85,7 @@ steps:
     depends_on:
       - wpbuild
       - jpbuild
-    command: ".buildkite/commands/create-github-release.sh"
+    command: |
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/create-github-release.sh
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -13,12 +13,36 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
-      echo "RELEASE_VERSION: $RELEASE_VERSION"
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
       validate_gradle_wrapper
     plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
+
+  #################
+  # Lint
+  #################
+  - group: "🕵️ Lint"
+    steps:
+
+      - label: "🕵️ Lint WordPress"
+        key: wplint
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh wordpress
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
+
+      - label: "🕵️ Lint Jetpack"
+        key: jplint
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh jetpack
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
   #################
   # Beta Builds
@@ -29,7 +53,9 @@ steps:
       - label: ":wordpress: :android: Beta Build"
         key: wpbuild
         command: |
-          echo "RELEASE_VERSION: $RELEASE_VERSION"
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/beta-build.sh wordpress
+        depends_on: wplint
         plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
@@ -41,7 +67,9 @@ steps:
       - label: ":jetpack: :android: Beta Build"
         key: jpbuild
         command: |
-          echo "RELEASE_VERSION: $RELEASE_VERSION"
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/beta-build.sh jetpack
+        depends_on: jplint
         plugins: [$CI_TOOLKIT]
         notify:
           - slack: "#build-and-ship"
@@ -58,5 +86,6 @@ steps:
       - wpbuild
       - jpbuild
     command: |
-      echo "RELEASE_VERSION: $RELEASE_VERSION"
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/create-github-release.sh
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/commands/checkout-editorial-branch.sh
+++ b/.buildkite/commands/checkout-editorial-branch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eu
 
+echo '--- :git: Checkout Editorial Branch'
+
 # EDITORIAL_BRANCH is passed as an environment variable from fastlane to Buildkite
 #
 if [[ -z "${EDITORIAL_BRANCH}" ]]; then

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,10 +1,8 @@
 #!/bin/bash -eu
 
-# RELEASE_VERSION is passed as an environment variable passed to Buildkite by ReleasesV2.
-if [[ -z "${RELEASE_VERSION}" ]]; then
-    echo "RELEASE_VERSION is not set."
-    exit 1
-fi
+echo "--- :git: Checkout Release Branch"
+
+RELEASE_VERSION="${1?Please provide a release version as an argument.}"
 
 # Buildkite, by default, checks out a specific commit. For many release actions, we need to be
 # on a release branch instead.

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -8,8 +8,7 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -8,7 +8,7 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      # .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems

--- a/.buildkite/complete-code-freeze.yml
+++ b/.buildkite/complete-code-freeze.yml
@@ -8,7 +8,7 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      # .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems

--- a/.buildkite/finalize-release.yml
+++ b/.buildkite/finalize-release.yml
@@ -8,8 +8,7 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :ruby: Setup Ruby Tools'
       install_gems

--- a/.buildkite/publish-release.yml
+++ b/.buildkite/publish-release.yml
@@ -8,8 +8,7 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      echo '--- :git: Checkout Release Branch'
-      .buildkite/commands/checkout-release-branch.sh
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
 
       echo '--- :ruby: Setup Ruby tools'
       install_gems

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -13,39 +13,13 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
-      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      # .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
       validate_gradle_wrapper
     priority: 1
     plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
-
-  #################
-  # Lint
-  #################
-  - group: "🕵️ Lint"
-    steps:
-
-      - label: "🕵️ Lint WordPress"
-        key: wplint
-        command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/lint.sh wordpress
-        priority: 1
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
-
-      - label: "🕵️ Lint Jetpack"
-        key: jplint
-        command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/lint.sh jetpack
-        priority: 1
-        plugins: [$CI_TOOLKIT]
-        artifact_paths:
-          - "**/build/reports/lint-results*.*"
 
   #################
   # Release Builds
@@ -56,32 +30,30 @@ steps:
       - label: ":wordpress: :android: Release Build"
         key: wpbuild
         command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/release-build.sh wordpress
+          echo "RELEASE_VERSION: $RELEASE_VERSION"
         priority: 1
         depends_on: wplint
         plugins: [$CI_TOOLKIT]
-        notify:
-          - slack: "#build-and-ship"
-        retry:
-          manual:
-            # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-            allowed: false
+        # notify:
+        #   - slack: "#build-and-ship"
+        # retry:
+        #   manual:
+        #     # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        #     allowed: false
 
       - label: ":jetpack: :android: Release Build"
         key: jpbuild
         command: |
-          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-          .buildkite/commands/release-build.sh jetpack
+          echo "RELEASE_VERSION: $RELEASE_VERSION"
         priority: 1
         depends_on: jplint
         plugins: [$CI_TOOLKIT]
-        notify:
-          - slack: "#build-and-ship"
-        retry:
-          manual:
-            # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-            allowed: false
+        # notify:
+        #   - slack: "#build-and-ship"
+        # retry:
+        #   manual:
+        #     # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        #     allowed: false
 
   #################
   # GitHub Release
@@ -91,7 +63,6 @@ steps:
       - wpbuild
       - jpbuild
     command: |
-      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
-      .buildkite/commands/create-github-release.sh
+      echo "RELEASE_VERSION: $RELEASE_VERSION"
     priority: 1
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -13,13 +13,39 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
-      # .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
       validate_gradle_wrapper
     priority: 1
     plugins: [$CI_TOOLKIT]
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
+
+  #################
+  # Lint
+  #################
+  - group: "🕵️ Lint"
+    steps:
+
+      - label: "🕵️ Lint WordPress"
+        key: wplint
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh wordpress
+        priority: 1
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
+
+      - label: "🕵️ Lint Jetpack"
+        key: jplint
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh jetpack
+        priority: 1
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/lint-results*.*"
 
   #################
   # Release Builds
@@ -30,30 +56,32 @@ steps:
       - label: ":wordpress: :android: Release Build"
         key: wpbuild
         command: |
-          echo "RELEASE_VERSION: $RELEASE_VERSION"
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/release-build.sh wordpress
         priority: 1
         depends_on: wplint
         plugins: [$CI_TOOLKIT]
-        # notify:
-        #   - slack: "#build-and-ship"
-        # retry:
-        #   manual:
-        #     # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        #     allowed: false
+        notify:
+          - slack: "#build-and-ship"
+        retry:
+          manual:
+            # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+            allowed: false
 
       - label: ":jetpack: :android: Release Build"
         key: jpbuild
         command: |
-          echo "RELEASE_VERSION: $RELEASE_VERSION"
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/release-build.sh jetpack
         priority: 1
         depends_on: jplint
         plugins: [$CI_TOOLKIT]
-        # notify:
-        #   - slack: "#build-and-ship"
-        # retry:
-        #   manual:
-        #     # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        #     allowed: false
+        notify:
+          - slack: "#build-and-ship"
+        retry:
+          manual:
+            # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+            allowed: false
 
   #################
   # GitHub Release
@@ -63,6 +91,7 @@ steps:
       - wpbuild
       - jpbuild
     command: |
-      echo "RELEASE_VERSION: $RELEASE_VERSION"
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/create-github-release.sh
     priority: 1
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -13,6 +13,7 @@ steps:
   #################
   - label: "Gradle Wrapper Validation"
     command: |
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
       validate_gradle_wrapper
     priority: 1
     plugins: [$CI_TOOLKIT]
@@ -28,7 +29,9 @@ steps:
 
       - label: "🕵️ Lint WordPress"
         key: wplint
-        command: ".buildkite/commands/lint.sh wordpress"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh wordpress
         priority: 1
         plugins: [$CI_TOOLKIT]
         artifact_paths:
@@ -36,7 +39,9 @@ steps:
 
       - label: "🕵️ Lint Jetpack"
         key: jplint
-        command: ".buildkite/commands/lint.sh jetpack"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/lint.sh jetpack
         priority: 1
         plugins: [$CI_TOOLKIT]
         artifact_paths:
@@ -50,7 +55,9 @@ steps:
 
       - label: ":wordpress: :android: Release Build"
         key: wpbuild
-        command: ".buildkite/commands/release-build.sh wordpress"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/release-build.sh wordpress
         priority: 1
         depends_on: wplint
         plugins: [$CI_TOOLKIT]
@@ -63,7 +70,9 @@ steps:
 
       - label: ":jetpack: :android: Release Build"
         key: jpbuild
-        command: ".buildkite/commands/release-build.sh jetpack"
+        command: |
+          .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+          .buildkite/commands/release-build.sh jetpack
         priority: 1
         depends_on: jplint
         plugins: [$CI_TOOLKIT]
@@ -81,6 +90,8 @@ steps:
     depends_on:
       - wpbuild
       - jpbuild
-    command: ".buildkite/commands/create-github-release.sh"
+    command: |
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      .buildkite/commands/create-github-release.sh
     priority: 1
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/update-release-notes.yml
+++ b/.buildkite/update-release-notes.yml
@@ -9,7 +9,6 @@ steps:
       echo '--- :robot_face: Use bot for git operations'
       source use-bot-for-git
 
-      echo '--- :git: Checkout Editorial Branch'
       .buildkite/commands/checkout-editorial-branch.sh
 
       echo '--- :ruby: Setup Ruby Tools'

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -122,24 +122,24 @@ platform :android do
   #####################################################################################
   desc 'Trigger a release build for a given app after code freeze'
   lane :complete_code_freeze do |options|
-    ensure_git_branch(branch: '^release/')
+    # ensure_git_branch(branch: '^release/')
     ensure_git_status_clean
 
     new_version = current_release_version
 
-    UI.important("Completing code freeze for: #{new_version}")
+    # UI.important("Completing code freeze for: #{new_version}")
 
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+    # UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
 
-    localize_libraries
-    update_frozen_strings_for_translation
+    # localize_libraries
+    # update_frozen_strings_for_translation
 
-    ensure_git_status_clean
-    push_to_git_remote(tags: false)
+    # ensure_git_status_clean
+    # push_to_git_remote(tags: false)
 
     trigger_beta_build(branch_to_build: "release/#{new_version}")
 
-    create_backmerge_pr
+    # create_backmerge_pr
   end
 
   # Updates a release branch for a new beta release, triggering a beta build using the `.buildkite/beta-builds.yml` pipeline.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -122,24 +122,24 @@ platform :android do
   #####################################################################################
   desc 'Trigger a release build for a given app after code freeze'
   lane :complete_code_freeze do |options|
-    # ensure_git_branch(branch: '^release/')
+    ensure_git_branch(branch: '^release/')
     ensure_git_status_clean
 
     new_version = current_release_version
 
-    # UI.important("Completing code freeze for: #{new_version}")
+    UI.important("Completing code freeze for: #{new_version}")
 
-    # UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
 
-    # localize_libraries
-    # update_frozen_strings_for_translation
+    localize_libraries
+    update_frozen_strings_for_translation
 
-    # ensure_git_status_clean
-    # push_to_git_remote(tags: false)
+    ensure_git_status_clean
+    push_to_git_remote(tags: false)
 
     trigger_beta_build(branch_to_build: "release/#{new_version}")
 
-    # create_backmerge_pr
+    create_backmerge_pr
   end
 
   # Updates a release branch for a new beta release, triggering a beta build using the `.buildkite/beta-builds.yml` pipeline.


### PR DESCRIPTION
## Description

iOS counterpart: https://github.com/wordpress-mobile/WordPress-iOS/pull/23782
Related: pdccJN-xR-p2

This PR uses the `release-toolkit` action `buildkite_pipeline_upload` implemented on https://github.com/wordpress-mobile/release-toolkit/pull/597.

Our release pipelines (such as `complete-code-freeze`, `finalize-release`, etc) usually require to start a separate pipeline to make a release build.
The changes in this PR will result in add the steps of a release pipeline to the currently running build, without starting a new build altogether.

## Testing information
## Testing information
I've added (and later reverted) a test commit 95c00cf720d596d59559e56335d5b42ca311e1b0 to test the `complete_code_freeze` lane.

This is a test build created using the Buildkite Web UI directly with `PIPELINE=complete-code-freeze.yml`:
- https://buildkite.com/automattic/wordpress-android/builds/20364

This PR can be tested in a similar way to the test above: creating a branch off this one, slightly modifying a release lane to prevent side effects and running the build directly on Buildkite.