### PR TITLE
Check the login mode before exiting when already logged in (25.7)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -156,7 +156,11 @@ public class LoginActivity extends BaseAppCompatActivity implements ConnectionCa
         // when displaying that screen
         mLoginHelper.bindCustomTabsService(this);
 
-        if (mLoginHelper.isLoggedIn()) {
+        // go no further if the user is already logged in and this is the login screen shown at startup
+        //      FULL = WPAndroid
+        //      JETPACK_LOGIN_ONLY = JPAndroid
+        LoginMode loginMode = getLoginMode();
+        if ((mLoginHelper.isLoggedIn()) && (loginMode == LoginMode.FULL || loginMode == LoginMode.JETPACK_LOGIN_ONLY)) {
             this.loggedInAndFinish(new ArrayList<Integer>(), true);
             return;
         }
@@ -173,7 +177,7 @@ public class LoginActivity extends BaseAppCompatActivity implements ConnectionCa
 
             mLoginAnalyticsListener.trackLoginAccessed();
 
-            switch (getLoginMode()) {
+            switch (loginMode) {
                 case FULL:
                 case JETPACK_LOGIN_ONLY:
                     mUnifiedLoginTracker.setSource(Source.DEFAULT);


### PR DESCRIPTION
Fixes #21694 

**Note:** This targets the `release/25.7` branch.

The problem was caused by always exiting the login screen when the user is already logged in. There are cases where the login screen is shown even when logged in, in this situation when adding a self-hosted site from the site picker.

**Test A:**

* From "My Site" choose to add a site
* When the site picker appears, select "Add a site"
* Choose "Add self-hosted site"
* Verify that a self-hosted site can be added

**Test B:**

* Clear storage or do a fresh install
* Verify that initial login works

It's recommended to run each test in both WPAndroid and JPAndroid.