### PR TITLE
Catch exception when attempting to load login uri in CustomTabsIntent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -485,7 +486,13 @@ public class LoginActivity extends BaseAppCompatActivity implements ConnectionCa
                 .setShowTitle(false)
                 .build();
 
-        intent.launchUrl(this, mLoginHelper.getWpcomLoginUri());
+        Uri loginUri = mLoginHelper.getWpcomLoginUri();
+        try {
+            intent.launchUrl(this, loginUri);
+        } catch (SecurityException | ActivityNotFoundException e) {
+            AppLog.e(AppLog.T.UTILS, "Error opening login uri in CustomTabsIntent, attempting external browser", e);
+            ActivityLauncher.openUrlExternal(this, loginUri.toString());
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes CMM-282

This crash occurred because we load the login Uri in a `CustomTabsIntent`, which can potentially cause an exception if the default browser doesn't support Chrome Custom Tabs. In this case we see that [OPay](https://play.google.com/store/apps/details?id=team.opay.pay&hl=en&gl=NG) and [MXPlayer](https://play.google.com/store/apps/details?id=com.mxtech.videoplayer.ad) are involved.

This fix catches the exception, and then attempts to fallback to the external browser. Note [there's no guarantee opening in the external browser will work](https://github.com/ice-blockchain/mobile-app/blob/da95250cb269583e4e843479f6601a01d79b2afd/src/utils/device.ts#L38-L53), either, but we attempt anyway and show a toast on failure, which is better than outright crashing.

To test, replace [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/c48c229597dc2faa6009732ce6cdd35302fdbcd8/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java#L491) with the line below and verify you can still login using the external browser:

```
throw new SecurityException("oops");
```