### PR TITLE
[Tooling] Skip jobs if there are no relevant code changes

### DIFF
--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/bash -eu
 
-set -euo pipefail
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
 
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 

--- a/.buildkite/commands/diff-merged-manifest.sh
+++ b/.buildkite/commands/diff-merged-manifest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/gradle-cache-build.sh
+++ b/.buildkite/commands/gradle-cache-build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/gradle-cache-build.sh
+++ b/.buildkite/commands/gradle-cache-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type lint; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type lint; then
   exit 0
 fi
 

--- a/.buildkite/commands/lint.sh
+++ b/.buildkite/commands/lint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type lint; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type build; then
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  mkdir -p buildkite-test-analytics && touch buildkite-test-analytics/empty.xml
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-instrumented-tests.sh
+++ b/.buildkite/commands/run-instrumented-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   mkdir -p buildkite-test-analytics && touch buildkite-test-analytics/empty.xml
   exit 0
 fi

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  mkdir -p buildkite-test-analytics && touch buildkite-test-analytics/empty.xml
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/restore-cache.sh"
 
 echo "--- 🧪 Testing"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   mkdir -p buildkite-test-analytics && touch buildkite-test-analytics/empty.xml
   exit 0
 fi

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,73 @@
+#!/bin/bash -eu
+
+# Usage: should-skip-job.sh --job-type [validation|build|lint]
+# --job-type validation: For jobs like unit/instrumented tests, manifest validation…
+#     Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type lint: For jobs doing linting, especially ones that might include linting of localization files
+#     Skip when changes are limited to documentation, tooling, and non-code files.
+#     Does not skip if localization files changed (so that linter can run to report translation inconsistencies)
+# --job-type build: For jobs building an apk binary, e.g. Assemble, Prototype Builds…
+#     Skip when changes are limited to documentation, tooling, and non-code files
+#
+# Return codes:
+# 0 - Job should be skipped (script also handles displaying the message and annotation)
+# 1 - Job should not be skipped
+# 15 - Error in script parameters
+
+COMMON_PATTERNS=(
+  "*.md"
+  "*.pot"
+  "*.txt"
+  ".gitignore"
+  "config/**"
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+  "gradle/**"
+  "version.properties"
+)
+
+# Check if arguments are valid
+if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
+  echo "Error: Must specify --job-type [validation|build|lint]"
+  buildkite-agent step cancel
+  exit 15
+fi
+
+# Function to display skip message and create annotation
+show_skip_message() {
+  local job_type=$1
+  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
+  
+  echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  echo "$message"
+}
+
+job_type="$2"
+case "$job_type" in
+  "validation")
+    # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
+    PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  "build"|"lint")
+    # We should skip if changes are limited to documentation, tooling, and non-code files
+    # We'll let the job run (won't skip) if PR includes changes in localization files though
+    PATTERNS=("${COMMON_PATTERNS[@]}")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    echo "Error: Job type must be either 'validation', 'build', or 'lint'"
+    buildkite-agent step cancel
+    exit 15
+    ;;
+esac

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh --job-type [validation|build|lint]
+# Usage: should-skip-job.sh --job-type [validation|lint|build]
 # --job-type validation: For jobs like unit/instrumented tests, manifest validation…
 #     Skip when changes are limited to documentation, tooling, non-code files, and localization files
 # --job-type lint: For jobs doing linting, especially ones that might include linting of localization files

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -16,6 +16,7 @@
 
 COMMON_PATTERNS=(
   "*.md"
+  "*.po"
   "*.pot"
   "*.txt"
   ".gitignore"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -28,9 +28,14 @@ COMMON_PATTERNS=(
   "version.properties"
 )
 
+# Define constants for job types
+VALIDATION="validation"
+BUILD="build"
+LINT="lint"
+
 # Check if arguments are valid
 if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
-  echo "Error: Must specify --job-type [validation|build|lint]"
+  echo "Error: Must specify --job-type [$VALIDATION|$BUILD|$LINT]"
   buildkite-agent step cancel
   exit 15
 fi
@@ -38,7 +43,7 @@ fi
 # Function to display skip message and create annotation
 show_skip_message() {
   local job_type=$1
-  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local message="Skipped ${BUILDKITE_LABEL:-Job} - no relevant files changed"
   local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
   
   echo "$message" | buildkite-agent annotate --style "info" --context "$context"
@@ -47,7 +52,7 @@ show_skip_message() {
 
 job_type="$2"
 case "$job_type" in
-  "validation")
+  $VALIDATION)
     # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
     PATTERNS=("${COMMON_PATTERNS[@]}" "**/strings.xml")
     if pr_changed_files --all-match "${PATTERNS[@]}"; then
@@ -56,7 +61,7 @@ case "$job_type" in
     fi
     exit 1
     ;;
-  "build"|"lint")
+  $BUILD|$LINT)
     # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
@@ -67,7 +72,7 @@ case "$job_type" in
     exit 1
     ;;
   *)
-    echo "Error: Job type must be either 'validation', 'build', or 'lint'"
+    echo "Error: Job type must be either '$VALIDATION', '$BUILD', or '$LINT'"
     buildkite-agent step cancel
     exit 15
     ;;

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,6 +39,10 @@ steps:
 
       - label: "🕵️ checkstyle"
         command: |
+          if .buildkite/commands/should-skip-job.sh --job-type validation; then
+            exit 0
+          fi
+
           ./gradlew checkstyle
         plugins: [$CI_TOOLKIT]
         artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,6 +46,10 @@ steps:
 
       - label: "🕵️ detekt"
         command: |
+          if .buildkite/commands/should-skip-job.sh --job-type validation; then
+            exit 0
+          fi
+
           ./gradlew detekt
         plugins: [$CI_TOOLKIT]
         artifact_paths:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,5 +3,5 @@
  # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
  # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.1.3"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#5.3.1"
 export TEST_COLLECTOR="test-collector#v1.10.1"


### PR DESCRIPTION
Internal reference: paaHJt-7Ss-p2

The main goal of this PR is to optimize the wait time for PRs with minor, non-code related changes, specially the ones related to the release process.

There's a script to check in jobs if the changes in a PR is relevant to the said job.
The jobs are the time consuming ones running UI tests or building the app:
- `should-skip-job.sh --job-type [build|lint]`: skips if the changes are limited to documentation, tooling, metadata, etc
- `should-skip-job.sh --job-type validation`: same as above, but also skip on localization changes. The idea is that it can be valuable to run things as a Prototype build when localization changes

## Testing
I've created the PR https://github.com/wordpress-mobile/WordPress-Android/pull/21882 to test a few scenarios skipping jobs:
- App version bump: https://buildkite.com/automattic/wordpress-android/builds/21917
- ++ Localization update: https://buildkite.com/automattic/wordpress-android/builds/21919
- ++ Metadata update: https://buildkite.com/automattic/wordpress-android/builds/21922