### PR TITLE
Fix the me icon tint color in dark mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -96,6 +96,8 @@ class WPMainNavigationView @JvmOverloads constructor(
         get() = getPageForItemId(navigationBarView.selectedItemId)
         set(pageType) = updateCurrentPosition(pages().indexOf(pageType))
 
+    private var gravatarLoaded = false
+
     interface OnPageListener {
         fun onPageChanged(position: Int)
         fun onNewPostButtonClicked(promptId: Int, origin: EntryPoint)
@@ -168,6 +170,7 @@ class WPMainNavigationView @JvmOverloads constructor(
                 ImageType.USER,
                 object : ImageManager.RequestListener<android.graphics.drawable.Drawable> {
                     override fun onLoadFailed(e: Exception?, model: Any?) {
+                        gravatarLoaded = false
                         val appLogMessage = "onLoadFailed while loading Gravatar image!"
                         if (e == null) {
                             AppLog.e(
@@ -304,11 +307,13 @@ class WPMainNavigationView @JvmOverloads constructor(
 
     private fun setImageViewSelected(position: Int, isSelected: Boolean) {
         getImageViewForPosition(position)?.let {
-            if(position == getPosition(ME)) {
-                if(!isSelected){
+            // Only change the saturation if we have loaded a Gravatar image
+            if (position == getPosition(ME) && gravatarLoaded) {
+                if (!isSelected) {
                     it.colorFilter = disabledColorFilter
-                } else
+                } else {
                     it.colorFilter = enabledColorFilter
+                }
             }
 
             it.isSelected = isSelected

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainNavigationView.kt
@@ -147,7 +147,7 @@ class WPMainNavigationView @JvmOverloads constructor(
             }
         }
 
-        if(getMainPageIndex() != getPosition(ME)) {
+        if (getMainPageIndex() != getPosition(ME)) {
             setImageViewSelected(getPosition(ME), false)
         }
 
@@ -187,6 +187,7 @@ class WPMainNavigationView @JvmOverloads constructor(
                     }
 
                     override fun onResourceReady(resource: android.graphics.drawable.Drawable, model: Any?) {
+                        gravatarLoaded = true
                         ImageViewCompat.setImageTintList(imgIcon, null)
                         if (resource is BitmapDrawable) {
                             var bitmap = resource.bitmap
@@ -318,7 +319,7 @@ class WPMainNavigationView @JvmOverloads constructor(
 
             it.isSelected = isSelected
             it.alpha = if (isSelected) 1f else unselectedButtonAlpha
-            if(it.isSelected) {
+            if (it.isSelected) {
                 val pop = AnimationUtils.loadAnimation(it.context, R.anim.bottom_nav_icon_pop)
                 it.startAnimation(pop)
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/image/ImageManager.kt
@@ -443,12 +443,18 @@ class ImageManager @Inject constructor(
      * Loads the Bitmap into the ImageView.
      */
     @JvmOverloads
-    fun load(imageView: ImageView, bitmap: Bitmap, scaleType: ScaleType = CENTER) {
+    fun load(
+        imageView: ImageView,
+        bitmap: Bitmap,
+        scaleType: ScaleType = CENTER,
+        requestListener: RequestListener<Drawable>? = null
+    ) {
         val context = imageView.context
         if (!context.isAvailable()) return
         Glide.with(context)
             .load(bitmap)
             .applyScaleType(scaleType)
+            .attachRequestListener(requestListener)
             .into(imageView)
             .clearOnDetach()
     }


### PR DESCRIPTION
## Description
This PR is fixing a UI glitch where the "Me" icon in the nav bar was drawn with the wrong tint.

The bug was introduced [here](https://github.com/wordpress-mobile/WordPress-Android/pull/19794), where we were swapping the avatar from colored to black and white. So, when the avatar is not ready yet, it was causing the default icon to be shown using the wrong color.

This fix has surfaced other side "bugs" that I'll ticket separately:
1. The Gravatar is not directly shown in the first login
2. Changing the gravatar, both in the app and in an external platform, is not taking effect in the "Me" icon

## Testing instructions

1. Set your device to dark mode
3. Log into the app
- [ ] Verify the right color is used for the "Me" bottom nav icon
4. Select the "Me" bottom nav icon
- [ ] Verify the "selected state color" is used
5. Close and open the app
- [ ] If you have a Gravatar image, verify it looks B&W when unselected and coloured when selected
- [ ] If you don't have a Gravatar image, verify it looks selected/unselected correctly

<img src="https://github.com/user-attachments/assets/427048de-5465-4d7b-9228-e407dcf1baf1" width="400" />
<img src="https://github.com/user-attachments/assets/6a160129-93c2-4a0a-b43a-b1c3c705e002" width="400" />
<img src="https://github.com/user-attachments/assets/2b1d1764-4aa6-4f3a-a42d-a4d7f94b8959" width="400" />
<img src="https://github.com/user-attachments/assets/8f71d356-704d-49aa-96e0-85e5bf4d0353" width="400" />
<img src="https://github.com/user-attachments/assets/9e15952e-02bf-4fb9-b7d6-57885a666a8a" width="400" />
<img src="https://github.com/user-attachments/assets/ea1d357e-cfca-4bbf-b775-f34f8cc8c976" width="400" />

1. Select light mode, and repeat all the steps
- [ ] Verify all looks as expected

<img src="https://github.com/user-attachments/assets/85dbeee2-58ce-4edd-bf40-897786ca3a95" width="400" />
<img src="https://github.com/user-attachments/assets/592a334c-4c16-47db-94eb-f37fecd1417e" width="400" />
<img src="https://github.com/user-attachments/assets/f047246c-c033-43d5-9908-6e724afacf5c" width="400" />
<img src="https://github.com/user-attachments/assets/6fbee2de-ecf7-4c05-a7cf-f266a67cafea" width="400" />
<img src="https://github.com/user-attachments/assets/5cd79396-8114-4a1f-bc6e-0753e0fb2199" width="400" />
<img src="https://github.com/user-attachments/assets/de141abf-027c-40fe-87d3-8b2bd4eb8b88" width="400" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
