### PR TITLE
Handle timeout in UploadService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -171,6 +171,13 @@ public class UploadService extends Service {
         return START_REDELIVER_INTENT;
     }
 
+    @Override
+    public void onTimeout(int startId) {
+        super.onTimeout(startId);
+        stopSelf(startId);
+        AppLog.i(T.MAIN, "UploadService > timed out");
+    }
+
     private void unpackMediaIntent(@NonNull Intent intent) {
         // TODO right now, in the case we had pending uploads and the app/service was restarted,
         // we don't really have a way to tell which media was supposed to be added to which post,


### PR DESCRIPTION
Fixes #21730

We've been seeing quite a few `ForegroundServiceDidNotStopInTimeException` reports in Sentry. This PR addresses the problem by implementing `onTimeout` in the upload service, as [recommended by Google](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout).

There aren't any testing steps, other than to verify that saving (uploading) a post still works as expected.