### PR TITLE
feat: Send editor feedback

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 25.7
 -----
-
+* [**] Send feedback from within the experimental editor "more" options menu. [#21586]
 
 25.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -1318,8 +1318,13 @@ public class ActivityLauncher {
     }
 
     public static void viewFeedbackForm(@NonNull Context context) {
+        viewFeedbackForm(context, null);
+    }
+
+    public static void viewFeedbackForm(@NonNull Context context, @Nullable String feedbackPrefix) {
         AnalyticsTracker.track(Stat.APP_REVIEWS_FEEDBACK_SCREEN_OPENED);
         Intent intent = new Intent(context, FeedbackFormActivity.class);
+        intent.putExtra(FeedbackFormActivity.EXTRA_FEEDBACK_PREFIX, feedbackPrefix);
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
@@ -19,6 +19,9 @@ class FeedbackFormActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val feedbackPrefix = intent.getStringExtra(EXTRA_FEEDBACK_PREFIX)
+        viewModel.feedbackPrefix = feedbackPrefix
+
         setContentView(
             ComposeView(this).apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -70,5 +73,9 @@ class FeedbackFormActivity : AppCompatActivity() {
                 viewModel.onPhotoPickerResult(this, it)
             }
         }
+    }
+
+    companion object {
+        const val EXTRA_FEEDBACK_PREFIX = "extra_feedback_prefix"
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.appcompat.app.AppCompatActivity
 import org.wordpress.android.ui.RequestCodes
+import org.wordpress.android.ui.accounts.HelpActivity
 
 @AndroidEntryPoint
 class FeedbackFormActivity : AppCompatActivity() {
@@ -45,13 +46,19 @@ class FeedbackFormActivity : AppCompatActivity() {
                             viewModel.onRemoveMediaClick(it)
                         },
                         onSupportClick = {
-                            // This will return to the Help screen, where the user can see the contact support link
-                            finish()
+                            navigateToHelpScreen()
                         },
                     )
                 }
             }
         )
+    }
+
+    private fun navigateToHelpScreen() {
+        val intent = Intent(this, HelpActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(intent)
+        finish()
     }
 
     @Deprecated("Deprecated in Java")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormViewModel.kt
@@ -61,6 +61,8 @@ class FeedbackFormViewModel @Inject constructor(
     private val _progressDialogState = MutableStateFlow<ProgressDialogState?>(null)
     val progressDialogState = _progressDialogState.asStateFlow()
 
+    var feedbackPrefix: String? = null
+
     fun updateMessageText(message: String) {
         if (message != _messageText.value) {
             _messageText.value = message
@@ -138,12 +140,13 @@ class FeedbackFormViewModel @Inject constructor(
         attachmentTokens: List<String> = emptyList()
     ) {
         showProgressDialog(R.string.sending)
+        val descriptionPrefix = feedbackPrefix?.let { "[$it] " } ?: ""
         zendeskHelper.createRequest(
             context = context,
             origin = HelpActivity.Origin.FEEDBACK_FORM,
             selectedSite = selectedSiteRepository.getSelectedSite(),
             extraTags = listOf("in_app_feedback"),
-            requestDescription = _messageText.value,
+            requestDescription = descriptionPrefix + _messageText.value,
             attachmentTokens = attachmentTokens,
             callback = object : ZendeskHelper.CreateRequestCallback() {
                 override fun onSuccess() {
@@ -303,4 +306,3 @@ class FeedbackFormViewModel @Inject constructor(
         private const val MAX_ATTACHMENTS = 5
     }
 }
-

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1412,6 +1412,8 @@ class EditPostActivity : AppCompatActivity(), EditorFragmentActivity, EditorImag
         val historyMenuItem = menu.findItem(R.id.menu_history)
         val settingsMenuItem = menu.findItem(R.id.menu_post_settings)
         val helpMenuItem = menu.findItem(R.id.menu_editor_help)
+        val sendFeedbackItem = menu.findItem(R.id.menu_editor_send_feedback)
+
         if (undoItem != null) {
             undoItem.setEnabled(menuHasUndo)
             undoItem.setVisible(!htmlModeMenuStateOn)
@@ -1496,6 +1498,11 @@ class EditPostActivity : AppCompatActivity(), EditorFragmentActivity, EditorImag
                 helpMenuItem.setVisible(false)
             }
         }
+
+        if (sendFeedbackItem != null) {
+            sendFeedbackItem.isVisible = editorFragment is GutenbergKitEditorFragment
+        }
+
         return super.onPrepareOptionsMenu(menu)
     }
 
@@ -1645,6 +1652,8 @@ class EditPostActivity : AppCompatActivity(), EditorFragmentActivity, EditorImag
                     analyticsTrackerWrapper.track(Stat.EDITOR_HELP_SHOWN, siteModel)
                     (editorFragment as GutenbergEditorFragment).showEditorHelp()
                 }
+            } else if (itemId == R.id.menu_editor_send_feedback) {
+                ActivityLauncher.viewFeedbackForm(this@EditPostActivity)
             } else if (itemId == R.id.menu_undo_action) {
                 if (editorFragment is GutenbergEditorFragment) {
                     (editorFragment as GutenbergEditorFragment).onUndoPressed()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1653,7 +1653,7 @@ class EditPostActivity : AppCompatActivity(), EditorFragmentActivity, EditorImag
                     (editorFragment as GutenbergEditorFragment).showEditorHelp()
                 }
             } else if (itemId == R.id.menu_editor_send_feedback) {
-                ActivityLauncher.viewFeedbackForm(this@EditPostActivity)
+                ActivityLauncher.viewFeedbackForm(this@EditPostActivity, "Editor")
             } else if (itemId == R.id.menu_undo_action) {
                 if (editorFragment is GutenbergEditorFragment) {
                     (editorFragment as GutenbergEditorFragment).onUndoPressed()

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -71,5 +71,10 @@
             android:title="@string/help_and_support" >
         </item>
 
+        <item
+            android:id="@+id/menu_editor_send_feedback"
+            android:title="@string/send_feedback" >
+        </item>
+
     </group>
 </menu>


### PR DESCRIPTION
Collecting feedback from users while in editor may uncover valuable
insights.

Related: 

* https://github.com/Automattic/dotcom-forge/issues/10125
* https://github.com/wordpress-mobile/WordPress-iOS/pull/23980

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Open the experimentla editor.
1. Tap the more button (three vertical dots) in the top-right corner.
1. Tap Send Feedback.
1. Submit feedback.
1. Verify its delivery within the customer support system.

## Regression Notes

1. Potential unintended areas of impact
    None likely with this limited addition.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A
3. What automated tests I added (or what prevented me from doing so)
    N/A

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
