### PR TITLE
Remove singleton for WpLoginClient creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -40,7 +40,6 @@ import org.wordpress.android.viewmodel.helpers.ConnectionStatus;
 import org.wordpress.android.viewmodel.helpers.ConnectionStatusLiveData;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 
 import dagger.Binds;
 import dagger.Module;

--- a/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ApplicationModule.java
@@ -152,7 +152,6 @@ public abstract class ApplicationModule {
     }
 
     @Provides
-    @Singleton
     public static WpLoginClient provideWpLoginClient() {
         return new WpLoginClient();
     }


### PR DESCRIPTION
## Description
According to [this](https://github.com/wordpress-mobile/WordPress-Android/pull/21957#discussion_r2160993108) discussion, we have now removed the singleton state for WpLoginClient creation

## Testing instructions
These changes are not affecting to logic. So, just review the code

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
