### PR TITLE
fix: DocsBot initialization

### DIFF
--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -59,7 +59,7 @@
             location.search.substr(1).split`&`.reduce((qd, item) => {
                 let [k, v] = item.split`=`;
                 v = v && decodeURIComponent(v);
-                (qd[k] = qd[k] || []).push(v);
+                qd[k] = v;
                 return qd
             }, {}) :
             {}


### PR DESCRIPTION
The previous `getQueryParams` implementation created an object with
key-value pairs, where each value was an array of a single string. This
appears unnecessary as each DocsBot configuration option expects a
string, not an array.

Seemingly, the previous implementation worked because:

First, we invoke `decodeURIComponent` on most options before passing
them to DocsBot, which performs an implicit type coercion from array to
string.

Second, we rely upon a remote `https://widget.docsbot.ai/chat.js`
script. Presumably, this remote script was performing implicit type
coercions on our behalf, but may have recently updated to no longer do
so. This resulted in new failures when attempting to invoke string
methods on an array:

```
[INFO:CONSOLE(44)] "Uncaught (in promise) TypeError: i.id.split is not a function", source: https://widget.docsbot.ai/chat.js (44)
```

From reviewing our [WP-iOS implementation](https://github.com/wordpress-mobile/WordPress-iOS/blob/a6eaa7aa8acb50828449df2d3fccaa50d7def821/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift#L81-L105), it initializes DocsBot with
string values, not arrays, further affirming this new approach.

## To Test:
<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->
1. Navigate to _Me_ → _Help & Support_ → _Contact Support_.
1. Verify the DocsBot WebView loads and chat functions.

## Regression Notes
1. Potential unintended areas of impact
    Possibly disrupt metadata captured for DocsBot chats.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verified iOS also sends options in the same manner.
3. What automated tests I added (or what prevented me from doing so)
    N/A, deemed unnecessary for this third-party WebView integration.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
