### PR TITLE
Add the Application Password login flow as an experimental feature in debug

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
@@ -19,6 +20,8 @@ import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem.QuickLinkItem
 import org.wordpress.android.ui.mysite.SiteNavigationAction
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.utils.ListItemInteraction
 import org.wordpress.android.ui.utils.UiString
 import org.wordpress.android.util.AppLog
@@ -34,6 +37,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
     private val siteSqlUtils: SiteSqlUtils,
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
+    private val experimentalFeatures: ExperimentalFeatures
 ) {
     lateinit var scope: CoroutineScope
 
@@ -52,15 +56,16 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
     val uiModelMutable = MutableLiveData<MySiteCardAndItem.Card?>()
     val uiModel: LiveData<MySiteCardAndItem.Card?> = uiModelMutable
 
-    var buildCard = false
-
     fun buildCard(siteModel: SiteModel) {
         // This is hidden for regular users.
         // After enabling it, please remove the Suppress annotation for buildCard and buildApplicationPasswordDiscovery
-        if (buildCard) {
+        if (shouldBuildCard()) {
             buildApplicationPasswordDiscovery(siteModel)
         }
     }
+
+    private fun shouldBuildCard(): Boolean =
+        experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE)
 
     private fun buildApplicationPasswordDiscovery(site: SiteModel) {
         // Check if the site URL is already cached

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -39,6 +39,11 @@ class ExperimentalFeatures @Inject constructor(
             "experimental_subscribers_feature",
             R.string.experimental_subscribers_feature,
             R.string.experimental_subscribers_feature_description
+        ),
+        EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE(
+            "experimental_application_password_feature",
+            R.string.experimental_application_password_feature,
+            R.string.experimental_application_password_feature_description
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -33,6 +33,9 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         // only show subscribers in debug builds
         return if (BuildConfig.DEBUG.not() && feature == Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
             false
+        } else if (BuildConfig.DEBUG.not() && feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE) {
+            // only show application password in debug builds
+            false
         } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR
         } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -970,6 +970,8 @@
     <string name="experimental_features_feedback_dialog_decline">Not now</string>
     <string name="experimental_subscribers_feature">Experimental subscribers</string>
     <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers (work in progress)</string>
+    <string name="experimental_application_password_feature">Application Password log in</string>
+    <string name="experimental_application_password_feature_description">Enable Application Password to log-in self-hosted sites</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -971,7 +971,7 @@
     <string name="experimental_subscribers_feature">Experimental subscribers</string>
     <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers (work in progress)</string>
     <string name="experimental_application_password_feature">Application Password log in</string>
-    <string name="experimental_application_password_feature_description">Enable Application Password to log-in self-hosted sites</string>
+    <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites.</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
@@ -22,6 +22,7 @@ import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
 import uniffi.wp_api.AutoDiscoveryAttemptSuccess
@@ -61,6 +62,9 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
 
+    @Mock
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private lateinit var siteTest: SiteModel
 
     private var applicationPasswordCard: MySiteCardAndItem.Card? = null
@@ -76,10 +80,11 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
             applicationPasswordLoginHelper,
             siteSqlUtils,
             wpLoginClient,
-            appLogWrapper
+            appLogWrapper,
+            experimentalFeatures
         ).apply {
             initialize(testScope())
-            buildCard = true
+            whenever(experimentalFeatures.isEnabled(any())).thenReturn(true)
         }
         siteTest = SiteModel().apply {
             id = TEST_SITE_ID


### PR DESCRIPTION
## Description
This PR is adding a new experimental feature toggle to enable the Application Password flow. This is to mimic the same behaviour as on iOS to allow direct self-hosted sites Application Password login.

## Testing instructions

1. Log in with a self hosted site
2. Go to MySite screen
- [ ] Verify you DON'T see the Application Password login card
3. Go to "Experimental Features" screen and enable "Application Password login"
4. Close the app, open it again, and go to MySite screen 
- [ ] Verify you DO see the Application Password login card
5. Disable the experimental feature again
6. Close the app, open it again, and go to MySite screen 
- [ ] Verify you DON'T see the Application Password login card

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
