### PR TITLE
task: Remote feature flag gates GutenbergKit plugins

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -235,6 +235,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource
 import org.wordpress.android.util.config.ContactSupportFeatureConfig
+import org.wordpress.android.util.config.GutenbergKitPluginsFeature
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.util.helpers.MediaFile
@@ -412,11 +413,11 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Inject lateinit var postConflictResolutionFeatureConfig: PostConflictResolutionFeatureConfig
 
+    @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
+
     private val gutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
     private val gutenbergKitThemeStylesConfig: ExperimentalFeature =
         ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
-    private val gutenbergKitPluginsConfig: ExperimentalFeature =
-        ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR_PLUGINS
 
     @Inject lateinit var storePostViewModel: StorePostViewModel
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
@@ -2519,7 +2520,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 "siteApiNamespace" to siteApiNamespace,
                 "themeStyles" to gutenbergKitThemeStylesConfig.isEnabled(),
                 // Limited to Simple sites until application passwords are supported
-                "plugins" to (gutenbergKitPluginsConfig.isEnabled() && site.isWPCom),
+                "plugins" to (gutenbergKitPluginsFeature.isEnabled() && site.isWPCom),
                 "webViewGlobals" to listOf(
                     WebViewGlobal(
                         "_currentSiteType",

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -48,10 +48,6 @@ enum class ExperimentalFeature(val prefKey: String, val labelResId: Int) {
     EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES(
         "experimental_block_editor_theme_styles",
         R.string.experimental_block_editor_theme_styles
-    ),
-    EXPERIMENTAL_BLOCK_EDITOR_PLUGINS(
-        "experimental_block_editor_plugins",
-        R.string.experimental_block_editor_plugins
     );
 
     fun isEnabled() : Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergKitPluginsFeature.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergKitPluginsFeature.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.GutenbergKitPluginsFeature.Companion.GUTENBERG_KIT_PLUGINS_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration for enabling/disabling Gutenberg Kit plugins
+ */
+@Feature(remoteField = GUTENBERG_KIT_PLUGINS_FIELD, defaultValue = false)
+class GutenbergKitPluginsFeature
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    false,
+    GUTENBERG_KIT_PLUGINS_FIELD
+) {
+    companion object {
+        const val GUTENBERG_KIT_PLUGINS_FIELD = "gutenberg_kit_plugins"
+    }
+}


### PR DESCRIPTION
Allow remotely controlling the availability of GutenbergKit plugin
support. Ref CMM-277.

Related:

* CMM-277-linear-issue
* 180578-ghe-Automattic/wpcom
* https://github.com/wordpress-mobile/WordPress-iOS/pull/24449

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

1. Enable the `Experimental block editor` feature flag.
1. Open the editor for a WordPress.com-hosted site.
1. Verify the expected presence of third-party blocks based on whether the
   logged in user account is an A11n or non-A11n.

## Regression Notes

1. Potential unintended areas of impact
    Unlikely for this feature flag change for an experimental feature.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental feature.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
