### PR TITLE
[Deps] Group Kotlin & KSP Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       - "bot: dependencies update"
     reviewers:
       - "wordpress-mobile/android-developers"
+    groups:
+      kotlin-ksp:
+        applies-to: version-updates
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "com.google.devtools.ksp*"
+        exclude-patterns:
+          - "org.jetbrains.kotlinx*"
     ignore:
       # The Android Gradle Plugin is a dependency that needs to be in sync with other
       # in-house libraries due to compatibility with composite build.


### PR DESCRIPTION
**Let's Test This!** :dependabot: 

With this configuration Dependabot should update both, the `Kotlin` and `KSP` related dependencies in one go, on a single Dependabot related PR.

FYI: Using the `applies-to key` is optional. If the `applies-to key` is absent from a set of grouping rules, it defaults to `version-updates` for backwards compatibility. I chose to use `applies-to` in order to be explicit about this and avoid any confusion related to the defaults.

For more info see: [Configuration options for the dependabot.yml file -> groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

N/A

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): N/A