### PR TITLE
feat: Allow experimental editor opt out

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -534,7 +534,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         onBackPressedDispatcher.addCallback(this, callback)
         dispatcher.register(this)
-        isGutenbergKitEditor = gutenbergKitFeatureConfig.isEnabled() || (gutenbergKitFeature.isEnabled() && !disableGutenbergKitFeatureConfig.isEnabled())
+        isGutenbergKitEditor = (gutenbergKitFeatureConfig.isEnabled() || gutenbergKitFeature.isEnabled()) && !disableGutenbergKitFeatureConfig.isEnabled()
 
         createEditShareMessageActivityResultLauncher()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -422,6 +422,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
     @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
 
+    private val disableGutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
     private val gutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
     private val gutenbergKitThemeStylesConfig: ExperimentalFeature =
         ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
@@ -533,7 +534,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         onBackPressedDispatcher.addCallback(this, callback)
         dispatcher.register(this)
-        isGutenbergKitEditor = gutenbergKitFeatureConfig.isEnabled() || gutenbergKitFeature.isEnabled()
+        isGutenbergKitEditor = gutenbergKitFeatureConfig.isEnabled() || (gutenbergKitFeature.isEnabled() && !disableGutenbergKitFeatureConfig.isEnabled())
 
         createEditShareMessageActivityResultLauncher()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -422,7 +422,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
     @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
 
-    private val disableGutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+    private val disableGutenbergKitFeatureConfig: ExperimentalFeature =
+        ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
     private val gutenbergKitFeatureConfig: ExperimentalFeature = ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
     private val gutenbergKitThemeStylesConfig: ExperimentalFeature =
         ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
@@ -522,7 +523,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ComplexMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)
@@ -534,7 +535,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         onBackPressedDispatcher.addCallback(this, callback)
         dispatcher.register(this)
-        isGutenbergKitEditor = (gutenbergKitFeatureConfig.isEnabled() || gutenbergKitFeature.isEnabled()) && !disableGutenbergKitFeatureConfig.isEnabled()
+        isGutenbergKitEditor = (gutenbergKitFeatureConfig.isEnabled() || gutenbergKitFeature.isEnabled())
+                && !disableGutenbergKitFeatureConfig.isEnabled()
 
         createEditShareMessageActivityResultLauncher()
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -43,7 +43,10 @@ import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.extensions.setContent
+import javax.inject.Inject
+import dagger.hilt.android.lifecycle.HiltViewModel
 
 enum class ExperimentalFeature(val prefKey: String, val labelResId: Int, val descriptionResId: Int) {
     DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
@@ -71,13 +74,22 @@ enum class ExperimentalFeature(val prefKey: String, val labelResId: Int, val des
     }
 }
 
-class FeatureViewModel : ViewModel() {
+@HiltViewModel
+class FeatureViewModel @Inject constructor(
+    private val gutenbergKitFeature: GutenbergKitFeature
+) : ViewModel() {
     private val _switchStates = MutableStateFlow<Map<ExperimentalFeature, Boolean>>(emptyMap())
     val switchStates: StateFlow<Map<ExperimentalFeature, Boolean>> = _switchStates.asStateFlow()
 
     init {
         val initialStates = ExperimentalFeature.entries
-            .filter { it != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR }
+            .filter { feature ->
+                if (gutenbergKitFeature.isEnabled()) {
+                    feature != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
+                } else {
+                    feature != ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+                }
+            }
             .associate { feature ->
                 feature to feature.isEnabled()
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -172,6 +173,12 @@ fun ExperimentalFeaturesScreen(
                         bottom = Margin.Large.value
                     )
                 ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Margin.ExtraLarge.value)
+                    )
                     Text(
                         text = stringResource(R.string.experimental_block_editor_note),
                         style = MaterialTheme.typography.bodySmall,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -27,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.extensions.setContent
 
 enum class ExperimentalFeature(val prefKey: String, val labelResId: Int) {
+    DISABLE_EXPERIMENTAL_BLOCK_EDITOR("disable_experimental_block_editor", R.string.disable_experimental_block_editor),
     EXPERIMENTAL_BLOCK_EDITOR("experimental_block_editor", R.string.experimental_block_editor),
     EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES(
         "experimental_block_editor_theme_styles",
@@ -64,9 +65,11 @@ class FeatureViewModel : ViewModel() {
     val switchStates: StateFlow<Map<ExperimentalFeature, Boolean>> = _switchStates.asStateFlow()
 
     init {
-        val initialStates = ExperimentalFeature.entries.associate { feature ->
-            feature to feature.isEnabled()
-        }
+        val initialStates = ExperimentalFeature.entries
+            .filter { it != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR }
+            .associate { feature ->
+                feature to feature.isEnabled()
+            }
         _switchStates.value = initialStates
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -43,12 +44,21 @@ import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.extensions.setContent
 
-enum class ExperimentalFeature(val prefKey: String, val labelResId: Int) {
-    DISABLE_EXPERIMENTAL_BLOCK_EDITOR("disable_experimental_block_editor", R.string.disable_experimental_block_editor),
-    EXPERIMENTAL_BLOCK_EDITOR("experimental_block_editor", R.string.experimental_block_editor),
+enum class ExperimentalFeature(val prefKey: String, val labelResId: Int, val descriptionResId: Int) {
+    DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
+        "disable_experimental_block_editor",
+        R.string.disable_experimental_block_editor,
+        R.string.disable_experimental_block_editor_description
+    ),
+    EXPERIMENTAL_BLOCK_EDITOR(
+        "experimental_block_editor",
+        R.string.experimental_block_editor,
+        R.string.experimental_block_editor_description
+    ),
     EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES(
         "experimental_block_editor_theme_styles",
-        R.string.experimental_block_editor_theme_styles
+        R.string.experimental_block_editor_theme_styles,
+        R.string.experimental_block_editor_theme_styles_description
     );
 
     fun isEnabled() : Boolean {
@@ -164,27 +174,29 @@ fun FeatureToggle(
     enabled: Boolean,
     onChange: (ExperimentalFeature, Boolean) -> Unit,
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .clickable { onChange(feature, !enabled) }
-            .padding(horizontal = Margin.ExtraLarge.value, vertical = Margin.MediumLarge.value)
-    ) {
-        Text(
-            text = stringResource(feature.labelResId),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier
-                .weight(1f)
-                .padding(horizontal = Margin.Medium.value)
-        )
-        Switch(
-            checked = enabled,
-            onCheckedChange = { newValue ->
-                onChange(feature, newValue)
-            },
-        )
-    }
+    ListItem(
+        headlineContent = {
+            Text(
+                text = stringResource(feature.labelResId),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = stringResource(feature.descriptionResId),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = enabled,
+                onCheckedChange = { newValue ->
+                    onChange(feature, newValue)
+                },
+            )
+        },
+        modifier = Modifier.clickable { onChange(feature, !enabled) }
+    )
 }
 
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -163,6 +163,22 @@ fun ExperimentalFeaturesScreen(
                         onChange = onFeatureToggled,
                     )
                 }
+
+                Column(
+                    modifier = Modifier.padding(
+                        start = Margin.ExtraLarge.value,
+                        end = Margin.ExtraLarge.value,
+                        top = Margin.Large.value,
+                        bottom = Margin.Large.value
+                    )
+                ) {
+                    Text(
+                        text = stringResource(R.string.experimental_block_editor_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Margin.Small.value)
+                    )
+                }
             }
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -958,8 +958,11 @@
     <!-- Experimental Features -->
     <string name="experimental_features_screen_title">Experimental Features</string>
     <string name="disable_experimental_block_editor">Disable experimental block editor</string>
+    <string name="disable_experimental_block_editor_description">Opt out of additional block types and settings</string>
     <string name="experimental_block_editor">Experimental block editor</string>
+    <string name="experimental_block_editor_description">Access additional block types and settings</string>
     <string name="experimental_block_editor_theme_styles">Experimental block editor styles</string>
+    <string name="experimental_block_editor_theme_styles_description">Apply theme styles to the editor</string>
     <string name="experimental_block_editor_plugins">Experimental block editor plugins</string>
     <string name="experimental_features_feedback_dialog_title">Share feedback</string>
     <string name="experimental_features_feedback_dialog_message">Are you willing to share feedback on the experimental editor?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -959,6 +959,7 @@
     <string name="experimental_features_screen_title">Experimental Features</string>
     <string name="disable_experimental_block_editor">Disable experimental block editor</string>
     <string name="disable_experimental_block_editor_description">Opt out of additional block types and settings</string>
+    <string name="experimental_block_editor_note">Experimental block editor will become the default in a future release and the ability to disable it will be removed.</string>
     <string name="experimental_block_editor">Experimental block editor</string>
     <string name="experimental_block_editor_description">Access additional block types and settings</string>
     <string name="experimental_block_editor_theme_styles">Experimental block editor styles</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -957,6 +957,7 @@
 
     <!-- Experimental Features -->
     <string name="experimental_features_screen_title">Experimental Features</string>
+    <string name="disable_experimental_block_editor">Disable experimental block editor</string>
     <string name="experimental_block_editor">Experimental block editor</string>
     <string name="experimental_block_editor_theme_styles">Experimental block editor styles</string>
     <string name="experimental_block_editor_plugins">Experimental block editor plugins</string>


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Utilize a remote feature flag to enable a phased roll out. Allow opting out of
the experimental editor for a TBD period of time.

Because WP-Android's experimental features are separate from the remote 
feature flag architecture, we add a "Disable [feature]" toggle to use in tandem 
with the remote feature flag. 

The enable or disable toggle is conditionally presented based upon the remote
feature flag status. 

> [!Note]
> Given WP-Android's experimental features are detached from remote feature,
> an edge case is possible where a user would be unable to opt into 
> GutenbergKit. It feels too unlikely and unimportant to address. 
>
> Achieving the edge case would require:
> 1. Include the user in a remote, phased roll out cohort. 
> 1. User toggles the "Disable experimental block editor" ON. 
> 1. Remove user from the aforementioned cohort. 
> 1. A user enabling "Experimental block editor" would have no impact at this point. 

Ref CMM-291.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
> [!Tip]
> An example feature flag can be found in 181762-ghe-Automattic/wpcom. 

**1: When remote feature flag is not truthy, app presents enable toggle**
1. Navigate to _Me_ → _Experimental Features_. 
2. Verify the _Experimental block editor_ toggle is available, controlling GBK as expected. 

**2: When remote feature flag is truthy, app presents disable toggle**
1. Set a truthy `gutenberg_kit` feature flag in your WPCOM sandbox. 
2. Route your test device `public-api.wordpress.com` traffic to your sandbox. 
1. Navigate to _Me_ → _Experimental Features_. 
3. Verify the _Disable experimental block editor_ toggle is available, controlling GBK as expected. 

| Light | Dark |
| - | - |
| ![light-mode](https://github.com/user-attachments/assets/255e8e38-a374-4653-b048-298cd13fcb4f) | ![dark-mode](https://github.com/user-attachments/assets/a10f60e2-7d74-4570-87ce-81b83ab48b2a) |

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->