### PR TITLE
Merge `25.7.2` to `trunk`

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=25.7.1
-versionCode=1461
+versionName=25.7.2
+versionCode=1462


### PR DESCRIPTION
Hotfix changes are merged in #21754 & #21755, so this PR only has the version bump change.