### PR TITLE
Remove experimental per app feature flag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -952,11 +952,7 @@ class AppInitializer @Inject constructor(
         override fun onConfigurationChanged(newConfig: Configuration) {
             // If per-app locale is enabled make sure the in-app locale is correct,
             // otherwise reapply in-app locale on configuration change
-            if (perAppLocaleManager.isPerAppLanguagePrefsEnabled()) {
-                perAppLocaleManager.checkAndUpdateOldLanguagePrefKey()
-            } else {
-                LocaleManager.setLocale(context)
-            }
+            perAppLocaleManager.checkAndUpdateOldLanguagePrefKey()
         }
 
         override fun onLowMemory() {

--- a/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
+++ b/WordPress/src/main/java/org/wordpress/android/AppInitializer.kt
@@ -950,8 +950,7 @@ class AppInitializer @Inject constructor(
      */
     private inner class MemoryAndConfigChangeMonitor : ComponentCallbacks2 {
         override fun onConfigurationChanged(newConfig: Configuration) {
-            // If per-app locale is enabled make sure the in-app locale is correct,
-            // otherwise reapply in-app locale on configuration change
+            // Make sure the in-app locale is correct
             perAppLocaleManager.checkAndUpdateOldLanguagePrefKey()
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
@@ -3,9 +3,6 @@ package org.wordpress.android.ui
 import android.content.Context
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
-import org.wordpress.android.ui.prefs.AppPrefs
-import org.wordpress.android.util.LocaleManager
-import org.wordpress.android.util.PerAppLocaleManager
 
 /**
  * Newer versions of the AppCompat library no longer support locale changes at application level,
@@ -27,29 +24,13 @@ abstract class LocaleAwareActivity : AppCompatActivity() {
      * Used to update locales on API 21 to API 25.
      */
     override fun attachBaseContext(newBase: Context?) {
-        if (isPerAppLocaleEnabled()) {
-            super.attachBaseContext(newBase)
-        } else {
-            super.attachBaseContext(LocaleManager.setLocale(newBase))
-        }
+        super.attachBaseContext(newBase)
     }
 
     /**
      * Used to update locales on API 26 and beyond.
      */
     override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
-        if (isPerAppLocaleEnabled()) {
-            super.applyOverrideConfiguration(overrideConfiguration)
-        } else {
-            super.applyOverrideConfiguration(LocaleManager.updatedConfigLocale(baseContext, overrideConfiguration))
-        }
-    }
-
-    /**
-     * Ideally we would use [PerAppLocaleManager.isPerAppLanguagePrefsEnabled] here, but we
-     * can't inject [PerAppLocaleManager] into an abstract class
-     */
-    private fun isPerAppLocaleEnabled(): Boolean {
-        return AppPrefs.getManualFeatureConfig(PerAppLocaleManager.EXPERIMENTAL_PER_APP_LANGUAGE_PREF_KEY)
+        super.applyOverrideConfiguration(overrideConfiguration)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
@@ -5,19 +5,9 @@ import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
 
 /**
- * Newer versions of the AppCompat library no longer support locale changes at application level,
- * so this activity is used to help handle those changes at activity level.
- * Reference: https://issuetracker.google.com/issues/141869006#comment9
- *
- * All the actual logic is inside the LocaleManager class, which should be used directly in cases where
- * extending from this class is not possible/preferable.
- *
- * Note: please be mindful of the principle of favoring composition over inheritance and refrain from
- * building upon this class unless it's absolutely necessary.
- *
  * Update Dec 2024: We've added experimental support for per-app language preferences which
- * will eventually negate the need for this class. Instead of extending from this class, we
- * should extend from AppCompatActivity once this feature is out of the experimental phase.
+ * negate the need for this class. Instead of extending from this class, we should extend
+ * from AppCompatActivity.
  */
 abstract class LocaleAwareActivity : AppCompatActivity() {
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/LocaleAwareActivity.kt
@@ -5,8 +5,8 @@ import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
 
 /**
- * Update Dec 2024: We've added experimental support for per-app language preferences which
- * negate the need for this class. Instead of extending from this class, we should extend
+ * Update Dec 2024: We've added support for per-app language preferences which negate
+ * the need for this class. Instead of extending from this class, we should extend
  * from AppCompatActivity.
  */
 abstract class LocaleAwareActivity : AppCompatActivity() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -57,7 +57,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppThemeUtils;
 import org.wordpress.android.util.BuildConfigWrapper;
 import org.wordpress.android.util.JetpackBrandingUtils;
-import org.wordpress.android.util.LocaleProvider;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PerAppLocaleManager;
 import org.wordpress.android.util.ToastUtils;
@@ -103,7 +102,6 @@ public class AppSettingsFragment extends PreferenceFragment
     @Inject FeatureAnnouncementProvider mFeatureAnnouncementProvider;
     @Inject BuildConfigWrapper mBuildConfigWrapper;
     @Inject JetpackBrandingUtils mJetpackBrandingUtils;
-    @Inject LocaleProvider mLocaleProvider;
     @Inject DeepLinkOpenWebLinksWithJetpackHelper mOpenWebLinksWithJetpackHelper;
     @Inject UiHelpers mUiHelpers;
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -597,7 +597,7 @@ public class AppSettingsFragment extends PreferenceFragment
     }
 
     private boolean handleAppLocalePickerClick() {
-        // if  the device is on API 33+, take the user to the system app settings to change the language
+        // if the device is on API 33+, take the user to the system app settings to change the language
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mPerAppLocaleManager.openAppLanguageSettings(getContext());
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,14 +39,11 @@ import kotlinx.coroutines.flow.update
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
-import org.wordpress.android.util.PerAppLocaleManager
 import org.wordpress.android.util.extensions.setContent
-import javax.inject.Inject
 
 val experimentalFeatures = listOf(
     Feature(key = "experimental_block_editor"),
     Feature(key = "experimental_block_editor_theme_styles"),
-    Feature(key = PerAppLocaleManager.EXPERIMENTAL_PER_APP_LANGUAGE_PREF_KEY)
 )
 
 data class Feature(
@@ -55,10 +51,7 @@ data class Feature(
     val key: String,
 )
 
-@HiltViewModel
-class FeatureViewModel @Inject constructor(
-    private val perAppLocaleManager: PerAppLocaleManager
-) : ViewModel() {
+class FeatureViewModel : ViewModel() {
     private val _switchStates = MutableStateFlow<Map<String, Feature>>(emptyMap())
     val switchStates: StateFlow<Map<String, Feature>> = _switchStates.asStateFlow()
 
@@ -74,18 +67,6 @@ class FeatureViewModel @Inject constructor(
             currentStates.toMutableMap().apply {
                 this[key] = Feature(enabled, key)
                 AppPrefs.setManualFeatureConfig(enabled, key)
-            }
-        }
-
-        featureToggled(key, enabled)
-    }
-
-    private fun featureToggled(key: String, enabled: Boolean) {
-        if (key == PerAppLocaleManager.EXPERIMENTAL_PER_APP_LANGUAGE_PREF_KEY) {
-            if (enabled) {
-                perAppLocaleManager.performMigrationIfNecessary()
-            } else {
-                perAppLocaleManager.resetApplicationLocale()
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -77,31 +77,25 @@ class PerAppLocaleManager @Inject constructor(
      * Previously the app locale was stored in SharedPreferences, so here we migrate to AndroidX per-app language prefs
      */
     fun performMigrationIfNecessary() {
-        if (isPerAppLanguagePrefsEnabled()) {
-            if (isApplicationLocaleEmpty()) {
-                val prefKey = LocaleManager.getLocalePrefKeyString()
-                val previousLanguage = appPrefsWrapper.getPrefString(prefKey, "")
-                if (previousLanguage?.isNotEmpty() == true) {
-                    appLogWrapper.d(
-                        AppLog.T.SETTINGS,
-                        "PerAppLocaleManager: performing migration to AndroidX per-app language prefs"
-                    )
-                    setCurrentLocaleByLanguageCode(previousLanguage)
-                } else {
-                    appLogWrapper.d(
-                        AppLog.T.SETTINGS,
-                        "PerAppLocaleManager: setting default locale"
-                    )
-                    setCurrentLocaleByLanguageCode(Locale.getDefault().language)
-                }
+        if (isApplicationLocaleEmpty()) {
+            val prefKey = LocaleManager.getLocalePrefKeyString()
+            val previousLanguage = appPrefsWrapper.getPrefString(prefKey, "")
+            if (previousLanguage?.isNotEmpty() == true) {
+                appLogWrapper.d(
+                    AppLog.T.SETTINGS,
+                    "PerAppLocaleManager: performing migration to AndroidX per-app language prefs"
+                )
+                setCurrentLocaleByLanguageCode(previousLanguage)
             } else {
-                checkAndUpdateOldLanguagePrefKey()
+                appLogWrapper.d(
+                    AppLog.T.SETTINGS,
+                    "PerAppLocaleManager: setting default locale"
+                )
+                setCurrentLocaleByLanguageCode(Locale.getDefault().language)
             }
+        } else {
+            checkAndUpdateOldLanguagePrefKey()
         }
-    }
-
-    fun isPerAppLanguagePrefsEnabled(): Boolean {
-        return appPrefsWrapper.getManualFeatureConfig(EXPERIMENTAL_PER_APP_LANGUAGE_PREF_KEY)
     }
 
     /**
@@ -116,9 +110,5 @@ class PerAppLocaleManager @Inject constructor(
             intent.setData(Uri.parse("package:" + context.packageName))
             context.startActivity(intent)
         }
-    }
-
-    companion object {
-        const val EXPERIMENTAL_PER_APP_LANGUAGE_PREF_KEY = "experimental_per_app_language_prefs"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -126,7 +126,7 @@ class PerAppLocaleManager @Inject constructor(
 
     /**
      * Called when the device language is changed from our in-app language picker
-     * TODO: Detect when language changed from app settings dialog
+     * TODO Detect when language changed from app settings dialog
      */
     fun onLanguageChanged(languageCode: String) {
         if (languageCode.isEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -134,7 +134,7 @@ class PerAppLocaleManager @Inject constructor(
         }
 
         // Only update if the language is different
-        if (languageCode.equals(getCurrentLocaleLanguageCode()).not()) {
+        if (languageCode != getCurrentLocaleLanguageCode()) {
             setCurrentLocaleByLanguageCode(languageCode)
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -8,8 +8,16 @@ import android.provider.Settings
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
+import org.wordpress.android.WordPress.Companion.getContext
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask
+import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter
+import org.wordpress.android.util.analytics.AnalyticsUtils
+import java.util.EnumSet
 import java.util.Locale
 import javax.inject.Inject
 
@@ -20,6 +28,8 @@ import javax.inject.Inject
 class PerAppLocaleManager @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val appLogWrapper: AppLogWrapper,
+    private val siteStore: SiteStore,
+    private val accountStore: AccountStore,
 ) {
     private fun getCurrentLocale(): Locale {
         return if (isApplicationLocaleEmpty()) {
@@ -30,6 +40,8 @@ class PerAppLocaleManager @Inject constructor(
     }
 
     fun getCurrentLocaleDisplayName(): String = getCurrentLocale().displayName
+
+    fun getCurrentLocaleLanguageCode(): String = getCurrentLocale().language
 
     /**
      * Important: this should only be called after Activity.onCreate()
@@ -65,7 +77,7 @@ class PerAppLocaleManager @Inject constructor(
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
     }
 
-    fun setCurrentLocaleByLanguageCode(languageCode: String) {
+    private fun setCurrentLocaleByLanguageCode(languageCode: String) {
         // We shouldn't have to replace "_" with "-" but this is in order to work with our existing language picker
         // on pre-Android 13 devices
         val appLocale = LocaleListCompat.forLanguageTags(languageCode.replace("_", "-"))
@@ -110,5 +122,31 @@ class PerAppLocaleManager @Inject constructor(
             intent.setData(Uri.parse("package:" + context.packageName))
             context.startActivity(intent)
         }
+    }
+
+    /**
+     * Called when the device language is changed from our in-app language picker
+     * TODO: Detect when language changed from app settings dialog
+     */
+    fun onLanguageChanged(languageCode: String) {
+        if (languageCode.isEmpty()) {
+            return
+        }
+
+        if (languageCode.equals(getCurrentLocaleLanguageCode()).not()) {
+            setCurrentLocaleByLanguageCode(languageCode)
+        }
+
+        // Track language change on Analytics because we have both the device language and app selected language
+        // data in Tracks metadata.
+        val properties: MutableMap<String, Any?> = HashMap()
+        properties["app_locale"] = languageCode
+        AnalyticsTracker.track(AnalyticsTracker.Stat.ACCOUNT_SETTINGS_LANGUAGE_CHANGED, properties)
+
+        // Language is now part of metadata, so we need to refresh them
+        AnalyticsUtils.refreshMetadata(accountStore, siteStore)
+
+        // update Reader tags as they need be localized
+        ReaderUpdateServiceStarter.startService(getContext(), EnumSet.of(UpdateTask.TAGS))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -133,6 +133,7 @@ class PerAppLocaleManager @Inject constructor(
             return
         }
 
+        // Only update if the language is different
         if (languageCode.equals(getCurrentLocaleLanguageCode()).not()) {
             setCurrentLocaleByLanguageCode(languageCode)
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt
@@ -41,7 +41,7 @@ class PerAppLocaleManager @Inject constructor(
 
     fun getCurrentLocaleDisplayName(): String = getCurrentLocale().displayName
 
-    fun getCurrentLocaleLanguageCode(): String = getCurrentLocale().language
+    private fun getCurrentLocaleLanguageCode(): String = getCurrentLocale().language
 
     /**
      * Important: this should only be called after Activity.onCreate()

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -963,7 +963,6 @@
     <string name="experimental_features_screen_title">Experimental Features</string>
     <string name="experimental_block_editor">Experimental block editor</string>
     <string name="experimental_block_editor_theme_styles">Experimental block editor styles</string>
-    <string name="experimental_per_app_language_prefs">Experimental per-app language preferences</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>


### PR DESCRIPTION
This PR removes the [experimental feature flag for per app language prefs](https://github.com/wordpress-mobile/WordPress-Android/pull/21504), which enables per app prefs for all users. This targets the `feature/per-app-language-prefs` feature branch rather than `trunk` because there's much more work to do before this feature can be released (most notably, dropping the `LocaleAwareActivity`). In addition, we also want the experimental feature flag to be available in at least one release before removing it.

Test 1:

- Run the app on a device using Android 13 or later
- Go to App Settings and tap "Interface language"
- Note that the system dialog for "App Language" appears instead of our own
- Verify changing languages works

Test 2:

- Perform the above with an older device and verify our own language dialog appears and changing languages works
