### PR TITLE
Setting jetpack flavour as the default one

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -201,7 +201,6 @@ android {
 
     productFlavors {
         wordpress {
-            isDefault true
             dimension "app"
 
             applicationId "org.wordpress.android"
@@ -216,6 +215,7 @@ android {
         }
 
         jetpack {
+            isDefault true
             dimension "app"
 
             applicationId "com.jetpack.android"


### PR DESCRIPTION
## Description

Since we are mostly working with the jetpack variant/flavour, this PR is setting it as the default build to be sure it's selected when AS has no previous configuration or when it's updated.

## Testing instructions

Just check the code and check the CI is green

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
