### PR TITLE
Populate Gradle Build Cache on trunk (or: not only for PRs)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -189,11 +189,9 @@ steps:
     steps:
       - label: ":wordpress: Populate Gradle build cache"
         command: ".buildkite/commands/gradle-cache-build.sh wordpress"
-        if: build.pull_request.id != null
         plugins: [ $CI_TOOLKIT ]
 
       - label: ":jetpack: Populate Gradle build cache"
         command: ".buildkite/commands/gradle-cache-build.sh jetpack"
-        if: build.pull_request.id != null
         plugins: [ $CI_TOOLKIT ]
 


### PR DESCRIPTION
### Description

This small PR updates the Gradle Cache CI jobs to run not only on PRs (so artifacts from `trunk` are available to fetch from remote cache).