### PR TITLE
Use lint from AGP 8.8.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,9 @@ android.enableR8.fullMode=false
 
 # Dependency Analysis Plugin
 dependency.analysis.android.ignored.variants=release,wordpressVanillaDebug,wordpressVanillaRelease,wordpressWasabiDebug,wordpressWasabiRelease,wordpressJalapenoRelease,jetpackVanillaDebug,jetpackVanillaRelease,jetpackWasabiDebug,jetpackWasabiRelease,jetpackJalapenoRelease
+
+# Use lint from AGP 8.8.1
+# The lint shipped with currently used AGP (8.7.3) combined with androidx.lifecycle 2.9.0 crashes
+# https://issuetracker.google.com/issues/418014548
+# Remove this after bumping AGP to 8.8.1 or higher
+android.experimental.lint.version=8.8.1


### PR DESCRIPTION
Closes: AINFRA-654

## Description

This PR fixes failing lint. The problem is the combination of `androidx.lifecycle:2.9.0` **and** `AGP:8.7.3`.

See: https://issuetracker.google.com/issues/418014548

It goes as follows:

- ✅ https://github.com/wordpress-mobile/WordPress-Android/pull/21919 passed as it was based on an older `trunk`: `lifecycle:2.8.7` + `AGP:8.7.3`

- ✅ e.g. a306dbaa49daf59a3870b0cb1f34ac85a378b2ca `trunk` just before AGP downgrade passed: `lifecycle:2.9.0` + `AGP:8.8.1`

- ❌ f9eb16a213e53aa1ade967e62b064627a38f9c3d current `trunk` after merging AGP downgrade: `lifecycle:2.9.0` + `AGP:8.7.3`

---

I propose the solution of temporary upgrading Lint version to `8.8.1`, while leaving the rest of the AGP in `8.7.3` for reasons described in https://github.com/wordpress-mobile/WordPress-Android/pull/21919