### PR TITLE
Replace Dependabot reviewers config with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Dependabot
+/gradle/libs.versions.toml @wordpress-mobile/android-developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: "daily"
     labels:
       - "bot: dependencies update"
-    reviewers:
-      - "wordpress-mobile/android-developers"
     groups:
       kotlin-ksp:
         applies-to: version-updates


### PR DESCRIPTION
## Description

Removes the reviewers configuration of Dependabot and replaces it with CODEOWNERS. See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Testing
- Confirm that GitHub validates the CODEOWNERS file.