### PR TITLE
[Buildkite] Test Android Staging on `ami-0953ca1d949c23a58` -> `ami-0f976e0b4de96aa28`

### DIFF
--- a/.buildkite/beta-builds.yml
+++ b/.buildkite/beta-builds.yml
@@ -5,7 +5,7 @@
 # only used for beta builds
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################

--- a/.buildkite/commands/save-cache.sh
+++ b/.buildkite/commands/save-cache.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- 📦 Download Dependencies"
-./gradlew downloadDependencies androidDependencies
+./gradlew downloadDependencies
 echo ""
 
 echo "--- 💾 Save Cache"

--- a/.buildkite/commands/save-cache.sh
+++ b/.buildkite/commands/save-cache.sh
@@ -2,38 +2,8 @@
 
 set -euo pipefail
 
-echo "--- :rubygems: Setting up Gems"
-install_gems
-
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
-# .buildkite/commands/prototype-build.sh -> build_and_upload_$1_prototype_build
-# -> PROTOTYPE_BUILD_FLAVOR = 'Jalapeno'
-# -> PROTOTYPE_BUILD_TYPE = 'Debug'
-echo "--- 🛠 Download Mobile App Dependencies [Assemble Jetpack App]"
-./gradlew assembleJetpackJalapenoDebug
-echo ""
-
-# .buildkite/commands/lint.sh -> ./gradlew lintJetpackVanillaRelease
-echo "--- 🧹 Download Lint Dependencies [Lint Jetpack App]"
-./gradlew lintJetpackJalapenoDebug
-echo ""
-
-# .buildkite/commands/run-unit-tests.sh -> ./gradlew $test_suite
-# -> test_suite="testWordpressVanillaRelease koverXmlReportWordpressVanillaRelease"
-# -> test_suite=":libs:processors:test :libs:processors:koverXmlReport"
-# -> test_suite=":libs:image-editor:testReleaseUnitTest :libs:image-editor:koverXmlReportRelease"
-# -> test_suite=":libs:fluxc:testReleaseUnitTest :libs:fluxc:koverXmlReportRelease"
-# -> test_suite=":libs:login:testReleaseUnitTest :libs:login:koverXmlReportRelease"
-echo "--- 🧪 Download Unit Test Dependencies [Assemble Unit Tests]"
-./gradlew assembleJetpackJalapenoDebugUnitTest assembleDebugUnitTest testClasses
-echo ""
-
-# .buildkite/commands/run-instrumented-tests.sh -> build_and_run_instrumented_test
-# -> gradle(tasks: ["WordPress:assemble#{app.to_s.capitalize}VanillaDebug", "WordPress:assemble#{app.to_s.capitalize}VanillaDebugAndroidTest"])
-echo "--- 🧪 Download Android Test Dependencies [Assemble Android Tests]"
-./gradlew assembleJetpackJalapenoDebugAndroidTest
+echo "--- 📦 Download Dependencies"
+./gradlew downloadDependencies androidDependencies
 echo ""
 
 echo "--- 💾 Save Cache"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@
 # only used for release builds
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################

--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "dependency analysis"

--- a/.buildkite/schedules/dependency-cache.yml
+++ b/.buildkite/schedules/dependency-cache.yml
@@ -2,7 +2,7 @@
 ---
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   - label: "dependency cache"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.9.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#4aed409fb7535d16c4e08794997fad3773389a9b"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Related: [a8c-ci-toolkit-buildkite-plugin##142
](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/142)

AMI Name: `android-build-image-6.12.0v1.5-rc-1`

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0953ca1d949c23a58` works as expected.

---

### Before the Change

---

- [Saving Gradle dependency cache...](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41/460-461)
  - Duration: [0 minutes and 55 seconds](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41/460-471)
  - Cache Size: [1076.73 MB](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41/460-472)
- Build Time: [22m 59s](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41)

-----

- [Restoring Gradle dependency cache...](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e/192-193)
  - Duration: [0 minutes and 22 seconds](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e/192-201)
  - Cache Size: [1076.73 MB](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e/192-202)
- [Build](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e) (`Lint`): [Build Scan](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e/259-391) -> [Network Activity*](https://scans.gradle.com/s/yki6krscgr7fo/performance/network-activity)
  - Files Downloaded: `54`
  - Network Requests: `79`
  - Time Spent: `5s`

(*) Although, note that these numbers might not be very representative because `trunk` is using a dependency cache that is already outdated (5 days has passed since it was last updated, every Sunday).

---

### After the Change

---

- [Saving Gradle dependency cache...](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43/23409-23410)
  - Duration: [1 minutes and 40 seconds](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43/23409-23420)
  - Cache Size: [1563.65 MB](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43/23409-23421)
- Build Time: [8m 29s](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43)

-----

- [Restoring Gradle dependency cache...](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846/194-195)
  - Duration: [0 minutes and 33 seconds](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846/194-203)
  - Cache Size: [1563.65 MB](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846/194-204)
- [Build](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846) (`Lint`): [Build Scan](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846/261-330) -> [Network Activity](https://scans.gradle.com/s/2c6q4zhfmwheo/performance/network-activity)
  - Files Downloaded: `0`
  - Network Requests: `0`
  - Time Spent: `0`

---

### Conclusions

As expected, using `./gradlew downloadDependencies androidDependencies` is:
1. Simpler, much less configuration and reasoning about which tasks to use.
2. Scalable, no need to add any more tasks to the `save-cache.sh` script as the project evolves.
3. Producing a bigger cache,
    - Before: [1076.73 MB](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41/460-472)
    - After: [1563.65 MB](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43/23409-23421)
    - Result: `+ 486.92 MB` more data downloaded, which means even less network requests on CI.
4. Slower, both in saving and restoring the cache, which is the only drawable:
    - Save:
        - Before: [0 minutes and 55 seconds](https://buildkite.com/automattic/wordpress-android/builds/20909#01947bdd-80e0-4097-922d-842f5b65ef41/460-471)
        - After: [1 minutes and 40 seconds](https://buildkite.com/automattic/wordpress-android/builds/20967#019498f1-bb31-4eba-8b4b-9a7bfda1bd43/23409-23420)
        - Result: `+ 45 seconds` to save the cache.
    - Restore:
        - Before: [0 minutes and 22 seconds](https://buildkite.com/automattic/wordpress-android/builds/20961#019497f2-ab5f-4014-a5a3-d40af06de47e/192-201)
        - After: [0 minutes and 33 seconds](https://buildkite.com/automattic/wordpress-android/builds/20968#019498fd-4d26-4c23-a6bd-74d4d0387846/194-203)
        - Result: `+ 11 seconds` to restore the cache.