### PR TITLE
Add missing `environment` parameter to Buildkite trigger call

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -565,6 +565,7 @@ platform :android do
         buildkite_pipeline: 'wordpress-android',
         branch: branch,
         pipeline_file: pipeline_file,
+        environment: environment,
         message: message
       )
 


### PR DESCRIPTION
As noticed by @oguzkocer [during the 25.6 release train.](https://buildkite.com/automattic/wordpress-android/builds/20980#01949a7e-d723-452a-8fcc-21b4792b3ba5)

Looking at the Git log, the `environment` hash was introduced in b80c544e2756ce73b3c2f2c71a9ebe4134320df7 as part of adding support for a different build trigger workflow when running in CI.

At the time, we did not notice that the pre-existing method to trigger builds did not include environment variables. I guess the need for env vars is something we didn't have before those changes, hence why we never noticed the lack of it till now.

Notice that the iOS counterpart includes the `environment` dictionary, https://github.com/wordpress-mobile/WordPress-iOS/blob/afd3a6533b61c71ec661d2621e9a3486aaadef01/fastlane/lanes/release.rb#L476-L500

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Run either `trigger_beta_build` or `trigger_release_build` and notice how the resulting build includes the `RELEASE_VERSION` env var which was [previously missing](https://buildkite.com/automattic/wordpress-android/builds/20980#01949a7e-d723-452a-8fcc-21b4792b3ba5). (Cancel the build after checking.)

My tests were https://buildkite.com/automattic/wordpress-android/builds/21009 and https://buildkite.com/automattic/wordpress-android/builds/21010

![image](https://github.com/user-attachments/assets/5ca70b08-9089-4d99-b892-d1a304be19ed)

![image](https://github.com/user-attachments/assets/3ab680b7-735c-4a71-b206-ca9e47baa7ae)


-----

## Regression Notes

1. Potential unintended areas of impact

    - N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N.A.

3. What automated tests I added (or what prevented me from doing so)

    - N.A.

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones):

Not an app source PR.