### PR TITLE
Support dark mode in Blaze WebViews

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/blaze/blazepromote/BlazePromoteWebViewFragment.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.blaze.blazepromote
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -218,9 +219,16 @@ class BlazePromoteWebViewFragment : Fragment(), OnBlazeWebViewClientListener,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
                     scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-                    settings.userAgentString = model.userAgent
-                    settings.javaScriptEnabled = model.enableJavascript
-                    settings.domStorageEnabled = model.enableDomStorage
+
+                    with(settings) {
+                        userAgentString = model.userAgent
+                        javaScriptEnabled = model.enableJavascript
+                        domStorageEnabled = model.enableDomStorage
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            setAlgorithmicDarkeningAllowed(true)
+                        }
+                    }
+
                     webViewClient = BlazeWebViewClient(this@BlazePromoteWebViewFragment)
                     chromeClient = WPWebChromeClientWithFileChooser(
                         activity,


### PR DESCRIPTION
Fixes #21487 

Previously Blaze web views would show with light mode colors even in dark mode. This PR addresses this. 

To test:

* Enable dark mode either in the app or the device
* Tap the ☰ menu on the Blaze card
* Tap "Learn more"
* Tap "Blaze a post right now"
* Verify the WebView screen uses dark colors
* Disable dark mode and verify Blaze uses light colors

**Note**: Dark mode support is only available in Android 33 (Tiramisu) and above.


https://github.com/user-attachments/assets/5a42a4c9-d177-4681-8f82-6400459a8ae8

