### PR TITLE
Remove Jetpack Lazy Images setting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -19,7 +19,6 @@ public class JetpackSettingsModel {
     // Modules
     public boolean serveImagesFromOurServers;
     public boolean serveStaticFilesFromOurServers;
-    public boolean lazyLoadImages;
     public boolean commentLikes;
     public boolean sharingEnabled = true;
     public boolean improvedSearch;
@@ -47,7 +46,6 @@ public class JetpackSettingsModel {
         jetpackProtectAllowlist.addAll(other.jetpackProtectAllowlist);
         serveImagesFromOurServers = other.serveImagesFromOurServers;
         serveStaticFilesFromOurServers = other.serveStaticFilesFromOurServers;
-        lazyLoadImages = other.lazyLoadImages;
         sharingEnabled = other.sharingEnabled;
         improvedSearch = other.improvedSearch;
         adFreeVideoHosting = other.adFreeVideoHosting;
@@ -66,7 +64,6 @@ public class JetpackSettingsModel {
                && ssoRequireTwoFactor == otherModel.ssoRequireTwoFactor
                && serveImagesFromOurServers == otherModel.serveImagesFromOurServers
                && serveStaticFilesFromOurServers == otherModel.serveStaticFilesFromOurServers
-               && lazyLoadImages == otherModel.lazyLoadImages
                && commentLikes == otherModel.commentLikes
                && sharingEnabled == otherModel.sharingEnabled
                && improvedSearch == otherModel.improvedSearch

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -278,10 +278,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     private WPSwitchPreference mJpMatchEmailPref;
     private WPSwitchPreference mJpUseTwoFactorPref;
 
-    // Speed up settings
-    private WPSwitchPreference mLazyLoadImages;
-    private WPSwitchPreference mLazyLoadImagesNested;
-
     // Jetpack media settings
     private WPSwitchPreference mAdFreeVideoHosting;
     private WPSwitchPreference mAdFreeVideoHostingNested;
@@ -720,8 +716,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mJpUseTwoFactorPref) {
             mJpUseTwoFactorPref.setChecked((Boolean) newValue);
             mSiteSettings.enableJetpackSsoTwoFactor((Boolean) newValue);
-        } else if (preference == mLazyLoadImages || preference == mLazyLoadImagesNested) {
-            setLazyLoadImagesChecked((Boolean) newValue);
         } else if (preference == mAdFreeVideoHosting || preference == mAdFreeVideoHostingNested) {
             setAdFreeHostingChecked((Boolean) newValue);
         } else if (preference == mImprovedSearch) {
@@ -1044,9 +1038,6 @@ public class SiteSettingsFragment extends PreferenceFragment
                 (WPSwitchPreference) getChangePref(R.string.pref_key_serve_static_files_from_our_servers);
         mServeStaticFilesFromOurServersNested =
                 (WPSwitchPreference) getChangePref(R.string.pref_key_serve_static_files_from_our_servers_nested);
-
-        mLazyLoadImages = (WPSwitchPreference) getChangePref(R.string.pref_key_lazy_load_images);
-        mLazyLoadImagesNested = (WPSwitchPreference) getChangePref(R.string.pref_key_lazy_load_images_nested);
 
         mAdFreeVideoHosting = (WPSwitchPreference) getChangePref(R.string.pref_key_ad_free_video_hosting);
         mAdFreeVideoHostingNested = (WPSwitchPreference) getChangePref(R.string.pref_key_ad_free_video_hosting_nested);
@@ -1499,7 +1490,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         mWeekStartPref.setValue(mSiteSettings.getStartOfWeek());
         mWeekStartPref.setSummary(mWeekStartPref.getEntry());
         mGutenbergDefaultForNewPosts.setChecked(SiteUtils.isBlockEditorDefaultForNewPost(mSite));
-        setLazyLoadImagesChecked(mSiteSettings.isLazyLoadImagesEnabled());
         setAdFreeHostingChecked(mSiteSettings.isAdFreeHostingEnabled());
         boolean checked = mSiteSettings.isImprovedSearchEnabled() || mSiteSettings.getJetpackSearchEnabled();
         mImprovedSearch.setChecked(checked);
@@ -1558,12 +1548,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void setSiteAcceleratorChecked(boolean checked) {
         mSiteAccelerator.setChecked(checked);
         mSiteAcceleratorNested.setChecked(checked);
-    }
-
-    private void setLazyLoadImagesChecked(boolean checked) {
-        mSiteSettings.enableLazyLoadImages(checked);
-        mLazyLoadImages.setChecked(checked);
-        mLazyLoadImagesNested.setChecked(checked);
     }
 
     private void setAdFreeHostingChecked(boolean checked) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -701,14 +701,6 @@ public abstract class SiteSettingsInterface {
         return mJpSettings.serveStaticFilesFromOurServers;
     }
 
-    void enableLazyLoadImages(boolean enabled) {
-        mJpSettings.lazyLoadImages = enabled;
-    }
-
-    boolean isLazyLoadImagesEnabled() {
-        return mJpSettings.lazyLoadImages;
-    }
-
     void enableAdFreeHosting(boolean enabled) {
         mJpSettings.adFreeVideoHosting = enabled;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
@@ -69,7 +69,6 @@ class WPComSiteSettings extends SiteSettingsInterface {
     // Jetpack modules
     private static final String SERVE_IMAGES_FROM_OUR_SERVERS = "photon";
     private static final String SERVE_STATIC_FILES_FROM_OUR_SERVERS = "photon-cdn";
-    private static final String LAZY_LOAD_IMAGES = "lazy-images";
     private static final String SHARING_MODULE = "sharedaddy";
 
     private static final String AD_FREE_VIDEO_HOSTING_MODULE = "videopress";
@@ -135,7 +134,6 @@ class WPComSiteSettings extends SiteSettingsInterface {
             if (supportsJetpackSiteAcceleratorSettings(mSite)) {
                 pushServeImagesFromOurServersModuleSettings();
                 pushServeStaticFilesFromOurServersModuleSettings();
-                pushLazyLoadModule();
             }
             pushImprovedSearchModule();
             pushAdFreeVideoHostingModule();
@@ -347,9 +345,6 @@ class WPComSiteSettings extends SiteSettingsInterface {
                                     case SERVE_STATIC_FILES_FROM_OUR_SERVERS:
                                         mRemoteJpSettings.serveStaticFilesFromOurServers = isActive;
                                         break;
-                                    case LAZY_LOAD_IMAGES:
-                                        mRemoteJpSettings.lazyLoadImages = isActive;
-                                        break;
                                     case SHARING_MODULE:
                                         mRemoteJpSettings.sharingEnabled = isActive;
                                         break;
@@ -364,7 +359,6 @@ class WPComSiteSettings extends SiteSettingsInterface {
                             mJpSettings.serveImagesFromOurServers = mRemoteJpSettings.serveImagesFromOurServers;
                             mJpSettings.serveStaticFilesFromOurServers =
                                     mRemoteJpSettings.serveStaticFilesFromOurServers;
-                            mJpSettings.lazyLoadImages = mRemoteJpSettings.lazyLoadImages;
                             mJpSettings.sharingEnabled = mRemoteJpSettings.sharingEnabled;
                             mJpSettings.improvedSearch = mRemoteJpSettings.improvedSearch;
                             mJpSettings.adFreeVideoHosting = mRemoteJpSettings.adFreeVideoHosting;
@@ -540,31 +534,6 @@ class WPComSiteSettings extends SiteSettingsInterface {
         }
     }
 
-    private void pushLazyLoadModule() {
-        ++mSaveRequestCount;
-        // The API returns 400 if we try to sync the same value twice so we need to keep it locally.
-        if (mJpSettings.lazyLoadImages != mRemoteJpSettings.lazyLoadImages) {
-            final boolean fallbackValue = mRemoteJpSettings.lazyLoadImages;
-            mRemoteJpSettings.lazyLoadImages = mJpSettings.lazyLoadImages;
-            WordPress.getRestClientUtilsV1_1().setJetpackModuleSettings(
-                    mSite.getSiteId(), LAZY_LOAD_IMAGES, mJpSettings.lazyLoadImages, new RestRequest.Listener() {
-                        @Override
-                        public void onResponse(JSONObject response) {
-                            AppLog.d(AppLog.T.API, "Jetpack module updated - Lazy load images");
-                            onSaveResponseReceived(null);
-                        }
-                    }, new RestRequest.ErrorListener() {
-                        @Override
-                        public void onErrorResponse(VolleyError error) {
-                            mRemoteJpSettings.lazyLoadImages = fallbackValue;
-                            error.printStackTrace();
-                            AppLog.w(AppLog.T.API, "Error updating Jetpack module - Lazy load images: " + error);
-                            onSaveResponseReceived(error);
-                        }
-                    });
-        }
-    }
-
     private void pushImprovedSearchModule() {
         ++mSaveRequestCount;
         // The API returns 400 if we try to sync the same value twice so we need to keep it locally.
@@ -700,7 +669,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
         String remoteGmtOffset = settingsObject.optString(GMT_OFFSET_KEY, "");
         // UTC-7 comes back as gmt_offset: -7, UTC+7 as just gmt_offset: 7 without the +, hence adding prefix
         String remoteGmtTimezone = remoteGmtOffset.startsWith("-") ? "UTC" + remoteGmtOffset : "UTC+" + remoteGmtOffset;
-        
+
         mRemoteSettings.timezone = !TextUtils.isEmpty(remoteTimezone) ? remoteTimezone : remoteGmtTimezone;
 
         mRemoteSettings.postsPerPage = settingsObject.optInt(POSTS_PER_PAGE_KEY, 0);

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -94,9 +94,6 @@
     <!-- Front page settings -->
     <string name="pref_key_homepage" translatable="false">wp_pref_key_homepage</string>
     <string name="pref_key_homepage_settings" translatable="false">wp_pref_key_homepage_settings</string>
-    <!-- Speed up your site -->
-    <string name="pref_key_lazy_load_images" translatable="false">wp_pref_lazy_load_images</string>
-    <string name="pref_key_lazy_load_images_nested" translatable="false">wp_pref_lazy_load_images_nested</string>
     <!-- Jetpack performance settings -->
     <string name="pref_key_jetpack_performance_settings" translatable="false">wp_pref_jetpack_performance_settings</string>
     <string name="pref_key_site_accelerator" translatable="false">wp_pref_site_accelerator</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -727,14 +727,10 @@
     <string name="file_size_in_gigabytes">%s GB</string>
     <string name="file_size_in_terabytes">%s TB</string>
 
-    <!-- Speed up your site -->
-    <string name="site_settings_lazy_load_images_summary">Improve your site\'s speed by only loading images visible on the screen.</string>
-
     <!-- Site accelerator -->
     <string name="site_settings_site_accelerator">Site Accelerator</string>
     <string name="site_settings_site_accelerator_on">On</string>
     <string name="site_settings_site_accelerator_off">Off</string>
-    <string name="site_settings_lazy_load_images">Lazy load images</string>
     <string name="site_settings_faster_images">Faster images</string>
     <string name="site_settings_faster_static_files">Faster static files</string>
     <string name="site_settings_site_accelerator_summary">Load pages faster by allowing Jetpack to optimize your images and static files (like CSS and JavaScript).</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -10,6 +10,31 @@
         android:key="@string/pref_key_site_general"
         android:title="@string/site_settings_general_header">
 
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_title"
+            android:key="@string/pref_key_site_title"
+            android:title="@string/site_settings_title_title"
+            app:longClickHint="@string/site_settings_title_hint"
+            app:maxSummaryLines="2"
+            app:summaryLines="1" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_tagline"
+            android:key="@string/pref_key_site_tagline"
+            android:title="@string/site_settings_tagline_title"
+            app:longClickHint="@string/site_settings_tagline_hint"
+            app:maxSummaryLines="1"
+            app:summaryLines="1" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_address"
+            android:enabled="false"
+            android:key="@string/pref_key_site_address"
+            android:title="@string/site_settings_address_title"
+            app:longClickHint="@string/site_settings_address_hint"
+            app:maxSummaryLines="1"
+            app:summaryLines="1" />
+
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_site_privacy"
             android:defaultValue="-2"
@@ -27,31 +52,6 @@
             android:key="@string/pref_key_site_language"
             android:title="@string/site_settings_language_title"
             app:longClickHint="@string/site_settings_language_hint" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_address"
-            android:enabled="false"
-            android:key="@string/pref_key_site_address"
-            android:title="@string/site_settings_address_title"
-            app:longClickHint="@string/site_settings_address_hint"
-            app:maxSummaryLines="1"
-            app:summaryLines="1" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_title"
-            android:key="@string/pref_key_site_title"
-            android:title="@string/site_settings_title_title"
-            app:longClickHint="@string/site_settings_title_hint"
-            app:maxSummaryLines="2"
-            app:summaryLines="1" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_tagline"
-            android:key="@string/pref_key_site_tagline"
-            android:title="@string/site_settings_tagline_title"
-            app:longClickHint="@string/site_settings_tagline_hint"
-            app:maxSummaryLines="1"
-            app:summaryLines="1" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_site_timezone"
@@ -97,6 +97,16 @@
         android:key="@string/pref_key_site_account"
         android:title="@string/site_settings_account_header">
 
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_username"
+            android:enabled="false"
+            android:key="@string/pref_key_site_username"
+            android:maxLength="@integer/max_length_username"
+            android:title="@string/site_settings_username_title"
+            app:longClickHint="@string/site_settings_username_hint"
+            app:maxSummaryLines="2"
+            app:summaryLines="1" />
+
         <org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation
             android:id="@+id/pref_site_password"
             android:dialogTitle="@string/site_settings_password_dialog_title"
@@ -106,16 +116,6 @@
             android:maxLength="@integer/max_length_password"
             android:title="@string/site_settings_password_title"
             app:longClickHint="@string/site_settings_password_hint"
-            app:maxSummaryLines="2"
-            app:summaryLines="1" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_username"
-            android:enabled="false"
-            android:key="@string/pref_key_site_username"
-            android:maxLength="@integer/max_length_username"
-            android:title="@string/site_settings_username_title"
-            app:longClickHint="@string/site_settings_username_hint"
             app:maxSummaryLines="2"
             app:summaryLines="1" />
 
@@ -146,6 +146,18 @@
             android:title="@string/site_settings_default_category_title"
             app:longClickHint="@string/site_settings_category_hint" />
 
+        <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_categories"
+            android:key="@string/pref_key_site_categories"
+            android:title="@string/site_settings_categories_title"
+            app:longClickHint="@string/site_settings_categories_hint" />
+
+        <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_tags"
+            android:key="@string/pref_key_site_tags"
+            android:title="@string/site_settings_tags_title"
+            app:longClickHint="@string/site_settings_tags_hint" />
+
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_format"
             android:entries="@array/post_format_display_names"
@@ -153,19 +165,6 @@
             android:key="@string/pref_key_site_format"
             android:title="@string/site_settings_default_format_title"
             app:longClickHint="@string/site_settings_format_hint" />
-
-        <org.wordpress.android.ui.prefs.DetailListPreference
-            android:id="@+id/pref_week_starts"
-            android:entries="@array/site_settings_weekdays"
-            android:entryValues="@array/site_settings_weekday_values"
-            android:key="@string/pref_key_site_week_start"
-            android:title="@string/site_settings_week_start_title" />
-
-        <org.wordpress.android.ui.prefs.WPPreference
-            android:id="@+id/pref_categories"
-            android:key="@string/pref_key_site_categories"
-            android:title="@string/site_settings_categories_title"
-            app:longClickHint="@string/site_settings_categories_hint" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_date_format"
@@ -177,11 +176,12 @@
             android:key="@string/pref_key_site_time_format"
             android:title="@string/site_settings_time_format_title" />
 
-        <org.wordpress.android.ui.prefs.WPPreference
-            android:id="@+id/pref_tags"
-            android:key="@string/pref_key_site_tags"
-            android:title="@string/site_settings_tags_title"
-            app:longClickHint="@string/site_settings_tags_hint" />
+        <org.wordpress.android.ui.prefs.DetailListPreference
+            android:id="@+id/pref_week_starts"
+            android:entries="@array/site_settings_weekdays"
+            android:entryValues="@array/site_settings_weekday_values"
+            android:key="@string/pref_key_site_week_start"
+            android:title="@string/site_settings_week_start_title" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_related_posts"
@@ -238,8 +238,6 @@
             android:key="@string/pref_key_site_accelerator_settings"
             android:title="@string/site_settings_site_accelerator">
 
-            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
-
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_site_accelerator"
                 android:key="@string/pref_key_site_accelerator"
@@ -257,7 +255,14 @@
                 android:title="@string/site_settings_faster_static_files"
                 app:startOffset="@dimen/margin_extra_large" />
 
+            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
+
         </PreferenceScreen>
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_ad_free_video_hosting"
+            android:key="@string/pref_key_ad_free_video_hosting"
+            android:title="@string/site_settings_ad_free_video_hosting" />
 
         <PreferenceScreen
             android:id="@+id/pref_jetpack_performance_more_settings"
@@ -274,7 +279,10 @@
                     android:key="@string/pref_key_site_accelerator_settings_nested"
                     android:title="@string/site_settings_site_accelerator">
 
-                    <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
+                    <org.wordpress.android.ui.prefs.WPSwitchPreference
+                        android:id="@+id/pref_site_accelerator_nested"
+                        android:key="@string/pref_key_site_accelerator_nested"
+                        android:title="@string/site_settings_site_accelerator" />
 
                     <org.wordpress.android.ui.prefs.WPSwitchPreference
                         android:id="@+id/pref_serve_images_from_our_servers_nested"
@@ -288,10 +296,7 @@
                         android:title="@string/site_settings_faster_static_files"
                         app:startOffset="@dimen/margin_extra_large" />
 
-                    <org.wordpress.android.ui.prefs.WPSwitchPreference
-                        android:id="@+id/pref_site_accelerator_nested"
-                        android:key="@string/pref_key_site_accelerator_nested"
-                        android:title="@string/site_settings_site_accelerator" />
+                    <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
 
                 </PreferenceScreen>
 
@@ -322,11 +327,6 @@
 
         </PreferenceScreen>
 
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_ad_free_video_hosting"
-            android:key="@string/pref_key_ad_free_video_hosting"
-            android:title="@string/site_settings_ad_free_video_hosting" />
-
     </PreferenceCategory>
 
     <!-- Discussion settings -->
@@ -335,6 +335,24 @@
         android:key="@string/pref_key_site_discussion"
         android:title="@string/site_settings_discussion_header"
         app:longClickHint="@string/site_settings_discussion_hint">
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_allow_comments"
+            android:key="@string/pref_key_site_allow_comments"
+            android:title="@string/site_settings_allow_comments_title"
+            app:longClickHint="@string/site_settings_allow_comments_hint" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_send_pingbacks"
+            android:key="@string/pref_key_site_send_pingbacks"
+            android:title="@string/site_settings_send_pingbacks_title"
+            app:longClickHint="@string/site_settings_send_pingbacks_hint" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_receive_pingbacks"
+            android:key="@string/pref_key_site_receive_pingbacks"
+            android:title="@string/site_settings_receive_pingbacks_title"
+            app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
 
         <PreferenceScreen
             android:id="@+id/pref_more_discussion_settings"
@@ -346,15 +364,11 @@
                 android:id="@+id/pref_site_new_posts_defaults"
                 android:title="@string/site_settings_discussion_new_posts_header">
 
-                <org.wordpress.android.ui.prefs.LearnMorePreference
-                    android:id="@+id/pref_learn_more"
-                    android:key="@string/pref_key_site_learn_more"
-                    android:title="@string/site_settings_learn_more_header"
-                    app:caption="@string/site_settings_learn_more_caption"
-                    app:layout="@layout/learn_more_pref_old"
-                    app:openInDialog="true"
-                    app:url="https://wordpress.com/support/settings/discussion-settings/#default-article-settings"
-                    app:useCustomJsFormatting="true" />
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_allow_comments_nested"
+                    android:key="@string/pref_key_site_allow_comments_nested"
+                    android:title="@string/site_settings_allow_comments_title"
+                    app:longClickHint="@string/site_settings_allow_comments_hint" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_send_pingbacks_nested"
@@ -368,17 +382,40 @@
                     android:title="@string/site_settings_receive_pingbacks_title"
                     app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_allow_comments_nested"
-                    android:key="@string/pref_key_site_allow_comments_nested"
-                    android:title="@string/site_settings_allow_comments_title"
-                    app:longClickHint="@string/site_settings_allow_comments_hint" />
+                <org.wordpress.android.ui.prefs.LearnMorePreference
+                    android:id="@+id/pref_learn_more"
+                    android:key="@string/pref_key_site_learn_more"
+                    android:title="@string/site_settings_learn_more_header"
+                    app:caption="@string/site_settings_learn_more_caption"
+                    app:layout="@layout/learn_more_pref_old"
+                    app:openInDialog="true"
+                    app:url="https://wordpress.com/support/settings/discussion-settings/#default-article-settings"
+                    app:useCustomJsFormatting="true" />
 
             </PreferenceCategory>
 
             <PreferenceCategory
                 android:id="@+id/pref_site_comments"
                 android:title="@string/site_settings_comments_header">
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_identity_required"
+                    android:key="@string/pref_key_site_identity_required"
+                    android:title="@string/site_settings_identity_required_title"
+                    app:longClickHint="@string/site_settings_identity_required_hint" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_user_account_required"
+                    android:key="@string/pref_key_site_user_account_required"
+                    android:title="@string/site_settings_account_required_title"
+                    app:longClickHint="@string/site_settings_user_account_required_hint" />
+
+                <org.wordpress.android.ui.prefs.WPPreference
+                    android:id="@+id/pref_close_after"
+                    android:defaultValue="0"
+                    android:key="@string/pref_key_site_close_after"
+                    android:title="@string/site_settings_close_after_title"
+                    app:longClickHint="@string/site_settings_close_after_hint" />
 
                 <org.wordpress.android.ui.prefs.DetailListPreference
                     android:id="@+id/pref_sort_by"
@@ -388,22 +425,6 @@
                     android:key="@string/pref_key_site_sort_by"
                     android:title="@string/site_settings_sort_by_title"
                     app:longClickHint="@string/site_settings_sort_by_hint" />
-
-                <org.wordpress.android.ui.prefs.DetailListPreference
-                    android:id="@+id/pref_allowlist"
-                    android:entries="@array/site_settings_auto_approve_entries"
-                    android:entryValues="@array/site_settings_auto_approve_values"
-                    android:key="@string/pref_key_site_allowlist"
-                    android:title="@string/site_settings_allowlist_title"
-                    app:entryDetails="@array/site_settings_auto_approve_details"
-                    app:longClickHint="@string/site_settings_allowlist_hint" />
-
-                <org.wordpress.android.ui.prefs.WPPreference
-                    android:id="@+id/pref_close_after"
-                    android:defaultValue="0"
-                    android:key="@string/pref_key_site_close_after"
-                    android:title="@string/site_settings_close_after_title"
-                    app:longClickHint="@string/site_settings_close_after_hint" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_threading"
@@ -418,6 +439,15 @@
                     android:key="@string/pref_key_site_paging"
                     android:title="@string/site_settings_paging_title"
                     app:longClickHint="@string/site_settings_paging_hint" />
+
+                <org.wordpress.android.ui.prefs.DetailListPreference
+                    android:id="@+id/pref_allowlist"
+                    android:entries="@array/site_settings_auto_approve_entries"
+                    android:entryValues="@array/site_settings_auto_approve_values"
+                    android:key="@string/pref_key_site_allowlist"
+                    android:title="@string/site_settings_allowlist_title"
+                    app:entryDetails="@array/site_settings_auto_approve_details"
+                    app:longClickHint="@string/site_settings_allowlist_hint" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_multiple_links"
@@ -437,39 +467,9 @@
                     android:title="@string/site_settings_denylist_title"
                     app:longClickHint="@string/site_settings_denylist_hint" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_identity_required"
-                    android:key="@string/pref_key_site_identity_required"
-                    android:title="@string/site_settings_identity_required_title"
-                    app:longClickHint="@string/site_settings_identity_required_hint" />
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_user_account_required"
-                    android:key="@string/pref_key_site_user_account_required"
-                    android:title="@string/site_settings_account_required_title"
-                    app:longClickHint="@string/site_settings_user_account_required_hint" />
-
             </PreferenceCategory>
 
         </PreferenceScreen>
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_send_pingbacks"
-            android:key="@string/pref_key_site_send_pingbacks"
-            android:title="@string/site_settings_send_pingbacks_title"
-            app:longClickHint="@string/site_settings_send_pingbacks_hint" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_receive_pingbacks"
-            android:key="@string/pref_key_site_receive_pingbacks"
-            android:title="@string/site_settings_receive_pingbacks_title"
-            app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_allow_comments"
-            android:key="@string/pref_key_site_allow_comments"
-            android:title="@string/site_settings_allow_comments_title"
-            app:longClickHint="@string/site_settings_allow_comments_hint" />
 
     </PreferenceCategory>
 
@@ -484,9 +484,31 @@
             android:key="@string/pref_key_jetpack_security_screen"
             android:title="@string/jetpack_security_setting_title">
 
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_monitor_uptime"
+                android:key="@string/pref_key_jetpack_monitor_uptime"
+                android:title="@string/jetpack_monitor_uptime_title" />
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_email_notifications"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime"
+                android:key="@string/pref_key_jetpack_send_email_notifications"
+                android:title="@string/jetpack_send_email_notifications_title" />
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_wp_notifications"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime"
+                android:key="@string/pref_key_jetpack_send_wp_notifications"
+                android:title="@string/jetpack_send_wp_notifications_title" />
+
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_brute_force"
                 android:title="@string/jetpack_prevent_brute_force_category_title">
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_prevent_brute_force"
+                    android:key="@string/pref_key_jetpack_prevent_brute_force"
+                    android:title="@string/jetpack_prevent_brute_force_title" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_brute_force_allowlist"
@@ -494,25 +516,16 @@
                     android:key="@string/pref_key_jetpack_brute_force_allowlist"
                     android:title="@string/jetpack_brute_force_allowlist_title" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_prevent_brute_force"
-                    android:key="@string/pref_key_jetpack_prevent_brute_force"
-                    android:title="@string/jetpack_prevent_brute_force_title" />
-
             </PreferenceCategory>
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_wpcom_sign_in"
                 android:title="@string/jetpack_wpcom_sign_in_category_title">
 
-                <org.wordpress.android.ui.prefs.LearnMorePreference
-                    android:id="@+id/pref_jetpack_learn_more"
-                    android:key="@string/pref_key_jetpack_learn_more"
-                    android:title="@string/site_settings_learn_more_header"
-                    app:layout="@layout/learn_more_pref_old"
-                    app:openInDialog="true"
-                    app:url="https://jetpack.com/support/sso/"
-                    app:useCustomJsFormatting="false" />
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_allow_wpcom_sign_in"
+                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
+                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_match_wpcom_email"
@@ -526,29 +539,16 @@
                     android:key="@string/pref_key_jetpack_require_two_factor"
                     android:title="@string/jetpack_require_two_factor_title" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_allow_wpcom_sign_in"
-                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
-                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
+                <org.wordpress.android.ui.prefs.LearnMorePreference
+                    android:id="@+id/pref_jetpack_learn_more"
+                    android:key="@string/pref_key_jetpack_learn_more"
+                    android:title="@string/site_settings_learn_more_header"
+                    app:layout="@layout/learn_more_pref_old"
+                    app:openInDialog="true"
+                    app:url="https://jetpack.com/support/sso/"
+                    app:useCustomJsFormatting="false" />
 
             </PreferenceCategory>
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_wp_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_wp_notifications"
-                android:title="@string/jetpack_send_wp_notifications_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_monitor_uptime"
-                android:key="@string/pref_key_jetpack_monitor_uptime"
-                android:title="@string/jetpack_monitor_uptime_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_email_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_email_notifications"
-                android:title="@string/jetpack_send_email_notifications_title" />
         </PreferenceScreen>
     </PreferenceCategory>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -238,6 +238,11 @@
             android:key="@string/pref_key_site_accelerator_settings"
             android:title="@string/site_settings_site_accelerator">
 
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_site_accelerator"
+                android:key="@string/pref_key_site_accelerator"
+                android:title="@string/site_settings_site_accelerator" />
+
             <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
@@ -251,11 +256,6 @@
                 android:key="@string/pref_key_serve_static_files_from_our_servers"
                 android:title="@string/site_settings_faster_static_files"
                 app:startOffset="@dimen/margin_extra_large" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_site_accelerator"
-                android:key="@string/pref_key_site_accelerator"
-                android:title="@string/site_settings_site_accelerator" />
 
         </PreferenceScreen>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -10,31 +10,6 @@
         android:key="@string/pref_key_site_general"
         android:title="@string/site_settings_general_header">
 
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_title"
-            android:key="@string/pref_key_site_title"
-            android:title="@string/site_settings_title_title"
-            app:longClickHint="@string/site_settings_title_hint"
-            app:maxSummaryLines="2"
-            app:summaryLines="1" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_tagline"
-            android:key="@string/pref_key_site_tagline"
-            android:title="@string/site_settings_tagline_title"
-            app:longClickHint="@string/site_settings_tagline_hint"
-            app:maxSummaryLines="1"
-            app:summaryLines="1" />
-
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_address"
-            android:enabled="false"
-            android:key="@string/pref_key_site_address"
-            android:title="@string/site_settings_address_title"
-            app:longClickHint="@string/site_settings_address_hint"
-            app:maxSummaryLines="1"
-            app:summaryLines="1" />
-
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_site_privacy"
             android:defaultValue="-2"
@@ -52,6 +27,31 @@
             android:key="@string/pref_key_site_language"
             android:title="@string/site_settings_language_title"
             app:longClickHint="@string/site_settings_language_hint" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_address"
+            android:enabled="false"
+            android:key="@string/pref_key_site_address"
+            android:title="@string/site_settings_address_title"
+            app:longClickHint="@string/site_settings_address_hint"
+            app:maxSummaryLines="1"
+            app:summaryLines="1" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_title"
+            android:key="@string/pref_key_site_title"
+            android:title="@string/site_settings_title_title"
+            app:longClickHint="@string/site_settings_title_hint"
+            app:maxSummaryLines="2"
+            app:summaryLines="1" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_tagline"
+            android:key="@string/pref_key_site_tagline"
+            android:title="@string/site_settings_tagline_title"
+            app:longClickHint="@string/site_settings_tagline_hint"
+            app:maxSummaryLines="1"
+            app:summaryLines="1" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_site_timezone"
@@ -97,16 +97,6 @@
         android:key="@string/pref_key_site_account"
         android:title="@string/site_settings_account_header">
 
-        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
-            android:id="@+id/pref_site_username"
-            android:enabled="false"
-            android:key="@string/pref_key_site_username"
-            android:maxLength="@integer/max_length_username"
-            android:title="@string/site_settings_username_title"
-            app:longClickHint="@string/site_settings_username_hint"
-            app:maxSummaryLines="2"
-            app:summaryLines="1" />
-
         <org.wordpress.android.ui.prefs.EditTextPreferenceWithValidation
             android:id="@+id/pref_site_password"
             android:dialogTitle="@string/site_settings_password_dialog_title"
@@ -116,6 +106,16 @@
             android:maxLength="@integer/max_length_password"
             android:title="@string/site_settings_password_title"
             app:longClickHint="@string/site_settings_password_hint"
+            app:maxSummaryLines="2"
+            app:summaryLines="1" />
+
+        <org.wordpress.android.ui.prefs.SummaryEditTextPreference
+            android:id="@+id/pref_site_username"
+            android:enabled="false"
+            android:key="@string/pref_key_site_username"
+            android:maxLength="@integer/max_length_username"
+            android:title="@string/site_settings_username_title"
+            app:longClickHint="@string/site_settings_username_hint"
             app:maxSummaryLines="2"
             app:summaryLines="1" />
 
@@ -146,18 +146,6 @@
             android:title="@string/site_settings_default_category_title"
             app:longClickHint="@string/site_settings_category_hint" />
 
-        <org.wordpress.android.ui.prefs.WPPreference
-            android:id="@+id/pref_categories"
-            android:key="@string/pref_key_site_categories"
-            android:title="@string/site_settings_categories_title"
-            app:longClickHint="@string/site_settings_categories_hint" />
-
-        <org.wordpress.android.ui.prefs.WPPreference
-            android:id="@+id/pref_tags"
-            android:key="@string/pref_key_site_tags"
-            android:title="@string/site_settings_tags_title"
-            app:longClickHint="@string/site_settings_tags_hint" />
-
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_format"
             android:entries="@array/post_format_display_names"
@@ -165,6 +153,19 @@
             android:key="@string/pref_key_site_format"
             android:title="@string/site_settings_default_format_title"
             app:longClickHint="@string/site_settings_format_hint" />
+
+        <org.wordpress.android.ui.prefs.DetailListPreference
+            android:id="@+id/pref_week_starts"
+            android:entries="@array/site_settings_weekdays"
+            android:entryValues="@array/site_settings_weekday_values"
+            android:key="@string/pref_key_site_week_start"
+            android:title="@string/site_settings_week_start_title" />
+
+        <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_categories"
+            android:key="@string/pref_key_site_categories"
+            android:title="@string/site_settings_categories_title"
+            app:longClickHint="@string/site_settings_categories_hint" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_date_format"
@@ -176,12 +177,11 @@
             android:key="@string/pref_key_site_time_format"
             android:title="@string/site_settings_time_format_title" />
 
-        <org.wordpress.android.ui.prefs.DetailListPreference
-            android:id="@+id/pref_week_starts"
-            android:entries="@array/site_settings_weekdays"
-            android:entryValues="@array/site_settings_weekday_values"
-            android:key="@string/pref_key_site_week_start"
-            android:title="@string/site_settings_week_start_title" />
+        <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/pref_tags"
+            android:key="@string/pref_key_site_tags"
+            android:title="@string/site_settings_tags_title"
+            app:longClickHint="@string/site_settings_tags_hint" />
 
         <org.wordpress.android.ui.prefs.WPPreference
             android:id="@+id/pref_related_posts"
@@ -238,10 +238,7 @@
             android:key="@string/pref_key_site_accelerator_settings"
             android:title="@string/site_settings_site_accelerator">
 
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_site_accelerator"
-                android:key="@string/pref_key_site_accelerator"
-                android:title="@string/site_settings_site_accelerator" />
+            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_serve_images_from_our_servers"
@@ -255,20 +252,12 @@
                 android:title="@string/site_settings_faster_static_files"
                 app:startOffset="@dimen/margin_extra_large" />
 
-            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_site_accelerator"
+                android:key="@string/pref_key_site_accelerator"
+                android:title="@string/site_settings_site_accelerator" />
 
         </PreferenceScreen>
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_lazy_load_images"
-            android:key="@string/pref_key_lazy_load_images"
-            android:summary="@string/site_settings_lazy_load_images_summary"
-            android:title="@string/site_settings_lazy_load_images" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_ad_free_video_hosting"
-            android:key="@string/pref_key_ad_free_video_hosting"
-            android:title="@string/site_settings_ad_free_video_hosting" />
 
         <PreferenceScreen
             android:id="@+id/pref_jetpack_performance_more_settings"
@@ -285,10 +274,7 @@
                     android:key="@string/pref_key_site_accelerator_settings_nested"
                     android:title="@string/site_settings_site_accelerator">
 
-                    <org.wordpress.android.ui.prefs.WPSwitchPreference
-                        android:id="@+id/pref_site_accelerator_nested"
-                        android:key="@string/pref_key_site_accelerator_nested"
-                        android:title="@string/site_settings_site_accelerator" />
+                    <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
 
                     <org.wordpress.android.ui.prefs.WPSwitchPreference
                         android:id="@+id/pref_serve_images_from_our_servers_nested"
@@ -302,15 +288,13 @@
                         android:title="@string/site_settings_faster_static_files"
                         app:startOffset="@dimen/margin_extra_large" />
 
-                    <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
+                    <org.wordpress.android.ui.prefs.WPSwitchPreference
+                        android:id="@+id/pref_site_accelerator_nested"
+                        android:key="@string/pref_key_site_accelerator_nested"
+                        android:title="@string/site_settings_site_accelerator" />
 
                 </PreferenceScreen>
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_lazy_load_images_nested"
-                    android:key="@string/pref_key_lazy_load_images_nested"
-                    android:summary="@string/site_settings_lazy_load_images_summary"
-                    android:title="@string/site_settings_lazy_load_images" />
             </PreferenceCategory>
 
             <PreferenceCategory
@@ -338,6 +322,11 @@
 
         </PreferenceScreen>
 
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_ad_free_video_hosting"
+            android:key="@string/pref_key_ad_free_video_hosting"
+            android:title="@string/site_settings_ad_free_video_hosting" />
+
     </PreferenceCategory>
 
     <!-- Discussion settings -->
@@ -346,24 +335,6 @@
         android:key="@string/pref_key_site_discussion"
         android:title="@string/site_settings_discussion_header"
         app:longClickHint="@string/site_settings_discussion_hint">
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_allow_comments"
-            android:key="@string/pref_key_site_allow_comments"
-            android:title="@string/site_settings_allow_comments_title"
-            app:longClickHint="@string/site_settings_allow_comments_hint" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_send_pingbacks"
-            android:key="@string/pref_key_site_send_pingbacks"
-            android:title="@string/site_settings_send_pingbacks_title"
-            app:longClickHint="@string/site_settings_send_pingbacks_hint" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_receive_pingbacks"
-            android:key="@string/pref_key_site_receive_pingbacks"
-            android:title="@string/site_settings_receive_pingbacks_title"
-            app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
 
         <PreferenceScreen
             android:id="@+id/pref_more_discussion_settings"
@@ -375,11 +346,15 @@
                 android:id="@+id/pref_site_new_posts_defaults"
                 android:title="@string/site_settings_discussion_new_posts_header">
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_allow_comments_nested"
-                    android:key="@string/pref_key_site_allow_comments_nested"
-                    android:title="@string/site_settings_allow_comments_title"
-                    app:longClickHint="@string/site_settings_allow_comments_hint" />
+                <org.wordpress.android.ui.prefs.LearnMorePreference
+                    android:id="@+id/pref_learn_more"
+                    android:key="@string/pref_key_site_learn_more"
+                    android:title="@string/site_settings_learn_more_header"
+                    app:caption="@string/site_settings_learn_more_caption"
+                    app:layout="@layout/learn_more_pref_old"
+                    app:openInDialog="true"
+                    app:url="https://wordpress.com/support/settings/discussion-settings/#default-article-settings"
+                    app:useCustomJsFormatting="true" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_send_pingbacks_nested"
@@ -393,40 +368,17 @@
                     android:title="@string/site_settings_receive_pingbacks_title"
                     app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
 
-                <org.wordpress.android.ui.prefs.LearnMorePreference
-                    android:id="@+id/pref_learn_more"
-                    android:key="@string/pref_key_site_learn_more"
-                    android:title="@string/site_settings_learn_more_header"
-                    app:caption="@string/site_settings_learn_more_caption"
-                    app:layout="@layout/learn_more_pref_old"
-                    app:openInDialog="true"
-                    app:url="https://wordpress.com/support/settings/discussion-settings/#default-article-settings"
-                    app:useCustomJsFormatting="true" />
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_allow_comments_nested"
+                    android:key="@string/pref_key_site_allow_comments_nested"
+                    android:title="@string/site_settings_allow_comments_title"
+                    app:longClickHint="@string/site_settings_allow_comments_hint" />
 
             </PreferenceCategory>
 
             <PreferenceCategory
                 android:id="@+id/pref_site_comments"
                 android:title="@string/site_settings_comments_header">
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_identity_required"
-                    android:key="@string/pref_key_site_identity_required"
-                    android:title="@string/site_settings_identity_required_title"
-                    app:longClickHint="@string/site_settings_identity_required_hint" />
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_user_account_required"
-                    android:key="@string/pref_key_site_user_account_required"
-                    android:title="@string/site_settings_account_required_title"
-                    app:longClickHint="@string/site_settings_user_account_required_hint" />
-
-                <org.wordpress.android.ui.prefs.WPPreference
-                    android:id="@+id/pref_close_after"
-                    android:defaultValue="0"
-                    android:key="@string/pref_key_site_close_after"
-                    android:title="@string/site_settings_close_after_title"
-                    app:longClickHint="@string/site_settings_close_after_hint" />
 
                 <org.wordpress.android.ui.prefs.DetailListPreference
                     android:id="@+id/pref_sort_by"
@@ -436,6 +388,22 @@
                     android:key="@string/pref_key_site_sort_by"
                     android:title="@string/site_settings_sort_by_title"
                     app:longClickHint="@string/site_settings_sort_by_hint" />
+
+                <org.wordpress.android.ui.prefs.DetailListPreference
+                    android:id="@+id/pref_allowlist"
+                    android:entries="@array/site_settings_auto_approve_entries"
+                    android:entryValues="@array/site_settings_auto_approve_values"
+                    android:key="@string/pref_key_site_allowlist"
+                    android:title="@string/site_settings_allowlist_title"
+                    app:entryDetails="@array/site_settings_auto_approve_details"
+                    app:longClickHint="@string/site_settings_allowlist_hint" />
+
+                <org.wordpress.android.ui.prefs.WPPreference
+                    android:id="@+id/pref_close_after"
+                    android:defaultValue="0"
+                    android:key="@string/pref_key_site_close_after"
+                    android:title="@string/site_settings_close_after_title"
+                    app:longClickHint="@string/site_settings_close_after_hint" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_threading"
@@ -450,15 +418,6 @@
                     android:key="@string/pref_key_site_paging"
                     android:title="@string/site_settings_paging_title"
                     app:longClickHint="@string/site_settings_paging_hint" />
-
-                <org.wordpress.android.ui.prefs.DetailListPreference
-                    android:id="@+id/pref_allowlist"
-                    android:entries="@array/site_settings_auto_approve_entries"
-                    android:entryValues="@array/site_settings_auto_approve_values"
-                    android:key="@string/pref_key_site_allowlist"
-                    android:title="@string/site_settings_allowlist_title"
-                    app:entryDetails="@array/site_settings_auto_approve_details"
-                    app:longClickHint="@string/site_settings_allowlist_hint" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_multiple_links"
@@ -478,9 +437,39 @@
                     android:title="@string/site_settings_denylist_title"
                     app:longClickHint="@string/site_settings_denylist_hint" />
 
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_identity_required"
+                    android:key="@string/pref_key_site_identity_required"
+                    android:title="@string/site_settings_identity_required_title"
+                    app:longClickHint="@string/site_settings_identity_required_hint" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_user_account_required"
+                    android:key="@string/pref_key_site_user_account_required"
+                    android:title="@string/site_settings_account_required_title"
+                    app:longClickHint="@string/site_settings_user_account_required_hint" />
+
             </PreferenceCategory>
 
         </PreferenceScreen>
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_send_pingbacks"
+            android:key="@string/pref_key_site_send_pingbacks"
+            android:title="@string/site_settings_send_pingbacks_title"
+            app:longClickHint="@string/site_settings_send_pingbacks_hint" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_receive_pingbacks"
+            android:key="@string/pref_key_site_receive_pingbacks"
+            android:title="@string/site_settings_receive_pingbacks_title"
+            app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_allow_comments"
+            android:key="@string/pref_key_site_allow_comments"
+            android:title="@string/site_settings_allow_comments_title"
+            app:longClickHint="@string/site_settings_allow_comments_hint" />
 
     </PreferenceCategory>
 
@@ -495,31 +484,9 @@
             android:key="@string/pref_key_jetpack_security_screen"
             android:title="@string/jetpack_security_setting_title">
 
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_monitor_uptime"
-                android:key="@string/pref_key_jetpack_monitor_uptime"
-                android:title="@string/jetpack_monitor_uptime_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_email_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_email_notifications"
-                android:title="@string/jetpack_send_email_notifications_title" />
-
-            <org.wordpress.android.ui.prefs.WPSwitchPreference
-                android:id="@+id/pref_jetpack_send_wp_notifications"
-                android:dependency="@string/pref_key_jetpack_monitor_uptime"
-                android:key="@string/pref_key_jetpack_send_wp_notifications"
-                android:title="@string/jetpack_send_wp_notifications_title" />
-
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_brute_force"
                 android:title="@string/jetpack_prevent_brute_force_category_title">
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_prevent_brute_force"
-                    android:key="@string/pref_key_jetpack_prevent_brute_force"
-                    android:title="@string/jetpack_prevent_brute_force_title" />
 
                 <org.wordpress.android.ui.prefs.WPPreference
                     android:id="@+id/pref_brute_force_allowlist"
@@ -527,16 +494,25 @@
                     android:key="@string/pref_key_jetpack_brute_force_allowlist"
                     android:title="@string/jetpack_brute_force_allowlist_title" />
 
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_prevent_brute_force"
+                    android:key="@string/pref_key_jetpack_prevent_brute_force"
+                    android:title="@string/jetpack_prevent_brute_force_title" />
+
             </PreferenceCategory>
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_wpcom_sign_in"
                 android:title="@string/jetpack_wpcom_sign_in_category_title">
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_allow_wpcom_sign_in"
-                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
-                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
+                <org.wordpress.android.ui.prefs.LearnMorePreference
+                    android:id="@+id/pref_jetpack_learn_more"
+                    android:key="@string/pref_key_jetpack_learn_more"
+                    android:title="@string/site_settings_learn_more_header"
+                    app:layout="@layout/learn_more_pref_old"
+                    app:openInDialog="true"
+                    app:url="https://jetpack.com/support/sso/"
+                    app:useCustomJsFormatting="false" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_match_wpcom_email"
@@ -550,16 +526,29 @@
                     android:key="@string/pref_key_jetpack_require_two_factor"
                     android:title="@string/jetpack_require_two_factor_title" />
 
-                <org.wordpress.android.ui.prefs.LearnMorePreference
-                    android:id="@+id/pref_jetpack_learn_more"
-                    android:key="@string/pref_key_jetpack_learn_more"
-                    android:title="@string/site_settings_learn_more_header"
-                    app:layout="@layout/learn_more_pref_old"
-                    app:openInDialog="true"
-                    app:url="https://jetpack.com/support/sso/"
-                    app:useCustomJsFormatting="false" />
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_allow_wpcom_sign_in"
+                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
+                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
 
             </PreferenceCategory>
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_wp_notifications"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime"
+                android:key="@string/pref_key_jetpack_send_wp_notifications"
+                android:title="@string/jetpack_send_wp_notifications_title" />
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_monitor_uptime"
+                android:key="@string/pref_key_jetpack_monitor_uptime"
+                android:title="@string/jetpack_monitor_uptime_title" />
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_email_notifications"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime"
+                android:key="@string/pref_key_jetpack_send_email_notifications"
+                android:title="@string/jetpack_send_email_notifications_title" />
         </PreferenceScreen>
     </PreferenceCategory>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -238,12 +238,12 @@
             android:key="@string/pref_key_site_accelerator_settings"
             android:title="@string/site_settings_site_accelerator">
 
+            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
+
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_site_accelerator"
                 android:key="@string/pref_key_site_accelerator"
                 android:title="@string/site_settings_site_accelerator" />
-
-            <org.wordpress.android.ui.prefs.WPPreference android:summary="@string/site_settings_site_accelerator_summary" />
 
             <org.wordpress.android.ui.prefs.WPSwitchPreference
                 android:id="@+id/pref_serve_images_from_our_servers"


### PR DESCRIPTION
Fixes #21574

As noted on [this iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/23966), the Jetpack "Lazy images" setting has been removed from the backend, but we continued to show it in the apps.

This PR addresses this by removing this setting, and also adjusts the Site Accelerator screen to make more visual sense. Note that there's more to do here - our Jetpack settings are a bit of a mess - but this is a step in the right direction.

To test:

* Switch to a Jetpack site
* Go to Site settings
* Scroll down to the Performance section
* Note that there's no "Lazy load images" setting under this section
* Tap on Site Accelerator
* Note that the screen makes more visual sense(before and after below)

**BEFORE**

![before](https://github.com/user-attachments/assets/9960c9ff-03f3-42d0-9837-e3f2002d0569)

**AFTER**

![after](https://github.com/user-attachments/assets/83a3c0af-b1a9-4112-bce7-516417dacb34)
