### PR TITLE
[Tooling] Fix handling of empty release notes

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -198,23 +198,23 @@ platform :android do
 
       unless skip_release_notes
         version_suffix = version.split('.').join
-        files["release_note_#{version_suffix}"] = {
-          desc: 'changelogs/default.txt',
-          max_size: 500,
-          alternate_key: "release_note_short_#{version_suffix}"
-        }
 
-        # Clear release notes if the source file is empty
         source_notes_file = File.join(metadata_source_dir, 'release_notes.txt')
         if !File.exist?(source_notes_file) || File.read(source_notes_file).strip.empty?
+          # Clear release notes if the source file is empty
           all_app_locales = locales + [%w[en en-US]]
           all_app_locales.each_value do |google_play_locale|
             changelog_dir = File.join(metadata_download_path, google_play_locale, 'changelogs')
             FileUtils.mkdir_p(changelog_dir)
             File.write(File.join(changelog_dir, 'default.txt'), '')
           end
-          # Skip downloading release notes translations since the source is empty
-          files.delete("release_note_#{version_suffix}")
+        else
+          # Make sure to also download the release notes translations as the source file (release_notes.txt) is not empty
+          files["release_note_#{version_suffix}"] = {
+            desc: 'changelogs/default.txt',
+            max_size: 500,
+            alternate_key: "release_note_short_#{version_suffix}"
+          }
         end
       end
 

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -207,8 +207,8 @@ platform :android do
         # Clear release notes if the source file is empty
         source_notes_file = File.join(metadata_source_dir, 'release_notes.txt')
         if !File.exist?(source_notes_file) || File.read(source_notes_file).strip.empty?
-          all_app_locales = locales + [['en', 'en-US']]
-          all_app_locales.each do |_, google_play_locale|
+          all_app_locales = locales + [%w[en en-US]]
+          all_app_locales.each_value do |google_play_locale|
             changelog_dir = File.join(metadata_download_path, google_play_locale, 'changelogs')
             FileUtils.mkdir_p(changelog_dir)
             File.write(File.join(changelog_dir, 'default.txt'), '')


### PR DESCRIPTION
Reference: p1733408151597889-slack-CC7L49W13

The main change is to better handle in the lane `download_metadata_strings` the scenario when the source release notes files (`WordPress/metadata/release_notes.txt` or `WordPress/jetpack_metadata/release_notes.txt`) are empty, clearing the localized files used by Fastlane (`fastlane/metadata/android/*/changelogs/default.txt` or `fastlane/jetpack_metadata/android/*/changelogs/default.txt`).

Additionally, I've also updated the lane `download_metadata_strings` lane to use keywords syntax for parameters.

-----

## To Test:

You can run the `download_metadata_strings` lane using the command below (avoiding commiting/pushing) to make sure the `default.txt` files are cleared when the source notes `release_notes.txt` are empty. When `release_notes.txt` has content, the `default.txt` files should be fetched from GlotPress using the specified `version`.

- `bundle exec fastlane download_metadata_strings version:25.2 skip_commit:true`