### PR TITLE
Fix Button Layout Overflow 

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -1807,16 +1807,19 @@
     <style name="MaterialAlertDialogPositiveButton"  parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:layout_gravity">left</item>
         <item name="android:gravity">left</item>
+        <item name="android:layout_weight">1</item>
     </style>
 
     <style name="MaterialAlertDialogNegativeButton"  parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:layout_gravity">left</item>
         <item name="android:gravity">left</item>
+        <item name="android:layout_weight">1</item>
     </style>
 
     <style name="MaterialAlertDialogCancelButton"  parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:layout_gravity">left</item>
         <item name="android:gravity">left</item>
+        <item name="android:layout_weight">1</item>
     </style>
 
     <!-- My Site Activity Card  -->


### PR DESCRIPTION
Fix Button Layout Overflow [#21137](https://github.com/wordpress-mobile/WordPress-Android/issues/21137)

>Solution: Added the android:layout_weight="1" property to the button's style, which ensures that the button receives equal space alongside other buttons, preventing it from breaking into multiple lines.

Before:-
![WhatsApp Image 2025-01-11 at 9 08 04 PM](https://github.com/user-attachments/assets/8a847202-c612-439c-b422-ddef19bea4ec)


After:-
![WhatsApp Image 2025-01-11 at 9 08 03 PM](https://github.com/user-attachments/assets/511f64de-67b9-4f5e-acd6-04b4d703b97c)


>Result: The button now fits within the available width and maintains a consistent, clean appearance on different screen sizes, enhancing the overall user interface.