### PR TITLE
[25.6.1] Fix ClassCastException caused by assuming editorFragment was a Gutenb…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3991,8 +3991,7 @@ class EditPostActivity : LocaleAwareActivity(), EditorFragmentActivity, EditorIm
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ConnectionChangeEvent) {
-        if (editorFragment !is GutenbergNetworkConnectionListener) return
-        (editorFragment as GutenbergEditorFragment).onConnectionStatusChange(event.isConnected)
+        (editorFragment as? GutenbergNetworkConnectionListener)?.onConnectionStatusChange(event.isConnected)
     }
 
     private fun refreshEditorTheme() {


### PR DESCRIPTION
This PR includes the fix from #21665 but targets the `release/25.6.1` branch.