### PR TITLE
 Gravatar Image Issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -19,6 +19,7 @@ public class JetpackSettingsModel {
     // Modules
     public boolean serveImagesFromOurServers;
     public boolean serveStaticFilesFromOurServers;
+    public boolean lazyLoadImages;
     public boolean commentLikes;
     public boolean sharingEnabled = true;
     public boolean improvedSearch;
@@ -46,6 +47,7 @@ public class JetpackSettingsModel {
         jetpackProtectAllowlist.addAll(other.jetpackProtectAllowlist);
         serveImagesFromOurServers = other.serveImagesFromOurServers;
         serveStaticFilesFromOurServers = other.serveStaticFilesFromOurServers;
+        lazyLoadImages = other.lazyLoadImages;
         sharingEnabled = other.sharingEnabled;
         improvedSearch = other.improvedSearch;
         adFreeVideoHosting = other.adFreeVideoHosting;
@@ -64,6 +66,7 @@ public class JetpackSettingsModel {
                && ssoRequireTwoFactor == otherModel.ssoRequireTwoFactor
                && serveImagesFromOurServers == otherModel.serveImagesFromOurServers
                && serveStaticFilesFromOurServers == otherModel.serveStaticFilesFromOurServers
+               && lazyLoadImages == otherModel.lazyLoadImages
                && commentLikes == otherModel.commentLikes
                && sharingEnabled == otherModel.sharingEnabled
                && improvedSearch == otherModel.improvedSearch

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
@@ -11,6 +11,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
+import android.util.Log
 import android.view.View
 import android.view.View.OnClickListener
 import androidx.appcompat.app.AppCompatActivity
@@ -483,16 +484,19 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
         if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(accountStore, siteStore)) {
             return
         }
+
         // we only want to show user details for WordPress.com users
         if (accountStore.hasAccessToken()) {
             val defaultAccount = accountStore.account
+            val email = defaultAccount.email
+            val avatarUrl = meGravatarLoader.constructGravatarUrl(email)
             meDisplayName.visibility = View.VISIBLE
             meUsername.visibility = View.VISIBLE
             cardAvatar.visibility = View.VISIBLE
             rowMyProfile.visibility = View.VISIBLE
             myProfileDivider.visibility = View.VISIBLE
             accountSettingsDivider.visibility = View.VISIBLE
-            loadAvatar(null)
+            loadAvatar(avatarUrl)
             meUsername.text = getString(R.string.at_username, defaultAccount.userName)
             meLoginLogoutTextView.setText(R.string.me_disconnect_from_wordpress_com)
             meDisplayName.text = defaultAccount.displayName.ifEmpty { defaultAccount.userName }
@@ -516,7 +520,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
 
     private fun MeFragmentBinding.loadAvatar(injectFilePath: String?, forceRefresh: Boolean = false) {
         val newAvatarUploaded = !injectFilePath.isNullOrEmpty()
-        val avatarUrl = meGravatarLoader.constructGravatarUrl(accountStore.account.avatarUrl)
+        val avatarUrl = meGravatarLoader.constructGravatarUrl(accountStore.account.email)
         val newAvatarSelected = newAvatarUploaded || forceRefresh
         meGravatarLoader.load(
             newAvatarSelected,
@@ -526,6 +530,7 @@ class MeFragment : Fragment(R.layout.me_fragment), OnScrollToTopListener {
             AVATAR_WITHOUT_BACKGROUND,
             object : RequestListener<Drawable> {
                 override fun onLoadFailed(e: Exception?, model: Any?) {
+                    Log.e("Gravatar", "Failed to load image: ${e?.message}")
                     val appLogMessage = "onLoadFailed while loading Gravatar image!"
                     if (e == null) {
                         AppLog.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.main.utils
 
 import android.graphics.drawable.Drawable
+import android.util.Log
 import android.widget.ImageView
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
@@ -10,6 +11,8 @@ import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageManager.RequestListener
 import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.viewmodel.ResourceProvider
+import java.math.BigInteger
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -57,10 +60,18 @@ class MeGravatarLoader @Inject constructor(
             )
         }
     }
-
-    fun constructGravatarUrl(rawAvatarUrl: String, forceRefresh: Boolean = false): String {
+    fun constructGravatarUrl(email: String, forceRefresh: Boolean = false): String {
         val avatarSz = resourseProvider.getDimensionPixelSize(R.dimen.avatar_sz_extra_small)
-        val cacheBuster = if (forceRefresh) System.currentTimeMillis().toString() else null
-        return WPAvatarUtils.rewriteAvatarUrl(rawAvatarUrl, avatarSz, cacheBuster)
+        val trimmedEmail = email.trim().lowercase()
+        val md5Hash = md5Hash(trimmedEmail)
+        val cacheBuster = if (forceRefresh) "?d=${System.currentTimeMillis()}" else ""
+        return "https://www.gravatar.com/avatar/$md5Hash?s=$avatarSz$cacheBuster"
+    }
+
+    fun md5Hash(input: String): String{
+        val md = MessageDigest.getInstance("MD5")
+        return BigInteger(1, md.digest(input.toByteArray()))
+            .toString(16)
+            .padStart(32, '0')
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -278,6 +278,10 @@ public class SiteSettingsFragment extends PreferenceFragment
     private WPSwitchPreference mJpMatchEmailPref;
     private WPSwitchPreference mJpUseTwoFactorPref;
 
+    // Speed up settings
+    private WPSwitchPreference mLazyLoadImages;
+    private WPSwitchPreference mLazyLoadImagesNested;
+
     // Jetpack media settings
     private WPSwitchPreference mAdFreeVideoHosting;
     private WPSwitchPreference mAdFreeVideoHostingNested;
@@ -716,6 +720,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mJpUseTwoFactorPref) {
             mJpUseTwoFactorPref.setChecked((Boolean) newValue);
             mSiteSettings.enableJetpackSsoTwoFactor((Boolean) newValue);
+        } else if (preference == mLazyLoadImages || preference == mLazyLoadImagesNested) {
+            setLazyLoadImagesChecked((Boolean) newValue);
         } else if (preference == mAdFreeVideoHosting || preference == mAdFreeVideoHostingNested) {
             setAdFreeHostingChecked((Boolean) newValue);
         } else if (preference == mImprovedSearch) {
@@ -1038,6 +1044,9 @@ public class SiteSettingsFragment extends PreferenceFragment
                 (WPSwitchPreference) getChangePref(R.string.pref_key_serve_static_files_from_our_servers);
         mServeStaticFilesFromOurServersNested =
                 (WPSwitchPreference) getChangePref(R.string.pref_key_serve_static_files_from_our_servers_nested);
+
+        mLazyLoadImages = (WPSwitchPreference) getChangePref(R.string.pref_key_lazy_load_images);
+        mLazyLoadImagesNested = (WPSwitchPreference) getChangePref(R.string.pref_key_lazy_load_images_nested);
 
         mAdFreeVideoHosting = (WPSwitchPreference) getChangePref(R.string.pref_key_ad_free_video_hosting);
         mAdFreeVideoHostingNested = (WPSwitchPreference) getChangePref(R.string.pref_key_ad_free_video_hosting_nested);
@@ -1490,6 +1499,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mWeekStartPref.setValue(mSiteSettings.getStartOfWeek());
         mWeekStartPref.setSummary(mWeekStartPref.getEntry());
         mGutenbergDefaultForNewPosts.setChecked(SiteUtils.isBlockEditorDefaultForNewPost(mSite));
+        setLazyLoadImagesChecked(mSiteSettings.isLazyLoadImagesEnabled());
         setAdFreeHostingChecked(mSiteSettings.isAdFreeHostingEnabled());
         boolean checked = mSiteSettings.isImprovedSearchEnabled() || mSiteSettings.getJetpackSearchEnabled();
         mImprovedSearch.setChecked(checked);
@@ -1548,6 +1558,12 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void setSiteAcceleratorChecked(boolean checked) {
         mSiteAccelerator.setChecked(checked);
         mSiteAcceleratorNested.setChecked(checked);
+    }
+
+    private void setLazyLoadImagesChecked(boolean checked) {
+        mSiteSettings.enableLazyLoadImages(checked);
+        mLazyLoadImages.setChecked(checked);
+        mLazyLoadImagesNested.setChecked(checked);
     }
 
     private void setAdFreeHostingChecked(boolean checked) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -701,6 +701,14 @@ public abstract class SiteSettingsInterface {
         return mJpSettings.serveStaticFilesFromOurServers;
     }
 
+    void enableLazyLoadImages(boolean enabled) {
+        mJpSettings.lazyLoadImages = enabled;
+    }
+
+    boolean isLazyLoadImagesEnabled() {
+        return mJpSettings.lazyLoadImages;
+    }
+
     void enableAdFreeHosting(boolean enabled) {
         mJpSettings.adFreeVideoHosting = enabled;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPComSiteSettings.java
@@ -69,6 +69,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
     // Jetpack modules
     private static final String SERVE_IMAGES_FROM_OUR_SERVERS = "photon";
     private static final String SERVE_STATIC_FILES_FROM_OUR_SERVERS = "photon-cdn";
+    private static final String LAZY_LOAD_IMAGES = "lazy-images";
     private static final String SHARING_MODULE = "sharedaddy";
 
     private static final String AD_FREE_VIDEO_HOSTING_MODULE = "videopress";
@@ -134,6 +135,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
             if (supportsJetpackSiteAcceleratorSettings(mSite)) {
                 pushServeImagesFromOurServersModuleSettings();
                 pushServeStaticFilesFromOurServersModuleSettings();
+                pushLazyLoadModule();
             }
             pushImprovedSearchModule();
             pushAdFreeVideoHostingModule();
@@ -345,6 +347,9 @@ class WPComSiteSettings extends SiteSettingsInterface {
                                     case SERVE_STATIC_FILES_FROM_OUR_SERVERS:
                                         mRemoteJpSettings.serveStaticFilesFromOurServers = isActive;
                                         break;
+                                    case LAZY_LOAD_IMAGES:
+                                        mRemoteJpSettings.lazyLoadImages = isActive;
+                                        break;
                                     case SHARING_MODULE:
                                         mRemoteJpSettings.sharingEnabled = isActive;
                                         break;
@@ -359,6 +364,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
                             mJpSettings.serveImagesFromOurServers = mRemoteJpSettings.serveImagesFromOurServers;
                             mJpSettings.serveStaticFilesFromOurServers =
                                     mRemoteJpSettings.serveStaticFilesFromOurServers;
+                            mJpSettings.lazyLoadImages = mRemoteJpSettings.lazyLoadImages;
                             mJpSettings.sharingEnabled = mRemoteJpSettings.sharingEnabled;
                             mJpSettings.improvedSearch = mRemoteJpSettings.improvedSearch;
                             mJpSettings.adFreeVideoHosting = mRemoteJpSettings.adFreeVideoHosting;
@@ -534,6 +540,31 @@ class WPComSiteSettings extends SiteSettingsInterface {
         }
     }
 
+    private void pushLazyLoadModule() {
+        ++mSaveRequestCount;
+        // The API returns 400 if we try to sync the same value twice so we need to keep it locally.
+        if (mJpSettings.lazyLoadImages != mRemoteJpSettings.lazyLoadImages) {
+            final boolean fallbackValue = mRemoteJpSettings.lazyLoadImages;
+            mRemoteJpSettings.lazyLoadImages = mJpSettings.lazyLoadImages;
+            WordPress.getRestClientUtilsV1_1().setJetpackModuleSettings(
+                    mSite.getSiteId(), LAZY_LOAD_IMAGES, mJpSettings.lazyLoadImages, new RestRequest.Listener() {
+                        @Override
+                        public void onResponse(JSONObject response) {
+                            AppLog.d(AppLog.T.API, "Jetpack module updated - Lazy load images");
+                            onSaveResponseReceived(null);
+                        }
+                    }, new RestRequest.ErrorListener() {
+                        @Override
+                        public void onErrorResponse(VolleyError error) {
+                            mRemoteJpSettings.lazyLoadImages = fallbackValue;
+                            error.printStackTrace();
+                            AppLog.w(AppLog.T.API, "Error updating Jetpack module - Lazy load images: " + error);
+                            onSaveResponseReceived(error);
+                        }
+                    });
+        }
+    }
+
     private void pushImprovedSearchModule() {
         ++mSaveRequestCount;
         // The API returns 400 if we try to sync the same value twice so we need to keep it locally.
@@ -669,7 +700,7 @@ class WPComSiteSettings extends SiteSettingsInterface {
         String remoteGmtOffset = settingsObject.optString(GMT_OFFSET_KEY, "");
         // UTC-7 comes back as gmt_offset: -7, UTC+7 as just gmt_offset: 7 without the +, hence adding prefix
         String remoteGmtTimezone = remoteGmtOffset.startsWith("-") ? "UTC" + remoteGmtOffset : "UTC+" + remoteGmtOffset;
-
+        
         mRemoteSettings.timezone = !TextUtils.isEmpty(remoteTimezone) ? remoteTimezone : remoteGmtTimezone;
 
         mRemoteSettings.postsPerPage = settingsObject.optInt(POSTS_PER_PAGE_KEY, 0);

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -94,6 +94,9 @@
     <!-- Front page settings -->
     <string name="pref_key_homepage" translatable="false">wp_pref_key_homepage</string>
     <string name="pref_key_homepage_settings" translatable="false">wp_pref_key_homepage_settings</string>
+    <!-- Speed up your site -->
+    <string name="pref_key_lazy_load_images" translatable="false">wp_pref_lazy_load_images</string>
+    <string name="pref_key_lazy_load_images_nested" translatable="false">wp_pref_lazy_load_images_nested</string>
     <!-- Jetpack performance settings -->
     <string name="pref_key_jetpack_performance_settings" translatable="false">wp_pref_jetpack_performance_settings</string>
     <string name="pref_key_site_accelerator" translatable="false">wp_pref_site_accelerator</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -727,10 +727,14 @@
     <string name="file_size_in_gigabytes">%s GB</string>
     <string name="file_size_in_terabytes">%s TB</string>
 
+    <!-- Speed up your site -->
+    <string name="site_settings_lazy_load_images_summary">Improve your site\'s speed by only loading images visible on the screen.</string>
+
     <!-- Site accelerator -->
     <string name="site_settings_site_accelerator">Site Accelerator</string>
     <string name="site_settings_site_accelerator_on">On</string>
     <string name="site_settings_site_accelerator_off">Off</string>
+    <string name="site_settings_lazy_load_images">Lazy load images</string>
     <string name="site_settings_faster_images">Faster images</string>
     <string name="site_settings_faster_static_files">Faster static files</string>
     <string name="site_settings_site_accelerator_summary">Load pages faster by allowing Jetpack to optimize your images and static files (like CSS and JavaScript).</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -260,6 +260,12 @@
         </PreferenceScreen>
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_lazy_load_images"
+            android:key="@string/pref_key_lazy_load_images"
+            android:summary="@string/site_settings_lazy_load_images_summary"
+            android:title="@string/site_settings_lazy_load_images" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_ad_free_video_hosting"
             android:key="@string/pref_key_ad_free_video_hosting"
             android:title="@string/site_settings_ad_free_video_hosting" />
@@ -300,6 +306,11 @@
 
                 </PreferenceScreen>
 
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_lazy_load_images_nested"
+                    android:key="@string/pref_key_lazy_load_images_nested"
+                    android:summary="@string/site_settings_lazy_load_images_summary"
+                    android:title="@string/site_settings_lazy_load_images" />
             </PreferenceCategory>
 
             <PreferenceCategory


### PR DESCRIPTION
Working on https://github.com/wordpress-mobile/WordPress-Android/issues/21415

I pushed a fix for the Gravatar URL issue, but the image still doesn't load dynamically when using accountStore.account in meFragment.kt

I updated the code like this in meFragment.kt to load Gravatar based on email:
val email = defaultAccount.email
val avatarUrl = meGravatarLoader.constructGravatarUrl(email)

// Initially loading with null, then updating with the constructed URL
loadAvatar(null)
loadAvatar(avatarUrl)

However, it works fine when I pass my email directly in MeGravatarLoader.kt, I tested it by passing my email directly inside constructGravatarUrl, and it loads the image correctly

So it seems like accountStore.account.email is not returning the expected value.

Could you check my PR and help me debug this issue?

changes made file:
>WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.kt
>WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt