### PR TITLE
Application password login add analytic events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -4,15 +4,20 @@ import android.util.Log
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.util.BuildConfigWrapper
 import javax.inject.Inject
 import javax.inject.Named
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val siteSqlUtils: SiteSqlUtils,
-    private val uriLoginWrapper: UriLoginWrapper
+    private val uriLoginWrapper: UriLoginWrapper,
+    private val buildConfigWrapper: BuildConfigWrapper,
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -35,6 +40,13 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     siteSqlUtils.insertOrUpdateSite(site)
                     Log.d("WP_RS", "Saved application password credentials for: ${uriLogin.siteUrl}")
                     processedAppPasswordData = url
+                    AnalyticsTracker.track(
+                        if (buildConfigWrapper.isJetpackApp) {
+                            Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_JP
+                        } else {
+                            Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_WP
+                        }
+                    )
                     true
                 } else {
                     Log.e("WP_RS", "Cannot save application password credentials for: ${uriLogin.siteUrl}")

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -59,9 +59,9 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         properties[SUCCESS_TAG] = "true"
         AnalyticsTracker.track(
             if (buildConfigWrapper.isJetpackApp) {
-                Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_JP
+                Stat.JP_ANDROID_APPLICATION_PASSWORD_LOGIN
             } else {
-                Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_WP
+                Stat.WP_ANDROID_APPLICATION_PASSWORD_LOGIN
             },
             properties
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -7,10 +7,7 @@ import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
-import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.modules.BG_THREAD
-import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment.Companion.SOURCE
-import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment.Companion.SOURCE_SIGNUP_EPILOGUE
 import org.wordpress.android.util.BuildConfigWrapper
 import javax.inject.Inject
 import javax.inject.Named

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -35,18 +35,13 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             } else {
                 val site = siteSqlUtils.getSites().firstOrNull { it.url == uriLogin.siteUrl }
                 if (site != null) {
-                    site.apiRestUsername = uriLogin.user
-                    site.apiRestPassword = uriLogin.password
+                    site.apply {
+                        apiRestUsername = uriLogin.user
+                        apiRestPassword = uriLogin.password
+                    }
                     siteSqlUtils.insertOrUpdateSite(site)
-                    Log.d("WP_RS", "Saved application password credentials for: ${uriLogin.siteUrl}")
-                    processedAppPasswordData = url
-                    AnalyticsTracker.track(
-                        if (buildConfigWrapper.isJetpackApp) {
-                            Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_JP
-                        } else {
-                            Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_WP
-                        }
-                    )
+                    uriLogin.siteUrl?.let { trackSuccessful(it) }
+                    processedAppPasswordData = url // Save locally to avoid duplicated calls
                     true
                 } else {
                     Log.e("WP_RS", "Cannot save application password credentials for: ${uriLogin.siteUrl}")
@@ -54,6 +49,17 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun trackSuccessful(siteUrl: String) {
+        AnalyticsTracker.track(
+            if (buildConfigWrapper.isJetpackApp) {
+                Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_JP
+            } else {
+                Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_WP
+            }
+        )
+        Log.d("WP_RS", "Saved application password credentials for: $siteUrl")
     }
 
     fun getSiteUrlFromUrl(url: String): String {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -9,9 +9,14 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.AccountStore.AuthEmailPayloadScheme
 import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment.Companion.SOURCE
+import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment.Companion.SOURCE_SIGNUP_EPILOGUE
 import org.wordpress.android.util.BuildConfigWrapper
 import javax.inject.Inject
 import javax.inject.Named
+
+private const val URL_TAG = "url"
+private const val SUCCESS_TAG = "success"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
@@ -52,12 +57,16 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     private fun trackSuccessful(siteUrl: String) {
+        val properties: MutableMap<String, String?> = HashMap()
+        properties[URL_TAG] = siteUrl
+        properties[SUCCESS_TAG] = "true"
         AnalyticsTracker.track(
             if (buildConfigWrapper.isJetpackApp) {
                 Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_JP
             } else {
                 Stat.APPLICATION_PASSWORD_LOGIN_SUCCESS_WP
-            }
+            },
+            properties
         )
         Log.d("WP_RS", "Saved application password credentials for: $siteUrl")
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.util.BuildConfigWrapper
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -29,12 +30,15 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
      @Mock
      lateinit var uriLoginWrapper: ApplicationPasswordLoginHelper.UriLoginWrapper
 
+     @Mock
+     lateinit var buildConfigWrapper: BuildConfigWrapper
+
     private lateinit var helper: ApplicationPasswordLoginHelper
 
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        helper = ApplicationPasswordLoginHelper(testDispatcher(), siteSqlUtils, uriLoginWrapper)
+        helper = ApplicationPasswordLoginHelper(testDispatcher(), siteSqlUtils, uriLoginWrapper, buildConfigWrapper)
         whenever(uriLoginWrapper.parseUriLogin(any()))
             .thenReturn(
                 ApplicationPasswordLoginHelper.UriLogin(TEST_URL, TEST_USER, TEST_PASSWORD)

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1157,8 +1157,8 @@ public final class AnalyticsTracker {
         VOICE_TO_CONTENT_BUTTON_RECORDING_LIMIT_REACHED,
         BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL,
         BACKGROUND_REST_AUTODISCOVERY_FAILED,
-        APPLICATION_PASSWORD_LOGIN_SUCCESS_WP("wp_android_application_password_login"),
-        APPLICATION_PASSWORD_LOGIN_SUCCESS_JP("jp_android_application_password_login");
+        WP_ANDROID_APPLICATION_PASSWORD_LOGIN,
+        JP_ANDROID_APPLICATION_PASSWORD_LOGIN;
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -1156,7 +1156,9 @@ public final class AnalyticsTracker {
         VOICE_TO_CONTENT_BUTTON_CLOSE_TAPPED,
         VOICE_TO_CONTENT_BUTTON_RECORDING_LIMIT_REACHED,
         BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL,
-        BACKGROUND_REST_AUTODISCOVERY_FAILED;
+        BACKGROUND_REST_AUTODISCOVERY_FAILED,
+        APPLICATION_PASSWORD_LOGIN_SUCCESS_WP("wp_android_application_password_login"),
+        APPLICATION_PASSWORD_LOGIN_SUCCESS_JP("jp_android_application_password_login");
         /*
          * Please set the event name in the enum only if the new Stat's name in lower case does not match it.
          * In that case you also need to add the event in the `AnalyticsTrackerNosaraTest.specialNames` map.


### PR DESCRIPTION
## Description

This PR is adding a simple event to know about the successful Application Password login.

## Testing instructions

1. Set the variable `ApplicationPasswordViewModelSlice.buildCard` to true
![Screenshot 2025-05-16 at 09 23 53](https://github.com/user-attachments/assets/2722615d-175c-4891-9f4a-9a2fa3ff619f)

2. Log in with a self-hosted site
3. Open MySite screen, wait for the Application Password card to appear
4. Log in using the Application Password flow
- [ ] Verify the event `jp_android_application_password_login` is sent (you can see it in logcat)
> WordPress-STATS         com.jetpack.android.beta             I  🔵 Tracked: jp_android_application_password_login, Properties: {"success":"true","url":"https:\/\/vanilla.wpmt.co"}
<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
