### PR TITLE
Renamed People to Users

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -732,7 +732,7 @@
         <!--People Management-->
         <activity
             android:name=".ui.people.PeopleManagementActivity"
-            android:label="@string/people"
+            android:label="@string/users"
             android:launchMode="singleTop"
             android:theme="@style/WordPress.NoActionBar"/>
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -137,7 +137,7 @@ class SiteListItemBuilder @Inject constructor(
         return if (site.hasCapabilityListUsers) {
             ListItem(
                 R.drawable.ic_user_white_24dp,
-                UiStringRes(R.string.people),
+                UiStringRes(R.string.users),
                 onClick = ListItemInteraction.create(PEOPLE, onClick),
                 listItemAction = PEOPLE
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -189,7 +189,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         if (actionBar != null) {
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setTitle(R.string.invite_people);
+            actionBar.setTitle(R.string.invite_users);
         }
 
         mInviteLinkContainer = rootView.findViewById(R.id.invite_links_container);
@@ -389,7 +389,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         });
 
         // important for accessibility - talkback
-        getActivity().setTitle(R.string.invite_people);
+        getActivity().setTitle(R.string.invite_users);
     }
 
     private void resetEditTextContent(EditText editText) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -117,7 +117,7 @@ public class PeopleListFragment extends Fragment {
         if (actionBar != null) {
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setTitle(R.string.people);
+            actionBar.setTitle(R.string.users);
         }
 
         mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
@@ -264,7 +264,7 @@ public class PeopleListFragment extends Fragment {
     @Override public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // important for accessibility - talkback
-        getActivity().setTitle(R.string.people);
+        getActivity().setTitle(R.string.users);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -609,7 +609,7 @@ public class PeopleManagementActivity extends BaseAppCompatActivity
 
             ActionBar actionBar = getSupportActionBar();
             if (actionBar != null) {
-                actionBar.setTitle(R.string.people);
+                actionBar.setTitle(R.string.users);
             }
             return true;
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2732,7 +2732,7 @@
     <string name="subscriber_remove_confirmation_message">If removed, this subscriber will stop receiving notifications about this site, unless they re-subscribe.\n\nWould you still like to remove this subscriber?</string>
     <string name="viewer_remove_confirmation_message">If you remove this viewer, he or she will not be able to visit this site.\n\nWould you still like to remove this viewer?</string>
     <string name="person_removed">Successfully removed %1$s</string>
-    <string name="invite_people">Invite People</string>
+    <string name="invite_users">Invite users</string>
     <string name="invite_names_title">Usernames or emails</string>
     <string name="invite">Invite</string>
     <string name="button_invite" translatable="false">@string/invite</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2721,7 +2721,6 @@
     <string name="themes_empty_list">No themes matching your search</string>
 
     <!--People Management-->
-    <string name="people">People</string>
     <string name="users">Users</string>
     <string name="user">User</string>
     <string name="no_users">No users</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -81,7 +81,7 @@ val ADMIN_ITEM = ListItem(
 )
 val PEOPLE_ITEM = ListItem(
     R.drawable.ic_user_white_24dp,
-    UiStringRes(R.string.people),
+    UiStringRes(R.string.users),
     onClick = ListItemInteraction.create(ListItemAction.PEOPLE, SITE_ITEM_ACTION),
     listItemAction = ListItemAction.PEOPLE
 )


### PR DESCRIPTION
The iOS app recently renamed the "People" feature to "Users" to match the web app. As part of the upcoming Subscribers feature, in this PR the people screens are renamed "Users." 

To test:

- Verify that the people card on the Me screen is titled "Users"
- Verify that the people list is titled "Users"
- Verify that the invite screen is titled "Invite users"
- Verify that the "Personalize home tab" feature (accessed from the bottom of the My Site screen) shows "Users" as the title of the shortcut

Note that I haven't renamed all the classes, variables, etc., to refer to users instead of people. I started to do this but decided against it due to the huge number of changes. We can reconsider this down the road if desired.