### PR TITLE
Convert reader adapter to ViewPager2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -9,11 +9,9 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.AttributeSet
-import android.util.SparseArray
 import android.view.MenuItem
 import android.view.View
 import android.widget.ProgressBar
-import androidx.activity.OnBackPressedCallback
 import androidx.core.os.BundleCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -89,7 +87,6 @@ import org.wordpress.android.util.UrlUtilsWrapper
 import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
-import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.WPSwipeSnackbar
 import org.wordpress.android.widgets.WPViewPager2Transformer
 import java.io.UnsupportedEncodingException
@@ -218,23 +215,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
 
         setContentView(R.layout.reader_activity_post_pager)
 
-        val callback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                val fragment = activeDetailFragment
-                if (fragment != null && fragment.isCustomViewShowing) {
-                    // if full screen video is showing, hide the custom view rather than navigate back
-                    fragment.hideCustomView()
-                } else {
-                    if (fragment != null && fragment.goBackInPostHistory()) {
-                        // noop - fragment moved back to a previous post
-                    } else {
-                        onBackPressedDispatcher.onBackPressedCompat(this)
-                    }
-                }
-            }
-        }
-        onBackPressedDispatcher.addCallback(this, callback)
-
         // Start migration flow passing deep link data if requirements are met
         if (jetpackAppMigrationFlowUtils.shouldShowMigrationFlow()) {
             val deepLinkData = PreMigrationDeepLinkData(
@@ -330,18 +310,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 trackPostAtPositionIfNeeded(position)
-
-                if (lastSelectedPosition > -1 && lastSelectedPosition != position) {
-                    // pause the previous web view - important because otherwise embedded content
-                    // will continue to play
-                    val lastFragment = getDetailFragmentAtPosition(lastSelectedPosition)
-                    lastFragment?.pauseWebView()
-                }
-
-                // resume the newly active webView if it was previously paused
-                val thisFragment = getDetailFragmentAtPosition(position)
-                thisFragment?.resumeWebViewIfPaused()
-
                 lastSelectedPosition = position
             }
         })
@@ -925,24 +893,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         return currentTag != null
     }
 
-    private val activePagerFragment: Fragment?
-        get() {
-            val adapter = pagerAdapter ?: return null
-            return adapter.activeFragment
-        }
-
-    private val activeDetailFragment: ReaderPostDetailFragment?
-        get() = activePagerFragment as? ReaderPostDetailFragment
-
-    private fun getPagerFragmentAtPosition(position: Int): Fragment? {
-        val adapter = pagerAdapter ?: return null
-        return adapter.getFragmentAtPosition(position)
-    }
-
-    private fun getDetailFragmentAtPosition(position: Int): ReaderPostDetailFragment? {
-        return getPagerFragmentAtPosition(position) as? ReaderPostDetailFragment
-    }
-
     /*
      * called when user scrolls towards the last posts - requests older posts with the
      * current tag or in the current blog
@@ -1111,13 +1061,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         private val idList = ids.clone() as ReaderBlogIdPostIdList
         var allPostsLoaded: Boolean = false
 
-        // this is used to retain created fragments so we can access them in
-        // getFragmentAtPosition() - necessary because the pager provides no
-        // built-in way to do this - note that destroyItem() removes fragments
-        // from this map when they're removed from the adapter, so this doesn't
-        // retain *every* fragment
-        private val fragmentMap = SparseArray<Fragment>()
-
         fun canRequestMostPosts(): Boolean {
             return !allPostsLoaded && !isSinglePostView && (idList.size < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY)
                     && NetworkUtils.isNetworkAvailable(this@ReaderPostPagerActivity)
@@ -1134,7 +1077,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 requestMorePosts()
             }
 
-            val fragment = newInstance(
+            return newInstance(
                 isFeed,
                 idList[position].blogId,
                 idList[position].postId,
@@ -1145,26 +1088,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 postListType,
                 postSlugsResolutionUnderway
             )
-
-
-            fragmentMap.put(position, fragment)
-            return fragment
-        }
-
-        /*override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
-            fragmentMap.remove(position)
-            super.destroyItem(container, position, `object`)
-        }*/
-
-        val activeFragment: Fragment?
-            get() = getFragmentAtPosition(viewPager.currentItem)
-
-        fun getFragmentAtPosition(position: Int): Fragment? {
-            return if (isValidPosition(position)) {
-                fragmentMap[position]
-            } else {
-                null
-            }
         }
 
         val currentBlogIdPostId: ReaderBlogIdPostId?

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -1,6 +1,3 @@
-// TODO this class is deprecated due to the use of FragmentStatePagerAdapter which should be updated to a ViewPager2
-@file:Suppress("DEPRECATION")
-
 package org.wordpress.android.ui.reader
 
 import android.content.Context

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -15,7 +15,6 @@ import androidx.core.os.BundleCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
@@ -874,7 +873,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                         "reader pager > creating adapter"
                     )
                     val adapter =
-                        PostPagerAdapter(idList, this@ReaderPostPagerActivity)
+                        PostPagerAdapter(idList)
                     viewPager.adapter = adapter
                     if (adapter.isValidPosition(newPosition)) {
                         viewPager.currentItem = newPosition
@@ -1058,10 +1057,8 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
      * ViewPager2 adapter containing post detail fragments
      */
     private inner class PostPagerAdapter(
-        ids: ReaderBlogIdPostIdList,
-        fragmentActivity: FragmentActivity
-    ) : FragmentStateAdapter(fragmentActivity) {
-        private val idList = ids.clone() as ReaderBlogIdPostIdList
+        private val idList: ReaderBlogIdPostIdList,
+    ) : FragmentStateAdapter(this@ReaderPostPagerActivity) {
         var allPostsLoaded: Boolean = false
 
         fun canRequestMostPosts(): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -725,9 +725,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    private fun hasPagerAdapter(): Boolean {
-        return (viewPager.adapter != null)
-    }
+    private fun hasPagerAdapter() = viewPager.adapter != null
 
     private val pagerAdapter: PostPagerAdapter?
         get() = viewPager.adapter as? PostPagerAdapter?
@@ -766,15 +764,10 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
     }
 
     private val adapterCurrentBlogIdPostId: ReaderBlogIdPostId?
-        get() {
-            val adapter = pagerAdapter ?: return null
-            return adapter.currentBlogIdPostId
-        }
+        get() = pagerAdapter?.currentBlogIdPostId
 
-    private fun getAdapterBlogIdPostIdAtPosition(position: Int): ReaderBlogIdPostId? {
-        val adapter = pagerAdapter ?: return null
-        return adapter.getBlogIdPostIdAtPosition(position)
-    }
+    private fun getAdapterBlogIdPostIdAtPosition(position: Int) =
+        pagerAdapter?.getBlogIdPostIdAtPosition(position)
 
     /*
      * perform analytics tracking and bump the page view for the post at the passed position
@@ -880,9 +873,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         }.start()
     }
 
-    private fun hasCurrentTag(): Boolean {
-        return currentTag != null
-    }
+    private fun hasCurrentTag() = currentTag != null
 
     /*
      * called when user scrolls towards the last posts - requests older posts with the
@@ -938,7 +929,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         val adapter = pagerAdapter ?: return
 
         isRequestingMorePosts = false
-        progressBar!!.visibility = View.GONE
+        progressBar?.visibility = View.GONE
 
         if (event.result == ReaderActions.UpdateResult.HAS_NEW) {
             AppLog.d(AppLog.T.READER, "reader pager > older posts received")
@@ -1043,7 +1034,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
     }
 
     /**
-     * pager adapter containing post detail fragments
+     * ViewPager2 adapter containing post detail fragments
      */
     private inner class PostPagerAdapter(
         ids: ReaderBlogIdPostIdList,
@@ -1057,9 +1048,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                     && NetworkUtils.isNetworkAvailable(this@ReaderPostPagerActivity)
         }
 
-        fun isValidPosition(position: Int): Boolean {
-            return (position in 0..< itemCount)
-        }
+        fun isValidPosition(position: Int) = position in 0..< itemCount
 
         override fun getItemCount() = idList.size
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -10,6 +10,7 @@ import android.util.AttributeSet
 import android.view.MenuItem
 import android.view.View
 import android.widget.ProgressBar
+import androidx.activity.addCallback
 import androidx.core.os.BundleCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -85,6 +86,7 @@ import org.wordpress.android.util.UrlUtilsWrapper
 import org.wordpress.android.util.WPActivityUtils
 import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
+import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.WPSwipeSnackbar
 import org.wordpress.android.widgets.WPViewPager2Transformer
 import java.io.UnsupportedEncodingException
@@ -307,13 +309,28 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             postListType = ReaderPostListType.TAG_FOLLOWED
         }
 
-        viewPager.registerOnPageChangeCallback(object: ViewPager2.OnPageChangeCallback() {
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 trackPostAtPositionIfNeeded(position)
+                // pause the previous web view - otherwise embedded content will continue to play
+                if (lastSelectedPosition > -1 && lastSelectedPosition != position) {
+                    pagerAdapter?.getFragmentAtPosition(lastSelectedPosition)?.pauseWebView()
+                }
                 lastSelectedPosition = position
             }
         })
+
+        onBackPressedDispatcher.addCallback(this) {
+            pagerAdapter?.getFragmentAtPosition(lastSelectedPosition)?.let { fragment ->
+                // if full screen video is showing, hide the custom view rather than navigate back
+                if (fragment.isCustomViewShowing) {
+                    fragment.hideCustomView()
+                } else if (!fragment.goBackInPostHistory()) {
+                    onBackPressedDispatcher.onBackPressedCompat(this)
+                }
+            }
+        }
 
         viewPager.setPageTransformer(
             WPViewPager2Transformer(WPViewPager2Transformer.TransformType.SlideOver)
@@ -1086,6 +1103,15 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 null
             }
         }
+
+        /**
+         * In ViewPager2 the FragmentManager by default have assigned tags to fragments like this:
+         *  Fragment in 1st position has a tag of "f0"
+         *  Fragment in 2nd position has a tag of "f1"
+         *  etc.
+         */
+        fun getFragmentAtPosition(position: Int) =
+                supportFragmentManager.findFragmentByTag("f$position") as? ReaderPostDetailFragment
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -3,28 +3,25 @@
 
 package org.wordpress.android.ui.reader
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Parcelable
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import android.widget.ProgressBar
 import androidx.activity.OnBackPressedCallback
 import androidx.core.os.BundleCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
-import androidx.viewpager.widget.ViewPager.SimpleOnPageChangeListener
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -94,8 +91,6 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.WPSwipeSnackbar
-import org.wordpress.android.widgets.WPViewPager
-import org.wordpress.android.widgets.WPViewPagerTransformer
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.util.regex.Pattern
@@ -136,7 +131,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         POST_LIKE,
     }
 
-    private lateinit var viewPager: WPViewPager
+    private lateinit var viewPager: ViewPager2
     private var progressBar: ProgressBar? = null
 
     private var currentTag: ReaderTag? = null
@@ -330,7 +325,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             postListType = ReaderPostListType.TAG_FOLLOWED
         }
 
-        viewPager.addOnPageChangeListener(object : SimpleOnPageChangeListener() {
+        viewPager.registerOnPageChangeCallback(object: ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 trackPostAtPositionIfNeeded(position)
@@ -350,10 +345,10 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             }
         })
 
+        /* TODO
         viewPager.setPageTransformer(
-            false,
             WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER)
-        )
+        )*/
 
         observeOverlayEvents()
     }
@@ -906,7 +901,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                         "reader pager > creating adapter"
                     )
                     val adapter =
-                        PostPagerAdapter(supportFragmentManager, idList)
+                        PostPagerAdapter(idList, this@ReaderPostPagerActivity)
                     viewPager.adapter = adapter
                     if (adapter.isValidPosition(newPosition)) {
                         viewPager.currentItem = newPosition
@@ -917,7 +912,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                     }
 
                     // let the user know they can swipe between posts
-                    if (adapter.count > 1 && !AppPrefs.isReaderSwipeToNavigateShown()) {
+                    if (adapter.itemCount > 1 && !AppPrefs.isReaderSwipeToNavigateShown()) {
                         WPSwipeSnackbar.show(viewPager)
                         AppPrefs.setReaderSwipeToNavigateShown(true)
                     }
@@ -1109,11 +1104,10 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
     /**
      * pager adapter containing post detail fragments
      */
-    private inner class PostPagerAdapter @SuppressLint("WrongConstant") constructor(
-        fm: FragmentManager,
-        ids: ReaderBlogIdPostIdList
-    ) :
-        FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+    private inner class PostPagerAdapter(
+        ids: ReaderBlogIdPostIdList,
+        fragmentActivity: FragmentActivity
+    ) : FragmentStateAdapter(fragmentActivity) {
         private val idList = ids.clone() as ReaderBlogIdPostIdList
         var allPostsLoaded: Boolean = false
 
@@ -1124,42 +1118,23 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         // retain *every* fragment
         private val fragmentMap = SparseArray<Fragment>()
 
-        override fun restoreState(state: Parcelable?, loader: ClassLoader?) {
-            // work around "Fragement no longer exists for key" Android bug
-            // by catching the IllegalStateException
-            // https://code.google.com/p/android/issues/detail?id=42601
-            try {
-                AppLog.d(AppLog.T.READER, "reader pager > adapter restoreState")
-                super.restoreState(state, loader)
-            } catch (e: IllegalStateException) {
-                AppLog.e(AppLog.T.READER, e)
-            }
-        }
-
-        override fun saveState(): Parcelable? {
-            AppLog.d(AppLog.T.READER, "reader pager > adapter saveState")
-            return super.saveState()
-        }
-
         fun canRequestMostPosts(): Boolean {
             return !allPostsLoaded && !isSinglePostView && (idList.size < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY)
                     && NetworkUtils.isNetworkAvailable(this@ReaderPostPagerActivity)
         }
 
         fun isValidPosition(position: Int): Boolean {
-            return (position in 0..<count)
+            return (position in 0..< itemCount)
         }
 
-        override fun getCount(): Int {
-            return idList.size
-        }
+        override fun getItemCount() = idList.size
 
-        override fun getItem(position: Int): Fragment {
-            if ((position == count - 1) && canRequestMostPosts()) {
+        override fun createFragment(position: Int): Fragment {
+            if ((position == itemCount - 1) && canRequestMostPosts()) {
                 requestMorePosts()
             }
 
-            return newInstance(
+            val fragment = newInstance(
                 isFeed,
                 idList[position].blogId,
                 idList[position].postId,
@@ -1170,20 +1145,16 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 postListType,
                 postSlugsResolutionUnderway
             )
+
+
+            fragmentMap.put(position, fragment)
+            return fragment
         }
 
-        override fun instantiateItem(container: ViewGroup, position: Int): Any {
-            val item = super.instantiateItem(container, position)
-            if (item is Fragment) {
-                fragmentMap.put(position, item)
-            }
-            return item
-        }
-
-        override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        /*override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
             fragmentMap.remove(position)
             super.destroyItem(container, position, `object`)
-        }
+        }*/
 
         val activeFragment: Fragment?
             get() = getFragmentAtPosition(viewPager.currentItem)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -928,7 +928,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         }
     }
 
-    @Suppress("unused")
+    @Suppress("UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: UpdatePostsStarted?) {
         if (isFinishing) {
@@ -939,7 +939,6 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         progressBar!!.visibility = View.VISIBLE
     }
 
-    @Suppress("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: UpdatePostsEnded) {
         if (isFinishing) {
@@ -964,7 +963,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         }
     }
 
-    @Suppress("unused")
+    @Suppress("UNUSED_PARAMETER")
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: DoSignIn?) {
         if (isFinishing) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -91,6 +91,7 @@ import org.wordpress.android.util.analytics.AnalyticsUtilsWrapper
 import org.wordpress.android.util.config.SeenUnseenWithCounterFeatureConfig
 import org.wordpress.android.util.extensions.onBackPressedCompat
 import org.wordpress.android.widgets.WPSwipeSnackbar
+import org.wordpress.android.widgets.WPViewPager2Transformer
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.util.regex.Pattern
@@ -345,10 +346,9 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             }
         })
 
-        /* TODO
         viewPager.setPageTransformer(
-            WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER)
-        )*/
+            WPViewPager2Transformer(WPViewPager2Transformer.TransformType.SlideOver)
+        )
 
         observeOverlayEvents()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -730,13 +730,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
     }
 
     private val pagerAdapter: PostPagerAdapter?
-        get() {
-            return if (viewPager.adapter != null) {
-                viewPager.adapter as PostPagerAdapter?
-            } else {
-                null
-            }
-        }
+        get() = viewPager.adapter as? PostPagerAdapter?
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(ReaderConstants.ARG_IS_SINGLE_POST, isSinglePostView)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -748,7 +748,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
     private fun hasPagerAdapter() = viewPager.adapter != null
 
     private val pagerAdapter: PostPagerAdapter?
-        get() = viewPager.adapter as? PostPagerAdapter?
+        get() = viewPager.adapter as? PostPagerAdapter
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(ReaderConstants.ARG_IS_SINGLE_POST, isSinglePostView)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -224,6 +225,9 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         }
 
         viewPager = findViewById(R.id.viewpager)
+        @SuppressLint("WrongConstant")
+        viewPager.offscreenPageLimit = OFFSCREEN_PAGE_LIMIT
+
         progressBar = findViewById(R.id.progress_loading)
 
         if (savedInstanceState != null) {
@@ -1044,7 +1048,9 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         var allPostsLoaded: Boolean = false
 
         fun canRequestMostPosts(): Boolean {
-            return !allPostsLoaded && !isSinglePostView && (idList.size < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY)
+            return !allPostsLoaded &&
+                    !isSinglePostView &&
+                    (idList.size < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY)
                     && NetworkUtils.isNetworkAvailable(this@ReaderPostPagerActivity)
         }
 
@@ -1058,15 +1064,15 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
             }
 
             return newInstance(
-                isFeed,
-                idList[position].blogId,
-                idList[position].postId,
-                directOperation,
-                commentId,
-                isRelatedPostView,
-                interceptedUri,
-                postListType,
-                postSlugsResolutionUnderway
+                isFeed = isFeed,
+                blogId = idList[position].blogId,
+                postId = idList[position].postId,
+                directOperation = directOperation,
+                commentId = commentId,
+                isRelatedPost = isRelatedPostView,
+                interceptedUri = interceptedUri,
+                postListType = postListType,
+                postSlugsResolutionUnderway = postSlugsResolutionUnderway
             )
         }
 
@@ -1080,5 +1086,9 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 null
             }
         }
+    }
+
+    companion object {
+        private const val OFFSCREEN_PAGE_LIMIT = 2
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -317,6 +317,8 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 if (lastSelectedPosition > -1 && lastSelectedPosition != position) {
                     pagerAdapter?.getFragmentAtPosition(lastSelectedPosition)?.pauseWebView()
                 }
+                // unpause this web view if it was previously paused
+                pagerAdapter?.getFragmentAtPosition(position)?.resumeWebViewIfPaused()
                 lastSelectedPosition = position
             }
         })

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -226,6 +226,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
         }
 
         viewPager = findViewById(R.id.viewpager)
+        // lint complains about OFFSCREEN_PAGE_LIMIT, even through it's a valid constant (?)
         @SuppressLint("WrongConstant")
         viewPager.offscreenPageLimit = OFFSCREEN_PAGE_LIMIT
 

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -25,7 +25,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <org.wordpress.android.widgets.WPViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
Fixes CMM-305

As part of the goal to modernize the outdated Reader codebase, this PR converts the deprecated `ReaderPostPagerActivity` view pager to a `ViewPager2` and the related adapter to a `ViewPager2.FragmentStateAdapter`.

**To test:**
* Go to the reader
* Tap subscriptions
* Tap blogs
* Select a single blog such as [WordPress News](https://wordpress.com/blog/)
* Tap a post
* Swipe between posts and verify all works as expected

As a bonus, this change enables us to drop the [fragment map](https://github.com/wordpress-mobile/WordPress-Android/blob/2aaa18305274c78a1009b670ba96f6fb01eaa3a0/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt#L1125) from the adapter, which always felt like a hack to me.