### PR TITLE
Don't send sentry mapping files from local machines

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -199,7 +199,7 @@ android {
         targetCompatibility JvmTarget.fromTarget(libs.versions.java.get()).target
     }
 
-    flavorDimensions "app", "buildType"
+    flavorDimensions = ['app', 'buildType']
 
     productFlavors {
         wordpress {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -74,9 +74,8 @@ sentry {
     autoInstallation.enabled = false
     includeDependenciesReport = false
 
-    Boolean isCi = System.getenv('CI')?.toBoolean() ?: false
-    includeSourceContext = isCi
-    includeProguardMapping = isCi
+    includeSourceContext = gradle.ext.isCi
+    includeProguardMapping = gradle.ext.isCi
     /* Sentry won't send source context or add performance instrumentations for debug builds
     so we can save build times. Sending events will still work in debug builds
     (if enabled in WPCrashLoggingDataProvider).
@@ -303,7 +302,7 @@ android {
         checkGeneratedSources = true
         lintConfig file("${project.rootDir}/config/lint/lint.xml")
         baseline file("${project.rootDir}/config/lint/baseline.xml")
-        sarifReport = System.getenv('CI') ? true : false
+        sarifReport = gradle.ext.isCi
     }
 
     packagingOptions {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -72,9 +72,11 @@ sentry {
         logcat.enabled = false
     }
     autoInstallation.enabled = false
-    includeSourceContext = true
-    autoUploadSourceContext = true
     includeDependenciesReport = false
+
+    Boolean isCi = System.getenv('CI')?.toBoolean() ?: false
+    includeSourceContext = isCi
+    includeProguardMapping = isCi
     /* Sentry won't send source context or add performance instrumentations for debug builds
     so we can save build times. Sending events will still work in debug builds
     (if enabled in WPCrashLoggingDataProvider).

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ measureBuilds {
                 findProperty('appsMetricsToken')
         )
     }
-    attachGradleScanId = System.getenv('CI')?.toBoolean() ?: false
+    attachGradleScanId = gradle.ext.isCi
 }
 
 allprojects {

--- a/config/gradle/gradle_build_cache.gradle
+++ b/config/gradle/gradle_build_cache.gradle
@@ -1,6 +1,6 @@
 
 // Only run build cache on CI builds.
-if (System.getenv('CI')) {
+if (gradle.ext.isCi) {
     buildCache {
         remote(HttpBuildCache) {
             url = "http://10.0.2.215:5071/cache/"

--- a/config/gradle/gradle_build_scan.gradle
+++ b/config/gradle/gradle_build_scan.gradle
@@ -1,6 +1,6 @@
 
 // Only run build scan on CI builds.
-if (System.getenv('CI')) {
+if (gradle.ext.isCi) {
     develocity {
         buildScan {
             termsOfUseUrl = 'https://gradle.com/terms-of-service'

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,8 @@ plugins {
     id "com.gradle.develocity" version "3.18.1"
 }
 
+gradle.ext.isCi = System.getenv('CI')?.toBoolean() ?: false
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
### Description

When building release on local machine, we shouldn't send debug files to Sentry as it's not needed: clutters the Sentry dashboard and slows down the local build. This tiny PR addresses this problem.

### Testing

1. `./gradlew assembleJetpackVanillaRelease` does not send debug files (see console output)
2. `CI=true ./gradlew assembleJetpackVanillaRelease` sends debug files