### PR TITLE
feat: Request feedback when disabling the experimental editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -17,9 +19,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +37,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import org.wordpress.android.R
+import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.main.BaseAppCompatActivity
@@ -85,10 +90,26 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
         setContent {
             AppThemeM3 {
                 val features by viewModel.switchStates.collectAsStateWithLifecycle()
+                val showDialog = remember { mutableStateOf(false) }
+
+                if (showDialog.value) {
+                    FeedbackDialog(
+                        onDismiss = { showDialog.value = false },
+                        onSendFeedback = {
+                            showDialog.value = false
+                            ActivityLauncher.viewFeedbackForm(this, "Editor")
+                        }
+                    )
+                }
 
                 ExperimentalFeaturesScreen(
                     features = features,
-                    onFeatureToggled = viewModel::onFeatureToggled,
+                    onFeatureToggled = { feature, enabled ->
+                        if (feature == ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR && !enabled) {
+                            showDialog.value = true
+                        }
+                        viewModel.onFeatureToggled(feature, enabled)
+                    },
                     onNavigateBack = onBackPressedDispatcher::onBackPressed
                 )
             }
@@ -161,6 +182,25 @@ fun FeatureToggle(
             },
         )
     }
+}
+
+@Composable
+fun FeedbackDialog(onDismiss: () -> Unit, onSendFeedback: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_title)) },
+        text = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_message)) },
+        confirmButton = {
+            Button(onClick = onSendFeedback) {
+                Text(text = stringResource(R.string.send_feedback))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.experimental_features_feedback_dialog_decline))
+            }
+        }
+    )
 }
 
 @Preview

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -959,6 +959,9 @@
     <string name="experimental_features_screen_title">Experimental Features</string>
     <string name="experimental_block_editor">Experimental block editor</string>
     <string name="experimental_block_editor_theme_styles">Experimental block editor styles</string>
+    <string name="experimental_features_feedback_dialog_title">Share feedback</string>
+    <string name="experimental_features_feedback_dialog_message">Are you willing to share feedback on the experimental editor?</string>
+    <string name="experimental_features_feedback_dialog_decline">Not now</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>


### PR DESCRIPTION
Relates to https://github.com/Automattic/dotcom-forge/issues/10126https://github.com/Automattic/dotcom-forge/issues/10126. Users disabling the experimental editor may have valuable feedback
regarding why they are no longer using it.

<details><summary>Screen recording</summary>
<p>


https://github.com/user-attachments/assets/624cb3bc-d5b1-45e0-bf0b-7fd9c51ac2a1




</p>
</details> 

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Navigate to _Me_ → _Experimental Features_. 
2. Disable the _Experimental block editor_. 
3. Verify declining to share feedback succeeds; verify sending feedback succeeds.

## Regression Notes

1. Potential unintended areas of impact
    Unlikely with this limited change.
4. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A
5. What automated tests I added (or what prevented me from doing so)
    N/A

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
