### PR TITLE
Fix: #21432 - Add padding to voice-to-content BottomSheet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -83,6 +84,7 @@ fun VoiceToContentScreen(
                 .wrapContentHeight()
                 .nestedScroll(rememberNestedScrollInteropConnection()) // Enable nested scrolling for the bottom sheet
                 .verticalScroll(rememberScrollState()) // Enable vertical scrolling for the bottom sheet
+                .navigationBarsPadding() // Account for navigation bar padding
         ) {
             VoiceToContentView(state, recordingUpdate, isRecording)
         }


### PR DESCRIPTION
### Title  
**Fix voice-to-content BottomSheet UI overlap on small screens**

---

### Issue  
Fixes [#21432](https://github.com/wordpress-mobile/WordPress-Android/issues/21432)

---

### Description  
This PR addresses the issue where the voice-to-content BottomSheet is partially obscured on smaller screens. I think the root cause was missing navigation bar padding, causing UI elements to be obscured. The fix adds `.navigationBarsPadding()` to the BottomSheet container.

Due to the voice-to-content feature being inaccessible in the dev build, full voice-to-content testing has not yet been possible. I plan to test the changes with the CI build once available.

---

### **Question for reviewers:** 
Is there a recommended way to enable or test the voice-to-content feature in the dev build environment?

---

### Testing Instructions  
1. Launch the app on a device or emulator with a small screen or gesture navigation enabled.  
1. Enable voice_to_content in Debug Settings > Remote Features
2. Tap the FAB on My Site
3. Select "Post from audio"
3. Verify that the BottomSheet content is fully visible within the display area without clipping or overlap.

---

### Labels  
- [Type] Bug  
- UI  
- Good First Issue  

---

Thank you for reviewing!
