### PR TITLE
Add subscribers card to My Site when feature flag is enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -9,6 +9,7 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -716,6 +717,11 @@ public class ActivityLauncher {
         intent.putExtra(WordPress.SITE, site);
         context.startActivity(intent);
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_THEMES_BROWSER, site);
+    }
+
+    public static void viewCurrentBlogSubscribers(@NonNull Context context, @NonNull SiteModel site) {
+        // TODO - subscribers screen
+        Toast.makeText(context, R.string.coming_soon, Toast.LENGTH_SHORT).show();
     }
 
     public static void viewCurrentBlogPeople(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -643,6 +643,9 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
             action.isNewSite
         )
         is SiteNavigationAction.OpenAdmin -> ActivityLauncher.viewBlogAdmin(activity, action.site)
+        is SiteNavigationAction.OpenSubscribers -> {
+            ActivityLauncher.viewCurrentBlogSubscribers(requireActivity(), action.site)
+        }
         is SiteNavigationAction.OpenPeople -> {
             ActivityLauncher.viewCurrentBlogPeople(activity, action.site)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -31,6 +31,7 @@ sealed class SiteNavigationAction {
     ) : SiteNavigationAction()
 
     data class OpenAdmin(val site: SiteModel) : SiteNavigationAction()
+    data class OpenSubscribers(val site: SiteModel) : SiteNavigationAction()
     data class OpenPeople(val site: SiteModel) : SiteNavigationAction()
     data class OpenSelfHostedUsers(val site: SiteModel) : SiteNavigationAction()
     data class OpenSharing(val site: SiteModel) : SiteNavigationAction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandler.kt
@@ -29,6 +29,7 @@ class ListItemActionHandler @Inject constructor(
             ListItemAction.POSTS -> SiteNavigationAction.OpenPosts(selectedSite)
             ListItemAction.PAGES -> SiteNavigationAction.OpenPages(selectedSite)
             ListItemAction.ADMIN -> SiteNavigationAction.OpenAdmin(selectedSite)
+            ListItemAction.SUBSCRIBERS -> SiteNavigationAction.OpenSubscribers(selectedSite)
             ListItemAction.PEOPLE -> SiteNavigationAction.OpenPeople(selectedSite)
             ListItemAction.SELF_HOSTED_USERS -> SiteNavigationAction.OpenSelfHostedUsers(selectedSite)
             ListItemAction.SHARING -> SiteNavigationAction.OpenSharing(selectedSite)

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/ListItemAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/ListItemAction.kt
@@ -9,6 +9,7 @@ enum class ListItemAction (val trackingLabel: String) {
     PAGES("pages"),
     ADMIN("admin"),
     PEOPLE("people"),
+    SUBSCRIBERS("subscribers"),
     SELF_HOSTED_USERS("self_hosted_users"),
     SHARING("sharing"),
     DOMAINS("domains"),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -84,6 +84,8 @@ class SiteItemsBuilder @Inject constructor(
                 showFocusPoint = showStatsFocusPoint,
                 listItemAction = ListItemAction.STATS
             ),
+            // TODO verify whether this is JP-dependant
+            siteListItemBuilder.buildSubscribersItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildBlazeItemIfAvailable(params.isBlazeEligible, params.onClick)
         )
     }
@@ -150,14 +152,14 @@ class SiteItemsBuilder @Inject constructor(
 
         return if (!jetpackFeatureRemovalOverlayUtil.shouldHideJetpackFeatures()) {
             listOfNotNull(
-                    siteListItemBuilder.buildPeopleItemIfAvailable(params.site, params.onClick),
-                    siteListItemBuilder.buildSelfHostedUserListItemIfAvailable(params.site, params.onClick),
-                    siteListItemBuilder.buildPluginItemIfAvailable(params.site, params.onClick),
-                    siteListItemBuilder.buildShareItemIfAvailable(
-                            params.site,
-                            params.onClick,
-                            showEnablePostSharingFocusPoint
-                    )
+                siteListItemBuilder.buildPeopleItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildSelfHostedUserListItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildPluginItemIfAvailable(params.site, params.onClick),
+                siteListItemBuilder.buildShareItemIfAvailable(
+                    params.site,
+                    params.onClick,
+                    showEnablePostSharingFocusPoint
+                )
             )
         } else emptyList()
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteItemsBuilder.kt
@@ -84,7 +84,6 @@ class SiteItemsBuilder @Inject constructor(
                 showFocusPoint = showStatsFocusPoint,
                 listItemAction = ListItemAction.STATS
             ),
-            // TODO verify whether this is JP-dependant
             siteListItemBuilder.buildSubscribersItemIfAvailable(params.site, params.onClick),
             siteListItemBuilder.buildBlazeItemIfAvailable(params.isBlazeEligible, params.onClick)
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -138,7 +138,7 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildSubscribersItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        return if (site.hasCapabilityListUsers &&
+        return if (site.hasCapabilityListSubscribers &&
             experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)
         ) {
             ListItem(

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -138,7 +138,6 @@ class SiteListItemBuilder @Inject constructor(
     }
 
     fun buildSubscribersItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
-        // TODO verify if this site capability is necessary
         return if (site.hasCapabilityListUsers &&
             experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -139,7 +139,9 @@ class SiteListItemBuilder @Inject constructor(
 
     fun buildSubscribersItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         // TODO verify if this site capability is necessary
-        return if (site.hasCapabilityListUsers && experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)) {
+        return if (site.hasCapabilityListUsers &&
+            experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)
+        ) {
             ListItem(
                 R.drawable.ic_mail_white_24dp,
                 UiStringRes(R.string.subscribers),

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt
@@ -21,8 +21,11 @@ import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SCAN
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SELF_HOSTED_USERS
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SHARING
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SITE_SETTINGS
+import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.SUBSCRIBERS
 import org.wordpress.android.ui.mysite.items.listitem.ListItemAction.THEMES
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString.UiStringRes
@@ -45,6 +48,7 @@ class SiteListItemBuilder @Inject constructor(
     private val jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper,
     private val siteMonitoringFeatureConfig: SiteMonitoringFeatureConfig,
     private val selfHostedUsersFeatureConfig: SelfHostedUsersFeatureConfig,
+    private val experimentalFeatures: ExperimentalFeatures,
 ) {
     fun buildActivityLogItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
         val isWpComOrJetpack = siteUtilsWrapper.isAccessedViaWPComRest(
@@ -131,6 +135,20 @@ class SiteListItemBuilder @Inject constructor(
                 listItemAction = ADMIN
             )
         } else null
+    }
+
+    fun buildSubscribersItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {
+        // TODO verify if this site capability is necessary
+        return if (site.hasCapabilityListUsers && experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)) {
+            ListItem(
+                R.drawable.ic_mail_white_24dp,
+                UiStringRes(R.string.subscribers),
+                onClick = ListItemInteraction.create(SUBSCRIBERS, onClick),
+                listItemAction = SUBSCRIBERS
+            )
+        } else {
+            null
+        }
     }
 
     fun buildPeopleItemIfAvailable(site: SiteModel, onClick: (ListItemAction) -> Unit): ListItem? {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="dismiss">Dismiss</string>
     <string name="sending">Sending</string>
     <string name="item_selected">Selected</string>
+    <string name="coming_soon">Coming soon!</string>
 
     <string name="button_not_now">Not now</string>
     <string name="button_skip">Skip</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemFixtures.kt
@@ -79,6 +79,12 @@ val ADMIN_ITEM = ListItem(
     onClick = ListItemInteraction.create(ListItemAction.ADMIN, SITE_ITEM_ACTION),
     listItemAction = ListItemAction.ADMIN
 )
+val SUBSCRIBERS_ITEM = ListItem(
+    R.drawable.ic_mail_white_24dp,
+    UiStringRes(R.string.subscribers),
+    onClick = ListItemInteraction.create(ListItemAction.SUBSCRIBERS, SITE_ITEM_ACTION),
+    listItemAction = ListItemAction.SUBSCRIBERS
+)
 val PEOPLE_ITEM = ListItem(
     R.drawable.ic_user_white_24dp,
     UiStringRes(R.string.users),

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/SiteItemsBuilderTest.kt
@@ -81,6 +81,7 @@ class SiteItemsBuilderTest {
             addPlanItem = false,
             addPagesItem = true,
             addAdminItem = true,
+            addSubscribersItem = true,
             addPeopleItem = true,
             addPluginItem = true,
             addShareItem = true,
@@ -106,6 +107,7 @@ class SiteItemsBuilderTest {
             COMMENTS_ITEM,
             TRAFFIC_HEADER,
             STATS_ITEM,
+            SUBSCRIBERS_ITEM,
             MANAGE_HEADER,
             ACTIVITY_ITEM,
             BACKUP_ITEM,
@@ -236,6 +238,7 @@ class SiteItemsBuilderTest {
         addPlanItem: Boolean = false,
         addPagesItem: Boolean = false,
         addAdminItem: Boolean = false,
+        addSubscribersItem: Boolean = false,
         addPeopleItem: Boolean = false,
         addPluginItem: Boolean = false,
         addShareItem: Boolean = false,
@@ -292,6 +295,11 @@ class SiteItemsBuilderTest {
         if (addAdminItem) {
             whenever(siteListItemBuilder.buildAdminItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
                 ADMIN_ITEM
+            )
+        }
+        if (addSubscribersItem) {
+            whenever(siteListItemBuilder.buildSubscribersItemIfAvailable(siteModel, SITE_ITEM_ACTION)).thenReturn(
+                SUBSCRIBERS_ITEM
             )
         }
         if (addPeopleItem) {

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilderTest.kt
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.mysite.items.SITE_ITEM_ACTION
 import org.wordpress.android.ui.mysite.items.SITE_MONITORING_ITEM
 import org.wordpress.android.ui.mysite.items.SITE_SETTINGS_ITEM
 import org.wordpress.android.ui.plugins.PluginUtilsWrapper
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.themes.ThemeBrowserUtils
 import org.wordpress.android.util.BuildConfigWrapper
 import org.wordpress.android.util.SiteUtilsWrapper
@@ -61,6 +62,9 @@ class SiteListItemBuilderTest {
     @Mock
     lateinit var selfHostedUsersFeatureConfig: SelfHostedUsersFeatureConfig
 
+    @Mock
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private lateinit var siteListItemBuilder: SiteListItemBuilder
 
     @Before
@@ -73,7 +77,8 @@ class SiteListItemBuilderTest {
             themeBrowserUtils,
             jetpackFeatureRemovalPhaseHelper,
             siteMonitoringFeatureConfig,
-            selfHostedUsersFeatureConfig
+            selfHostedUsersFeatureConfig,
+            experimentalFeatures
         )
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -570,6 +570,14 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mHasCapabilityListUsers = capabilityListUsers;
     }
 
+    /**
+     * This may change, but for now the newsletter subscribers feature requires a
+     * WP.com or Atomic site with user list capabilities.
+     */
+    public boolean getHasCapabilityListSubscribers() {
+        return getHasCapabilityListUsers() && (isWPCom() || isWPComAtomic());
+    }
+
     public boolean getHasCapabilityManageCategories() {
         return mHasCapabilityManageCategories;
     }


### PR DESCRIPTION
As part of the Newsletter Subscribers feature, this PR adds a Subscribers card to the "My Site" screen. This PR simply provides the plumbing for adding the actual screen, which will come next.

**To test:**

- Enable the experimental subscribers feature
- Go to "My Site" and tap More
- Verify that Subscribers shows up in the Traffic section (this matches iOS)
- Return to "My Site" and tap "Personalize your home tab"
- Verify that Subscribers shows up under shortcuts
- Verify that enabling the Subscribers shortcut adds it to the "My Site" screen
- Disable the experimental feature and verify that the Subscribers card doesn't appear anywhere

**Note:** As discussed on Slack ( p1748012837332749/1748008409.051569-slack-C04PWEZSYFL ) this card is only shown for WP.com or Atomic sites with "list users" capability.


<img src="https://github.com/user-attachments/assets/c01db572-13c0-498e-b1b2-da69e7b37527" width=256 />