### PR TITLE
Full screen reader detail

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -535,7 +535,7 @@
         <activity
             android:name=".ui.reader.ReaderPostPagerActivity"
             android:excludeFromRecents="true"
-            android:theme="@style/ReaderPostPagerTheme"
+            android:theme="@style/WordPress.NoActionBar"
             android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -535,7 +535,7 @@
         <activity
             android:name=".ui.reader.ReaderPostPagerActivity"
             android:excludeFromRecents="true"
-            android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
+            android:theme="@style/ReaderPostPagerTheme"
             android:windowSoftInputMode="adjustResize" >
         </activity>
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -536,8 +536,7 @@
             android:name=".ui.reader.ReaderPostPagerActivity"
             android:excludeFromRecents="true"
             android:theme="@style/WordPress.NoActionBar"
-            android:windowSoftInputMode="adjustResize" >
-        </activity>
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".ui.engagement.EngagedPeopleListActivity"
             android:theme="@style/WordPress.NoActionBar"

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
 import org.wordpress.android.ui.reader.ReaderCommentListActivity
+import org.wordpress.android.ui.reader.ReaderPostPagerActivity
 import org.wordpress.android.ui.selfhostedusers.SelfHostedUsersActivity
 import org.wordpress.android.ui.sitemonitor.SiteMonitorParentActivity
 
@@ -90,6 +91,8 @@ private val excludedActivities = listOf(
     SelfHostedUsersActivity::class.java.name,
     SiteMonitorParentActivity::class.java.name,
     SupportWebViewActivity::class.java.name,
+
+    ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping
     // their editors

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -92,6 +92,7 @@ private val excludedActivities = listOf(
     SiteMonitorParentActivity::class.java.name,
     SupportWebViewActivity::class.java.name,
 
+    // this is excluded because it uses edge-to-edge insets
     ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -92,7 +92,7 @@ private val excludedActivities = listOf(
     SiteMonitorParentActivity::class.java.name,
     SupportWebViewActivity::class.java.name,
 
-    // this is excluded because it uses edge-to-edge insets
+    // this is excluded because it explicitly enables edge-to-edge
     ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -16,6 +16,7 @@ import android.widget.ProgressBar;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.WindowCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -185,6 +186,7 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         setContentView(R.layout.reader_activity_post_pager);
 
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -17,9 +17,6 @@ import androidx.activity.EdgeToEdge;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -189,7 +186,9 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
-        EdgeToEdge.enable(this); // TODO check on pre-API35
+        EdgeToEdge.enable(this);
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+
         setContentView(R.layout.reader_activity_post_pager);
 
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
@@ -301,18 +300,6 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
                 false,
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER)
         );
-
-        // ensure the system navigation bar isn't overlaid by our bottom appbar in edge-to-edge
-        ViewCompat.setOnApplyWindowInsetsListener(mViewPager, (v, windowInsets) -> {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
-            v.setPadding(
-                    insets.left,
-                    insets.top,
-                    insets.right,
-                    insets.bottom
-            );
-            return WindowInsetsCompat.CONSUMED;
-        });
 
         observeOverlayEvents();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -13,10 +13,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
+import androidx.activity.EdgeToEdge;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.view.WindowCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -186,7 +189,7 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
-        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        EdgeToEdge.enable(this); // TODO check on pre-API35
         setContentView(R.layout.reader_activity_post_pager);
 
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
@@ -298,6 +301,18 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
                 false,
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER)
         );
+
+        // ensure the system navigation bar isn't overlaid by our bottom appbar in edge-to-edge
+        ViewCompat.setOnApplyWindowInsetsListener(mViewPager, (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars());
+            v.setPadding(
+                    insets.left,
+                    insets.top,
+                    insets.right,
+                    insets.bottom
+            );
+            return WindowInsetsCompat.CONSUMED;
+        });
 
         observeOverlayEvents();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -2,22 +2,25 @@ package org.wordpress.android.ui.reader;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.text.TextUtils;
+import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 
-import androidx.activity.EdgeToEdge;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
@@ -187,12 +190,6 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
-        // enable edge-to-edge full screen
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            EdgeToEdge.enable(this);
-            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
-        }
-
         setContentView(R.layout.reader_activity_post_pager);
 
         OnBackPressedCallback callback = new OnBackPressedCallback(true) {
@@ -306,6 +303,21 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         );
 
         observeOverlayEvents();
+    }
+
+    @Override
+    @Nullable
+    public View onCreateView(@Nullable View parent, @NonNull String name, @NonNull Context context,
+                             @NonNull AttributeSet attrs) {
+        // enable full screen for Android 33+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getWindow().setDecorFitsSystemWindows(false);
+            WindowInsetsControllerCompat controller =
+                    new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView());
+            controller.hide(WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.navigationBars());
+            controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+        }
+        return super.onCreateView(parent, name, context, attrs);
     }
 
     private void observeOverlayEvents() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.text.TextUtils;
@@ -186,8 +187,11 @@ public class ReaderPostPagerActivity extends BaseAppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mJetpackFullScreenViewModel = new ViewModelProvider(this).get(JetpackFeatureFullScreenOverlayViewModel.class);
 
-        EdgeToEdge.enable(this);
-        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+        // enable edge-to-edge full screen
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            EdgeToEdge.enable(this);
+            getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+        }
 
         setContentView(R.layout.reader_activity_post_pager);
 

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -17,6 +17,7 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
+    <!-- this coordinator exists only for snackbars -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinator"
         android:layout_width="match_parent"
@@ -24,7 +25,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- this coordinator exists only for snackbars -->
     <org.wordpress.android.widgets.WPViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -1,27 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.wordpress.android.widgets.WPViewPager
-        android:id="@+id/viewpager"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
     <ProgressBar
         android:id="@+id/progress_loading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
         android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
-    <!-- this coordinator exists only for snackbars -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinator"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-</RelativeLayout>
+    <!-- this coordinator exists only for snackbars -->
+    <org.wordpress.android.widgets.WPViewPager
+        android:id="@+id/viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -10,10 +10,6 @@
         <item name="android:windowFullscreen">true</item>
     </style>
 
-    <style name="ReaderPostPagerTheme" parent="WordPress.NoActionBar">
-        <item name="android:windowFullscreen">true</item>
-    </style>
-
     <style name="ReaderRecyclerView">
         <item name="android:background">@color/reader_post_list_background</item>
     </style>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -10,6 +10,10 @@
         <item name="android:windowFullscreen">true</item>
     </style>
 
+    <style name="ReaderPostPagerTheme" parent="WordPress.NoActionBar">
+        <item name="android:windowFullscreen">true</item>
+    </style>
+
     <style name="ReaderRecyclerView">
         <item name="android:background">@color/reader_post_list_background</item>
     </style>
@@ -47,7 +51,7 @@
         <item name="android:maxLines">1</item>
         <item name="android:alpha">@dimen/material_emphasis_high_type</item>
     </style>
-    
+
     <style name="ReaderTextView.Post.Title" parent="ReaderTextView">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fixes CMM-181

This PR adds support for edge-to-edge (full screen) Reader posts. To test:

* View a reader post that has a featured image and note the post is edge-to-edge (full screen)
* View with a post that doesn't have a featured image and note the post is still edge-to-edge
* Verify that navigation works as expected

Note this only works with posts shown in the Reader tab - it doesn't work with posts shown in Notifications. That will be a separate task. Also note that we don't enable edge-to-edge for devices prior to Android 33 because even though they support it, they don't handle it well (ex: system navigation bar keeps popping up).

<img src="https://github.com/user-attachments/assets/8046c44c-0093-434d-9bf3-74062068c2f4" width=256 />

<img src="https://github.com/user-attachments/assets/d3d023f9-ab71-4d83-a129-c47ab1cd4757" width=256 />
