### PR TITLE
Stats: remove avg "view more" link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -16,12 +16,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.UseCaseMode.VIEW_ALL
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.insights.InsightUseCaseFactory
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
 import org.wordpress.android.ui.stats.refresh.utils.StatsSiteProvider
-import org.wordpress.android.ui.utils.ListItemInteraction
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -103,6 +101,7 @@ class PostAverageViewsPerDayUseCase(
         return this != null && this.yearsAverage.isNotEmpty() && this.yearsAverage.any { it.value > 0 }
     }
 
+    @Suppress("unused")
     private fun onLinkClick() {
         navigateTo(ViewDayAverageStats)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -86,14 +86,16 @@ class PostAverageViewsPerDayUseCase(
         )
 
         items.addAll(yearList)
-        if (useCaseMode == BLOCK && domainModel.yearsAverage.size > itemsToLoad) {
+
+        // TODO we don't currently have a detail view for this
+        /*if (useCaseMode == BLOCK && domainModel.yearsAverage.size > itemsToLoad) {
             items.add(
                 Link(
                     text = R.string.stats_insights_view_more,
                     navigateAction = ListItemInteraction.create(this::onLinkClick)
                 )
             )
-        }
+        }*/
         return items
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCase.kt
@@ -7,7 +7,6 @@ import org.wordpress.android.fluxc.store.StatsStore.PostDetailType
 import org.wordpress.android.fluxc.store.stats.PostDetailStore
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
-import org.wordpress.android.ui.stats.refresh.NavigationTarget.ViewDayAverageStats
 import org.wordpress.android.ui.stats.refresh.lists.BLOCK_ITEM_COUNT
 import org.wordpress.android.ui.stats.refresh.lists.VIEW_ALL_ITEM_COUNT
 import org.wordpress.android.ui.stats.refresh.lists.detail.PostDetailMapper.ExpandedYearUiState
@@ -85,12 +84,13 @@ class PostAverageViewsPerDayUseCase(
 
         items.addAll(yearList)
 
-        // TODO we don't currently have a detail view for this
+        // We don't currently have a detail view for this
+        // https://github.com/wordpress-mobile/WordPress-Android/issues/21458
         /*if (useCaseMode == BLOCK && domainModel.yearsAverage.size > itemsToLoad) {
             items.add(
                 Link(
                     text = R.string.stats_insights_view_more,
-                    navigateAction = ListItemInteraction.create(this::onLinkClick)
+                    navigateAction = ListItemInteraction.create(navigateTo(ViewDayAverageStats))
                 )
             )
         }*/
@@ -99,11 +99,6 @@ class PostAverageViewsPerDayUseCase(
 
     private fun PostDetailStatsModel?.hasData(): Boolean {
         return this != null && this.yearsAverage.isNotEmpty() && this.yearsAverage.any { it.value > 0 }
-    }
-
-    @Suppress("unused")
-    private fun onLinkClick() {
-        navigateTo(ViewDayAverageStats)
     }
 
     override fun buildLoadingItem(): List<BlockListItem> {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -31,12 +31,10 @@ import org.wordpress.android.ui.stats.refresh.lists.sections.BaseStatsUseCase.Us
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ExpandableItem
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Header
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Link
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.ListItemWithIcon
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Title
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.EXPANDABLE_ITEM
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.HEADER
-import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LINK
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.LIST_ITEM_WITH_ICON
 import org.wordpress.android.ui.stats.refresh.lists.sections.BlockListItem.Type.TITLE
 import org.wordpress.android.ui.stats.refresh.utils.StatsPostProvider
@@ -206,7 +204,13 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
             assertYear(this[2], year.year.toString(), year.value)
             assertLink(this[3])
         }
-    }*/
+    }
+
+    private fun assertLink(item: BlockListItem) {
+        assertThat(item.type).isEqualTo(LINK)
+        assertThat((item as Link).text).isEqualTo(R.string.stats_insights_view_more)
+    }
+    */
 
     @Test
     fun `maps error item to UI model`() = test {
@@ -277,11 +281,6 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
         assertThat((item as ExpandableItem).header.text).isEqualTo(label)
         assertThat(item.header.value).isEqualTo(views.toString())
         return item
-    }
-
-    private fun assertLink(item: BlockListItem) {
-        assertThat(item.type).isEqualTo(LINK)
-        assertThat((item as Link).text).isEqualTo(R.string.stats_insights_view_more)
     }
 
     private suspend fun loadData(refresh: Boolean, forced: Boolean): UseCaseModel {

--- a/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/stats/refresh/lists/detail/PostAverageViewsPerDayUseCaseTest.kt
@@ -164,7 +164,8 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
         assertMonth(this[3], "Jan", month.count.toString())
     }
 
-    @Test
+    // See https://github.com/wordpress-mobile/WordPress-Android/pull/21457
+    /*@Test
     fun `adds view more button when hasMore`() = test {
         val forced = false
         val data = List(10) { year }
@@ -205,7 +206,7 @@ class PostAverageViewsPerDayUseCaseTest : BaseUnitTest() {
             assertYear(this[2], year.year.toString(), year.value)
             assertLink(this[3])
         }
-    }
+    }*/
 
     @Test
     fun `maps error item to UI model`() = test {


### PR DESCRIPTION
Partially resolves #21451

As noted in the issue, tapping this link in stats does nothing because [this line of code](https://github.com/wordpress-mobile/WordPress-Android/blob/0a324b6e200e402f9f8a933fa67cffc7c2459277/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/utils/StatsNavigator.kt#L243) explicitly states to do nothing.

![stats](https://github.com/user-attachments/assets/ecbb766b-d817-457e-bbc3-b22cbc45d617)

It turns out this was simply due to fixing a warning about a non-exhaustive `when` clause.

![nothing](https://github.com/user-attachments/assets/2b8f5d94-cbb5-48ce-9933-0b7fb45bd540)

We don't have a screen for average daily views and creating one doesn't seem like a priority, so this PR simply removes the "View more" link. I've filed #21458 as a reminder that we should add that screen at some point to match iOS.


