### PR TITLE
Show the correct years for stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -77,7 +77,7 @@ class PostAverageViewsPerDayUseCase(
         items.add(
             header
         )
-        val shownYears = domainModel.yearsAverage.sortedByDescending { it.year }.takeLast(itemsToLoad)
+        val shownYears = domainModel.yearsAverage.sortedByDescending { it.year }.take(itemsToLoad)
         val yearList = postDetailMapper.mapYears(
             shownYears,
             uiState,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostMonthsAndYearsUseCase.kt
@@ -77,7 +77,7 @@ class PostMonthsAndYearsUseCase(
         items.add(
             header
         )
-        val shownYears = domainModel.yearsTotal.sortedByDescending { it.year }.takeLast(itemsToLoad)
+        val shownYears = domainModel.yearsTotal.sortedByDescending { it.year }.take(itemsToLoad)
         val yearList = postDetailMapper.mapYears(
             shownYears,
             uiState,


### PR DESCRIPTION
Fixes #21448

Prior to this PR, "Years and Months" stats incorrectly showed the six earliest years instead of the six most recent. For example:

![stats](https://github.com/user-attachments/assets/e77214b4-b16d-49d9-b55e-e1af79fa305c)

This PR resolves the problem by showing the six most recent:

![stats](https://github.com/user-attachments/assets/ada725ec-afee-41f2-975b-9701418de100)

To test:

- Select a site that has received traffic for a number of years
- Go to Stats
- Change the filter to Years
- Under Posts & Pages choose a popular post (such as the home page)
- Note that the most recent years are showing
- Scroll down to "Avg views per day" and note the correct years are showing

**Note:** While working on this I noticed that the "View more" link under "Avg views per day" wasn't working. I tracked that down to [this line of code](https://github.com/wordpress-mobile/WordPress-Android/blob/0a324b6e200e402f9f8a933fa67cffc7c2459277/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt#L243), which explicitly says to do nothing. I'll file a separate issue for that.
