### PR TITLE
fix: Address editor crashes from null listeners

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 -----
 * [**] Send feedback from within the experimental editor "more" options menu. [#21586]
 * [**] Support accessing the code editor within the experimental editor. [#21582]
+* [*] Fix experimental editor crash when changing the device orienation. [#21657]
 
 25.6
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2572,7 +2572,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 PAGE_CONTENT -> {
                     editorFragment = fragment as EditorFragmentAbstract
                     editorFragment?.setImageLoader(imageLoader)
-                    // TODO: Refactor GutenbergKit to rely upon this observer rather than its custom implementation
+                    // Refactor GutenbergKit to rely upon this observer rather than its custom implementation
                     if (editorFragment !is GutenbergKitEditorFragment) {
                         editorFragment?.titleOrContentChanged?.observe(this@EditPostActivity) { _: Editable? ->
                             storePostViewModel.savePostWithDelay()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1983,7 +1983,61 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun initializeEditorFragment() {
-        if (editorFragment is AztecEditorFragment) {
+        if (editorFragment is GutenbergKitEditorFragment) {
+            editorFragment?.onEditorContentChanged(object : GutenbergView.ContentChangeListener {
+                override fun onContentChanged(title: String, content: String) {
+                    storePostViewModel.savePostWithDelay()
+                }
+            })
+            editorFragment?.onEditorHistoryChanged(object : GutenbergView.HistoryChangeListener {
+                override fun onHistoryChanged(hasUndo: Boolean, hasRedo: Boolean) {
+                    onToggleUndo(!hasUndo)
+                    onToggleRedo(!hasRedo)
+                }
+            })
+            editorFragment?.onOpenMediaLibrary(object: GutenbergView.OpenMediaLibraryListener {
+                override fun onOpenMediaLibrary(config: GutenbergView.OpenMediaLibraryConfig) {
+                    editorPhotoPicker?.allowMultipleSelection = config.multiple
+                    val mediaType = mapAllowedTypesToMediaBrowserType(config.allowedTypes, config.multiple)
+                    val initialSelection = when (val value = config.value) {
+                        is GutenbergView.Value.Single -> listOf(value.value)
+                        is GutenbergView.Value.Multiple -> value.toList()
+                        else -> emptyList()
+                    }
+                    openMediaLibrary(mediaType, initialSelection)
+                }
+            })
+            editorFragment?.onLogJsException(object : GutenbergView.LogJsExceptionListener {
+                override fun onLogJsException(exception: GutenbergJsException) {
+                    val stackTraceElements = exception.stackTrace.map { stackTrace ->
+                        JsExceptionStackTraceElement(
+                            stackTrace.fileName,
+                            stackTrace.lineNumber,
+                            stackTrace.colNumber,
+                            stackTrace.function
+                        )
+                    }
+
+                    val jsException = JsException(
+                        exception.type,
+                        exception.message,
+                        stackTraceElements,
+                        exception.context,
+                        exception.tags,
+                        exception.isHandled,
+                        exception.handledBy
+                    )
+
+                    val callback = object : JsExceptionCallback {
+                        override fun onReportSent(success: Boolean) {
+                            // Do nothing
+                        }
+                    }
+
+                    onLogJsException(jsException, callback)
+                }
+            })
+        } else if (editorFragment is AztecEditorFragment) {
             val aztecEditorFragment = editorFragment as AztecEditorFragment
             aztecEditorFragment.setEditorImageSettingsListener(this@EditPostActivity)
             aztecEditorFragment.setMediaToolbarButtonClickListener(editorPhotoPicker)
@@ -2518,61 +2572,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 PAGE_CONTENT -> {
                     editorFragment = fragment as EditorFragmentAbstract
                     editorFragment?.setImageLoader(imageLoader)
-                    if (isGutenbergKitEditor) {
-                        editorFragment?.onEditorContentChanged(object : GutenbergView.ContentChangeListener {
-                            override fun onContentChanged(title: String, content: String) {
-                                storePostViewModel.savePostWithDelay()
-                            }
-                        })
-                        editorFragment?.onEditorHistoryChanged(object : GutenbergView.HistoryChangeListener {
-                            override fun onHistoryChanged(hasUndo: Boolean, hasRedo: Boolean) {
-                                onToggleUndo(!hasUndo)
-                                onToggleRedo(!hasRedo)
-                            }
-                        })
-                        editorFragment?.onOpenMediaLibrary(object: GutenbergView.OpenMediaLibraryListener {
-                            override fun onOpenMediaLibrary(config: GutenbergView.OpenMediaLibraryConfig) {
-                                editorPhotoPicker?.allowMultipleSelection = config.multiple
-                                val mediaType = mapAllowedTypesToMediaBrowserType(config.allowedTypes, config.multiple)
-                                val initialSelection = when (val value = config.value) {
-                                    is GutenbergView.Value.Single -> listOf(value.value)
-                                    is GutenbergView.Value.Multiple -> value.toList()
-                                    else -> emptyList()
-                                }
-                                openMediaLibrary(mediaType, initialSelection)
-                            }
-                        })
-                        editorFragment?.onLogJsException(object : GutenbergView.LogJsExceptionListener {
-                            override fun onLogJsException(exception: GutenbergJsException) {
-                                val stackTraceElements = exception.stackTrace.map { stackTrace ->
-                                    JsExceptionStackTraceElement(
-                                        stackTrace.fileName,
-                                        stackTrace.lineNumber,
-                                        stackTrace.colNumber,
-                                        stackTrace.function
-                                    )
-                                }
-
-                                val jsException = JsException(
-                                    exception.type,
-                                    exception.message,
-                                    stackTraceElements,
-                                    exception.context,
-                                    exception.tags,
-                                    exception.isHandled,
-                                    exception.handledBy
-                                )
-
-                                val callback = object : JsExceptionCallback {
-                                    override fun onReportSent(success: Boolean) {
-                                        // Do nothing
-                                    }
-                                }
-
-                                onLogJsException(jsException, callback)
-                            }
-                        })
-                    } else {
+                    // TODO: Refactor GutenbergKit to rely upon this observer rather than its custom implementation
+                    if (editorFragment !is GutenbergKitEditorFragment) {
                         editorFragment?.titleOrContentChanged?.observe(this@EditPostActivity) { _: Editable? ->
                             storePostViewModel.savePostWithDelay()
                         }

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import org.wordpress.android.editor.BuildConfig;
 import org.wordpress.android.editor.EditorEditMediaListener;
 import org.wordpress.android.editor.EditorFragmentAbstract;
+import org.wordpress.android.editor.EditorFragmentActivity;
 import org.wordpress.android.editor.EditorImagePreviewListener;
 import org.wordpress.android.editor.EditorMediaUploadListener;
 import org.wordpress.android.editor.EditorThemeUpdateListener;
@@ -127,6 +128,11 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         if (getArguments() != null) {
             mSettings = (Map<String, Object>) getArguments().getSerializable(ARG_GUTENBERG_KIT_SETTINGS);
+        }
+
+        // request dependency injection. Do this after setting min/max dimensions
+        if (getActivity() instanceof EditorFragmentActivity) {
+            ((EditorFragmentActivity) getActivity()).initializeEditorFragment();
         }
 
         mGutenbergView = GutenbergWebViewPool.getPreloadedWebView(requireContext());


### PR DESCRIPTION
Setting the listeners within `instantiateItem` appears problematic as
this only runs for the initial launch, but not for other events that
destroy and recreate the fragment—e.g., screen rotation events.

To address this, GutenbergKit now follow the pattern of the Aztec and
GutenbergMobile editors, invoking the `initializeEditorFragment` method.
This method is described as "requesting dependency injection," which
feels like an odd statement. There is likely further opportunity to
refactor this architecture for simplicity.

Fixes #21656.

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
See: https://github.com/wordpress-mobile/WordPress-Android/issues/21656

## Regression Notes
1. Potential unintended areas of impact
    Regressions in the Aztec and Gutenberg Mobile editors.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental editor.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
