### PR TITLE
[Dependabot] Update Ignore Configuration (`AGP`, `FluxC`, `Login` and `Stories`)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,6 @@ updates:
       # dependapot.
       - dependency-name: "org.wordpress:utils"
       - dependency-name: "org.wordpress.gutenberg-mobile:react-native-gutenberg-bridge"
-      - dependency-name: "com.automattic:stories"
-      - dependency-name: "com.automattic.stories:mp4compose"
-      - dependency-name: "com.automattic.stories:photoeditor"
       - dependency-name: "org.wordpress:aztec"
       - dependency-name: "org.wordpress.aztec:wordpress-shortcodes"
       - dependency-name: "org.wordpress.aztec:wordpress-comments"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,8 @@ updates:
       - dependency-name: "com.facebook.fbjni:fbjni"
       # Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with
       # dependapot.
-      - dependency-name: "org.wordpress:fluxc"
       - dependency-name: "org.wordpress:utils"
       - dependency-name: "org.wordpress.gutenberg-mobile:react-native-gutenberg-bridge"
-      - dependency-name: "org.wordpress:login"
       - dependency-name: "com.automattic:stories"
       - dependency-name: "com.automattic.stories:mp4compose"
       - dependency-name: "com.automattic.stories:photoeditor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,6 @@ updates:
         exclude-patterns:
           - "org.jetbrains.kotlinx*"
     ignore:
-      # The Android Gradle Plugin is a dependency that needs to be in sync with other
-      # in-house libraries due to compatibility with composite build.
-      - dependency-name: "com.android.tools.build:gradle"
-      - dependency-name: "com.android.application"
-      - dependency-name: "com.android.library"
       # Bumping 2.13.3 to the newest version requires lots of changes, including changes to
       # Gutenberg. As such, and as agreed, any update is paused. For more details, see
       # https://github.com/wordpress-mobile/WordPress-Android/pull/17936#issuecomment-1553227875


### PR DESCRIPTION
## Description:

1. [Stop ignoring the agp update](https://github.com/wordpress-mobile/WordPress-Android/commit/6758b3a90c31cdfb79e63eef9d57307371999c11)
2. [Remove unnecessary dependencies from ignore list](https://github.com/wordpress-mobile/WordPress-Android/commit/13b1e040ed733149f5a6d6845fdb734bbde232ea) (`fluxc` + `login`)
3. [Remove unnecessary dependencies from ignore list](https://github.com/wordpress-mobile/WordPress-Android/commit/dc83fe11a0197caafe2ae056092b86fc505842ef) (`stories`)

-----

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

It'll just start working after merge. 🤷

-----

## Regression Notes

1. Potential unintended areas of impact

    - N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)

    - N/A

5. What automated tests I added (or what prevented me from doing so)

    - N/A

-----

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

-----

## Testing Checklist (strike-out the not-applying and unnecessary ones): `N/A`