### PR TITLE
Remove UsingMaterialAndMaterial3Libraries from lint 

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -78,8 +78,6 @@
     </issue>
     <issue id="IconDensities" severity="warning" /> <!--    fluxc-->
     <!-- INTEROPERABILITY -->
-    <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/issues/21065 -->
-    <issue id="UsingMaterialAndMaterial3Libraries" severity="error" />
     <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/pull/21430 -->
     <issue id="ObsoleteLintCustomCheck" severity="warning" />
 </lint>


### PR DESCRIPTION
Fixes #21590

As per the comment [here](https://github.com/wordpress-mobile/WordPress-Android/pull/21583#pullrequestreview-2555110107):

> About switching from warning to error, just because this [UsingMaterialAndMaterial3Libraries](https://googlesamples.github.io/android-custom-lint-rules/checks/UsingMaterialAndMaterial3Libraries.md.html) check is of Warning severity by default, but we are anyway treating all warning as errors ([WordPress/build.gradle#L317](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/build.gradle#L317)), I would recommend deleting this whole configuration and its comment (https://github.com/wordpress-mobile/WordPress-Android/issues/21065), doing that we will end-up with the same result.

This PR addresses this issue.