### PR TITLE
Fix edge-to-edge on reader unfollow bottom sheet

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -321,6 +321,7 @@
 
     <style name="WordPress.BottomSheetDialogTheme.NonTranslucent" parent="WordPress.BottomSheetDialogTheme">
         <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:fitsSystemWindows">false</item>
     </style>
 
     <style name="WordPress.BottomSheetDialogTheme.BottomSheetStyle" parent="@style/Widget.MaterialComponents.BottomSheet">


### PR DESCRIPTION
Closes CMM-337

Prior to this PR, the reader unfollow bottom sheet showed without any padding, like this:

<img src="https://github.com/user-attachments/assets/ec43791f-1b26-4265-afcd-49f7975e54f6" width=256 />

This PR fixes the problem by disabling `fitsSystemWindows` on the bottom sheet style, like this:

<img src="https://github.com/user-attachments/assets/f2ad90fd-c522-42a5-893d-76634a64381b" width=256 />

**To test:**

- Open a post in the reader
- Tap "Follow conversation"
- Tap on the bell icon
- Verify the bottom sheet appears correctly

Note the fix for this was to modify the `WordPress.BottomSheetDialogTheme.NonTranslucent` style, which is only used by `CommentNotificationsBottomSheetFragment`



