### PR TITLE
Make `wasabi` a default build type

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -253,6 +253,7 @@ android {
         // Used for local development - preferred variant for developers.
         // AppName: WordPress Beta/Jetpack Beta
         wasabi {
+            isDefault true
             applicationIdSuffix ".beta"
             dimension "buildType"
         }
@@ -260,7 +261,6 @@ android {
         // Used for CI builds on PRs (aka "Prototype Builds"). Can be used locally when a developer needs to install multiple versions of the app on the same device.
         // AppName: WordPress Pre-Alpha/Jetpack Pre-Alpha
         jalapeno {
-            isDefault true
             applicationIdSuffix ".prealpha"
             dimension "buildType"
         }


### PR DESCRIPTION
### Description

As `wasabi` is "preferred variant for developers", it should be selected by default when opening Android Studio. AGP reference: https://developer.android.com/reference/tools/gradle-api/8.7/com/android/build/api/dsl/ApplicationProductFlavor#isDefault()

### Testing

Fresh clone the project and open it in AS: `wasabi` should be selected as the current build variant.