### PR TITLE
Remove feedback form from help activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.kt
@@ -122,10 +122,6 @@ class HelpActivity : BaseAppCompatActivity() {
                 startActivity(Intent(v.context, AppLogViewerActivity::class.java))
             }
 
-            feedbackButton.setOnClickListener {
-                ActivityLauncher.viewFeedbackForm(this@HelpActivity)
-            }
-
             if (originFromExtras == Origin.JETPACK_MIGRATION_HELP) {
                 configureForJetpackMigrationHelp()
             }

--- a/WordPress/src/main/res/layout/help_activity.xml
+++ b/WordPress/src/main/res/layout/help_activity.xml
@@ -130,11 +130,6 @@
                     style="@style/HelpActivitySingleText"
                     android:text="@string/contact_support" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/feedbackButton"
-                    style="@style/HelpActivitySingleText"
-                    android:text="@string/send_feedback" />
-
                 <LinearLayout
                     android:id="@+id/forumContainer"
                     android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #21629

This PR removes the feedback form form the "Help & Support" screen, as noted at pfln9p-1ns-p2#comment-1554

To test:

* Visit Help & Support and verify that "Send feedback" is no longer listed
* Ensure the block editor is enabled in "Experimental Features" and create or edit a post
* From the dot-dot-dot menu choose "Send feedback" and verify everything works as expected