### PR TITLE
Hotfix: Exclude editor from edge-to-edge

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -604,7 +604,7 @@
         <activity
             android:name=".ui.reader.ReaderCommentListActivity"
             android:label="@string/reader_title_comments"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="adjustResize|stateHidden" />
         <activity
             android:name=".ui.reader.NoSiteToReblogActivity"
@@ -711,7 +711,7 @@
         <!-- Notifications activities -->
         <activity
             android:name=".ui.notifications.NotificationsDetailActivity"
-            android:theme="@style/WordPress.NoActionBar" />
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge" />
 
         <!--People Management-->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -269,7 +269,7 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.EditPostActivity"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">
             <meta-data

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.pages.PagesActivity
+import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
@@ -108,6 +109,10 @@ open class BaseAppCompatActivity : AppCompatActivity() {
             applyBottomOffset = false
         ),
         EditJetpackSocialShareMessageActivity::class.java.name to ActivityOffsets(
+            applyTopOffset = false,
+            applyBottomOffset = false
+        ),
+        EditPostActivity::class.java.name to ActivityOffsets(
             applyTopOffset = false,
             applyBottomOffset = false
         ),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -22,11 +22,13 @@ import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
+import org.wordpress.android.ui.notifications.NotificationsDetailActivity
 import org.wordpress.android.ui.pages.PagesActivity
 import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.PostsListActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
+import org.wordpress.android.ui.reader.ReaderCommentListActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 import org.wordpress.android.ui.stats.refresh.StatsActivity
@@ -112,10 +114,6 @@ open class BaseAppCompatActivity : AppCompatActivity() {
             applyTopOffset = false,
             applyBottomOffset = false
         ),
-        EditPostActivity::class.java.name to ActivityOffsets(
-            applyTopOffset = false,
-            applyBottomOffset = false
-        ),
         ExperimentalFeaturesActivity::class.java.name to ActivityOffsets(
             applyTopOffset = false,
             applyBottomOffset = false
@@ -192,5 +190,20 @@ open class BaseAppCompatActivity : AppCompatActivity() {
             applyTopOffset = true,
             applyBottomOffset = false
         ),
-    )
+
+        // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping
+        // their editors
+        EditPostActivity::class.java.name to ActivityOffsets(
+            applyTopOffset = false,
+            applyBottomOffset = false
+        ),
+        NotificationsDetailActivity::class.java.name to ActivityOffsets(
+            applyTopOffset = false,
+            applyBottomOffset = false
+        ),
+        ReaderCommentListActivity::class.java.name to ActivityOffsets(
+            applyTopOffset = false,
+            applyBottomOffset = false
+        ),
+   )
 }


### PR DESCRIPTION
Fixes #21728 

Users were reporting issues with text selection in the 25.7 release, which we discussed here:

p1741182246286099/1741086813.917239-slack-C06NXHR5WQ1

Specifically, the keyboard was covering up the bottom of the editor, making it difficult (if not impossible) to select the text at the end of a post.

We tracked the problem down to the recent edge-to-edge support. This PR resolves the problem by excluding `EditPostActivity` from edge-to-edge support. The same problem was also noticed with the editors on the comment and notification detail, so the same fix was applied to them.

To test:

* In the release branch, open a long post in the editor
* Tap the post to enable the soft keyboard
* Scroll to the bottom and note that the keyboard covers the end of the post
* Pull this branch and note that the keyboard no longer covers the end of the post