### PR TITLE
Hotfix for 25.7.2 Docsbot and crop toolbar

### DIFF
--- a/WordPress/src/jetpack/assets/support_chat_widget.js
+++ b/WordPress/src/jetpack/assets/support_chat_widget.js
@@ -59,7 +59,7 @@
             location.search.substr(1).split`&`.reduce((qd, item) => {
                 let [k, v] = item.split`=`;
                 v = v && decodeURIComponent(v);
-                (qd[k] = qd[k] || []).push(v);
+                qd[k] = v;
                 return qd
             }, {}) :
             {}

--- a/libs/image-editor/src/main/res/values-v35/styles.xml
+++ b/libs/image-editor/src/main/res/values-v35/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <style name="Base.ImageEditorTheme" parent="Theme.MaterialComponents.NoActionBar.Bridge">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
This is a hotfix for 25.7.2 which includes changes from these two PRs:

#21755 - fix: DocsBot initialization
#21754 - Fix editor photo cropper toolbar

To test, follow the steps in each of those PRs and verify that they work as expected in this PR.

Note that while testing the image cropper in this release, you may notice the toolbar dropping down after selecting an image:

![photo-selection](https://github.com/user-attachments/assets/27b7db9d-8599-4569-a0a0-dfc14bd49aa9)

This bug already existed in `release/25.7.1` and has been fixed in `trunk`. However, that fix involved a number of changes to `BaseAppCompatActivity`, and they are too numerous to include in this quick hotfix.