### PR TITLE
Drop language migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -369,8 +369,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                 InstallationReferrerServiceStarter.startService(this, null);
             }
 
-            mPerAppLocaleManager.performMigrationIfNecessary();
-
             if (FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)
                 && !AppPrefs.getIsJetpackMigrationInProgress()) {
                 NotificationType notificationType =


### PR DESCRIPTION
Closes CMM-400

As noted in [this comment](https://github.com/wordpress-mobile/WordPress-Android/blob/0f38d45a3c93ea0868048db6abd8093b8f49af48/WordPress/src/main/java/org/wordpress/android/util/PerAppLocaleManager.kt#L58), the migration to in-app language prefs is no longer necessary. In that code we detected whether the user had previously chosen a specific language for the app and if so we migrate them to in-app prefs.

This PR removes this unnecessary code.