### PR TITLE
Stats: Use correct color for visitors 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/viewholders/BarChartViewHolder.kt
@@ -231,7 +231,7 @@ class BarChartViewHolder(parent: ViewGroup) : BlockListItemViewHolder(
     private fun buildOverlappingDataSet(context: Context, cut: List<BarEntry>): BarDataSet {
         val dataSet = BarDataSet(cut, "Overlapping data")
         chart.renderer.paintRender.shader = null
-        dataSet.color = ContextCompat.getColor(context, R.color.primary_60)
+        dataSet.color = ContextCompat.getColor(context, R.color.stats_bar_chart_bottom)
         dataSet.formLineWidth = 0f
         dataSet.setDrawValues(false)
         dataSet.isHighlightEnabled = true


### PR DESCRIPTION
Fixes #21366 

As noted in the issue, in dark mode stats didn't differentiate between views & visitors, instead showing them in the same color. This PR addresses this. 

To test, simply verify that views and visitors are shown with different colors in both dark and light modes. Before and after shot below.

![before](https://github.com/user-attachments/assets/8a055797-388a-488a-86a1-2d9eae5465a0)
