### PR TITLE
Fix: Check if email verified before allowing to update avatar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -71,6 +71,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.utils.UiHelpers
+import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.ui.utils.UiString.UiStringText
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.MAIN
@@ -201,20 +202,36 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
         val showPickerListener = OnClickListener {
             AnalyticsTracker.track(ME_GRAVATAR_TAPPED)
-            if (gravatarQuickEditorFeatureConfig.isEnabled()) {
-                GravatarQuickEditor.show(
-                    fragment = this@MeFragment,
-                    gravatarQuickEditorParams = GravatarQuickEditorParams {
-                        email = Email(accountStore.account.email)
-                        avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
-                    },
-                    authenticationMethod = AuthenticationMethod.Bearer(accountStore.accessToken.orEmpty()),
-                    onAvatarSelected = {
-                        loadAvatar(null, true)
-                    },
-                )
+            if (accountStore.account.emailVerified) {
+                if (gravatarQuickEditorFeatureConfig.isEnabled()) {
+                    GravatarQuickEditor.show(
+                        fragment = this@MeFragment,
+                        gravatarQuickEditorParams = GravatarQuickEditorParams {
+                            email = Email(accountStore.account.email)
+                            avatarPickerContentLayout = AvatarPickerContentLayout.Horizontal
+                        },
+                        authenticationMethod = AuthenticationMethod.Bearer(accountStore.accessToken.orEmpty()),
+                        onAvatarSelected = {
+                            loadAvatar(null, true)
+                        },
+                    )
+                } else {
+                    showPhotoPickerForGravatar()
+                }
             } else {
-                showPhotoPickerForGravatar()
+                view?.let { view ->
+                    sequencer.enqueue(
+                        SnackbarItem(
+                            Info(
+                                view,
+                                UiString.UiStringRes(R.string.avatar_update_email_unverified),
+                                Snackbar.LENGTH_LONG
+                            ),
+                            null,
+                            null
+                        )
+                    )
+                }
             }
         }
         avatarContainer.setOnClickListener(showPickerListener)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3054,6 +3054,7 @@
     <string name="error_locating_image">Error locating the cropped image</string>
     <string name="error_refreshing_gravatar">Error reloading your Gravatar</string>
     <string name="error_updating_gravatar">Error updating your Gravatar</string>
+    <string name="avatar_update_email_unverified">To update your avatar, you need to verify your email address first.</string>
 
     <!-- Editor -->
     <string name="discard">Discard</string>
@@ -4972,6 +4973,4 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="voice_to_content_generic_error">Post from audio is unavailable at the moment, please try again later.</string>
     <string name="gutenberg_native_replace_image" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Replace image</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>
-
-    <string name="avatar_update_email_unverified">To update your avatar, you need to verify your email address first.</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4972,4 +4972,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="voice_to_content_generic_error">Post from audio is unavailable at the moment, please try again later.</string>
     <string name="gutenberg_native_replace_image" tools:ignore="UnusedResources" a8c-src-lib="gutenberg">Replace image</string>
     <string name="default_web_client_id" a8c-src-lib="module:login">placeholder</string>
+
+    <string name="avatar_update_email_unverified">To update your avatar, you need to verify your email address first.</string>
 </resources>


### PR DESCRIPTION
There was a backend fix applied at Gravatar to disallow using authenticated endpoints with account that hasn't verified the email. Using authenticated endpoint creates a Gravatar profile, but this shouldn't happen if email is not verified. 

This means that before uploading a photo (via REST API or QuickEditor) we need to make sure the email is verified. If not, a proper message should be shown to the user. 

This is the corresponding iOS [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/23920). The copy for the message matches it as well.

Here's how it looks:

<img width="677" alt="Screenshot 2025-01-08 at 12 32 00" src="https://github.com/user-attachments/assets/c6400848-f078-445c-9225-6f92dd3629d0" />
 

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Create a new account without verifying the email (I was only able to do it via web)
2. Login in the Jetpack app
3. Got the the `me` section
4. Tap on the avatar in the top left
5. Confirm you see a snack with the proper message about unverified email
6. Log out and log in with your standard account
7. Repeat steps 3 and 4 and confirm the Quick Editor was shown
8. You can also disable the `gravatar_quick_editor` feature flag to test the old flow, but the email verification check is the same so if the above works, this should too. 

-----

## Regression Notes

1. Potential unintended areas of impact

    - None

9. What I did to test those areas of impact (or what existing automated tests I relied on)

    - TODO

10. What automated tests I added (or what prevented me from doing so)

    - TODO

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
