### PR TITLE
Use fullscreen style for media preview on v35+

### DIFF
--- a/WordPress/src/main/res/values-v35/styles.xml
+++ b/WordPress/src/main/res/values-v35/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <style name="WordPress.Media.Preview" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fixes #21647

With the addition of edge-to-edge display in SDK 35+, the media preview toolbar overlaps the status bar. We originally tried to resolve this in #21648, but that turned out to be problematic. This PR aims to provide a simpler solution by updating to a fullscreen style for just SDK 35+. To test:

- Run the app on SDK 35+
- Go to your media library and tap an image to view it full screen
- Ensure the toolbar doesn't overlap the status bar
- Repeat with a Pre-35 SDK