### PR TITLE
WPAndroid: Fix keyboard overlaps editor (again)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -41,7 +41,7 @@ open class BaseAppCompatActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         // apply insets for Android 15+ edge-to-edge
         if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
-            excludedActivities.contains(this.localClassName).not()
+            !isExcludedActivity(this)
         ) {
             applyInsetOffsets()
         }
@@ -66,6 +66,9 @@ open class BaseAppCompatActivity : AppCompatActivity() {
         }
     }
 }
+
+private fun isExcludedActivity(activity: BaseAppCompatActivity) =
+    excludedActivities.contains(activity::class.java.name)
 
 /**
  * Activities that are excluded from the edge-to-edge offset. Note that many of these excluded activities are

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -1,5 +1,5 @@
 /**
- * This suppression is so we can include deprecated activities (CommentDetailActivity)
+ * This suppression is so we can include deprecated activities (CommentsDetailActivity)
  */
 @file:Suppress("DEPRECATION")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -1,3 +1,8 @@
+/**
+ * This suppression is so we can include deprecated activities (CommentDetailActivity)
+ */
+@file:Suppress("DEPRECATION")
+
 package org.wordpress.android.ui.main
 
 import android.os.Build
@@ -10,6 +15,7 @@ import org.wordpress.android.designsystem.DesignSystemActivity
 import org.wordpress.android.support.SupportWebViewActivity
 import org.wordpress.android.ui.blaze.blazecampaigns.BlazeCampaignParentActivity
 import org.wordpress.android.ui.bloggingprompts.promptslist.BloggingPromptsListActivity
+import org.wordpress.android.ui.comments.CommentsDetailActivity
 import org.wordpress.android.ui.debug.preferences.DebugSharedPreferenceFlagsActivity
 import org.wordpress.android.ui.domains.management.DomainManagementActivity
 import org.wordpress.android.ui.domains.management.newdomainsearch.NewDomainSearchActivity
@@ -101,6 +107,7 @@ private val excludedActivities = listOf(
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping
     // their editors
+    CommentsDetailActivity::class.java.name,
     EditPostActivity::class.java.name,
     NotificationsDetailActivity::class.java.name,
     ReaderCommentListActivity::class.java.name,


### PR DESCRIPTION
Fixes #21931

We had a few more reviews stating that the keyboard overlap bug was still occurring. Debugging this, it turns out it only happens on WPAndroid, not JPAndroid.

The problem was due to using the wrong string for the class comparison [here](https://github.com/wordpress-mobile/WordPress-Android/blob/9d01155860bfec872dc0486054c2a859e9e96884/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt#L44). On JPAndroid, `this.localClassName` is `org.wordpress.android.ui.posts.EditPostActivity`, which matches the `::class.java.name`. But on WPAndroid, `this.localClassName` is `ui.posts.EditPostActivity`, which doesn't match the `::class.java.name`. This PR corrects this.

**To test:**
- In `trunk` open a long post in the editor 
- Scroll to the bottom
- Tap to show the keyboard and note it covers the bottom of the post
- Pull this branch
- Note the problem no longer occurs
- Also verify the editor in reader comments appears correctly
