### PR TITLE
Use WordPress.com for login redirect URL

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -209,9 +209,9 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"org.wordpress.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "false"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "true"
-            buildConfigField "String", "WPCOM_REDIRECT_URI", '"wordpress://wpcom-authorize"'
+            buildConfigField "String", "WPCOM_REDIRECT_URI", '"https://wordpress.com"'
 
-            manifestPlaceholders = [magicLinkScheme:"wordpress"]
+            manifestPlaceholders = [magicLinkScheme:"https"]
         }
 
         jetpack {
@@ -230,9 +230,9 @@ android {
             buildConfigField "String", "PUSH_NOTIFICATIONS_APP_KEY", '"com.jetpack.android"'
             buildConfigField "boolean", "ENABLE_QRCODE_AUTH_FLOW", "true"
             buildConfigField "boolean", "ENABLE_OPEN_WEB_LINKS_WITH_JP_FLOW", "false"
-            buildConfigField "String", "WPCOM_REDIRECT_URI", '"jetpack://wpcom-authorize"'
+            buildConfigField "String", "WPCOM_REDIRECT_URI", '"https://wordpress.com"'
 
-            manifestPlaceholders = [magicLinkScheme:"jetpack"]
+            manifestPlaceholders = [magicLinkScheme:"https"]
 
             // Limit string resources to Mag16 only for Jetpack
             // Note 1: this only affects included _locales_; variants for `values-night`, `values-land` and other configs are _still_ preserved in Jetpack and not filtered by this.

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -115,14 +115,15 @@
             android:theme="@style/LoginTheme.TransparentSystemBars"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
-
-            <intent-filter>
+            
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:host="wpcom-authorize"
-                    android:scheme="${magicLinkScheme}" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="wordpress.com" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Fixes a warning by the litter about custom scheme intents.

To test:
- Try logging in using WP.com, it should work exactly the same