### PR TITLE
fix: GutenbergKit WebView presents native pickers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -797,7 +797,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun setupEditor() {
         if (isGutenbergKitEditor) {
-            GutenbergWebViewPool.getPreloadedWebView(getContext())
+            GutenbergWebViewPool.getPreloadedWebView(this)
         }
         // Check whether to show the visual editor
 


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-389.

In order to present native pickers and dialogs, a WebView must be
initialized with the activity context, not the application context.

See: https://stackoverflow.com/a/55075067/378228


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Insert an Image block.
2. Attach media from the Media Library.
3. Open the block settings.
4. Tap the _Resolutions_ select menu.
5. Verify the native picker is rendered and changing the selected option is
   possible.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
