### PR TITLE
[Buildkite] Test Android Staging on `ami-0ed66347bb94c070a` -> `ami-03794d38ac4991af7`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################


### PR DESCRIPTION
Related: [buildkite-ci#610](https://github.com/Automattic/buildkite-ci/pull/610)

AMI Name: `android-build-image-6.12.0v1.7-rc-1` -> `android-build-image-6.12.0v1.8-rc-1`

-----

## Description:

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0ed66347bb94c070a` works as expected.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

Check CI and verify everything is working as expected with the `android-staging` agent.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To Test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`