### PR TITLE
[Tooling] Update GitHub Actions

### DIFF
--- a/.github/workflows/automated-version-update-pr.yml
+++ b/.github/workflows/automated-version-update-pr.yml
@@ -36,7 +36,7 @@ jobs:
           echo "::set-output name=description::$PR_DESCRIPTION"
         id: pr_description
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Update Gutenberg Mobile Version

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Reference: p7H4VZ-59z-p2

WordPress Android doesn't use one of the GitHub Actions about to have its older versions deprecated as `actions/upload-artifact`, `actions/download-artifact` or `actions/cache`, but I used this opportunity to upgrade `actions/checkout` and `gradle/actions/wrapper-validation`.