### PR TITLE
[Tooling] Move Gradle Wrapper Validation to the `linter` queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,10 +14,10 @@ steps:
   #################
   # Gradle Wrapper Validation
   #################
-  - label: "Gradle Wrapper Validation"
-    command: |
-      validate_gradle_wrapper
-    plugins: [$CI_TOOLKIT]
+  - label: Gradle Wrapper Validation
+    command: validate_gradle_wrapper
+    agents:
+      queue: linter
 
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait


### PR DESCRIPTION
Reference: paaHJt-7yE-p2

While monitoring the `linter` queue, I noticed WPAndroid hasn't migrated the Gradle Wrapper Validation jobs to run in the Linter Agents, so this PR updates it.