### PR TITLE
Disable Samsung predictive text in the Aztec editor

### DIFF
--- a/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -254,6 +254,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mContent.setMinImagesWidth(minMediaSize);
         mContent.setMaxImagesWidth(maxMediaSize);
 
+        // On some Samsung devices, predictive text may cause the content to be malformed.
+        // To resolve this we disable predicative text. Note that Aztec only enforces this
+        // setting on devices using the Samsung keyboard and running API 33+.
+        // see https://github.com/wordpress-mobile/WordPress-Android/issues/21739
+        mContent.enableSamsungPredictiveBehaviorOverride();
+
         // request dependency injection. Do this after setting min/max dimensions
         if (getActivity() instanceof EditorFragmentActivity) {
             ((EditorFragmentActivity) getActivity()).initializeEditorFragment();


### PR DESCRIPTION
Fixes #21739

Support ticket: 9482638-zd-a8c
Slack discussion: p1741286044939189-slack-C04PWEZSYFL

A user reported that changing links in their post in the Android app caused images to be replaced with `[OBJ]` blocks. We were unable to reproduce the issue on Pixel devices, but we were able to reproduce it on a Samsung device.

We then discovered that this exact issue [has occurred before](https://github.com/wordpress-mobile/AztecEditor-Android/pull/1024), and the proposed solution was to use [AztecText.enableSamsungPredictiveBehaviorOverride](https://github.com/wordpress-mobile/AztecEditor-Android/blob/2f305d694c7603972d9bbe20c0a59abe4ce1c30b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1918) to disable predictive text on Samsung devices running API 33+. This PR adds this solution.

To test:
* Follow the instructions at P9ugOq-4rN-p2 to create a post that will enable the Aztec editor on Android
* Add at least one image to the post and make the text long enough that the image can be scrolled offscreen in the app
* In `trunk`, open the post in a Samsung device using the Samsung keyboard, scroll down past the image, and modify the text (note the user reported that adding a hyperlink caused the issue)
* Note the image is replaced by `[OBJ]`
* Do the same with this branch and note the image is _not_ replaced