### PR TITLE
Fix editor photo cropper toolbar

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -791,10 +791,6 @@
             android:label="@string/edit_photo_screen_title"
             android:theme="@style/WordPress.NoActionBar"/>
 
-        <activity android:name="org.wordpress.android.imageeditor.EditImageActivity"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
-            tools:replace="android:theme" />
-
         <activity
             android:name=".ui.posts.JetpackSecuritySettingsActivity"
             android:theme="@style/WordPress.NoActionBar"/>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -791,6 +791,10 @@
             android:label="@string/edit_photo_screen_title"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <activity android:name="org.wordpress.android.imageeditor.EditImageActivity"
+            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            tools:replace="android:theme" />
+
         <activity
             android:name=".ui.posts.JetpackSecuritySettingsActivity"
             android:theme="@style/WordPress.NoActionBar"/>

--- a/libs/image-editor/src/main/res/values-v35/styles.xml
+++ b/libs/image-editor/src/main/res/values-v35/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <style name="Base.ImageEditorTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
Fixes #21753

We discovered another edge-to-edge bug, this time in the photo cropper. This turned out to be due to our [ImageEditor](https://github.com/wordpress-mobile/WordPress-Android/tree/26d1780717789bde54806071c19af6857e7b0db1/libs/image-editor) library not handling edge-to-edge on API 35+.

This PR address the problem by changing the photo editor activity style for API 35+ to support fullscreen.

To test:

* Edit a post in Gutenberg on an API 35+ device
* Choose to add a photo from the device
* Select a photo, then tap the "Edit Photo" button in the toolbar (to the left of the checkmark)
* Verify the photo editor toolbar is not obscured by the status bar
* Do the same on an older device and verify it works as expected