### PR TITLE
Remove LocaleManager.getSafeLocale

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -29,7 +29,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.HtmlUtils;
-import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.analytics.AnalyticsUtils;
@@ -489,9 +488,9 @@ public class PostUtils {
         String secondPart =
                 String.format(context.getString(R.string.dialog_confirm_load_remote_post_body_2),
                         getFormattedDateForLastModified(
-                                context, DateTimeUtils.timestampFromIso8601Millis(lastModified)),
+                                DateTimeUtils.timestampFromIso8601Millis(lastModified)),
                         getFormattedDateForLastModified(
-                                context, DateTimeUtils.timestampFromIso8601Millis(post.getRemoteLastModified())));
+                                DateTimeUtils.timestampFromIso8601Millis(post.getRemoteLastModified())));
         return firstPart + secondPart;
     }
 
@@ -505,24 +504,20 @@ public class PostUtils {
         String secondPart =
                 String.format(context.getString(R.string.dialog_confirm_autosave_body_second_part),
                         getFormattedDateForLastModified(
-                                context, DateTimeUtils.timestampFromIso8601Millis(lastModified)),
+                                DateTimeUtils.timestampFromIso8601Millis(lastModified)),
                         getFormattedDateForLastModified(
-                                context, DateTimeUtils.timestampFromIso8601Millis(post.getAutoSaveModified())));
+                                DateTimeUtils.timestampFromIso8601Millis(post.getAutoSaveModified())));
         return new UiStringText(firstPart + secondPart);
     }
 
     /**
      * E.g. Jul 2, 2013 @ 21:57
      */
-    public static String getFormattedDateForLastModified(Context context, long timeSinceLastModified) {
+    public static String getFormattedDateForLastModified(long timeSinceLastModified) {
         Date date = new Date(timeSinceLastModified);
 
-        DateFormat dateFormat = DateFormat.getDateInstance(
-                DateFormat.MEDIUM,
-                LocaleManager.getSafeLocale(context));
-        DateFormat timeFormat = DateFormat.getTimeInstance(
-                DateFormat.SHORT,
-                LocaleManager.getSafeLocale(context));
+        DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM);
+        DateFormat timeFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
 
         dateFormat.setTimeZone(Calendar.getInstance().getTimeZone());
         timeFormat.setTimeZone(Calendar.getInstance().getTimeZone());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -19,7 +19,6 @@ import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.services.update.TagUpdateClientUtilsProvider;
 import org.wordpress.android.util.FormatUtils;
-import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -167,15 +166,14 @@ public class ReaderUtils {
                     return context.getString(R.string.reader_likes_you_and_one);
                 default:
                     String youAndMultiLikes = context.getString(R.string.reader_likes_you_and_multi);
-                    return String.format(
-                            LocaleManager.getSafeLocale(context), youAndMultiLikes, numLikes - 1);
+                    return String.format(youAndMultiLikes, numLikes - 1);
             }
         } else {
             if (numLikes == 1) {
                 return context.getString(R.string.reader_likes_one);
             } else {
                 String likes = context.getString(R.string.reader_likes_multi);
-                return String.format(LocaleManager.getSafeLocale(context), likes, numLikes);
+                return String.format(likes, numLikes);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -22,7 +22,6 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.ui.reader.tracker.ReaderTracker;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
-import org.wordpress.android.util.LocaleManager;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.PhotonUtils.Quality;
@@ -32,6 +31,7 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.image.BlavatarShape;
 import org.wordpress.android.util.image.ImageManager;
 
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -213,8 +213,10 @@ public class ReaderSiteHeaderView extends LinearLayout {
 
     private void loadFollowCount(ReaderBlog blogInfo, TextView txtFollowCount) {
         final CompactDecimalFormat compactDecimalFormat =
-                CompactDecimalFormat.getInstance(LocaleManager.getSafeLocale(getContext()),
-                        CompactDecimalFormat.CompactStyle.SHORT);
+                CompactDecimalFormat.getInstance(
+                        Locale.getDefault(),
+                        CompactDecimalFormat.CompactStyle.SHORT
+                );
 
         final int followersStringRes;
         if (blogInfo.numSubscribers == 1) {
@@ -231,7 +233,6 @@ public class ReaderSiteHeaderView extends LinearLayout {
             formattedNumberSubscribers = NumberFormat.getInstance().format(blogInfo.numSubscribers);
         }
         txtFollowCount.setText(String.format(
-                LocaleManager.getSafeLocale(getContext()),
                 getContext().getString(followersStringRes), formattedNumberSubscribers)
         );
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.kt
@@ -44,33 +44,6 @@ object LocaleManager {
         return langID ?: deviceLanguageCode
     }
 
-    @Suppress("ForbiddenComment")
-    /**
-     * Method gets around a bug in the java.util.Formatter for API 7.x as detailed here
-     * [https://bugs.openjdk.java.net/browse/JDK-8167567]. Any strings that contain
-     * locale-specific grouping separators should use:
-     *
-     * `String.format(LocaleManager.getSafeLocale(context), baseString, val)`
-     *
-     * An example of a string that contains locale-specific grouping separators:
-     * `
-     * <string name="test">%,d likes</string>
-    `*
-     * TODO: This is a workaround for a bug in API 7, which we no longer support. Investigate removing this.
-     */
-    @JvmStatic
-    fun getSafeLocale(context: Context?): Locale {
-        val baseLocale: Locale
-        if (context == null) {
-            baseLocale = Locale.getDefault()
-        } else {
-            val config = context.resources.configuration
-            baseLocale = config.locales[0]
-        }
-
-        return languageLocale(baseLocale.language)
-    }
-
     /**
      * Gets a locale for the given language code.
      *


### PR DESCRIPTION
This PR removes `getSafeLocale()` from `LocaleManager`. That code was added as a workaround for a bug in Android 7, but we no longer support that version so the function was unnecessary.

Passing CI should be sufficient to approve this.