### PR TITLE
Fix IllegalStateException in domain registration fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/compose/DomainItem.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.sitecreation.domains.compose
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -61,6 +62,7 @@ fun DomainItem(uiState: DomainUiState): Unit = with(uiState) {
                     indication = ripple(color = HighlightBgColor),
                     onClick = onClick::invoke,
                 )
+                .focusable(enabled = true)
                 .then(if (cost is Cost.Paid) {
                     Modifier.padding(top = Margin.ExtraLarge.value)
                 } else {


### PR DESCRIPTION
Fixes #21563 - Note that this targets 25.6

In `trunk` follow these steps to reproduce the crash:

- From the My Site tab, tap to change sites
- Choose Add a site
- Choose Create WordPress.com site
- Skip choosing a topic or theme
- When you get to Choose a domain, search for a domain ("Test" works fine)
- Scroll down then tap the Search button on the soft keyboard
- Boom!

Then pull this branch, follow the same steps, and notice no Boom!

