### PR TITLE
feat: Preload editor settings within My Site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -52,6 +52,7 @@ import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.UpdateTokenPayload;
+import org.wordpress.android.fluxc.store.EditorSettingsStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.QuickStartStore;
@@ -271,6 +272,8 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     @Inject ShortcutsNavigator mShortcutsNavigator;
     @Inject ShortcutUtils mShortcutUtils;
     @Inject QuickStartStore mQuickStartStore;
+    // Injected to ensure the store responds to dispatched actions
+    @Inject EditorSettingsStore mEditorSettingsStore;
     @Inject UploadActionUseCase mUploadActionUseCase;
     @Inject SystemNotificationsTracker mSystemNotificationsTracker;
     @Inject GCMMessageHandler mGCMMessageHandler;

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -102,7 +102,7 @@ class SelectedSiteRepository @Inject constructor(
     }
 
     private fun fetchEditorSettings(site: SiteModel) {
-        val payload = FetchEditorSettingsPayload(site)
+        val payload = FetchEditorSettingsPayload(site, skipNetworkIfCacheExists = true)
         dispatcher.dispatch(EditorSettingsActionBuilder.newFetchEditorSettingsAction(payload))
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.ExperimentalFeature
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -33,6 +34,8 @@ class SelectedSiteRepository @Inject constructor(
     val showSiteIconProgressBar = _showSiteIconProgressBar as LiveData<Boolean>
 
     val siteSelected = _selectedSiteChange.mapSafe { it?.id }.distinctUntilChanged()
+
+    @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
 
     fun refresh() {
         updateSiteSettingsIfNecessary()
@@ -133,7 +136,7 @@ class SelectedSiteRepository @Inject constructor(
         }
 
         // Fetch the site's editor theme and settings
-        if (ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR.isEnabled()) {
+        if (ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR.isEnabled() || gutenbergKitFeature.isEnabled()) {
             fetchEditorSettings(selectedSite)
         } else {
             fetchEditorTheme(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -4,12 +4,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.action.EditorSettingsActionBuilder
 import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettingsPayload
 import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
+import org.wordpress.android.ui.prefs.ExperimentalFeature
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
 import org.wordpress.android.util.mapSafe
 import javax.inject.Inject
@@ -98,6 +101,11 @@ class SelectedSiteRepository @Inject constructor(
         }
     }
 
+    private fun fetchEditorSettings(site: SiteModel) {
+        val payload = FetchEditorSettingsPayload(site)
+        dispatcher.dispatch(EditorSettingsActionBuilder.newFetchEditorSettingsAction(payload))
+    }
+
     fun updateSiteSettingsIfNecessary() {
         // If the selected site is null, we can't update its site settings
         val selectedSite = getSelectedSite() ?: return
@@ -123,8 +131,13 @@ class SelectedSiteRepository @Inject constructor(
 
             siteSettings?.init(true)
         }
-        // Fetch editor theme to update block-based-theme flag
-        fetchEditorTheme(selectedSite)
+
+        // Fetch the site's editor theme and settings
+        if (ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR.isEnabled()) {
+            fetchEditorSettings(selectedSite)
+        } else {
+            fetchEditorTheme(selectedSite)
+        }
     }
 
     fun isSiteIconUploadInProgress(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -102,7 +102,6 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
-import org.wordpress.android.fluxc.store.EditorSettingsStore
 import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettingsPayload
 import org.wordpress.android.fluxc.store.EditorSettingsStore.OnEditorSettingsChanged
 import org.wordpress.android.fluxc.store.EditorThemeStore
@@ -353,8 +352,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var uploadStore: UploadStore
 
     @Inject lateinit var editorThemeStore: EditorThemeStore
-
-    @Inject lateinit var editorSettingsStore: EditorSettingsStore
 
     @Inject lateinit var imageLoader: FluxCImageLoader
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
 import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.AppInitializer
+import org.wordpress.android.fluxc.action.EditorSettingsAction
 
 @ExperimentalCoroutinesApi
 class SelectedSiteRepositoryTest : BaseUnitTest() {
@@ -257,12 +258,38 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
     }
 
     @Test
-    fun `Should fetch EditorTheme when updateSiteSettingsIfNecessary is called`() {
+    fun `Should fetch EditorTheme when GutenbergKit and ExperimentalBlockEditor are disabled`() {
+        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
         initializeSiteAndSiteSettings()
 
         selectedSiteRepository.updateSiteSettingsIfNecessary()
 
         assertThat(actions.last().type).isEqualTo(EditorThemeAction.FETCH_EDITOR_THEME)
+    }
+
+    @Test
+    fun `Should fetch EditorSettings when GutenbergKit is enabled`() {
+        whenever(gutenbergKitFeature.isEnabled()).thenReturn(true)
+        initializeSiteAndSiteSettings()
+
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
+
+        assertThat(actions.last().type).isEqualTo(EditorSettingsAction.FETCH_EDITOR_SETTINGS)
+    }
+
+    @Test
+    fun `Should fetch EditorSettings when ExperimentalBlockEditor is enabled`() {
+        // Mocking via the specific key is required as ExperimentalFeature currently relies upon AppPrefs rather than
+        // AppPrefsWrapper, making mocking a bit more difficult
+        whenever(sharedPreferences.getBoolean(
+            eq("EXPERIMENTAL_FEATURE_CONFIGexperimental_block_editor"),
+            eq(false)
+        )).thenReturn(true)
+        initializeSiteAndSiteSettings()
+
+        selectedSiteRepository.updateSiteSettingsIfNecessary()
+
+        assertThat(actions.last().type).isEqualTo(EditorSettingsAction.FETCH_EDITOR_SETTINGS)
     }
 
     private fun initializeSiteAndSiteSettings() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/SelectedSiteRepositoryTest.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.ui.mysite
 
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.SharedPreferences.Editor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -21,6 +24,8 @@ import org.wordpress.android.fluxc.annotations.action.Action
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
+import org.wordpress.android.util.config.GutenbergKitFeature
+import org.wordpress.android.AppInitializer
 
 @ExperimentalCoroutinesApi
 class SelectedSiteRepositoryTest : BaseUnitTest() {
@@ -36,6 +41,18 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
     @Mock
     lateinit var appPrefsWrapper: AppPrefsWrapper
 
+    @Mock
+    lateinit var gutenbergKitFeature: GutenbergKitFeature
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var sharedPreferences: SharedPreferences
+
+    @Mock
+    lateinit var editor: Editor
+
     private lateinit var siteModel: SiteModel
     private var siteIconProgressBarVisible: Boolean = false
     private var selectedSite: SiteModel? = null
@@ -48,11 +65,27 @@ class SelectedSiteRepositoryTest : BaseUnitTest() {
 
     @Before
     fun setUp() {
+        // Mock AppInitializer.context
+        AppInitializer::class.java.getDeclaredField("context").apply {
+            isAccessible = true
+            set(null, context)
+        }
+
+        // Mock shared preferences
+        whenever(context.getSharedPreferences(any(), any())).thenReturn(sharedPreferences)
+
+        // Mock AppPrefsWrapper
+        whenever(appPrefsWrapper.setSelectedSite(any())).then { }
+
+        // Mock GutenbergKitFeature
+        whenever(gutenbergKitFeature.isEnabled()).thenReturn(false)
+
         selectedSiteRepository = SelectedSiteRepository(
             dispatcher,
             siteSettingsInterfaceFactory,
             appPrefsWrapper,
         )
+        selectedSiteRepository.gutenbergKitFeature = gutenbergKitFeature
         selectedSiteRepository.showSiteIconProgressBar.observeForever { siteIconProgressBarVisible = it == true }
         selectedSiteRepository.selectedSiteChange.observeForever { selectedSite = it }
         siteModel = SiteModel()


### PR DESCRIPTION
Improve editor load speed through preloading the editor settings. 

## Testing instructions

> [!Important]
> Enabling the `Experimental block editor` feature is required. 

**1: My Site without cache fetches editor settings**
1. Observe the network activity of the app.
1. Install and launch the app.
1. Switch sites. 
1. Verify a successful editor settings endpoint request is performed.

**2: My Site with cache does not fetch editor settings**
1. Switch to a previous site selected in test case 1. 
1. Verify an editor settings endpoint request is not performed. 

**3: Editor utilizes stale-while-revalidate caching**
1. Open the editor. 
2. Verify a successful editor settings endpoint request is performed.
3. Repeat steps one and two. 