### PR TITLE
Fix voice to content overlap

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -247,7 +247,7 @@ fun RecordingPanel(model: VoiceToContentUiState,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(IntrinsicSize.Max)
-                            .padding(48.dp)
+                            .padding(24.dp)
                     ) {
                         ScrollingWaveformVisualizer(recordingUpdate = recordingUpdate)
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -66,10 +68,10 @@ fun VoiceToContentScreen(
     val configuration = LocalConfiguration.current
     val windowInfo = LocalWindowInfo.current
     val localDensity = LocalDensity.current
-    val screenHeight = with(localDensity) {
-        val containerWidthInPixels = windowInfo.containerSize.width
-        containerWidthInPixels.toDp()
-    }
+//    val screenHeight = with(localDensity) {
+//        val containerWidthInPixels = windowInfo.containerSize.width
+//        containerWidthInPixels.toDp()
+//    }
     val isRecording by viewModel.isRecording.collectAsState()
 
     DisposableEffect(Unit) {
@@ -81,21 +83,22 @@ fun VoiceToContentScreen(
     }
 
     // Adjust the bottom sheet height based on orientation
-    val bottomSheetHeight = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-        screenHeight // Full height in landscape
-    } else {
-        screenHeight * 0.6f // 60% height in portrait
-    }
+//    val bottomSheetHeight = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+//        screenHeight // Full height in landscape
+//    } else {
+//        screenHeight
+//    }
 
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(bottomSheetHeight),
+            .wrapContentHeight(),
         color = MaterialTheme.colorScheme.surface
     ) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
+                .wrapContentHeight()
                 .nestedScroll(rememberNestedScrollInteropConnection()) // Enable nested scrolling for the bottom sheet
                 .verticalScroll(rememberScrollState()) // Enable vertical scrolling for the bottom sheet
         ) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -39,9 +38,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource

--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -65,13 +65,6 @@ fun VoiceToContentScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val recordingUpdate by viewModel.recordingUpdate.observeAsState(initial = RecordingUpdate())
-    val configuration = LocalConfiguration.current
-    val windowInfo = LocalWindowInfo.current
-    val localDensity = LocalDensity.current
-//    val screenHeight = with(localDensity) {
-//        val containerWidthInPixels = windowInfo.containerSize.width
-//        containerWidthInPixels.toDp()
-//    }
     val isRecording by viewModel.isRecording.collectAsState()
 
     DisposableEffect(Unit) {
@@ -81,13 +74,6 @@ fun VoiceToContentScreen(
             }
         }
     }
-
-    // Adjust the bottom sheet height based on orientation
-//    val bottomSheetHeight = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-//        screenHeight // Full height in landscape
-//    } else {
-//        screenHeight
-//    }
 
     Surface(
         modifier = Modifier


### PR DESCRIPTION
## Description
This PR is fixing the UI overlap described [here](https://github.com/wordpress-mobile/WordPress-Android/pull/21427#pullrequestreview-2419331688)
I've also reduced a but the padding to be sure it looks better in small-screen devices

Before:
![Screenshot 2025-05-29 at 12 05 57](https://github.com/user-attachments/assets/80c02611-86d2-4419-ae37-42280e7269ee)

After:
![Screenshot 2025-05-29 at 12 01 38](https://github.com/user-attachments/assets/e29cba91-6658-476f-8fc7-5534728f05b5)
![Screenshot 2025-05-29 at 12 02 00](https://github.com/user-attachments/assets/135bc611-0167-4c51-8752-6566017ab9f9)



## Testing instructions

1. Enable voice_to_content in Debug Settings > Remote Features
2. Tap the FAB on My Site
3. Select "Post from audio"
- [ ] Verify it looks as expected

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
