### PR TITLE
[Tooling] Automate GitHub release publishing for beta builds

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -463,7 +463,7 @@ platform :android do
     end.select { |f| File.exist?(f) }
 
     release_title = versions.last
-    set_prerelease_flag = prerelease.nil? ? /-rc-|alpha-/.match?(release_title) : prerelease
+    beta_release = prerelease.nil? ? /-rc-|alpha-/.match?(release_title) : prerelease
 
     UI.message("Creating release for #{release_title} with the following assets: #{release_assets.inspect}")
 
@@ -479,8 +479,9 @@ platform :android do
       repository: GITHUB_REPO,
       version: release_title,
       release_notes_file_path: tmp_file,
-      prerelease: set_prerelease_flag,
-      release_assets: release_assets.join(',')
+      release_assets: release_assets.join(','),
+      prerelease: beta_release, # Beta = prerelease, Final = normal Release
+      is_draft: !beta_release # Beta = publish immediately, Final = Draft (only publish after Apple approval)
     )
 
     FileUtils.rm(tmp_file)


### PR DESCRIPTION
Reference: pdnsEh-24G-p2

- iOS counterpart PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/24176
- ReleasesV2 PR: https://github.a8c.com/Automattic/wpcom/pull/176420

### Description
This PR updates the `create_gh_release` lane to automate the publishing of beta builds:

- Beta releases: Set as `prerelease=true` and `draft=false` to publish immediately as a pre-release
- Final releases: Set as `prerelease=false` and `draft=true` to create as a draft until we get Apple approval and can publish it

### Testing Steps

We'll be able to fully verify this works as expected during the next WP Android release cycle.

