### PR TITLE
Fix gravatar_quick_editor feature flag setup

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -163,7 +163,7 @@ android {
         buildConfigField "boolean", "VOICE_TO_CONTENT", "false"
         buildConfigField "boolean", "READER_FLOATING_BUTTON", "false"
         buildConfigField "boolean", "ENABLE_SELF_HOSTED_USERS", "false"
-        buildConfigField "boolean", "GRAVATAR_QUICK_EDITOR", "true"
+        buildConfigField "boolean", "GRAVATAR_QUICK_EDITOR", "false"
 
         // Override these constants in jetpack product flavor to enable/ disable features
         buildConfigField "boolean", "ENABLE_SITE_CREATION", "true"

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GravatarQuickEditorFeatureConfig.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GravatarQuickEditorFeatureConfig.kt
@@ -10,10 +10,6 @@ class GravatarQuickEditorFeatureConfig @Inject constructor(appConfig: AppConfig)
     BuildConfig.GRAVATAR_QUICK_EDITOR,
     GRAVATAR_QUICK_EDITOR_REMOTE_FIELD
 ) {
-    override fun isEnabled(): Boolean {
-        return super.isEnabled() && BuildConfig.GRAVATAR_QUICK_EDITOR
-    }
-
     companion object {
         const val GRAVATAR_QUICK_EDITOR_REMOTE_FIELD = "gravatar_quick_editor"
     }


### PR DESCRIPTION
The configuration of the `GravatarQuickEditorFeatureConfig` was wrong and it always resolved to `true` even when the remote flag was set to false.  

I misunderstood how this system works in the Jetpack app and that the build config value always overrides the remote one. 

This is now fixed. 

-----

## To Test:

1. Run the app fro this PR
2. Tap on the `Me` in the bottom bar
3. Tap the avatar in the top left
4. Confirm a Gravatar QuickEditor is shown 
5. Open `versions.properties` in AS and change `versionName` to 25.4
6. Repeat steps 1-3
7. Confirm a new screen titled Choose photo was shown and not the QuickEditor

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
