### PR TITLE
Edge to edge media preview toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -247,12 +247,7 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
 
     private void delayedFinish() {
         ToastUtils.showToast(this, R.string.error_media_not_found);
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                finish();
-            }
-        }, 1500);
+        new Handler().postDelayed(this::finish, 1500);
     }
 
     /*
@@ -360,7 +355,7 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
             public void onPageSelected(int position) {
                 switch (getPreviewType()) {
                     case MULTI_MEDIA_IDS:
-                        mMediaId = Integer.valueOf(mMediaIdOrUrlList.get(position));
+                        mMediaId = Integer.parseInt(mMediaIdOrUrlList.get(position));
                         // fire event so settings activity shows the same media as this activity (user may have swiped)
                         EventBus.getDefault().post(new MediaPreviewSwiped(mMediaId));
                         break;
@@ -394,7 +389,7 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
             MediaPreviewFragment fragment;
             switch (getPreviewType()) {
                 case MULTI_MEDIA_IDS:
-                    int id = Integer.valueOf(mMediaIdOrUrlList.get(position));
+                    int id = Integer.parseInt(mMediaIdOrUrlList.get(position));
                     MediaModel media = mMediaStore.getMediaWithLocalId(id);
                     // make sure we autoplay the initial item (relevant only for audio/video)
                     boolean autoPlay;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -63,7 +63,6 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
     private int mMediaId;
     private String mContentUri;
 
-    private int mLastPosition;
     private PreviewType mPreviewType;
 
     // note that mSite may be null
@@ -355,7 +354,6 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
         }
 
         mViewPager.setCurrentItem(initialPos);
-        mLastPosition = initialPos;
 
         mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
@@ -370,7 +368,6 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
                         mContentUri = mMediaIdOrUrlList.get(position);
                         break;
                 }
-                mLastPosition = position;
                 showToolbar();
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.media;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -10,6 +12,7 @@ import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.view.animation.Animation;
 
 import androidx.annotation.NonNull;
@@ -18,6 +21,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -194,6 +198,16 @@ public class MediaPreviewActivity extends BaseAppCompatActivity implements Media
 
         mToolbar = findViewById(R.id.toolbar);
         setSupportActionBar(mToolbar);
+
+        // on SDK 35+ move the toolbar down and make it transparent to account for edge-to-edge display
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.VANILLA_ICE_CREAM) {
+            int transparentColor = ContextCompat.getColor(this, android.R.color.transparent);
+            mToolbar.setBackgroundColor(transparentColor);
+            MarginLayoutParams marginLayoutParams = (MarginLayoutParams) mToolbar.getLayoutParams();
+            marginLayoutParams.topMargin =
+                    marginLayoutParams.topMargin + getResources().getDimensionPixelSize(R.dimen.toolbar_height);
+        }
+
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(false);


### PR DESCRIPTION
Fixes #21647 

This small PR fixes an issue where the media preview toolbar would overlap the status bar on SDK 35+. To test:

* Run the app on SDK 35+
* Go to your media library and tap an image to view it full screen
* Ensure the toolbar doesn't overlap the status bar
* Repeat with a Pre-35 SDK

Before and after shots below:

![preview-before](https://github.com/user-attachments/assets/9464e0d9-e441-43b1-a1c1-20e664e0c802)
