### PR TITLE
Removed collapsing toolbar from stats fragment

### DIFF
--- a/WordPress/src/main/res/layout/stats_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_fragment.xml
@@ -41,8 +41,6 @@
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                app:layout_collapseMode="pin"
-                app:layout_scrollFlags="scroll|enterAlways"
                 app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
                 app:theme="@style/WordPress.ActionBar"
                 app:title="@string/stats" />


### PR DESCRIPTION
This PR fixes a bug introduced by #21606 which causes the stats toolbar to overlap the status bar after scrolling.

After looking into this, I decided the best fix was to simply disable the collapsing toolbar. None of the other "My Site" screens (posts, pages, Media, etc.) collapse the toolbar, so changing Stats to behave the same made sense.

To test, open stats and ensure the scrolling works as expected and doesn't cause the toolbar to overlap the status bar.

**BEFORE**

https://github.com/user-attachments/assets/657bf5b1-c6f5-460a-ac9b-6b21a2b2b020

**AFTER**

https://github.com/user-attachments/assets/17f91399-ff66-472e-814e-c194303ec5ab



