### PR TITLE
fix: Prevent discarding editor WebView state during orientation change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 25.8
 -----
 * [*] Fix unselectable group blocks in the experimental editor [https://github.com/wordpress-mobile/GutenbergKit/pull/68]
+* [*] Prevent resetting content in the experimental editor when the device orientation changes [#21662]
 
 25.7
 -----

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -221,7 +221,6 @@
             android:theme="@style/WordPress.NoActionBar" />
         <activity
             android:name=".ui.prefs.ExperimentalFeaturesActivity"
-            android:configChanges="locale|orientation|screenSize"
             android:label="@string/me_btn_experimental_features"
             android:theme="@style/WordPress.NoActionBar" />
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -269,6 +269,7 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.EditPostActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -268,7 +268,8 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.EditPostActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="screenLayout|orientation|screenSize
+      |keyboard|keyboardHidden|smallestScreenSize"
             android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">

--- a/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/gutenberg/GutenbergKitEditorFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
@@ -168,6 +169,14 @@ public class GutenbergKitEditorFragment extends EditorFragmentAbstract implement
         );
 
         return mGutenbergView;
+    }
+
+    @Override public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        if (mGutenbergView != null) {
+            mGutenbergView.invalidate();
+        }
     }
 
     @Override


### PR DESCRIPTION
The GutenbergKit editor relies upon a WebView, which discarded all its
state—including content edits—when the device orientation changed.

`EditPostActivity` is currently also utilized by Aztec and Gutenberg
Mobile, so there could be negative side effects to those fragments with
this change.

This also removes an unnecessary `configChanges` value from the 
experimental features fragment. 

Fix https://github.com/wordpress-mobile/GutenbergKit/issues/71.

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Enable the experimental editor setting.
1. Launch the editor.
1. Modify the title and/or content.
1. Rotate the device.
1. Verify the title/content state is preserved.

## Regression Notes
1. Potential unintended areas of impact
    Regressions in the Aztec and Gutenberg Mobile editors.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested the editors.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental editor.

## PR Submission Checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)

