### PR TITLE
Add default values for e2e secrets

### DIFF
--- a/defaults.properties
+++ b/defaults.properties
@@ -1,5 +1,17 @@
 jp.sentry.dsn=https://00000000000000000000000000000000@sentry.io/00000000
 wp.docsbotai.id=wordpress
+wp.e2e.self_hosted_user.password=mocked_password
+wp.e2e.self_hosted_user.site_address=127.0.0.1:8080
+wp.e2e.self_hosted_user.username=e2eflowtestingmobile
+wp.e2e.signup_display_name=e2eflowsignuptestingmobile
+wp.e2e.signup_email=e2eflowsignuptestingmobile@example.com
+wp.e2e.signup_password=mocked_password
+wp.e2e.signup_username=e2eflowsignuptestingmobile
+wp.e2e.wp_com_passwordless_user.email=e2eflowtestingmobile+passwordless@example.com
+wp.e2e.wp_com_user.email=e2eflowtestingmobile@example.com
+wp.e2e.wp_com_user.password=mocked_password
+wp.e2e.wp_com_user.site_address=e2eflowtestingmobile.wordpress.com
+wp.e2e.wp_com_user.username=e2eflowtestingmobile
 wp.encrypted_logging_key=z0g+oVkqR4kWNUTxJfTozOZQjfXI7W9f6bD0uMJ5VkA=
 wp.oauth.app_id = wordpress
 wp.oauth.app_secret = wordpress


### PR DESCRIPTION
### Description

Add default values for e2e secrets so all project configurations can be built without access to secrets. Follow up to #21442 

### To test
1. Remove local secrets: `rm -rf ~/.configure/wordpress-android`
2. Run `buildHealth` task
3. Assert that the task was successful