### PR TITLE
Ignore site visibility

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -153,23 +153,23 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              String lastSearch,
                              boolean isInSearchMode,
                              @NonNull OnDataLoadedListener dataLoadedListener,
-                             SitePickerMode sitePickerMode
-    ) {
-        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                null, null, null, sitePickerMode, false, false);
-    }
-
-    public SitePickerAdapter(Context context,
-                             @LayoutRes int itemLayoutResourceId,
-                             int currentLocalBlogId,
-                             String lastSearch,
-                             boolean isInSearchMode,
-                             @NonNull OnDataLoadedListener dataLoadedListener,
                              @NonNull ViewHolderHandler<?> headerHandler,
                              @Nullable ArrayList<Integer> ignoreSitesIds
     ) {
-        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                headerHandler, null, ignoreSitesIds, SitePickerMode.DEFAULT_MODE, false, false);
+        this(
+                context,
+                itemLayoutResourceId,
+                currentLocalBlogId,
+                lastSearch,
+                isInSearchMode,
+                dataLoadedListener,
+                headerHandler,
+                null,
+                ignoreSitesIds,
+                SitePickerMode.DEFAULT_MODE,
+                false,
+                false
+        );
     }
 
     public SitePickerAdapter(Context context,
@@ -184,8 +184,20 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              SitePickerMode sitePickerMode,
                              boolean showAndReturn
     ) {
-        this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                headerHandler, footerHandler, ignoreSitesIds, sitePickerMode, false, showAndReturn);
+        this(
+                context,
+                itemLayoutResourceId,
+                currentLocalBlogId,
+                lastSearch,
+                isInSearchMode,
+                dataLoadedListener,
+                headerHandler,
+                footerHandler,
+                ignoreSitesIds,
+                sitePickerMode,
+                false,
+                showAndReturn
+        );
     }
 
     public SitePickerAdapter(Context context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -153,11 +153,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              String lastSearch,
                              boolean isInSearchMode,
                              @NonNull OnDataLoadedListener dataLoadedListener,
-                             SitePickerMode sitePickerMode,
-                             boolean isInEditMode
+                             SitePickerMode sitePickerMode
     ) {
         this(context, itemLayoutResourceId, currentLocalBlogId, lastSearch, isInSearchMode, dataLoadedListener,
-                null, null, null, sitePickerMode, isInEditMode, false);
+                null, null, null, sitePickerMode, false, false);
     }
 
     public SitePickerAdapter(Context context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -36,7 +36,6 @@ import org.wordpress.android.util.image.ImageManager;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -92,8 +91,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private final int mSelectedItemBackground;
 
-    private final float mDisabledSiteOpacity;
-
     private final LayoutInflater mInflater;
     @NonNull private final HashSet<Integer> mSelectedPositions = new HashSet<>();
     @Nullable private final ViewHolderHandler mHeaderHandler;
@@ -101,7 +98,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private boolean mIsMultiSelectEnabled;
     private final boolean mIsInSearchMode;
-    private boolean mShowHiddenSites = false;
     private final boolean mShowAndReturn;
     private boolean mShowSelfHostedSites = true;
     private String mLastSearch;
@@ -137,7 +133,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final ImageView mImgBlavatar;
         @Nullable private final View mItemDivider;
         @Nullable private final View mDivider;
-        private Boolean mIsSiteHidden;
         private final RadioButton mSelectedRadioButton;
 
         SiteViewHolder(View view) {
@@ -148,7 +143,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mImgBlavatar = view.findViewById(R.id.image_blavatar);
             mItemDivider = view.findViewById(R.id.item_divider);
             mDivider = view.findViewById(R.id.divider);
-            mIsSiteHidden = null;
             mSelectedRadioButton = view.findViewById(R.id.radio_selected);
         }
     }
@@ -229,7 +223,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 disabledAlpha,
                 true
         );
-        mDisabledSiteOpacity = disabledAlpha.getFloat();
         mSelectedItemBackground = ColorUtils
                 .setAlphaComponent(
                         ContextExtensionsKt.getColorFromAttribute(
@@ -250,8 +243,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (sitePickerMode == SitePickerMode.SIMPLE_MODE) {
             mShowSelfHostedSites = false;
         }
-
-        mShowHiddenSites = isInEditMode; // If site picker is in edit mode, show hidden sites.
 
         mShowAndReturn = showAndReturn;
 
@@ -350,13 +341,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.mLayoutContainer.setBackgroundColor(mSelectedItemBackground);
         } else {
             holder.mLayoutContainer.setBackground(null);
-        }
-
-        // different styling for visible/hidden sites
-        if (holder.mIsSiteHidden == null || holder.mIsSiteHidden != site.isHidden()) {
-            holder.mIsSiteHidden = site.isHidden();
-            holder.mTxtTitle.setAlpha(site.isHidden() ? mDisabledSiteOpacity : 1f);
-            holder.mImgBlavatar.setAlpha(site.isHidden() ? mDisabledSiteOpacity : 1f);
         }
 
         if (holder.mItemDivider != null) {
@@ -501,10 +485,8 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (enable) {
-            mShowHiddenSites = true;
             mShowSelfHostedSites = false;
         } else {
-            mShowHiddenSites = false;
             mShowSelfHostedSites = true;
         }
 
@@ -523,26 +505,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     int getNumSelected() {
         return mSelectedPositions.size();
-    }
-
-    int getNumHiddenSelected() {
-        int numHidden = 0;
-        for (Integer i : mSelectedPositions) {
-            if (isValidPosition(i) && mSites.get(i).isHidden()) {
-                numHidden++;
-            }
-        }
-        return numHidden;
-    }
-
-    int getNumVisibleSelected() {
-        int numVisible = 0;
-        for (Integer i : mSelectedPositions) {
-            if (i < mSites.size() && !mSites.get(i).isHidden()) {
-                numVisible++;
-            }
-        }
-        return numVisible;
     }
 
     private void toggleSelection(int position) {
@@ -627,48 +589,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return mSelectedPositions;
     }
 
-    List<SiteRecord> getHiddenSites() {
-        ArrayList<SiteRecord> hiddenSites = new ArrayList<>();
-        for (SiteRecord site : mSites) {
-            if (site.isHidden()) {
-                hiddenSites.add(site);
-            }
-        }
-
-        return hiddenSites;
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
-    Set<SiteRecord> setVisibilityForSelectedSites(boolean makeVisible) {
-        List<SiteRecord> sites = getSelectedSites();
-        Set<SiteRecord> changeSet = new HashSet<>();
-        if (sites.size() > 0) {
-            ArrayList<Integer> recentIds = AppPrefs.getRecentlyPickedSiteIds();
-            int selectedSiteLocalId = mSelectedSiteRepository.getSelectedSiteLocalId();
-            for (SiteRecord site : sites) {
-                int index = SiteRecordUtil.indexOf(mAllSites, site);
-                if (index > -1) {
-                    SiteRecord siteRecord = mAllSites.get(index);
-                    if (siteRecord.isHidden() == makeVisible) {
-                        changeSet.add(siteRecord);
-                        siteRecord.setHidden(!makeVisible);
-                        if (!makeVisible
-                            && siteRecord.getLocalId() != selectedSiteLocalId
-                            && recentIds.contains(siteRecord.getLocalId())) {
-                            AppPrefs.removeRecentlyPickedSiteId(siteRecord.getLocalId());
-                        }
-                    }
-                }
-            }
-
-            if (!changeSet.isEmpty()) {
-                notifyDataSetChanged();
-            }
-        }
-
-        return changeSet;
-    }
-
     @SuppressWarnings("deprecation")
     void loadSites() {
         new LoadSitesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
@@ -689,20 +609,12 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else if (mIsInSearchMode) {
             return mSiteStore.getSites();
         }
-        if (mShowHiddenSites) {
-            if (mShowSelfHostedSites) {
-                return mSiteStore.getSites();
-            } else {
-                return mSiteStore.getSitesAccessedViaWPComRest();
-            }
+        if (mShowSelfHostedSites) {
+            List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+            out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
+            return out;
         } else {
-            if (mShowSelfHostedSites) {
-                List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
-                out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
-                return out;
-            } else {
-                return mSiteStore.getVisibleSitesAccessedViaWPCom();
-            }
+            return mSiteStore.getVisibleSitesAccessedViaWPCom();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -167,36 +167,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 null,
                 ignoreSitesIds,
                 SitePickerMode.DEFAULT_MODE,
-                false,
                 false
-        );
-    }
-
-    public SitePickerAdapter(Context context,
-                             @LayoutRes int itemLayoutResourceId,
-                             int currentLocalBlogId,
-                             String lastSearch,
-                             boolean isInSearchMode,
-                             @NonNull OnDataLoadedListener dataLoadedListener,
-                             @NonNull ViewHolderHandler<?> headerHandler,
-                             @Nullable ViewHolderHandler<?> footerHandler,
-                             ArrayList<Integer> ignoreSitesIds,
-                             SitePickerMode sitePickerMode,
-                             boolean showAndReturn
-    ) {
-        this(
-                context,
-                itemLayoutResourceId,
-                currentLocalBlogId,
-                lastSearch,
-                isInSearchMode,
-                dataLoadedListener,
-                headerHandler,
-                footerHandler,
-                ignoreSitesIds,
-                sitePickerMode,
-                false,
-                showAndReturn
         );
     }
 
@@ -210,7 +181,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                              @Nullable ViewHolderHandler<?> footerHandler,
                              @Nullable ArrayList<Integer> ignoreSitesIds,
                              SitePickerMode sitePickerMode,
-                             boolean isInEditMode,
                              boolean showAndReturn
     ) {
         super();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SiteRecord.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SiteRecord.kt
@@ -15,7 +15,6 @@ class SiteRecord(siteModel: SiteModel) {
     val homeURL: String
     val blavatarUrl: String
     val blavatarType: ImageType
-    var isHidden: Boolean
     var isRecentPick = false
 
     init {
@@ -27,7 +26,6 @@ class SiteRecord(siteModel: SiteModel) {
         blavatarType = SiteUtils.getSiteImageType(
             siteModel.isWpForTeamsSite, BlavatarShape.SQUARE_WITH_ROUNDED_CORNERES
         )
-        isHidden = !siteModel.isVisible
     }
 
     val blogNameOrHomeURL: String

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1715,10 +1715,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
     }
 
     private void setSelectedSite(@NonNull SiteModel selectedSite) {
-        // Make selected site visible
-        selectedSite.setIsVisible(true);
-        mSelectedSiteRepository.updateSite(selectedSite);
-
         // When we select a site, we want to update its information or options
         mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(selectedSite));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/utils/SiteRecordUtil.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/utils/SiteRecordUtil.kt
@@ -48,7 +48,6 @@ object SiteRecordUtil {
 
         for (i in currentSites.indices) {
             if (currentSites[i].siteId != anotherSites[i].siteId ||
-                currentSites[i].isHidden != anotherSites[i].isHidden ||
                 currentSites[i].isRecentPick != anotherSites[i].isRecentPick
             ) return false
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -445,10 +445,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun newPostSetup(title: String? = null, content: String? = null) {
         isNewPost = true
-        if (!siteModel.isVisible) {
-            showErrorAndFinish(R.string.error_blog_hidden)
-            return
-        }
         // Create a new post
         editPostRepository.set {
             val post = postStore.instantiatePostModel(

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2108,7 +2108,6 @@
     <string name="error_media_xmlrpc_not_allowed">Your action is not allowed</string>
     <string name="error_media_xmlrcp_server_error">Internal server error occurred</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
-    <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>
     <string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -406,6 +406,10 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mDisplayName = displayName;
     }
 
+    /*
+     * Site visibility is no longer a feature on wp.com
+     */
+    @Deprecated
     public boolean isVisible() {
         return mIsVisible;
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -414,6 +414,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         return mIsVisible;
     }
 
+    @Deprecated
     public void setIsVisible(boolean visible) {
         mIsVisible = visible;
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -407,7 +407,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     /**
-     * @deprecated Site visibility is no longer a feature on wp.com
+     * @deprecated Hiding sites is no longer a feature on wp.com
      */
     @Deprecated
     public boolean isVisible() {
@@ -415,7 +415,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     /**
-     * @deprecated Site visibility is no longer a feature on wp.com
+     * @deprecated Hiding sites is no longer a feature on wp.com
      */
     @Deprecated
     public void setIsVisible(boolean visible) {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -406,14 +406,17 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mDisplayName = displayName;
     }
 
-    /*
-     * Site visibility is no longer a feature on wp.com
+    /**
+     * @deprecated Site visibility is no longer a feature on wp.com
      */
     @Deprecated
     public boolean isVisible() {
         return mIsVisible;
     }
 
+    /**
+     * @deprecated Site visibility is no longer a feature on wp.com
+     */
     @Deprecated
     public void setIsVisible(boolean visible) {
         mIsVisible = visible;

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/site/SiteRestClient.kt
@@ -1072,7 +1072,6 @@ class SiteRestClient @Inject constructor(
         site.setIsJetpackConnected(from.jetpack && from.jetpack_connection)
         site.setIsJetpackInstalled(from.jetpack)
         site.setIsJetpackCPConnected(from.jetpack_connection && !from.jetpack)
-        site.setIsVisible(from.visible)
         site.setIsDeleted(from.is_deleted)
         site.setIsPrivate(from.is_private)
         site.setIsComingSoon(from.is_coming_soon)

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/site/SiteStoreUnitTest.java
@@ -201,63 +201,6 @@ public class SiteStoreUnitTest {
     }
 
     @Test
-    public void testWPComSiteVisibility() throws DuplicateSiteException {
-        WellSqlTestUtils.setupWordPressComAccount();
-
-        // Should not cause any errors
-        mSiteStore.isWPComSiteVisibleByLocalId(45);
-        mSiteSqlUtils.setSiteVisibility(null, true);
-
-        SiteModel selfHostedNonJPSite = generateSelfHostedNonJPSite();
-        mSiteSqlUtils.insertOrUpdateSite(selfHostedNonJPSite);
-
-        // Attempt to use with id of self-hosted site
-        mSiteSqlUtils.setSiteVisibility(selfHostedNonJPSite, false);
-        // The self-hosted site should not be affected
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
-
-
-        SiteModel wpComSite = generateWPComSite();
-        mSiteSqlUtils.insertOrUpdateSite(wpComSite);
-
-        // Attempt to use with legitimate .com site
-        mSiteSqlUtils.setSiteVisibility(selfHostedNonJPSite, false);
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite.getId()).isVisible());
-        assertFalse(mSiteStore.isWPComSiteVisibleByLocalId(wpComSite.getId()));
-    }
-
-    @Test
-    public void testSetAllWPComSitesVisibility() throws DuplicateSiteException {
-        WellSqlTestUtils.setupWordPressComAccount();
-
-        SiteModel selfHostedNonJPSite = generateSelfHostedNonJPSite();
-        mSiteSqlUtils.insertOrUpdateSite(selfHostedNonJPSite);
-
-        // Attempt to use with id of self-hosted site
-        for (SiteModel site : mSiteStore.getWPComSites()) {
-            mSiteSqlUtils.setSiteVisibility(site, false);
-        }
-        // The self-hosted site should not be affected
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
-
-        SiteModel wpComSite1 = generateWPComSite();
-        SiteModel wpComSite2 = generateWPComSite();
-        wpComSite2.setId(44);
-        wpComSite2.setSiteId(284);
-
-        mSiteSqlUtils.insertOrUpdateSite(wpComSite1);
-        mSiteSqlUtils.insertOrUpdateSite(wpComSite2);
-
-        // Attempt to use with legitimate .com site
-        for (SiteModel site : mSiteStore.getWPComSites()) {
-            mSiteSqlUtils.setSiteVisibility(site, false);
-        }
-        assertTrue(mSiteStore.getSiteByLocalId(selfHostedNonJPSite.getId()).isVisible());
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite1.getId()).isVisible());
-        assertFalse(mSiteStore.getSiteByLocalId(wpComSite2.getId()).isVisible());
-    }
-
-    @Test
     public void testGetIdForIdMethods() throws DuplicateSiteException {
         WellSqlTestUtils.setupWordPressComAccount();
 
@@ -610,11 +553,11 @@ public class SiteStoreUnitTest {
         WellSqlTestUtils.setupWordPressComAccount();
 
         List<SiteModel> siteList = new ArrayList<>();
-        siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(2, "https://pony2.com", "https://pony2.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(3, "https://pony3.com", "https://pony3.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(4, "https://pony4.com", "https://pony4.com/xmlrpc.php", true, true));
-        siteList.add(generateTestSite(5, "https://pony5.com", "https://pony5.com/xmlrpc.php", true, true));
+        siteList.add(generateTestSite(1, "https://pony1.com", "https://pony1.com/xmlrpc.php", true));
+        siteList.add(generateTestSite(2, "https://pony2.com", "https://pony2.com/xmlrpc.php", true));
+        siteList.add(generateTestSite(3, "https://pony3.com", "https://pony3.com/xmlrpc.php", true));
+        siteList.add(generateTestSite(4, "https://pony4.com", "https://pony4.com/xmlrpc.php", true));
+        siteList.add(generateTestSite(5, "https://pony5.com", "https://pony5.com/xmlrpc.php", true));
 
         SitesModel sites = new SitesModel(siteList);
 
@@ -687,9 +630,9 @@ public class SiteStoreUnitTest {
     @Test
     public void testUpdateSiteUniqueConstraintFail() throws DuplicateSiteException {
         // Create 2 test sites
-        SiteModel site1 = generateTestSite(0, "https://pony1.com", "https://pony1.com/xmlrpc.php", false, true);
+        SiteModel site1 = generateTestSite(0, "https://pony1.com", "https://pony1.com/xmlrpc.php", false);
         mSiteSqlUtils.insertOrUpdateSite(site1);
-        SiteModel site2 = generateTestSite(0, "https://pony2.com", "https://pony2.com/xmlrpc.php", false, true);
+        SiteModel site2 = generateTestSite(0, "https://pony2.com", "https://pony2.com/xmlrpc.php", false);
         mSiteSqlUtils.insertOrUpdateSite(site2);
 
         // Update the second site and reuse the site url and id from the first

--- a/libs/fluxc/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
+++ b/libs/fluxc/src/test/java/org/wordpress/android/fluxc/site/SiteUtils.java
@@ -12,17 +12,15 @@ public class SiteUtils {
     private static final String ZENDESK_ADDON_SCAN_DAILY = "jetpack_addon_scan_daily";
 
     public static SiteModel generateWPComSite() {
-        return generateTestSite(556, "", "", true, true);
+        return generateTestSite(556, "", "", true);
     }
 
-    public static SiteModel generateTestSite(long remoteId, String url, String xmlRpcUrl, boolean isWPCom,
-                                             boolean isVisible) {
+    public static SiteModel generateTestSite(long remoteId, String url, String xmlRpcUrl, boolean isWPCom) {
         SiteModel example = new SiteModel();
         example.setUrl(url);
         example.setXmlRpcUrl(xmlRpcUrl);
         example.setSiteId(remoteId);
         example.setIsWPCom(isWPCom);
-        example.setIsVisible(isVisible);
         if (isWPCom) {
             example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
         } else {
@@ -37,7 +35,6 @@ public class SiteUtils {
         example.setIsWPCom(false);
         example.setIsJetpackInstalled(false);
         example.setIsJetpackConnected(false);
-        example.setIsVisible(true);
         example.setUrl("http://some.url");
         example.setXmlRpcUrl("http://some.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_XMLRPC);
@@ -51,7 +48,6 @@ public class SiteUtils {
         example.setIsWPCom(false);
         example.setIsJetpackInstalled(true);
         example.setIsJetpackConnected(true);
-        example.setIsVisible(true);
         example.setUsername("ponyuser");
         example.setPassword("ponypass");
         example.setUrl("http://jetpack.url");
@@ -66,7 +62,6 @@ public class SiteUtils {
         example.setIsWPCom(false);
         example.setIsJetpackInstalled(true);
         example.setIsJetpackConnected(true);
-        example.setIsVisible(true);
         example.setUrl("http://jetpack2.url");
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
@@ -80,7 +75,6 @@ public class SiteUtils {
         example.setIsJetpackInstalled(false);
         example.setIsJetpackConnected(false);
         example.setIsJetpackCPConnected(true);
-        example.setIsVisible(true);
         example.setUrl("http://jetpackcp.url");
         example.setXmlRpcUrl("http://jetpackcp.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_WPCOM_REST);
@@ -93,7 +87,6 @@ public class SiteUtils {
         example.setIsWPCom(false);
         example.setIsJetpackInstalled(false);
         example.setIsJetpackConnected(false);
-        example.setIsVisible(true);
         example.setUrl("http://jetpack2.url");
         example.setXmlRpcUrl("http://jetpack2.url/xmlrpc.php");
         example.setOrigin(SiteModel.ORIGIN_XMLRPC);


### PR DESCRIPTION
Fixes CMM-339

As discussed on Slack (p1746807373445579-slack-C04PWEZSYFL), site visibility was dropped from WP.com and from the iOS app, but we never fully removed it from the Android app. Most importantly, if a site was previously marked as hidden it wasn't possible to create a new post for it, and there was no way to unhide the site.

This PR addresses this by:

* Removing the hidden site check when creating a post
* Removing site visibility from `SitePickerAdapter`, `SiteRestClient`, and `SiteUtils`
* Removing unused "edit mode" from the `SitePickerAdapter`
* Removing site visibility tests
* Deprecating site visibility in `SiteModel`, similar to [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/23439/files#r1700381064)

To test, verify the site picker works as expected in the three places it's used:

- After logging in to choose a site
- Choosing a site from the My Site tab
- Sharing from an external app to Jetpack
