### PR TITLE
Changed default avatar version to 1 to fix gravatar not loading after…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/utils/MeGravatarLoader.kt
@@ -17,7 +17,7 @@ import javax.inject.Singleton
 class MeGravatarLoader @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper,
     private val imageManager: ImageManager,
-    private val resourseProvider: ResourceProvider
+    private val resourceProvider: ResourceProvider
 ) {
     fun load(
         newAvatarSelected: Boolean,
@@ -32,10 +32,10 @@ class MeGravatarLoader @Inject constructor(
             // request cache.
             WordPress.getBitmapCache().removeSimilar(avatarUrl)
             // Changing the signature invalidates Glide's cache
-            appPrefsWrapper.avatarVersion = appPrefsWrapper.avatarVersion + 1
+            appPrefsWrapper.avatarVersion += 1
         }
 
-        val bitmap = WordPress.getBitmapCache().get(avatarUrl)
+        val bitmap = WordPress.getBitmapCache()[avatarUrl]
         // Avatar's API doesn't synchronously update the image at avatarUrl. There is a replication lag
         // (cca 5s), before the old avatar is replaced with the new avatar. Therefore we need to use this workaround,
         // which temporary saves the new image into a local bitmap cache.
@@ -59,7 +59,7 @@ class MeGravatarLoader @Inject constructor(
     }
 
     fun constructGravatarUrl(rawAvatarUrl: String, forceRefresh: Boolean = false): String {
-        val avatarSz = resourseProvider.getDimensionPixelSize(R.dimen.avatar_sz_extra_small)
+        val avatarSz = resourceProvider.getDimensionPixelSize(R.dimen.avatar_sz_extra_small)
         val cacheBuster = if (forceRefresh) System.currentTimeMillis().toString() else null
         return WPAvatarUtils.rewriteAvatarUrl(rawAvatarUrl, avatarSz, cacheBuster)
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1056,7 +1056,7 @@ public class AppPrefs {
     }
 
     public static int getAvatarVersion() {
-        return getInt(DeletablePrefKey.AVATAR_VERSION, 0);
+        return getInt(DeletablePrefKey.AVATAR_VERSION, 1);
     }
 
     public static void setAvatarVersion(int version) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -1055,6 +1055,7 @@ public class AppPrefs {
         return getBoolean(UndeletablePrefKey.IS_INSTALLATION_REFERRER_OBTAINED, false);
     }
 
+    // Default to 1 rather than 0 because a signature of 0 will not affect the cache key
     public static int getAvatarVersion() {
         return getInt(DeletablePrefKey.AVATAR_VERSION, 1);
     }


### PR DESCRIPTION
**Fixes CMM-162**

From the issue:

> The "Me" tab in the Android app doesn't have my gravatar as an icon, it has a generic "Me" icon

What's happening is that the first time the account's avatar is requested we get the placeholder image. This is then stored in the image cache using the avatar url as the key, and the next time the image is requested it uses the same url, but we continue to get the placeholder since that's what is cached for that url.

The problem turned out to be that the default signature passed to Glide was 0 (zero), and according to the docs:

> A signature of "zero" or 0 will not affect the cache key, and the image will be loaded from the cache if the URL remains the same.

Changing the initial signature to 1 fixes the problem.

**To test:**

* Use a clean install, or clear storage
* Login
* Verify the correct avatar shows on the Me screen