### PR TITLE
Use separate link text for JP/WP feedback form

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/feedbackform/FeedbackFormScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.MediaUriPager
 import org.wordpress.android.ui.compose.components.ProgressDialog
@@ -111,7 +112,11 @@ private fun MessageSection(
     onMessageChanged: (String) -> Unit,
     onSupportClick: () -> Unit
 ) {
-    val linkText = stringResource(id = R.string.feedback_form_note_link)
+    val linkText = if (BuildConfig.IS_JETPACK_APP) {
+        stringResource(id = R.string.feedback_form_note_link_jetpack)
+    } else {
+        stringResource(id = R.string.feedback_form_note_link_wordpress)
+    }
     val linkAnnotation = LinkAnnotation.Url(
         url = "support",
         styles = TextLinkStyles(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1144,8 +1144,9 @@
     <string name="feedback_form_attachment_already_added">Attachment already added</string>
     <string name="feedback_form_unable_to_create_tempfile">Unable to create temporary file</string>
     <string name="feedback_form_add_attachments">Add attachments</string>
-    <string name="feedback_form_note_text">Please note this is not a support form, and we will not be able to reply. If you need support, please use our "</string>
-    <string name="feedback_form_note_link">Contact Support screen.</string>
+    <string name="feedback_form_note_text">Please note this is not a support form, and we will not be able to reply. If you need assistance, please use our "</string>
+    <string name="feedback_form_note_link_jetpack">Contact Support screen.</string>
+    <string name="feedback_form_note_link_wordpress">community forums.</string>
     <string name="media_pager_remove_item_content_description">Remove item %1$d</string>
 
     <!-- activity log -->


### PR DESCRIPTION
Fixes #21618 

Previously the feedback form mentioned "Contact support" on the Help & Support screen even for the WordPress app, but this screen is only available in the Jetpack app. This PR updates the feedback form to mention community forums when running the WordPress app.

**WordPress**

![wp](https://github.com/user-attachments/assets/709f2c29-8dcd-4224-8b2d-2ab34f565880)

**Jetpack**

![jp](https://github.com/user-attachments/assets/e5cc9703-d5fd-4200-84b2-241fb9a692be)

