### PR TITLE
Jetpack pre-publishing: use correct colors in categories and tags

### DIFF
--- a/WordPress/src/jetpack/res/values-night/colors_base.xml
+++ b/WordPress/src/jetpack/res/values-night/colors_base.xml
@@ -5,7 +5,7 @@
     <color name="colorSecondary">@color/primary_40</color>
     <color name="colorSecondaryVariant">@color/primary_50</color>
 
-    <color name="colorPrimaryEditor">@color/blue_30</color>
+    <color name="colorPrimaryEditor">@color/colorPrimary</color>
 
     <color name="nav_bar">@color/white</color>
     <color name="tab_indicator">@color/white</color>

--- a/WordPress/src/jetpack/res/values/colors_base.xml
+++ b/WordPress/src/jetpack/res/values/colors_base.xml
@@ -5,7 +5,7 @@
     <color name="colorSecondary">@color/primary</color>
     <color name="colorSecondaryVariant">@color/primary_40</color>
 
-    <color name="colorPrimaryEditor">@color/blue_50</color>
+    <color name="colorPrimaryEditor">@color/primary</color>
 
     <color name="primary">@color/jetpack_green_50</color>
     <color name="primary_0">@color/jetpack_green_0</color>

--- a/WordPress/src/jetpack/res/values/colors_base.xml
+++ b/WordPress/src/jetpack/res/values/colors_base.xml
@@ -5,7 +5,7 @@
     <color name="colorSecondary">@color/primary</color>
     <color name="colorSecondaryVariant">@color/primary_40</color>
 
-    <color name="colorPrimaryEditor">@color/primary</color>
+    <color name="colorPrimaryEditor">@color/colorPrimary</color>
 
     <color name="primary">@color/jetpack_green_50</color>
     <color name="primary_0">@color/jetpack_green_0</color>

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -27,7 +27,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text"
-                android:hint="@string/category_name"
                 tools:text="Pony" />
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -2,12 +2,12 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:theme="@style/PostSettingsTheme"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingEnd="@dimen/margin_extra_medium_large"
     android:paddingStart="@dimen/margin_extra_medium_large"
     android:paddingTop="@dimen/margin_extra_medium_large"
-    android:paddingEnd="@dimen/margin_extra_medium_large">
+    android:theme="@style/PostSettingsTheme">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -15,12 +15,35 @@
         android:orientation="vertical">
 
         <!-- Category name -->
+        <androidx.appcompat.widget.AppCompatSpinner
+            android:id="@+id/parent_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
+            tools:listitem="@layout/wp_simple_list_item_1" />
+
+        <!--  Parent category -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/submit_button"
+            style="@style/WordPress.PrepubPrimaryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:enabled="false"
+            android:text="@string/prepublishing_nudges_add_category_button"
+            android:visibility="gone" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/category_name_container"
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/category_name">
+            android:hint="@string/category_name"
+            app:hintTextColor="@color/colorPrimary"
+            app:boxStrokeColor="@color/colorPrimary">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/category_name"
@@ -30,7 +53,8 @@
                 tools:text="Pony" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <!--  Parent category -->
+        <!-- Submit button -->
+
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/parentDescLabel"
             android:layout_width="match_parent"
@@ -39,27 +63,5 @@
             android:labelFor="@+id/parent_category"
             android:text="@string/category_parent"
             android:textAppearance="?attr/textAppearanceSubtitle1" />
-
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/parent_category"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-            tools:listitem="@layout/wp_simple_list_item_1" />
-
-        <!-- Submit button -->
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/submit_button"
-            style="@style/WordPress.PrepubPrimaryButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_medium"
-            android:layout_marginEnd="@dimen/margin_medium"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:layout_marginBottom="@dimen/margin_medium"
-            android:enabled="false"
-            android:text="@string/prepublishing_nudges_add_category_button"
-            android:visibility="gone"/>
     </LinearLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -2,12 +2,12 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:theme="@style/PostSettingsTheme"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingEnd="@dimen/margin_extra_medium_large"
     android:paddingStart="@dimen/margin_extra_medium_large"
     android:paddingTop="@dimen/margin_extra_medium_large"
-    android:theme="@style/PostSettingsTheme">
+    android:paddingEnd="@dimen/margin_extra_medium_large">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -15,46 +15,23 @@
         android:orientation="vertical">
 
         <!-- Category name -->
-        <androidx.appcompat.widget.AppCompatSpinner
-            android:id="@+id/parent_category"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-            tools:listitem="@layout/wp_simple_list_item_1" />
-
-        <!--  Parent category -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/submit_button"
-            style="@style/WordPress.PrepubPrimaryButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_medium"
-            android:layout_marginEnd="@dimen/margin_medium"
-            android:layout_marginStart="@dimen/margin_medium"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:enabled="false"
-            android:text="@string/prepublishing_nudges_add_category_button"
-            android:visibility="gone" />
-
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/category_name_container"
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/category_name"
-            app:hintTextColor="@color/colorPrimary"
-            app:boxStrokeColor="@color/colorPrimary">
+            android:hint="@string/category_name">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/category_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text"
+                android:hint="@string/category_name"
                 tools:text="Pony" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <!-- Submit button -->
-
+        <!--  Parent category -->
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/parentDescLabel"
             android:layout_width="match_parent"
@@ -63,5 +40,27 @@
             android:labelFor="@+id/parent_category"
             android:text="@string/category_parent"
             android:textAppearance="?attr/textAppearanceSubtitle1" />
+
+        <androidx.appcompat.widget.AppCompatSpinner
+            android:id="@+id/parent_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
+            tools:listitem="@layout/wp_simple_list_item_1" />
+
+        <!-- Submit button -->
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/submit_button"
+            style="@style/WordPress.PrepubPrimaryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_medium"
+            android:layout_marginEnd="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:enabled="false"
+            android:text="@string/prepublishing_nudges_add_category_button"
+            android:visibility="gone"/>
     </LinearLayout>
 </ScrollView>

--- a/WordPress/src/main/res/values-night/colors_base.xml
+++ b/WordPress/src/main/res/values-night/colors_base.xml
@@ -5,7 +5,7 @@
     <color name="colorSecondary">@color/primary_30</color>
     <color name="colorSecondaryVariant">@color/primary_50</color>
 
-    <color name="colorPrimaryEditor">@color/primary_30</color>
+    <color name="colorPrimaryEditor">@color/colorPrimary</color>
 
     <color name="nav_bar">@color/colorPrimary</color>
     <color name="tab_indicator">@color/colorPrimary</color>

--- a/WordPress/src/main/res/values/colors_base.xml
+++ b/WordPress/src/main/res/values/colors_base.xml
@@ -5,7 +5,7 @@
     <color name="colorSecondary">@color/primary</color>
     <color name="colorSecondaryVariant">@color/primary_70</color>
 
-    <color name="colorPrimaryEditor">@color/blue_50</color>
+    <color name="colorPrimaryEditor">@color/colorPrimary</color>
 
     <color name="primary">@color/blue_50</color>
     <color name="primary_0">@color/blue_0</color>


### PR DESCRIPTION
Fixes #21592 

As noted in the issue, prior to this PR the categories and tags bottom sheets used the WordPress colors in the Jetpack app's pre-publishing bottom sheets. This PR resolves this.

To test:

* Edit a post
* Tap Update
* Tap Categories
* Tap + to add a category 
* Note that the app uses the correct colors
* Return to the post
* Tap Update
* Tap Tags
* Note that the app uses the correct colors

**Jetpack**

![jetpack](https://github.com/user-attachments/assets/f3a0dd86-63b1-4696-b3de-8add3a8b4597)

**WordPress**

![wordpress](https://github.com/user-attachments/assets/4c20fdfd-b27f-472e-ac3a-7a9aeb14d25d)

