### PR TITLE
Fix ClassCastException caused by assuming editorFragment was a Gutenb…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -4027,8 +4027,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ConnectionChangeEvent) {
-        if (editorFragment !is GutenbergNetworkConnectionListener) return
-        (editorFragment as GutenbergEditorFragment).onConnectionStatusChange(event.isConnected)
+        (editorFragment as? GutenbergNetworkConnectionListener)?.onConnectionStatusChange(event.isConnected)
     }
 
     private fun refreshEditorTheme() {


### PR DESCRIPTION
Closes #21664

This PR fixes a `ClassCastException` caused by assuming `editorFragment` was a `GutenbergEditorFragment` when it could be a `GutenbergKitEditorFragment` in this code:

```
   @Subscribe(threadMode = ThreadMode.MAIN)
    fun onEventMainThread(event: ConnectionChangeEvent) {
        if (editorFragment !is GutenbergNetworkConnectionListener) return
        (editorFragment as GutenbergEditorFragment).onConnectionStatusChange(event.isConnected)
    }
```

Since both of these fragments extend `GutenbergNetworkConnectionListener` we simply needed to change this to a safe cast for that listener.

@dcalhoun  This crash started happening with 25.6, but given this is an experimental feature I wasn't sure if a hotfix was necessary.

To test:

* Set a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/8d3363303a3be46e41ff0756ab9ebe88bd7755a5/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt#L4030)
* Run the app in debug
* Make sure the experimental editor is enabled
* Edit a post
* Turn on airplane mode
* Note that breakpoint is reached and the app doesn't crash


