### PR TITLE
task: Remote feature flag gates GutenbergKit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -235,6 +235,7 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource
 import org.wordpress.android.util.config.ContactSupportFeatureConfig
+import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.config.GutenbergKitPluginsFeature
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
@@ -413,6 +414,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Inject lateinit var postConflictResolutionFeatureConfig: PostConflictResolutionFeatureConfig
 
+    @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
     @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
 
     private val gutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
@@ -526,7 +528,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         onBackPressedDispatcher.addCallback(this, callback)
         dispatcher.register(this)
-        isGutenbergKitEditor = gutenbergKitFeatureConfig.isEnabled()
+        isGutenbergKitEditor = gutenbergKitFeatureConfig.isEnabled() || gutenbergKitFeature.isEnabled()
 
         createEditShareMessageActivityResultLauncher()
 

--- a/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergKitFeature.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/config/GutenbergKitFeature.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.util.config
+
+import org.wordpress.android.annotation.Feature
+import org.wordpress.android.util.config.GutenbergKitFeature.Companion.GUTENBERG_KIT_FIELD
+import javax.inject.Inject
+
+/**
+ * Configuration for enabling/disabling Gutenberg Kit
+ */
+@Feature(remoteField = GUTENBERG_KIT_FIELD, defaultValue = false)
+class GutenbergKitFeature
+@Inject constructor(appConfig: AppConfig) : FeatureConfig(
+    appConfig,
+    false,
+    GUTENBERG_KIT_FIELD
+) {
+    companion object {
+        const val GUTENBERG_KIT_FIELD = "gutenberg_kit"
+    }
+}


### PR DESCRIPTION
Augment the existing, user-controlled experimental feature toggle with a remote feature flag that can we used for a phased roll out GutenbergKit regardless of the experimental feature toggle state. 

## To Test:

<!-- Test instructions per dependency update: https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/docs/test_instructions_per_dependency_update.md -->

A remote feature flag has not yet been deployed on the server, so there should be no changes to the UX.

## Regression Notes

1. Potential unintended areas of impact
    Unlikely for this addition.
1. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
1. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental feature.

## PR Submission Checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing Checklist (strike-out the not-applying and unnecessary ones):

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] Talkback.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] Large and small screen sizes. (Tablet and smaller phones)
- [ ] Multi-tasking: Split screen and Pop-up view. (Android 10 or higher)
