### PR TITLE
[AndroidManifest] Reveal Manifest Changes in PR

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+"$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
+
+BUILD_VARIANT=$1
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- 💾 Diff Merged Manifest (Module: WordPress, Build Variant: ${BUILD_VARIANT})"
+comment_with_manifest_diff "WordPress" ${BUILD_VARIANT}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,11 +63,16 @@ steps:
         artifact_paths:
           - "**/build/reports/lint-results*.*"
 
-  - label: "Dependency Tree Diff"
-    command: |
-      comment_with_dependency_diff 'WordPress' 'wordpressVanillaReleaseRuntimeClasspath'
-    if: build.pull_request.id != null
-    plugins: [$CI_TOOLKIT]
+  #################
+  # Diff Reports
+  #################
+  - group: "🕵️‍♂️ Diff Reports"
+    steps:
+      - label: "Dependency Tree Diff"
+        command: |
+          comment_with_dependency_diff 'WordPress' 'wordpressVanillaReleaseRuntimeClasspath'
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
 
   #################
   # Unit Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,6 +76,20 @@ steps:
         artifact_paths:
           - "**/build/reports/diff/*"
 
+      - label: "Merged Manifest Diff WordPress"
+        command: ".buildkite/commands/diff-merged-manifest.sh wordpressVanillaRelease"
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff_manifest/**/**/*"
+
+      - label: "Merged Manifest Diff Jetpack"
+        command: ".buildkite/commands/diff-merged-manifest.sh jetpackVanillaRelease"
+        if: build.pull_request.id != null
+        plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff_manifest/**/**/*"
+
   #################
   # Unit Tests
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,6 +73,8 @@ steps:
           comment_with_dependency_diff 'WordPress' 'wordpressVanillaReleaseRuntimeClasspath'
         if: build.pull_request.id != null
         plugins: [$CI_TOOLKIT]
+        artifact_paths:
+          - "**/build/reports/diff/*"
 
   #################
   # Unit Tests

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.2"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.3"
 export TEST_COLLECTOR="test-collector#v1.10.1"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.10.1"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.2"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Project Thread: paaHJt-7Tl-p2
Tested By: #21737

-----

## Description:

This PR introduces the `Merged Manifest Diff` CI job that is aiming to help revealing merged manifest changes a PR might introduce.

The main problem this script is trying to address is the fact that:
1. Although explicit `AndroidManifest.xml` changes are visible on a PR review, just by looking at the `Files changed` tab for that specific change, this doesn't necessarily mean that the actual, auto-generated, merged `AndroidManifest.xml` file should have the same amount of changes.
2. Sometimes, implicit `AndroidManifest.xml` changes can occur (think new/updated dependency). Those changes are actually invisible for both, to the author and reviewer of that specific PR.

For more info on the technical/workflow side of things see: p1740739725150069/1740493471.859349-slack-C030U03RC8Y

---

### Review

@nbradbury I am adding you as an additional reviewer to @wzieba just so that at least one product engineer is aware of this new CI workflow and CI check. I hope this will, through you, give a decent heads-up to other product engineers as well.

FYI: At a later point of time a formal announcement will be posted.

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

You could check the associated test PR (#21737) and see when and how such comments might appear ([here](https://github.com/wordpress-mobile/WordPress-Android/pull/21737#issuecomment-2704218014) and [here](https://github.com/wordpress-mobile/WordPress-Android/pull/21737#issuecomment-2704218175)):

![image](https://github.com/user-attachments/assets/34fc74a0-7b92-4f4c-8db5-68f4bbfdd417)

FYI: The above test comment appeared due to an implicit `AndroidManifest.xml` change, adding the [singular](https://support.singular.net/hc/en-us/articles/360037581952-Android-SDK-Integration-Guide) dependency to the project. It would have been impossible for an engineer to know how the merged `AndroidManifest.xml` file got updated without doing such a check manually.

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)

    - See `To test` section above.

3. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`