### PR TITLE
Issue: CMM 168 stats not properly updated when pulling to refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -50,6 +50,7 @@ import org.wordpress.android.util.config.StatsTrafficSubscribersTabsFeatureConfi
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper
 import org.wordpress.android.viewmodel.observeEvent
 import org.wordpress.android.widgets.WPSnackbar
+import java.lang.ref.WeakReference
 import javax.inject.Inject
 
 private val statsSections = listOf(INSIGHTS, DAYS, WEEKS, MONTHS, YEARS)
@@ -74,6 +75,12 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
     private var restorePreviousSearch = false
 
     private var binding: StatsFragmentBinding? = null
+
+    private var currentStatsListFragment: WeakReference<StatsListFragment>? = null
+
+    fun setCurrentStatsListFragment(statsListFragment: StatsListFragment) {
+        currentStatsListFragment = WeakReference(statsListFragment)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -116,6 +123,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()
+            currentStatsListFragment?.get()?.onPullRefresh()
         }
         disabledView.statsDisabledView.button.setOnClickListener {
             viewModel.onEnableStatsModuleClick()

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/StatsFragment.kt
@@ -58,7 +58,8 @@ private val statsSectionsWithTrafficTab = listOf(TRAFFIC, INSIGHTS, SUBSCRIBERS)
 private var statsTrafficTabEnabled = false
 
 @AndroidEntryPoint
-class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializedListener {
+class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializedListener,
+    StatsPullToRefreshListener.PullToRefreshReceiverListener {
     @Inject
     lateinit var uiHelpers: UiHelpers
 
@@ -76,10 +77,13 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
     private var binding: StatsFragmentBinding? = null
 
-    private var currentStatsListFragment: WeakReference<StatsListFragment>? = null
+    private var currentStatsPullToRefreshListener:
+            WeakReference<StatsPullToRefreshListener.PullToRefreshEmitterListener>? = null
 
-    fun setCurrentStatsListFragment(statsListFragment: StatsListFragment) {
-        currentStatsListFragment = WeakReference(statsListFragment)
+    override fun setPullToRefreshReceiver(
+        pullToRefreshEmitterListener: StatsPullToRefreshListener.PullToRefreshEmitterListener
+    ) {
+        currentStatsPullToRefreshListener = WeakReference(pullToRefreshEmitterListener)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -123,7 +127,7 @@ class StatsFragment : Fragment(R.layout.stats_fragment), ScrollableViewInitializ
 
         swipeToRefreshHelper = WPSwipeToRefreshHelper.buildSwipeToRefreshHelper(pullToRefresh) {
             viewModel.onPullToRefresh()
-            currentStatsListFragment?.get()?.onPullRefresh()
+            currentStatsPullToRefreshListener?.get()?.onPullRefresh()
         }
         disabledView.statsDisabledView.button.setOnClickListener {
             viewModel.onEnableStatsModuleClick()
@@ -363,5 +367,14 @@ private class SelectedTabListener(val viewModel: StatsViewModel) : OnTabSelected
 
     override fun onTabSelected(tab: Tab) {
         viewModel.onSectionSelected(statsTabs[tab.position])
+    }
+}
+
+interface StatsPullToRefreshListener {
+    interface PullToRefreshReceiverListener {
+        fun setPullToRefreshReceiver(emitterListener: PullToRefreshEmitterListener)
+    }
+    interface PullToRefreshEmitterListener {
+        fun onPullRefresh()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -24,6 +24,8 @@ import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.ViewPagerFragment
 import org.wordpress.android.ui.stats.refresh.StatsFragment
+import org.wordpress.android.ui.stats.refresh.StatsPullToRefreshListener
+import org.wordpress.android.ui.stats.refresh.StatsPullToRefreshListener.PullToRefreshEmitterListener
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
@@ -46,7 +48,7 @@ import org.wordpress.android.viewmodel.observeEvent
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
+class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment), PullToRefreshEmitterListener {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
 
@@ -210,7 +212,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         super.onResume()
         @Suppress("DEPRECATION")
         setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
-        (parentFragment as? StatsFragment)?.setCurrentStatsListFragment(this)
+        (parentFragment as? StatsPullToRefreshListener.PullToRefreshReceiverListener)?.setPullToRefreshReceiver(this)
     }
 
     override fun onDestroyView() {
@@ -218,7 +220,7 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         binding = null
     }
 
-    fun onPullRefresh() {
+    override fun onPullRefresh() {
         viewModel.onRefresh()
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.ViewPagerFragment
-import org.wordpress.android.ui.stats.refresh.StatsFragment
 import org.wordpress.android.ui.stats.refresh.StatsPullToRefreshListener
 import org.wordpress.android.ui.stats.refresh.StatsPullToRefreshListener.PullToRefreshEmitterListener
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListFragment.kt
@@ -23,6 +23,7 @@ import org.wordpress.android.R
 import org.wordpress.android.databinding.StatsListFragmentBinding
 import org.wordpress.android.fluxc.network.utils.StatsGranularity
 import org.wordpress.android.ui.ViewPagerFragment
+import org.wordpress.android.ui.stats.refresh.StatsFragment
 import org.wordpress.android.ui.stats.refresh.StatsViewModel.DateSelectorUiModel
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.StatsSection
 import org.wordpress.android.ui.stats.refresh.lists.StatsListViewModel.UiModel
@@ -209,11 +210,16 @@ class StatsListFragment : ViewPagerFragment(R.layout.stats_list_fragment) {
         super.onResume()
         @Suppress("DEPRECATION")
         setHasOptionsMenu(statsSection == StatsSection.INSIGHTS)
+        (parentFragment as? StatsFragment)?.setCurrentStatsListFragment(this)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+    }
+
+    fun onPullRefresh() {
+        viewModel.onRefresh()
     }
 
     private fun StatsListFragmentBinding.initializeViewModels(activity: FragmentActivity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/StatsListViewModel.kt
@@ -141,6 +141,12 @@ abstract class StatsListViewModel(
         }
     }
 
+    fun onRefresh() {
+        launch {
+            statsUseCase.refreshData()
+        }
+    }
+
     fun onListSelected() {
         dateSelector?.updateDateSelector()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -110,11 +110,6 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     fun onUiState(newState: UI_STATE? = null) {
         uiState = newState ?: uiState
         updateState()
-        // Fetch possible new changes
-        launch(backgroundDispatcher) {
-            delay(100)
-            fetch(true, false)
-        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/refresh/lists/sections/BaseStatsUseCase.kt
@@ -87,7 +87,7 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
         }
     }
 
-    protected suspend fun evaluateState(state: State<DOMAIN_MODEL>) {
+    protected fun evaluateState(state: State<DOMAIN_MODEL>) {
         val useCaseState = when (state) {
             is Error -> ERROR
             is Data -> {
@@ -110,6 +110,11 @@ abstract class BaseStatsUseCase<DOMAIN_MODEL, UI_STATE>(
     fun onUiState(newState: UI_STATE? = null) {
         uiState = newState ?: uiState
         updateState()
+        // Fetch possible new changes
+        launch(backgroundDispatcher) {
+            delay(100)
+            fetch(true, false)
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

There was a report from a user complaining that the stats were not being updated properly, or at least the UX was not working smoothly. At first sight, it looked like a simple loading spinner could improve the experience. But after a bit of testing, I ended up in a scenario where the stats were not being updated at all when pulling to refresh. So, this could also explain the user problem. Especially because there is already a general loading spinner, and just adding new ones could be hiding other issues.

The problem basically was that there are two different UseCases taking care of the stats: the model UseCase and the UI one. So, after almost 2 days of investigation 😅, I noticed that the UI UseCase was not being updated at all. So, no matter the value of the model, the UI was always showing the cached version.

On this PR I've propagated the "PullToRefresh" action to the ViewPager fragments, so they are updated properly. I tried other approaches, but the UseCases look a bit complex to introduce more logic there, like extracting the cache or similar.
I've used a listener architecture, but if you think there's a better way, like a broadcast or just calling from one fragment to another, please let me know it @nbradbury 

Before:
![ezgif-3c88dac17d75db](https://github.com/user-attachments/assets/247ef9d1-7a9c-4b6e-b9d9-109596d9d55a)

After:
![ezgif-5c410f0bb3999b](https://github.com/user-attachments/assets/799278f4-108d-4e21-a63c-38fa37d4eaf6)

## Testing instructions
1. Load a sire stats
2. Visit the site to be sure you get visits
3. Manually refresh the stats
- [ ] Verify stats are updated. Note that it could take a while and probably it's not gonna work on the first refresh.
- [ ] Do other smoke tests on the stats to be sure nothing is broken.
