### PR TITLE
Fix site creation illegal state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -198,13 +198,17 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         }
 
         private fun showKeyboard() {
-            searchInput.requestFocus()
-            /**
-             * This workaround handles the case where the SiteCreationDomainsFragment appears after the
-             * DesignPreviewFragment dismisses and the keyboard fails to appear
-             */
-            showKeyboardHandler.postDelayed({ ActivityUtils.showKeyboard(searchInput) }, SHOW_KEYBOARD_DELAY)
-        }
+            if (searchInput.requestFocus()) {
+                /**
+                 * This workaround handles the case where the SiteCreationDomainsFragment appears after the
+                 * DesignPreviewFragment dismisses and the keyboard fails to appear
+                 */
+                showKeyboardHandler.postDelayed(
+                    { ActivityUtils.showKeyboard(searchInput) },
+                    SHOW_KEYBOARD_DELAY
+                )
+            }
+            }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -204,11 +204,13 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
                  * DesignPreviewFragment dismisses and the keyboard fails to appear
                  */
                 showKeyboardHandler.postDelayed(
-                    { ActivityUtils.showKeyboard(searchInput) },
+                    {
+                        ActivityUtils.showKeyboard(searchInput)
+                    },
                     SHOW_KEYBOARD_DELAY
                 )
             }
-            }
+        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -192,18 +192,18 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
             uiHelpers.updateVisibility(progressBar, uiState.showProgress)
             uiHelpers.updateVisibility(clearAllLayout, uiState.showClearButton)
             uiHelpers.updateVisibility(divider, uiState.showDivider)
-            showKeyboard(uiState.showKeyboard)
+            if (uiState.showKeyboard) {
+                showKeyboard()
+            }
         }
 
-        private fun showKeyboard(shouldShow: Boolean) {
-            if (shouldShow) {
-                searchInput.requestFocus()
-                /**
-                 * This workaround handles the case where the SiteCreationDomainsFragment appears after the
-                 * DesignPreviewFragment dismisses and the keyboard fails to appear
-                 */
-                showKeyboardHandler.postDelayed({ ActivityUtils.showKeyboard(searchInput) }, SHOW_KEYBOARD_DELAY)
-            }
+        private fun showKeyboard() {
+            searchInput.requestFocus()
+            /**
+             * This workaround handles the case where the SiteCreationDomainsFragment appears after the
+             * DesignPreviewFragment dismisses and the keyboard fails to appear
+             */
+            showKeyboardHandler.postDelayed({ ActivityUtils.showKeyboard(searchInput) }, SHOW_KEYBOARD_DELAY)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -188,7 +188,7 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
             uiHelpers.updateVisibility(progressBar, uiState.showProgress)
             uiHelpers.updateVisibility(clearAllLayout, uiState.showClearButton)
             uiHelpers.updateVisibility(divider, uiState.showDivider)
-            if (uiState.showKeyboard) {
+            if (uiState.focusSearch) {
                 searchInput.requestFocus()
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsFragment.kt
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.sitecreation.domains
 
 import android.content.Context
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
@@ -29,7 +27,6 @@ import org.wordpress.android.ui.sitecreation.misc.OnHelpClickedListener
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationHeaderUiState
 import org.wordpress.android.ui.sitecreation.misc.SiteCreationSearchInputUiState
 import org.wordpress.android.ui.utils.UiHelpers
-import org.wordpress.android.util.ActivityUtils
 import org.wordpress.android.util.DisplayUtilsWrapper
 import javax.inject.Inject
 
@@ -148,7 +145,6 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
         private val progressBar = rootView.findViewById<View>(R.id.progress_bar)
         private val clearAllLayout = rootView.findViewById<View>(R.id.clear_all_layout)
         private val divider = rootView.findViewById<View>(R.id.divider)
-        private val showKeyboardHandler = Handler(Looper.getMainLooper())
 
         var onTextChanged: ((String) -> Unit)? = null
 
@@ -193,29 +189,13 @@ class SiteCreationDomainsFragment : SiteCreationBaseFormFragment() {
             uiHelpers.updateVisibility(clearAllLayout, uiState.showClearButton)
             uiHelpers.updateVisibility(divider, uiState.showDivider)
             if (uiState.showKeyboard) {
-                showKeyboard()
-            }
-        }
-
-        private fun showKeyboard() {
-            if (searchInput.requestFocus()) {
-                /**
-                 * This workaround handles the case where the SiteCreationDomainsFragment appears after the
-                 * DesignPreviewFragment dismisses and the keyboard fails to appear
-                 */
-                showKeyboardHandler.postDelayed(
-                    {
-                        ActivityUtils.showKeyboard(searchInput)
-                    },
-                    SHOW_KEYBOARD_DELAY
-                )
+                searchInput.requestFocus()
             }
         }
     }
 
     companion object {
         const val TAG = "site_creation_domains_fragment_tag"
-        const val SHOW_KEYBOARD_DELAY = 200L
 
         fun newInstance(screenTitle: String): SiteCreationDomainsFragment {
             val fragment = SiteCreationDomainsFragment()

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/domains/SiteCreationDomainsViewModel.kt
@@ -397,7 +397,7 @@ private fun createSearchInputUiState(
             showProgress = showProgress,
             showClearButton = showClearButton,
             showDivider = showDivider,
-            showKeyboard = true
+            focusSearch = true
         )
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSearchInputUiState.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/sitecreation/misc/SiteCreationSearchInputUiState.kt
@@ -7,5 +7,5 @@ data class SiteCreationSearchInputUiState(
     val showProgress: Boolean,
     val showClearButton: Boolean,
     val showDivider: Boolean,
-    val showKeyboard: Boolean
+    val focusSearch: Boolean
 )


### PR DESCRIPTION
Potentially fixes #21669 

This was initially addressed in #21566 but we continue to see the crash even in 25.6, albeit less frequently.

I was not able to reproduce the crash in `trunk` but looking at the site creation code I noticed we were forcing the keyboard to appear with every single key press while searching. This could easily cause problems, especially if the `runnable` we used to delay the showing of the keyboard executed when the screen was no longer active.

To resolve this I chose to simply remove the force showing of the keyboard, instead letting the system handle it when the user taps the search field. I did note the following comment above the old code that forced the keyboard to show:

```
/**
 * This workaround handles the case where the SiteCreationDomainsFragment appears after the
 * DesignPreviewFragment dismisses and the keyboard fails to appear
 */
```

This is still an issue, but the keyboard will appear when the user taps the search field, and I think that's better than constantly forcing the keyboard to unnecessarily appear.