### PR TITLE
Hotfix: revert to AGP 8.7.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = '8.8.1'
+agp = '8.7.3'
 airbnb-lottie = '6.6.6'
 android-desugar = '2.1.5'
 android-installreferrer = '2.2'


### PR DESCRIPTION
Fixes CMM-401

As discussed on the [Google Issue Tracker](https://issuetracker.google.com/issues/406641857), updating to AGP 8.8 causes the per-app language preference to be lost. If you change the per-app language setting it is briefly retained, but quickly reverts back to the device's default language.

This was not resolved in either AGP 8.9 or 8.10, so the only option was to revert back to 8.7.3.

**To test:**

- Change the app language and verify that it's retained
- Smoke test the app with GBK enabled and verify that it works as expected
- Note that you may need to use a Pixel device/emulator to reproduce the original problem

Related Slack discussion: p1748343842443099-slack-C04HB8JU78A
