### PR TITLE
[Buildkite] Test Android Staging on `ami-0cf08ed9cee24c819`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ common_params:
       format: "junit"
 
 agents:
-  queue: "android"
+  queue: "android-staging"
 
 steps:
   #################


### PR DESCRIPTION
Related: [buildkite-ci#644](https://github.com/Automattic/buildkite-ci/pull/644)

AMI Name: `android-build-image-6.36.0v1.10-rc-2`

---

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

This PR changes the Buildkite agent from `android` to `android-staging`. This change is not meant to be merged, but rather used to verify that the new AMI `ami-0cf08ed9cee24c819` works as expected.

---

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

Check CI and verify everything is working as expected with the `android-staging` agent.

---

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
