### PR TITLE
Add autoVerify="true" to custom tabs service

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -1167,7 +1167,7 @@
         <intent>
             <action android:name="android.intent.action.MAIN" />
         </intent>
-        <intent>
+        <intent android:autoVerify="true">
             <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
         <!-- required for Android 11 (API level 30) or higher -->


### PR DESCRIPTION
Fixes #21631 

This tiny PR adds `autoVerify=true` to our `CustomTabsService` intent - which was added for WebView login - to address the following warning:

> Custom scheme intent filters should explicitly set the autoVerify attribute to true

To test, verify that CI no longer shows this warning, and that WebView login still works as expected.

[More about auto verify](https://developer.android.com/training/app-links/verify-android-applinks)