### PR TITLE
[Tooling] Fix `publish_release` lane

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -362,7 +362,7 @@ platform :android do
     UI.important "Publishing release #{version_number} on GitHub"
 
     publish_github_release(
-      repository: GITHUB_REPO,
+      repository: GHHELPER_REPO,
       name: version_number
     )
 
@@ -612,7 +612,7 @@ platform :android do
   # Delete a branch remotely, after having removed any GitHub branch protection
   #
   def delete_remote_git_branch!(branch_name)
-    remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
+    remove_branch_protection(repository: GHHELPER_REPO, branch: branch_name)
 
     Git.open(Dir.pwd).push('origin', branch_name, delete: true)
   end


### PR DESCRIPTION
**Internal reference**: p1738090326444939-slack-CC7L49W13

After a report of a failed "Publish Release" release task, I've noticed the repository constant used in the `publish_release` lane was incorrect (likely due to copying WPiOS code a while ago, and this hasn't been tested until now). This PR fixes the issue.

-----

## To Test:

These changes will be tested in the current `25.7` release, at the end of the cycle.
