### PR TITLE
Minor tweaks to pre-pub tags, pre-pub categories, and social connections

### DIFF
--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -44,7 +44,8 @@
             android:id="@+id/parent_category"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="-4dp"
+            android:layout_marginStart="-4dp"
+            android:layout_marginEnd="-4dp"
             app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
             tools:listitem="@layout/wp_simple_list_item_1" />
 

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -44,6 +44,7 @@
             android:id="@+id/parent_category"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="-4dp"
             app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
             tools:listitem="@layout/wp_simple_list_item_1" />
 

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -54,8 +54,6 @@
             style="@style/WordPress.PrepubPrimaryButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_medium"
-            android:layout_marginEnd="@dimen/margin_medium"
             android:layout_marginTop="@dimen/margin_medium"
             android:layout_marginBottom="@dimen/margin_medium"
             android:enabled="false"

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -4,6 +4,10 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <include
+        android:id="@+id/prepublishing_toolbar"
+        layout="@layout/prepublishing_toolbar" />
+
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -13,10 +17,6 @@
         android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />
-
-    <include
-        android:id="@+id/prepublishing_toolbar"
-        layout="@layout/prepublishing_toolbar" />
 
     <include
         android:id="@+id/fragment_post_settings_tags"

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_large"
+        android:layout_marginHorizontal="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
         android:text="@string/prepublishing_tags_description"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -11,10 +11,11 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_medium_large"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginHorizontal="@dimen/margin_large"
+        android:layout_marginVertical="@dimen/margin_medium_large"
+        android:gravity="center_horizontal"
         android:text="@string/prepublishing_tags_description"
-        android:textAlignment="viewStart"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />
 

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -11,8 +11,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_large"
-        android:layout_marginTop="@dimen/margin_large"
+        android:layout_margin="@dimen/margin_large"
         android:text="@string/prepublishing_tags_description"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -11,8 +11,7 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_large"
-        android:layout_marginVertical="@dimen/margin_large"
+        android:layout_margin="@dimen/margin_large"
         android:text="@string/prepublishing_tags_description"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />

--- a/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
+++ b/WordPress/src/main/res/layout/prepublishing_tags_fragment.xml
@@ -11,10 +11,8 @@
     <com.google.android.material.textview.MaterialTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
         android:layout_marginHorizontal="@dimen/margin_large"
-        android:layout_marginVertical="@dimen/margin_medium_large"
-        android:gravity="center_horizontal"
+        android:layout_marginVertical="@dimen/margin_large"
         android:text="@string/prepublishing_tags_description"
         android:textAppearance="?attr/textAppearanceBody1"
         android:textColor="?wpColorOnSurfaceMedium" />

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -114,7 +114,10 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_vertical"
+                        android:layout_marginEnd="@dimen/margin_extra_large"
                         android:layout_marginStart="@dimen/margin_extra_large"
+                        android:gravity="center_vertical"
+                        android:minHeight="@dimen/min_touch_target_sz"
                         android:text="@string/manage"
                         android:textAppearance="?attr/textAppearanceSubtitle1" />
                 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -3730,7 +3730,7 @@
     <string name="prepublishing_nudges_back_button">Back</string>
     <string name="prepublishing_nudges_toolbar_title_tags">Add Tags</string>
     <string name="prepublishing_nudges_toolbar_title_publish">Publish Date</string>
-    <string name="prepublishing_tags_description">Tags help tell readers what a post is about.</string>
+    <string name="prepublishing_tags_description">Tags help tell readers what a post is about</string>
     <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
     <string name="prepublishing_nudges_story_title_hint">Give your story a title</string>
     <string name="prepublishing_nudges_home_categories_not_set">Not set</string>


### PR DESCRIPTION
Fixes #21594 

As noted in the issue, there were some minor formatting issues with pre-pub tags, pre-pub categories, and social connections. This PR addresses all three.

![tags-fix](https://github.com/user-attachments/assets/b8ca090f-ac74-45b9-a5e1-6cbaa29fa27f)
![cat-fix](https://github.com/user-attachments/assets/c9d132e8-daef-44c4-835c-833c70f4321f)
![social-fix](https://github.com/user-attachments/assets/aa465725-f9f6-4d16-aae9-a26f62b2ffdb)
