### PR TITLE
Subscribers feature flag

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -236,7 +236,7 @@
             android:label="@string/me_btn_app_settings"
             android:theme="@style/WordPress.NoActionBar" />
         <activity
-            android:name=".ui.prefs.ExperimentalFeaturesActivity"
+            android:name=".ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity"
             android:label="@string/me_btn_experimental_features"
             android:theme="@style/WordPress.NoActionBar" />
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -97,7 +97,7 @@ import org.wordpress.android.ui.posts.RemotePreviewLogicHelper.RemotePreviewType
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
 import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
-import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity;
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
 import org.wordpress.android.ui.prefs.categories.detail.CategoryDetailActivity;
 import org.wordpress.android.ui.prefs.categories.list.CategoriesListActivity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -24,7 +24,7 @@ import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity
 import org.wordpress.android.ui.posts.EditPostActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
-import org.wordpress.android.ui.prefs.ExperimentalFeaturesActivity
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesActivity
 import org.wordpress.android.ui.reader.ReaderCommentListActivity
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity
 import org.wordpress.android.ui.reader.ReaderSubsActivity

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SelectedSiteRepository.kt
@@ -12,7 +12,7 @@ import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettings
 import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
-import org.wordpress.android.ui.prefs.ExperimentalFeature
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeature
 import org.wordpress.android.ui.prefs.SiteSettingsInterfaceWrapper
 import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.mapSafe

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -198,7 +198,7 @@ import org.wordpress.android.ui.posts.services.AztecVideoLoader
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity.Companion.createIntent
 import org.wordpress.android.ui.prefs.AppPrefs
-import org.wordpress.android.ui.prefs.ExperimentalFeature
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeature
 import org.wordpress.android.ui.prefs.SiteSettingsInterface
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -61,6 +61,11 @@ enum class ExperimentalFeature(val prefKey: String, val labelResId: Int, val des
         "experimental_block_editor_theme_styles",
         R.string.experimental_block_editor_theme_styles,
         R.string.experimental_block_editor_theme_styles_description
+    ),
+    EXPERIMENTAL_SUBSCRIBERS_FEATURE(
+        "experimental_subscribers_feature",
+        R.string.experimental_subscribers_feature,
+        R.string.experimental_subscribers_feature_description
     );
 
     fun isEnabled() : Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ExperimentalFeaturesActivity.kt
@@ -45,8 +45,13 @@ import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.extensions.setContent
 import javax.inject.Inject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.wordpress.android.BuildConfig
 
-enum class ExperimentalFeature(val prefKey: String, val labelResId: Int, val descriptionResId: Int) {
+enum class ExperimentalFeature(
+    private val prefKey: String,
+    val labelResId: Int,
+    val descriptionResId: Int
+) {
     DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
         "disable_experimental_block_editor",
         R.string.disable_experimental_block_editor,
@@ -87,16 +92,22 @@ class FeatureViewModel @Inject constructor(
     init {
         val initialStates = ExperimentalFeature.entries
             .filter { feature ->
-                if (gutenbergKitFeature.isEnabled()) {
-                    feature != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
-                } else {
-                    feature != ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
-                }
-            }
-            .associate { feature ->
-                feature to feature.isEnabled()
+                shouldShowFeature(feature)
+            }.associateWith {
+                feature -> feature.isEnabled()
             }
         _switchStates.value = initialStates
+    }
+
+    private fun shouldShowFeature(feature: ExperimentalFeature): Boolean {
+        // only show subscribers in debug builds
+        return if (BuildConfig.DEBUG.not() && feature == ExperimentalFeature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
+            false
+        } else if (gutenbergKitFeature.isEnabled()) {
+            feature != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
+        } else {
+            feature != ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+        }
     }
 
     fun onFeatureToggled(feature: ExperimentalFeature, enabled: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeature.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeature.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.prefs.experimentalfeatures
+
+import org.wordpress.android.R
+import org.wordpress.android.ui.prefs.AppPrefs
+
+enum class ExperimentalFeature(
+    private val prefKey: String,
+    val labelResId: Int,
+    val descriptionResId: Int
+) {
+    DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
+        "disable_experimental_block_editor",
+        R.string.disable_experimental_block_editor,
+        R.string.disable_experimental_block_editor_description
+    ),
+    EXPERIMENTAL_BLOCK_EDITOR(
+        "experimental_block_editor",
+        R.string.experimental_block_editor,
+        R.string.experimental_block_editor_description
+    ),
+    EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES(
+        "experimental_block_editor_theme_styles",
+        R.string.experimental_block_editor_theme_styles,
+        R.string.experimental_block_editor_theme_styles_description
+    ),
+    EXPERIMENTAL_SUBSCRIBERS_FEATURE(
+        "experimental_subscribers_feature",
+        R.string.experimental_subscribers_feature,
+        R.string.experimental_subscribers_feature_description
+    );
+
+    fun isEnabled() : Boolean {
+        return AppPrefs.getExperimentalFeatureConfig(prefKey)
+    }
+
+    fun setEnabled(isEnabled: Boolean) {
+        AppPrefs.setExperimentalFeatureConfig(isEnabled, prefKey)
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.prefs
+package org.wordpress.android.ui.prefs.experimentalfeatures
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.os.Bundle
@@ -29,100 +29,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
 import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.main.BaseAppCompatActivity
-import org.wordpress.android.util.config.GutenbergKitFeature
 import org.wordpress.android.util.extensions.setContent
-import javax.inject.Inject
-import dagger.hilt.android.lifecycle.HiltViewModel
-import org.wordpress.android.BuildConfig
-
-enum class ExperimentalFeature(
-    private val prefKey: String,
-    val labelResId: Int,
-    val descriptionResId: Int
-) {
-    DISABLE_EXPERIMENTAL_BLOCK_EDITOR(
-        "disable_experimental_block_editor",
-        R.string.disable_experimental_block_editor,
-        R.string.disable_experimental_block_editor_description
-    ),
-    EXPERIMENTAL_BLOCK_EDITOR(
-        "experimental_block_editor",
-        R.string.experimental_block_editor,
-        R.string.experimental_block_editor_description
-    ),
-    EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES(
-        "experimental_block_editor_theme_styles",
-        R.string.experimental_block_editor_theme_styles,
-        R.string.experimental_block_editor_theme_styles_description
-    ),
-    EXPERIMENTAL_SUBSCRIBERS_FEATURE(
-        "experimental_subscribers_feature",
-        R.string.experimental_subscribers_feature,
-        R.string.experimental_subscribers_feature_description
-    );
-
-    fun isEnabled() : Boolean {
-        return AppPrefs.getExperimentalFeatureConfig(prefKey)
-    }
-
-    fun setEnabled(isEnabled: Boolean) {
-        AppPrefs.setExperimentalFeatureConfig(isEnabled, prefKey)
-    }
-}
-
-@HiltViewModel
-class FeatureViewModel @Inject constructor(
-    private val gutenbergKitFeature: GutenbergKitFeature
-) : ViewModel() {
-    private val _switchStates = MutableStateFlow<Map<ExperimentalFeature, Boolean>>(emptyMap())
-    val switchStates: StateFlow<Map<ExperimentalFeature, Boolean>> = _switchStates.asStateFlow()
-
-    init {
-        val initialStates = ExperimentalFeature.entries
-            .filter { feature ->
-                shouldShowFeature(feature)
-            }.associateWith {
-                feature -> feature.isEnabled()
-            }
-        _switchStates.value = initialStates
-    }
-
-    private fun shouldShowFeature(feature: ExperimentalFeature): Boolean {
-        // only show subscribers in debug builds
-        return if (BuildConfig.DEBUG.not() && feature == ExperimentalFeature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
-            false
-        } else if (gutenbergKitFeature.isEnabled()) {
-            feature != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
-        } else {
-            feature != ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
-        }
-    }
-
-    fun onFeatureToggled(feature: ExperimentalFeature, enabled: Boolean) {
-        _switchStates.update { currentStates ->
-            currentStates.toMutableMap().apply {
-                this[feature] = enabled
-                feature.setEnabled(enabled)
-            }
-        }
-    }
-}
 
 @AndroidEntryPoint
 class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
-    private val viewModel: FeatureViewModel by viewModels()
+    private val viewModel: ExperimentalFeaturesViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -1,40 +1,14 @@
 package org.wordpress.android.ui.prefs.experimentalfeatures
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
-import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
-import org.wordpress.android.ui.compose.unit.Margin
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.extensions.setContent
 
@@ -72,134 +46,5 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                 )
             }
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun ExperimentalFeaturesScreen(
-    features: Map<ExperimentalFeature, Boolean>,
-    onFeatureToggled: (feature: ExperimentalFeature, enabled: Boolean) -> Unit,
-    onNavigateBack: () -> Unit
-) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(text = stringResource(R.string.experimental_features_screen_title))
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            stringResource(R.string.back)
-                        )
-                    }
-                },
-            )
-        },
-    ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
-            Column {
-                features.forEach { (feature, enabled) ->
-                    FeatureToggle(
-                        feature = feature,
-                        enabled = enabled,
-                        onChange = onFeatureToggled,
-                    )
-                }
-
-                Column(
-                    modifier = Modifier.padding(
-                        start = Margin.ExtraLarge.value,
-                        end = Margin.ExtraLarge.value,
-                        top = Margin.Large.value,
-                        bottom = Margin.Large.value
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(bottom = Margin.ExtraLarge.value)
-                    )
-                    Text(
-                        text = stringResource(R.string.experimental_block_editor_note),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(bottom = Margin.Small.value)
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun FeatureToggle(
-    feature: ExperimentalFeature,
-    enabled: Boolean,
-    onChange: (ExperimentalFeature, Boolean) -> Unit,
-) {
-    ListItem(
-        headlineContent = {
-            Text(
-                text = stringResource(feature.labelResId),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        },
-        supportingContent = {
-            Text(
-                text = stringResource(feature.descriptionResId),
-                style = MaterialTheme.typography.bodySmall,
-            )
-        },
-        trailingContent = {
-            Switch(
-                checked = enabled,
-                onCheckedChange = { newValue ->
-                    onChange(feature, newValue)
-                },
-            )
-        },
-        modifier = Modifier.clickable { onChange(feature, !enabled) }
-    )
-}
-
-@Composable
-fun FeedbackDialog(onDismiss: () -> Unit, onSendFeedback: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_title)) },
-        text = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_message)) },
-        confirmButton = {
-            Button(onClick = onSendFeedback) {
-                Text(text = stringResource(R.string.send_feedback))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(R.string.experimental_features_feedback_dialog_decline))
-            }
-        }
-    )
-}
-
-@Preview
-@Preview(uiMode = UI_MODE_NIGHT_YES)
-@Composable
-fun ExperimentalFeaturesScreenPreview() {
-    AppThemeM3 {
-        val featuresStatusAlternated = remember {
-            ExperimentalFeature.entries.toTypedArray().mapIndexed { index, feature ->
-                feature to (index % 2 == 0)
-            }.toMap()
-        }
-
-        ExperimentalFeaturesScreen(
-            features = featuresStatusAlternated,
-            onFeatureToggled = { _, _ -> },
-            onNavigateBack = {}
-        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -1,0 +1,159 @@
+package org.wordpress.android.ui.prefs.experimentalfeatures
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.ui.compose.unit.Margin
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExperimentalFeaturesScreen(
+    features: Map<ExperimentalFeature, Boolean>,
+    onFeatureToggled: (feature: ExperimentalFeature, enabled: Boolean) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(text = stringResource(R.string.experimental_features_screen_title))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            stringResource(R.string.back)
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            Column {
+                features.forEach { (feature, enabled) ->
+                    FeatureToggle(
+                        feature = feature,
+                        enabled = enabled,
+                        onChange = onFeatureToggled,
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.padding(
+                        start = Margin.ExtraLarge.value,
+                        end = Margin.ExtraLarge.value,
+                        top = Margin.Large.value,
+                        bottom = Margin.Large.value
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Margin.ExtraLarge.value)
+                    )
+                    Text(
+                        text = stringResource(R.string.experimental_block_editor_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Margin.Small.value)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun FeatureToggle(
+    feature: ExperimentalFeature,
+    enabled: Boolean,
+    onChange: (ExperimentalFeature, Boolean) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = stringResource(feature.labelResId),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = stringResource(feature.descriptionResId),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = enabled,
+                onCheckedChange = { newValue ->
+                    onChange(feature, newValue)
+                },
+            )
+        },
+        modifier = Modifier.clickable { onChange(feature, !enabled) }
+    )
+}
+
+@Composable
+fun FeedbackDialog(onDismiss: () -> Unit, onSendFeedback: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_title)) },
+        text = { Text(text = stringResource(R.string.experimental_features_feedback_dialog_message)) },
+        confirmButton = {
+            Button(onClick = onSendFeedback) {
+                Text(text = stringResource(R.string.send_feedback))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.experimental_features_feedback_dialog_decline))
+            }
+        }
+    )
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun ExperimentalFeaturesScreenPreview() {
+    AppThemeM3 {
+        val featuresStatusAlternated = remember {
+            ExperimentalFeature.entries.toTypedArray().mapIndexed { index, feature ->
+                feature to (index % 2 == 0)
+            }.toMap()
+        }
+
+        ExperimentalFeaturesScreen(
+            features = featuresStatusAlternated,
+            onFeatureToggled = { _, _ -> },
+            onNavigateBack = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -1,0 +1,49 @@
+package org.wordpress.android.ui.prefs.experimentalfeatures
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.wordpress.android.BuildConfig
+import org.wordpress.android.util.config.GutenbergKitFeature
+import javax.inject.Inject
+
+@HiltViewModel
+internal class ExperimentalFeaturesViewModel @Inject constructor(
+    private val gutenbergKitFeature: GutenbergKitFeature
+) : ViewModel() {
+    private val _switchStates = MutableStateFlow<Map<ExperimentalFeature, Boolean>>(emptyMap())
+    val switchStates: StateFlow<Map<ExperimentalFeature, Boolean>> = _switchStates.asStateFlow()
+
+    init {
+        val initialStates = ExperimentalFeature.entries
+            .filter { feature ->
+                shouldShowFeature(feature)
+            }.associateWith { feature ->
+                feature.isEnabled()
+            }
+        _switchStates.value = initialStates
+    }
+
+    private fun shouldShowFeature(feature: ExperimentalFeature): Boolean {
+        // only show subscribers in debug builds
+        return if (BuildConfig.DEBUG.not() && feature == ExperimentalFeature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
+            false
+        } else if (gutenbergKitFeature.isEnabled()) {
+            feature != ExperimentalFeature.EXPERIMENTAL_BLOCK_EDITOR
+        } else {
+            feature != ExperimentalFeature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR
+        }
+    }
+
+    fun onFeatureToggled(feature: ExperimentalFeature, enabled: Boolean) {
+        _switchStates.update { currentStates ->
+            currentStates.toMutableMap().apply {
+                this[feature] = enabled
+                feature.setEnabled(enabled)
+            }
+        }
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -968,6 +968,8 @@
     <string name="experimental_features_feedback_dialog_title">Share feedback</string>
     <string name="experimental_features_feedback_dialog_message">Are you willing to share feedback on the experimental editor?</string>
     <string name="experimental_features_feedback_dialog_decline">Not now</string>
+    <string name="experimental_subscribers_feature">Experimental subscribers</string>
+    <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -969,7 +969,7 @@
     <string name="experimental_features_feedback_dialog_message">Are you willing to share feedback on the experimental editor?</string>
     <string name="experimental_features_feedback_dialog_decline">Not now</string>
     <string name="experimental_subscribers_feature">Experimental subscribers</string>
-    <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
+    <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers (work in progress)</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>


### PR DESCRIPTION
This PR adds a "Subscribers" toggle to the experimental features screen. I chose to only enable this new setting in debug builds since there's nothing for end users to see yet.

As part of this, I also refactored the experimental features code. Previously the activity, enum, view model, and composables were all in `ExperimentalFeaturesActivity`. I moved all these to a new package and separated them into their own files.

To test, verify that the "Subscribers" experimental feature only appears in debug builds and that the toggle is remembered between sessions.