### PR TITLE
Fix positioning of toolbar in reader detail

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -535,7 +535,7 @@
         <activity
             android:name=".ui.reader.ReaderPostPagerActivity"
             android:excludeFromRecents="true"
-            android:theme="@style/WordPress.NoActionBar.TranslucentStatus"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -38,12 +38,8 @@ open class BaseAppCompatActivity : AppCompatActivity() {
     @Override
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // When both compileSdkVersion and targetSdkVersion are 35+, the OS defaults to
-        // using edge-to-edge. We need to adjust for this by applying insets as needed.
-        val targetSdkVersion = applicationContext.applicationInfo.targetSdkVersion
-        if ((targetSdkVersion >= Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
-            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM)
-        ) {
+        // adjust for Android 15+ edge-to-edge this by applying insets as needed
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             applyInsetOffsets()
         }
     }
@@ -162,24 +158,6 @@ open class BaseAppCompatActivity : AppCompatActivity() {
         SupportWebViewActivity::class.java.name to ActivityOffsets(
             applyTopOffset = false,
             applyBottomOffset = false
-        ),
-
-        // apply bottom offset only
-        MediaSettingsActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = true
-        ),
-        PagesActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = true
-        ),
-        PostsListActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = true
-        ),
-        StatsActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = true
         ),
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -181,11 +181,5 @@ open class BaseAppCompatActivity : AppCompatActivity() {
             applyTopOffset = false,
             applyBottomOffset = true
         ),
-
-        // apply top offset only
-        WPMainActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = true,
-            applyBottomOffset = false
-        ),
     )
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -19,16 +19,12 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.install.JetpackF
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallActivity
 import org.wordpress.android.ui.main.feedbackform.FeedbackFormActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
-import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
-import org.wordpress.android.ui.pages.PagesActivity
-import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
-import org.wordpress.android.ui.stats.refresh.StatsActivity
 
 /**
  * Base class for all activities - initially created to handle insets for Android 15's edge-to-edge support,
@@ -39,125 +35,56 @@ open class BaseAppCompatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // adjust for Android 15+ edge-to-edge this by applying insets as needed
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
+            excludedActivities.contains(this.localClassName).not()
+        ) {
             applyInsetOffsets()
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
     private fun applyInsetOffsets() {
-        val excludedActivity = excludedActivities[this.localClassName]
-        val applyTopOffset = excludedActivity?.applyTopOffset ?: true
-        val applyBottomOffset = excludedActivity?.applyBottomOffset ?: true
+        ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { view, insets ->
+            val innerPadding = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
 
-        if (applyTopOffset || applyBottomOffset) {
-            ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { view, insets ->
-                val innerPadding = insets.getInsets(
-                    WindowInsetsCompat.Type.systemBars()
-                            or WindowInsetsCompat.Type.displayCutout()
-                )
+            view.setPadding(
+                innerPadding.left,
+                innerPadding.top,
+                innerPadding.right,
+                innerPadding.bottom
+            )
 
-                view.setPadding(
-                    innerPadding.left,
-                    if (applyTopOffset) innerPadding.top else 0,
-                    innerPadding.right,
-                    if (applyBottomOffset) innerPadding.bottom else 0
-                )
-
-                WindowInsetsCompat.CONSUMED
-            }
+            WindowInsetsCompat.CONSUMED
         }
     }
-
-    private class ActivityOffsets(
-        var applyTopOffset: Boolean,
-        var applyBottomOffset: Boolean,
-    )
-
-    /**
-     * Activities that are excluded from the edge-to-edge top offset, bottom offset, or both. Activities not listed
-     * here will have both offsets applied. Note that many of these excluded activities are Compose-based because
-     * Compose automatically adjusts for edge-to-edge insets. We may want to revisit this approach as we add more
-     * Compose-based activities to the project.
-     */
-    private val excludedActivities: HashMap<String, ActivityOffsets> = hashMapOf(
-        // apply neither top nor bottom offset
-        BlazeCampaignParentActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        BloggingPromptsListActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        DebugSharedPreferenceFlagsActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        DesignSystemActivity::class.java.name to ActivityOffsets
-            (
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        DomainManagementActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        EditJetpackSocialShareMessageActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        ExperimentalFeaturesActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        FeedbackFormActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        JetpackFullPluginInstallActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        JetpackRemoteInstallActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        JetpackStaticPosterActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        MediaPreviewActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        MenuActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        NewDomainSearchActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        PersonalizationActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        PurchaseDomainActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        SelfHostedUsersActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        SiteMonitorParentActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-        SupportWebViewActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
-    )
 }
+
+/**
+ * Activities that are excluded from the edge-to-edge offset. Note that many of these excluded activities are
+ * Compose-based because Compose automatically adjusts for edge-to-edge insets. We may want to revisit this
+ * approach as we add more Compose-based activities to the project.
+ */
+private val excludedActivities = listOf(
+    BlazeCampaignParentActivity::class.java.name,
+    BloggingPromptsListActivity::class.java.name,
+    DebugSharedPreferenceFlagsActivity::class.java.name,
+    DesignSystemActivity::class.java.name,
+    DomainManagementActivity::class.java.name,
+    EditJetpackSocialShareMessageActivity::class.java.name,
+    ExperimentalFeaturesActivity::class.java.name,
+    FeedbackFormActivity::class.java.name,
+    JetpackFullPluginInstallActivity::class.java.name,
+    JetpackRemoteInstallActivity::class.java.name,
+    JetpackStaticPosterActivity::class.java.name,
+    MediaPreviewActivity::class.java.name,
+    MenuActivity::class.java.name,
+    NewDomainSearchActivity::class.java.name,
+    PersonalizationActivity::class.java.name,
+    PurchaseDomainActivity::class.java.name,
+    SelfHostedUsersActivity::class.java.name,
+    SiteMonitorParentActivity::class.java.name,
+    SupportWebViewActivity::class.java.name
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -68,7 +68,7 @@ open class BaseAppCompatActivity : AppCompatActivity() {
                     if (applyBottomOffset) innerPadding.bottom else 0
                 )
 
-                insets
+                WindowInsetsCompat.CONSUMED
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -34,7 +34,7 @@ open class BaseAppCompatActivity : AppCompatActivity() {
     @Override
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // adjust for Android 15+ edge-to-edge this by applying insets as needed
+        // apply insets for Android 15+ edge-to-edge
         if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
             excludedActivities.contains(this.localClassName).not()
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -493,12 +493,12 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                     layoutFooterBinding.root.findViewById<View>(R.id.reader_detail_footer_button_container)
                         ?.let { footerContainer ->
-                            footerContainer.setOnApplyWindowInsetsListener { _, insets ->
+                            ViewCompat.setOnApplyWindowInsetsListener(footerContainer) { _, insets ->
                                 val navigationBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
                                 val addedMargin = resources.getDimensionPixelSize(R.dimen.margin_small)
                                 (footerContainer.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin =
                                     addedMargin + navigationBarInsets.bottom
-                                insets
+                                WindowInsetsCompat.CONSUMED
                             }
                         }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -403,7 +403,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
         }
     }
 
-    @Suppress("DEPRECATION")
     private fun initAppBar(view: View) {
         appBar = view.findViewById(R.id.appbar_with_collapsing_toolbar_layout)
         toolBar = appBar.findViewById(R.id.toolbar_main)
@@ -412,11 +411,11 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
 
         // Fixes collapsing toolbar layout being obscured by the status bar when drawn behind it
         ViewCompat.setOnApplyWindowInsetsListener(appBar) { _: View, insets: WindowInsetsCompat ->
-            val insetTop = insets.systemWindowInsetTop
+            val insetTop = insets.getInsets(WindowInsetsCompat. Type. systemBars()).top
             if (insetTop > 0) {
                 toolBar.setPadding(0, insetTop, 0, 0)
             }
-            insets.consumeSystemWindowInsets()
+            WindowInsetsCompat.CONSUMED
         }
 
         // Fixes viewpager not displaying menu items for first fragment

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -498,7 +498,7 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                                 val addedMargin = resources.getDimensionPixelSize(R.dimen.margin_small)
                                 (footerContainer.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin =
                                     addedMargin + navigationBarInsets.bottom
-                                WindowInsetsCompat.CONSUMED
+                                insets
                             }
                         }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.kt
@@ -487,21 +487,6 @@ class ReaderPostDetailFragment : ViewPagerFragment(),
                         params.behavior = HideBottomViewOnScrollBehavior<View>()
                     }
                 layoutFooterBinding.root.isInvisible = true
-
-                // on SDK 35+ edge-to-edge is enabled so we want to avoid covering the navigation bar icons by
-                // taking the nav bar height into account (nav height will be 0 when gesture nav is enabled)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-                    layoutFooterBinding.root.findViewById<View>(R.id.reader_detail_footer_button_container)
-                        ?.let { footerContainer ->
-                            ViewCompat.setOnApplyWindowInsetsListener(footerContainer) { _, insets ->
-                                val navigationBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-                                val addedMargin = resources.getDimensionPixelSize(R.dimen.margin_small)
-                                (footerContainer.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin =
-                                    addedMargin + navigationBarInsets.bottom
-                                insets
-                            }
-                        }
-                }
             }
         }.also { stub ->
             stub.inflate()


### PR DESCRIPTION
Fixes #21718 

Prior to this PR, the toolbar in reader detail was too low on Android 15 (Vanilla Ice Cream). The primary cause for this was not correctly consuming the window insets in `BaseAppCompatActivity`, which meant when `ReaderDetailFragment` adjusted the toolbar to account for the window insets, the insets were applied twice. 

Resolving this uncovered the fact that `BaseAppCompatActivity` was more involved that it needed to be, so I greatly simplified it in this PR.

To test:

* On an Android 15+ device verify the toolbar in reader detail is correctly positioned
* Verify the same on an earlier device

Before and after shots of two screens below:

![before1](https://github.com/user-attachments/assets/8b8bab54-ad84-4bf1-b8c8-e31ceb9e8c69)
![before2](https://github.com/user-attachments/assets/2f177f4a-caf7-459a-b857-b40a1b04b24e)
