### PR TITLE
feat: Introduce `gutenberg_kit` editor session property

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -479,10 +479,13 @@ class EditPostActivity : AppCompatActivity(), EditorFragmentActivity, EditorImag
         site: SiteModel, isNewPost: Boolean
     ) {
         if (postEditorAnalyticsSession == null) {
+            val editor = when {
+                showGutenbergEditor && isGutenbergKitEditor -> PostEditorAnalyticsSession.Editor.GUTENBERG_KIT
+                showGutenbergEditor -> PostEditorAnalyticsSession.Editor.GUTENBERG
+                else -> PostEditorAnalyticsSession.Editor.CLASSIC
+            }
             postEditorAnalyticsSession = PostEditorAnalyticsSession(
-                if (showGutenbergEditor) PostEditorAnalyticsSession.Editor.GUTENBERG
-                else PostEditorAnalyticsSession.Editor.CLASSIC,
-                post, site, isNewPost, analyticsTrackerWrapper
+                editor, post, site, isNewPost, analyticsTrackerWrapper
             )
         }
     }


### PR DESCRIPTION
Enable analysis of editor sessions utilizing GutenbergKit.

Related: 

* https://github.com/Automattic/dotcom-forge/issues/8268.
* https://github.com/wordpress-mobile/WordPress-iOS/pull/23955
* https://github.com/wordpress-mobile/GutenbergKit/pull/54

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Launch the experimental editor.
1. Close the editor.
1. Verify `editor_session_start|end` events trigger with an `editor:
   gutenberg_kit` property value.

## Regression Notes
1. Potential unintended areas of impact
    Disruption to events within other text editors.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verified the editor session events continue working as expected.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for this experimental editor analytic event.

## PR Submission Checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
