### PR TITLE
Fix editor activities for edge-to-edge

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -605,7 +605,7 @@
         <activity
             android:name=".ui.reader.ReaderCommentListActivity"
             android:label="@string/reader_title_comments"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="adjustResize|stateHidden" />
         <activity
             android:name=".ui.reader.NoSiteToReblogActivity"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -256,7 +256,7 @@
             android:label="@string/edit_comment"/>
         <activity
             android:name=".ui.comments.CommentsDetailActivity"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="adjustResize"
             android:label="@string/comments"/>
         <activity
@@ -270,7 +270,7 @@
             android:name=".ui.posts.EditPostActivity"
             android:configChanges="screenLayout|orientation|screenSize
       |keyboard|keyboardHidden|smallestScreenSize"
-            android:theme="@style/WordPress.NoActionBar"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">
             <meta-data
@@ -712,7 +712,7 @@
         <!-- Notifications activities -->
         <activity
             android:name=".ui.notifications.NotificationsDetailActivity"
-            android:theme="@style/WordPress.NoActionBar" />
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge" />
 
         <!--People Management-->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -21,8 +21,11 @@ import org.wordpress.android.ui.main.feedbackform.FeedbackFormActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
+import org.wordpress.android.ui.notifications.NotificationsDetailActivity
+import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
+import org.wordpress.android.ui.reader.ReaderCommentListActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 
@@ -86,5 +89,11 @@ private val excludedActivities = listOf(
     PurchaseDomainActivity::class.java.name,
     SelfHostedUsersActivity::class.java.name,
     SiteMonitorParentActivity::class.java.name,
-    SupportWebViewActivity::class.java.name
+    SupportWebViewActivity::class.java.name,
+
+    // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping
+    // their editors
+    EditPostActivity::class.java.name,
+    NotificationsDetailActivity::class.java.name,
+    ReaderCommentListActivity::class.java.name
 )


### PR DESCRIPTION
This PR adds the fix from #21731 to the current release branch. As with that previous PR, to test simply verify that the keyboard doesn't cover the text in these screens:

* Main editor (`EditPostActivity`)
* Comment editor (`ReaderCommentListActivity`)
* Notification comment editor (`NotificationsDetailActivity`)