### PR TITLE
Email verification banner tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.wordpress.android.WordPress
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
@@ -21,6 +20,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtils
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,6 +33,7 @@ class EmailVerificationViewModel
     private val dispatcher: Dispatcher,
     private val accountStore: AccountStore,
     private val appLogWrapper: AppLogWrapper,
+    private val contextProvider: ContextProvider,
 ) : ScopedViewModel(mainDispatcher) {
     private val _verificationState = MutableStateFlow<VerificationState?>(null)
     val verificationState = _verificationState.asStateFlow()
@@ -71,7 +72,7 @@ class EmailVerificationViewModel
      * User clicked the "Send verification link" button on the email verification banner
      */
     fun onSendVerificationLinkClick() {
-        if (!NetworkUtils.checkConnection(WordPress.getContext())) {
+        if (!NetworkUtils.checkConnection(contextProvider.getContext())) {
             appLogWrapper.d(AppLog.T.MAIN, "$TAG: No connection")
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -19,8 +19,7 @@ import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.util.AppLog
-import org.wordpress.android.util.NetworkUtils
-import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.util.NetworkUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,7 +32,7 @@ class EmailVerificationViewModel
     private val dispatcher: Dispatcher,
     private val accountStore: AccountStore,
     private val appLogWrapper: AppLogWrapper,
-    private val contextProvider: ContextProvider,
+    private val networkUtilsWrapper: NetworkUtilsWrapper,
 ) : ScopedViewModel(mainDispatcher) {
     private val _verificationState = MutableStateFlow<VerificationState?>(null)
     val verificationState = _verificationState.asStateFlow()
@@ -72,8 +71,8 @@ class EmailVerificationViewModel
      * User clicked the "Send verification link" button on the email verification banner
      */
     fun onSendVerificationLinkClick() {
-        if (!NetworkUtils.checkConnection(contextProvider.getContext())) {
-            appLogWrapper.d(AppLog.T.MAIN, "$TAG: No connection")
+        if (!networkUtilsWrapper.isNetworkAvailable()) {
+            onVerificationLinkError("No connection")
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -82,7 +82,7 @@ class EmailVerificationViewModel
             pollingJob?.cancel()
         }
 
-        onVerificationEmailRequested()
+        onVerificationLinkRequested()
 
         // briefly delay the request so the user can see the updated banner if the request completes quickly
         launch(bgDispatcher) {
@@ -91,19 +91,18 @@ class EmailVerificationViewModel
         }
     }
 
-    fun onVerificationEmailRequested() {
+    fun onVerificationLinkRequested() {
+        _errorMessage.value = ""
         _verificationState.value = VerificationState.LINK_REQUESTED
         appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link requested")
     }
 
-    fun onVerificationEmailSent() {
-        if (_verificationState.value != VerificationState.LINK_SENT) {
-            _verificationState.value = VerificationState.LINK_SENT
-            appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link sent")
-        }
+    fun onVerificationLinkSent() {
+        _verificationState.value = VerificationState.LINK_SENT
+        appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link sent")
     }
 
-    fun onVerificationEmailError(message: String) {
+    fun onVerificationLinkError(message: String) {
         _errorMessage.value = message
         _verificationState.value = VerificationState.LINK_ERROR
         appLogWrapper.e(AppLog.T.MAIN, "$TAG: Error sending verification link, $message")
@@ -146,12 +145,12 @@ class EmailVerificationViewModel
     fun onAccountChanged(event: OnAccountChanged) {
         if (event.isError) {
             if (event.error.type == AccountErrorType.SEND_VERIFICATION_EMAIL_ERROR) {
-                onVerificationEmailError(event.error.message)
+                onVerificationLinkError(event.error.message)
             }
         } else if (event.causeOfChange == AccountAction.SEND_VERIFICATION_EMAIL ||
             event.causeOfChange == AccountAction.SENT_VERIFICATION_EMAIL
         ) {
-            onVerificationEmailSent()
+            onVerificationLinkSent()
             pollVerificationState()
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -82,14 +82,36 @@ class EmailVerificationViewModel
             pollingJob?.cancel()
         }
 
-        _verificationState.value = VerificationState.LINK_REQUESTED
-        appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link requested")
+        onVerificationEmailRequested()
 
         // briefly delay the request so the user can see the updated banner if the request completes quickly
         launch(bgDispatcher) {
             delay(REQUEST_LINK_DELAY)
             dispatcher.dispatch(AccountActionBuilder.newSendVerificationEmailAction())
         }
+    }
+
+    fun onVerificationEmailRequested() {
+        _verificationState.value = VerificationState.LINK_REQUESTED
+        appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link requested")
+    }
+
+    fun onVerificationEmailSent() {
+        if (_verificationState.value != VerificationState.LINK_SENT) {
+            _verificationState.value = VerificationState.LINK_SENT
+            appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link sent")
+        }
+    }
+
+    fun onVerificationEmailError(message: String) {
+        _errorMessage.value = message
+        _verificationState.value = VerificationState.LINK_ERROR
+        appLogWrapper.e(AppLog.T.MAIN, "$TAG: Error sending verification link, $message")
+    }
+
+    fun onEmailVerified() {
+        _verificationState.value = VerificationState.VERIFIED
+        appLogWrapper.d(AppLog.T.MAIN, "$TAG: Email verified")
     }
 
     /**
@@ -107,9 +129,8 @@ class EmailVerificationViewModel
                 delay(POLLING_INTERVAL_MS)
                 if (accountStore.account.emailVerified) {
                     withContext(mainDispatcher) {
-                        _verificationState.value = VerificationState.VERIFIED
-                        appLogWrapper.d(AppLog.T.MAIN, "$TAG: Email verified")
                         pollingJob?.cancel()
+                        onEmailVerified()
                         return@withContext
                     }
                 }
@@ -125,18 +146,13 @@ class EmailVerificationViewModel
     fun onAccountChanged(event: OnAccountChanged) {
         if (event.isError) {
             if (event.error.type == AccountErrorType.SEND_VERIFICATION_EMAIL_ERROR) {
-                _errorMessage.value = event.error.message
-                _verificationState.value = VerificationState.LINK_ERROR
-                appLogWrapper.e(AppLog.T.MAIN, "$TAG: Error sending verification link, ${event.error.message}")
+                onVerificationEmailError(event.error.message)
             }
         } else if (event.causeOfChange == AccountAction.SEND_VERIFICATION_EMAIL ||
             event.causeOfChange == AccountAction.SENT_VERIFICATION_EMAIL
         ) {
-            if (_verificationState.value != VerificationState.LINK_SENT) {
-                _verificationState.value = VerificationState.LINK_SENT
-                appLogWrapper.d(AppLog.T.MAIN, "$TAG: Verification link sent")
-                pollVerificationState()
-            }
+            onVerificationEmailSent()
+            pollVerificationState()
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
@@ -20,6 +21,7 @@ import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 import org.wordpress.android.viewmodel.ScopedViewModel
 import javax.inject.Inject
 import javax.inject.Named
@@ -32,6 +34,7 @@ class EmailVerificationViewModel
     private val dispatcher: Dispatcher,
     private val accountStore: AccountStore,
     private val appLogWrapper: AppLogWrapper,
+    private val contextProvider: ContextProvider,
     private val networkUtilsWrapper: NetworkUtilsWrapper,
 ) : ScopedViewModel(mainDispatcher) {
     private val _verificationState = MutableStateFlow<VerificationState?>(null)
@@ -59,7 +62,7 @@ class EmailVerificationViewModel
         _emailAddress.value = accountStore.account.email
 
         _verificationState.value = if (accountStore.account.emailVerified) {
-            VerificationState.VERIFIED
+            VerificationState.UNVERIFIED // TODO
         } else if (_emailAddress.value.isNotEmpty()) {
             VerificationState.UNVERIFIED
         } else {
@@ -72,7 +75,7 @@ class EmailVerificationViewModel
      */
     fun onSendVerificationLinkClick() {
         if (!networkUtilsWrapper.isNetworkAvailable()) {
-            onVerificationLinkError("No connection")
+            onVerificationLinkError(contextProvider.getContext().getString(R.string.no_network_message))
             return
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModel.kt
@@ -62,7 +62,7 @@ class EmailVerificationViewModel
         _emailAddress.value = accountStore.account.email
 
         _verificationState.value = if (accountStore.account.emailVerified) {
-            VerificationState.UNVERIFIED // TODO
+            VerificationState.VERIFIED
         } else if (_emailAddress.value.isNotEmpty()) {
             VerificationState.UNVERIFIED
         } else {

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationViewModel.VerificationState
 import org.wordpress.android.util.NetworkUtilsWrapper
+import org.wordpress.android.viewmodel.ContextProvider
 
 @ExperimentalCoroutinesApi
 class EmailVerificationViewModelTest : BaseUnitTest() {
@@ -25,6 +26,9 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
+
+    @Mock
+    lateinit var contextProvider: ContextProvider
 
     @Mock
     lateinit var networkUtilsWrapper: NetworkUtilsWrapper
@@ -46,6 +50,7 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
             dispatcher = dispatcher,
             accountStore = accountStore,
             appLogWrapper = appLogWrapper,
+            contextProvider = contextProvider,
             networkUtilsWrapper = networkUtilsWrapper,
         )
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -13,7 +13,7 @@ import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationViewModel.VerificationState
-import org.wordpress.android.viewmodel.ContextProvider
+import org.wordpress.android.util.NetworkUtilsWrapper
 
 @ExperimentalCoroutinesApi
 class EmailVerificationViewModelTest : BaseUnitTest() {
@@ -27,7 +27,7 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
     lateinit var appLogWrapper: AppLogWrapper
 
     @Mock
-    lateinit var contextProvider: ContextProvider
+    lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
     private lateinit var viewModel: EmailVerificationViewModel
 
@@ -46,70 +46,61 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
             dispatcher = dispatcher,
             accountStore = accountStore,
             appLogWrapper = appLogWrapper,
-            contextProvider = contextProvider,
+            networkUtilsWrapper = networkUtilsWrapper,
         )
     }
 
     @Test
     fun `when link requested, state changes to link requested`() = runTest {
-        // When
         viewModel.onVerificationLinkRequested()
 
-        // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
     }
 
     @Test
     fun `when link sent successfully, state changes to link sent`() = runTest {
-        // When
         viewModel.onVerificationLinkSent()
 
-        // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_SENT)
     }
 
     @Test
     fun `when link fails, state changes to error`() = runTest {
-        // When
         viewModel.onVerificationLinkError("Network error")
 
-        // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
         assertThat(viewModel.errorMessage.value).isEqualTo("Network error")
     }
 
     @Test
     fun `when email is verified, state changes to verified`() = runTest {
-        // When
         viewModel.onEmailVerified()
 
-        // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.VERIFIED)
     }
 
     @Test
     fun `error message is cleared when sending new verification email`() = runTest {
-        // Given
         viewModel.onVerificationLinkError("Previous error")
-
-        // When
         viewModel.onVerificationLinkRequested()
 
-        // Then
         assertThat(viewModel.errorMessage.value).isEmpty()
     }
 
     @Test
     fun `error state can be recovered from`() = runTest {
-        // Given
         viewModel.onVerificationLinkError("Error")
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
 
-        // When
         viewModel.onVerificationLinkRequested()
-
-        // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
         assertThat(viewModel.errorMessage.value).isEmpty()
+    }
+
+    @Test
+    fun `when no connection, state changes to error`() = runTest {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        viewModel.onSendVerificationLinkClick()
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -1,36 +1,53 @@
 package org.wordpress.android.ui.main.emailverificationbanner
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
-import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationViewModel.VerificationState
 import org.assertj.core.api.Assertions.assertThat
-import org.wordpress.android.CoroutineTestRule
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.model.AccountModel
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationViewModel.VerificationState
+import org.wordpress.android.viewmodel.ContextProvider
 
 @ExperimentalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
 class EmailVerificationViewModelTest : BaseUnitTest() {
-    @Rule
-    @JvmField
-    val coroutineRule = CoroutineTestRule()
+    @Mock
+    lateinit var dispatcher: Dispatcher
+
+    @Mock
+    lateinit var accountStore: AccountStore
+
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+
+    @Mock
+    lateinit var contextProvider: ContextProvider
 
     private lateinit var viewModel: EmailVerificationViewModel
-    private val verificationState = MutableStateFlow<VerificationState?>(null)
-    private val emailAddress = MutableStateFlow("test@example.com")
-    private val errorMessage = MutableStateFlow("")
 
     @Before
     fun setup() {
         viewModel = EmailVerificationViewModel(
-            initialState = VerificationState.UNVERIFIED,
-            coroutineDispatcher = coroutineRule.testDispatcher
+            mainDispatcher = testDispatcher(),
+            bgDispatcher = testDispatcher(),
+            dispatcher = dispatcher,
+            accountStore = accountStore,
+            appLogWrapper = appLogWrapper,
+            contextProvider = contextProvider,
         )
+
+        val accountModel = AccountModel()
+        accountModel.userName = "testuser"
+        accountModel.displayName = "Test User"
+
+        whenever(accountStore.account).thenReturn(accountModel)
     }
 
     @Test
@@ -50,9 +67,6 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
     @Test
     fun `when link sent successfully, state changes to link sent`() = runTest {
         // Given
-        viewModel.onSendVerificationLinkClick()
-
-        // When
         viewModel.onVerificationEmailSent()
 
         // Then
@@ -79,16 +93,6 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
         // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.VERIFIED)
-    }
-
-    @Test
-    fun `email address is exposed through state`() = runTest {
-        // Given
-        val testEmail = "test@example.com"
-        viewModel.updateEmailAddress(testEmail)
-
-        // Then
-        assertThat(viewModel.emailAddress.value).isEqualTo(testEmail)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.main.emailverificationbanner
 
+import android.content.Context
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
@@ -33,16 +35,19 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var networkUtilsWrapper: NetworkUtilsWrapper
 
+    @Mock
+    lateinit var context: Context
+
     private lateinit var viewModel: EmailVerificationViewModel
 
     @Before
     fun setup() {
         AccountModel().also {
-            it.userName = "testuser"
-            it.displayName = "Test User"
             it.email = "testuser@example.com"
             whenever(accountStore.account).thenReturn(it)
         }
+
+        whenever(contextProvider.getContext()).thenReturn(context)
 
         viewModel = EmailVerificationViewModel(
             mainDispatcher = testDispatcher(),
@@ -105,6 +110,7 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
     @Test
     fun `when no connection, state changes to error`() = runTest {
         whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+        whenever(context.getString(any())).thenReturn("No network")
         viewModel.onSendVerificationLinkClick()
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -1,0 +1,131 @@
+package org.wordpress.android.ui.main.emailverificationbanner
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.main.emailverificationbanner.EmailVerificationViewModel.VerificationState
+import org.assertj.core.api.Assertions.assertThat
+import org.wordpress.android.CoroutineTestRule
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class EmailVerificationViewModelTest : BaseUnitTest() {
+    @Rule
+    @JvmField
+    val coroutineRule = CoroutineTestRule()
+
+    private lateinit var viewModel: EmailVerificationViewModel
+    private val verificationState = MutableStateFlow<VerificationState?>(null)
+    private val emailAddress = MutableStateFlow("test@example.com")
+    private val errorMessage = MutableStateFlow("")
+
+    @Before
+    fun setup() {
+        viewModel = EmailVerificationViewModel(
+            initialState = VerificationState.UNVERIFIED,
+            coroutineDispatcher = coroutineRule.testDispatcher
+        )
+    }
+
+    @Test
+    fun `initial state is unverified`() = runTest {
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.UNVERIFIED)
+    }
+
+    @Test
+    fun `when send link clicked, state changes to link requested`() = runTest {
+        // When
+        viewModel.onSendVerificationLinkClick()
+
+        // Then
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
+    }
+
+    @Test
+    fun `when link sent successfully, state changes to link sent`() = runTest {
+        // Given
+        viewModel.onSendVerificationLinkClick()
+
+        // When
+        viewModel.onVerificationEmailSent()
+
+        // Then
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_SENT)
+    }
+
+    @Test
+    fun `when link fails, state changes to error`() = runTest {
+        // Given
+        viewModel.onSendVerificationLinkClick()
+
+        // When
+        viewModel.onVerificationEmailError("Network error")
+
+        // Then
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
+        assertThat(viewModel.errorMessage.value).isEqualTo("Network error")
+    }
+
+    @Test
+    fun `when email is verified, state changes to verified`() = runTest {
+        // When
+        viewModel.onEmailVerified()
+
+        // Then
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.VERIFIED)
+    }
+
+    @Test
+    fun `email address is exposed through state`() = runTest {
+        // Given
+        val testEmail = "test@example.com"
+        viewModel.updateEmailAddress(testEmail)
+
+        // Then
+        assertThat(viewModel.emailAddress.value).isEqualTo(testEmail)
+    }
+
+    @Test
+    fun `error message is cleared when sending new verification email`() = runTest {
+        // Given
+        viewModel.onVerificationEmailError("Previous error")
+
+        // When
+        viewModel.onSendVerificationLinkClick()
+
+        // Then
+        assertThat(viewModel.errorMessage.value).isEmpty()
+    }
+
+    @Test
+    fun `state transition sequence is correct`() = runTest {
+        // Test complete flow: UNVERIFIED -> LINK_REQUESTED -> LINK_SENT
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.UNVERIFIED)
+
+        viewModel.onSendVerificationLinkClick()
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
+
+        viewModel.onVerificationEmailSent()
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_SENT)
+    }
+
+    @Test
+    fun `error state can be recovered from`() = runTest {
+        // Given
+        viewModel.onVerificationEmailError("Error")
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
+
+        // When
+        viewModel.onSendVerificationLinkClick()
+
+        // Then
+        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
+        assertThat(viewModel.errorMessage.value).isEmpty()
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.Dispatcher
@@ -34,6 +33,13 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
+        AccountModel().also {
+            it.userName = "testuser"
+            it.displayName = "Test User"
+            it.email = "testuser@example.com"
+            whenever(accountStore.account).thenReturn(it)
+        }
+
         viewModel = EmailVerificationViewModel(
             mainDispatcher = testDispatcher(),
             bgDispatcher = testDispatcher(),
@@ -42,23 +48,12 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
             appLogWrapper = appLogWrapper,
             contextProvider = contextProvider,
         )
-
-        val accountModel = AccountModel()
-        accountModel.userName = "testuser"
-        accountModel.displayName = "Test User"
-
-        whenever(accountStore.account).thenReturn(accountModel)
     }
 
     @Test
-    fun `initial state is unverified`() = runTest {
-        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.UNVERIFIED)
-    }
-
-    @Test
-    fun `when send link clicked, state changes to link requested`() = runTest {
+    fun `when link requested, state changes to link requested`() = runTest {
         // When
-        viewModel.onSendVerificationLinkClick()
+        viewModel.onVerificationLinkRequested()
 
         // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
@@ -66,8 +61,8 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when link sent successfully, state changes to link sent`() = runTest {
-        // Given
-        viewModel.onVerificationEmailSent()
+        // When
+        viewModel.onVerificationLinkSent()
 
         // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_SENT)
@@ -75,11 +70,8 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
     @Test
     fun `when link fails, state changes to error`() = runTest {
-        // Given
-        viewModel.onSendVerificationLinkClick()
-
         // When
-        viewModel.onVerificationEmailError("Network error")
+        viewModel.onVerificationLinkError("Network error")
 
         // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
@@ -98,35 +90,23 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
     @Test
     fun `error message is cleared when sending new verification email`() = runTest {
         // Given
-        viewModel.onVerificationEmailError("Previous error")
+        viewModel.onVerificationLinkError("Previous error")
 
         // When
-        viewModel.onSendVerificationLinkClick()
+        viewModel.onVerificationLinkRequested()
 
         // Then
         assertThat(viewModel.errorMessage.value).isEmpty()
     }
 
     @Test
-    fun `state transition sequence is correct`() = runTest {
-        // Test complete flow: UNVERIFIED -> LINK_REQUESTED -> LINK_SENT
-        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.UNVERIFIED)
-
-        viewModel.onSendVerificationLinkClick()
-        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)
-
-        viewModel.onVerificationEmailSent()
-        assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_SENT)
-    }
-
-    @Test
     fun `error state can be recovered from`() = runTest {
         // Given
-        viewModel.onVerificationEmailError("Error")
+        viewModel.onVerificationLinkError("Error")
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_ERROR)
 
         // When
-        viewModel.onSendVerificationLinkClick()
+        viewModel.onVerificationLinkRequested()
 
         // Then
         assertThat(viewModel.verificationState.value).isEqualTo(VerificationState.LINK_REQUESTED)

--- a/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/main/emailverificationbanner/EmailVerificationViewModelTest.kt
@@ -42,12 +42,13 @@ class EmailVerificationViewModelTest : BaseUnitTest() {
 
     @Before
     fun setup() {
-        AccountModel().also {
-            it.email = "testuser@example.com"
-            whenever(accountStore.account).thenReturn(it)
-        }
-
         whenever(contextProvider.getContext()).thenReturn(context)
+
+        whenever(accountStore.account).thenReturn(
+            AccountModel().also {
+                it.email = "testuser@example.com"
+            }
+        )
 
         viewModel = EmailVerificationViewModel(
             mainDispatcher = testDispatcher(),


### PR DESCRIPTION
This PR adds basic tests to the email verification banner view model which [we recently added to the Me screen](https://github.com/wordpress-mobile/WordPress-Android/pull/21760), as [suggested](https://github.com/wordpress-mobile/WordPress-Android/pull/21760#issuecomment-2747379808) on the original PR:

> The only suggestion for me would be to add an associated view model test suite so that to help any readers understand any or all the use cases involved without needing to have it trigger this whole flow via manual UI testing.

Green CI should be sufficient to test this.

@oguzkocer I hope you don't mind me asking you for a review. I feel like I've worn David out with review requests :) No rush on this as I'm about to take a few days AFK.

