### PR TITLE
Update dependabot config to ignore more A8c dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,9 @@ updates:
       - dependency-name: "org.wordpress.aztec:picasso-loader"
       - dependency-name: "com.automattic:about"
       - dependency-name: "com.automattic:Automattic-Tracks-Android"
+      - dependency-name: "com.automattic.tracks:crashlogging"
+      - dependency-name: "rs.wordpress.api:android"
+      - dependency-name: "com.gravatar:gravatar"
       # Ignore dependencies that were added only to address security vulnerabilities of transitive WireMock dependencies
       - dependency-name: "org.eclipse.jetty:jetty-webapp"
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"


### PR DESCRIPTION
Which are problemattic for Dependabot, as they don't follow semantic versioning for PR builds. This should lower the number of Dependabot PRs that we have to close.
