### PR TITLE
Enable Subscribers on MenuActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -137,6 +137,7 @@ class MenuActivity : BaseAppCompatActivity() {
             is SiteNavigationAction.OpenPeople -> ActivityLauncher.viewCurrentBlogPeople(this, action.site)
             is SiteNavigationAction.OpenSharing -> ActivityLauncher.viewBlogSharing(this, action.site)
             is SiteNavigationAction.OpenSiteSettings -> ActivityLauncher.viewBlogSettingsForResult(this, action.site)
+            is SiteNavigationAction.OpenSubscribers -> ActivityLauncher.viewCurrentBlogSubscribers(this, action.site)
             is SiteNavigationAction.OpenThemes -> ActivityLauncher.viewCurrentBlogThemes(this, action.site)
             is SiteNavigationAction.OpenPlugins -> ActivityLauncher.viewPluginBrowser(this, action.site)
             is SiteNavigationAction.OpenMedia -> ActivityLauncher.viewCurrentBlogMedia(this, action.site)

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/ListItemActionHandlerTest.kt
@@ -101,6 +101,12 @@ class ListItemActionHandlerTest: BaseUnitTest() {
     }
 
     @Test
+    fun `subscribers item click emits OpenSubscribers navigation event`() {
+        val navigationAction = invokeItemClickAction(action =ListItemAction.SUBSCRIBERS)
+
+        assertEquals(navigationAction,SiteNavigationAction.OpenSubscribers(site))
+    }
+    @Test
     fun `themes item click emits OpenThemes navigation event`() {
         val navigationAction = invokeItemClickAction(action =ListItemAction.THEMES)
 


### PR DESCRIPTION
The experimental subscribers feature works from the My Site screen, but it will only be there if you've personalized the screen and added it. If you tap "More..." on My Site to view `MenuActivity` and tap subscribers, nothing happens.

I failed to notice this because I personalized My Site to have a subscribers shortcut to make it easier to access 🤦 

**To test**

- Use a debug build
- Enable subscribers in experimental features
- Tap "More..."
- Tap subscribers and note the dummy data now appears