### PR TITLE
Download store metadata when generating beta build

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -170,7 +170,6 @@ platform :android do
   #                         Defaults to current `versionName`. Only required if skip_release_notes is false
   # @param [Boolean] skip_release_notes Whether to skip downloading release notes. Default false
   # @param [Boolean] skip_commit If true, will skip the `git add`, `git commit` and `git push` operations. Default to false.
-  # @param [Boolean] skip_git_push If true, will skip the `git push` at the end. Default to false. Inferred to `true` if `skip_commit` is `true`.
   #
   # @return [void]
   #

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -174,7 +174,7 @@ platform :android do
   #
   # @return [void]
   #
-  lane :download_metadata_strings do |app: nil, version: current_release_version, skip_release_notes: false, skip_commit: false, skip_git_push: false|
+  lane :download_metadata_strings do |app: nil, version: current_release_version, skip_release_notes: false, skip_commit: false|
     version = nil if skip_release_notes
 
     # If no `app:` is specified, call this for both WordPress and Jetpack
@@ -246,7 +246,6 @@ platform :android do
       message += " for #{version}" unless version.nil?
       git_commit(path: metadata_download_path, message: message, allow_nothing_to_commit: true)
     end
-    push_to_git_remote unless skip_commit || skip_git_push
   end
 
   ########################################################################

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -173,6 +173,7 @@ platform :android do
 
     update_frozen_strings_for_translation
     download_translations
+    download_metadata_strings(version: current_release_version)
 
     # Bump the release version and build code
     UI.message 'Bumping beta version and build code...'

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -141,7 +141,7 @@ platform :android do
     end
     app = get_app_name_option!(options)
 
-    download_metadata_strings(app: app, skip_release_notes: true, skip_git_push: true) unless options.fetch(:skip_download_strings, false)
+    download_metadata_strings(app: app, skip_release_notes: true) unless options.fetch(:skip_download_strings, false)
 
     # Define intermediate folders
     raw_screenshots_dir = screenshots_dir(app: app, subfolder: 'raw')


### PR DESCRIPTION
Plus, remove code that automatically pushed when running the metadata download lane.

Downloading store metadata when generating beta build should provide earlier feedback on the metadata translation, at
least for the portion that has already been translated at the time a beta is made.

The approach is consistent with what we do in iOS, see https://github.com/wordpress-mobile/WordPress-iOS/blob/b9a0deaf091739f33051f20cffdbe9a2097f645e/fastlane/lanes/release.rb#L219

As for the push removal, automatically pushing from lanes other than the root-release lanes (code
freeze, new beta, finalize release, etc.) can result in undesired pushes, like it happened to me in https://github.com/wordpress-mobile/WordPress-Android/commit/edcd40a47f4e4b80b049dc26f97aa335d7043659 . 

Granted, I should have looked at the lane parameters before running it, but I think a case can be made for making the default behavior the desired one and for the desired behavior of a lane that "downloads metadata strings" to _not_ include pushing to the remote.

Moreover, not pushing to the remote is consistent with what iOS does, see https://github.com/wordpress-mobile/WordPress-iOS/blob/b9a0deaf091739f33051f20cffdbe9a2097f645e/fastlane/lanes/localization.rb#L394-L466

> [!IMPORTANT]
> @wordpress-mobile/apps-infrastructure I operated on the above under the assumption that the automation script is as is because we never got to update it, and that there is no reason for skipping downloading the metadata during the beta process. Having never been the release manager for WordPress Android, I might be missing something obvious here, so please do let me know if that's the case. Thanks!

-----

## To Test:

These changes will be tested in the real world during the next release cycle, that is 25.7.

You can test the new lane behavior by running `bundle exec fastlane download_metadata_strings` and noticing it does not push to the remote.

Example here's a screenshot of the run on my local, where you can see the logs do not include a git push and my terminal prompt shows `2⬆` which indicates my local branch is two commits ahead of the remote: the two metadata strings update commits, one for WP and one for JP.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N.A.

3. What automated tests I added (or what prevented me from doing so)

    - N.A.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes. - N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. - N.A.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

Not an app source PR.