### PR TITLE
[CI] Fix Incorrect Duration of Buildkite Groups

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.9.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
### Description

This change fixes incorrect duration of buildkite groups by updating `a8c-ci-toolkit` to [3.10.1](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/tag/3.10.1).

For more info see: [Do not echo three dashes at the end of restore cache script #146](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/146)

-----

## To Test

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

- Verify that all the CI checks are successful.
- Verify that the duration of Buildkite groups is now correct.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To Test` section above

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`