### PR TITLE
Disable smooth scroll to initial position

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -877,6 +877,9 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                     )
                     val adapter = PostPagerAdapter(idList)
                     viewPager.adapter = adapter
+
+                    // set the current position without smooth scrolling - otherwise the previous post in
+                    // the list may briefly appear
                     if (adapter.isValidPosition(newPosition)) {
                         viewPager.setCurrentItem(newPosition, false)
                         trackPostAtPositionIfNeeded(newPosition)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -875,14 +875,13 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                         AppLog.T.READER,
                         "reader pager > creating adapter"
                     )
-                    val adapter =
-                        PostPagerAdapter(idList)
+                    val adapter = PostPagerAdapter(idList)
                     viewPager.adapter = adapter
                     if (adapter.isValidPosition(newPosition)) {
-                        viewPager.currentItem = newPosition
+                        viewPager.setCurrentItem(newPosition, false)
                         trackPostAtPositionIfNeeded(newPosition)
                     } else if (adapter.isValidPosition(currentPosition)) {
-                        viewPager.currentItem = currentPosition
+                        viewPager.setCurrentItem(currentPosition, false)
                         trackPostAtPositionIfNeeded(currentPosition)
                     }
 


### PR DESCRIPTION
As shown in the video below, tapping a post in the reader list briefly showed the previous post before opening the tapped post. This was caused by `ViewPager2` defaulting to smooth scrolling when setting the page position. This PR corrects this by explicitly not smooth scrolling.

To test:

* In `trunk` reproduce the issue. Note that you need to scroll several posts down the list before tapping a post.
* Pull this branch and note this issue is resolved

https://github.com/user-attachments/assets/9c77c02f-756b-4bc6-8219-6f8f48884230

