### PR TITLE
[25.7] Fix ClassCastException caused by assuming editorFragment was a GutenbergEditorFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -4037,8 +4037,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ConnectionChangeEvent) {
-        if (editorFragment !is GutenbergNetworkConnectionListener) return
-        (editorFragment as GutenbergEditorFragment).onConnectionStatusChange(event.isConnected)
+        (editorFragment as? GutenbergNetworkConnectionListener)?.onConnectionStatusChange(event.isConnected)
     }
 
     private fun refreshEditorTheme() {


### PR DESCRIPTION
This PR includes the fix from #21665 but targets the `release/25.7` branch.