### PR TITLE
[Tooling] Add hotfix pipelines to be triggered by ReleasesV2

### DIFF
--- a/.buildkite/finalize-hotfix-release.yml
+++ b/.buildkite/finalize-hotfix-release.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+steps:
+  - label: Finalize Hotfix
+    plugins: [$CI_TOOLKIT]
+    command: |
+      echo '--- :robot_face: Use bot for Git operations'
+      source use-bot-for-git
+
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :shipit: Finalize hotfix'
+      bundle exec fastlane finalize_hotfix_release skip_confirm:true
+    agents:
+       queue: tumblr-metal
+    retry:
+      manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        allowed: false
+        reason: If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step

--- a/.buildkite/new-hotfix-release.yml
+++ b/.buildkite/new-hotfix-release.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+steps:
+  - label: New Hotfix Release
+    plugins: [$CI_TOOLKIT]
+    command: |
+      echo '--- :robot_face: Use bot for Git operations'
+      source use-bot-for-git
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :shipit: Start new hotfix'
+      bundle exec fastlane new_hotfix_release version_name:"$RELEASE_VERSION" build_code:"$BUILD_CODE" skip_confirm:true
+    agents:
+       queue: tumblr-metal
+    retry:
+      manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        allowed: false
+        reason: If this job fails, please trigger a new build from ReleasesV2 instead of retrying this step


### PR DESCRIPTION
Internal reference: pdnsEh-252-p2
Rv2 PR: https://github.a8c.com/Automattic/wpcom/pull/176594

This PR adds the pipelines used by the new WordPress Android Hotfix release type on ReleasesV2.

-----

## To Test:

We can test the pipelines creating a manual Buildkite build on branch `iangmaia/add-hotfix-pipelines` to simulate the Rv2 call:

- Manual build triggering `new-hotfix-release.yml`: https://buildkite.com/automattic/wordpress-android/builds/21376 (which generated the branch `release/25.5.1` (**to be deleted**) and the commit 1ffae3cdff4ba756cfb710e5012cd7384f86eb15
- Manual build triggering `finalize-hotfix-release.yml`: https://buildkite.com/automattic/wordpress-android/builds/21378

We'll be able to fully verify the entire flow in the next WordPress Android release cycle.