### PR TITLE
Fix SQLite exception when updating the app after the new application password columns addition

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/persistence/WellSqlConfig.kt
@@ -2068,7 +2068,7 @@ open class WellSqlConfig : DefaultWellConfig {
                 }
 
                 206 -> {
-                    db.execSQL("ALTER TABLE SiteModel ADD API_REST_USER_NAME TEXT")
+                    db.execSQL("ALTER TABLE SiteModel ADD API_REST_USERNAME TEXT")
                     db.execSQL("ALTER TABLE SiteModel ADD API_REST_PASSWORD TEXT")
                 }
             }


### PR DESCRIPTION
## Description

There was a bug introduced [here](https://github.com/wordpress-mobile/WordPress-Android/pull/21859) where the column name in the code and the alter table command were not using the same name. S, it was causing the app to crash when updating the db version.
In this PR we are fixing that problem.

## Testing instructions

1. Checkout and install a version before [this commit](https://github.com/wordpress-mobile/WordPress-Android/commit/5cbd82181ca3bb7e579efe7e3aa04ad7d9b76153)
2. Log into the app
3. Checkout this branch and run the app again
- [ ] Verify the app does not crash

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
