### PR TITLE
Add subscribers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -119,6 +119,7 @@ fun AddSubscribersScreen(
     }
 }
 
+@Suppress("ReturnCount")
 private fun isValidEntry(entry: String): Boolean {
     if (entry.isEmpty()) {
         return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -120,7 +120,7 @@ fun AddSubscribersScreen(
 private fun isValidEntry(entry: String): Boolean {
     parseEntry(entry).forEach {
         if (!validateEmail(it)) {
-            return false
+            return true
         }
     }
     return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -1,0 +1,129 @@
+package org.wordpress.android.ui.subscribers
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.wordpress.android.R
+import org.wordpress.android.ui.compose.theme.AppThemeM3
+import org.wordpress.android.util.validateEmail
+
+@Composable
+fun AddSubscribersScreen(
+    onSubmit: (List<String>) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var entry = ""
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Row(
+            modifier = modifier.fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = "",
+                onValueChange = {
+                    entry = it
+                },
+                label = {
+                    Text(stringResource(id = R.string.subscribers_add_email_hint))
+                },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (isValidEntry(entry)) {
+                            onSubmit(parseEntry(entry))
+                        }
+                    }
+                ),
+                modifier = modifier.fillMaxWidth()
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.subscribers_add_disclosure),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(stringResource(id = android.R.string.cancel))
+            }
+
+            Button(
+                onClick = { onSubmit(parseEntry(entry)) },
+                enabled = entry.isNotEmpty(),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(stringResource(id = R.string.send))
+            }
+        }
+    }
+}
+
+private fun isValidEntry(entry: String): Boolean {
+    parseEntry(entry).forEach {
+        if (!validateEmail(it)) {
+            return false
+        }
+    }
+    return true
+}
+
+private fun parseEntry(entry: String): List<String> {
+    return entry.split(",").map { it.trim() }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun AddSubscribersScreenPreview() {
+    AppThemeM3 {
+        AddSubscribersScreen(
+            onSubmit = {},
+            onCancel = {}
+        )
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -50,7 +49,7 @@ fun AddSubscribersScreen(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
+            .fillMaxWidth()
             .background(MaterialTheme.colorScheme.background)
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
@@ -72,7 +71,8 @@ fun AddSubscribersScreen(
                     onSubmit(parseEntry(entry))
                 }
             ),
-            modifier = modifier.fillMaxWidth()
+            singleLine = false,
+            modifier = Modifier.fillMaxWidth()
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -68,7 +68,9 @@ fun AddSubscribersScreen(
             ),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    onSubmit(parseEntry(entry))
+                    if (isValidEntry) {
+                        onSubmit(parseEntry(entry))
+                    }
                 }
             ),
             singleLine = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -120,6 +120,9 @@ fun AddSubscribersScreen(
 }
 
 private fun isValidEntry(entry: String): Boolean {
+    if (entry.isEmpty()) {
+        return false
+    }
     parseEntry(entry).forEach {
         if (!validateEmail(it)) {
             return false

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -58,7 +58,7 @@ fun AddSubscribersScreen(
             value = entry,
             onValueChange = {
                 entry = it
-                isValidEntry = isValidEntry(entry)
+                isValidEntry = isValidEntry(it)
             },
             label = {
                 Text(stringResource(id = R.string.subscribers_add_email_hint))

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.subscribers
 import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,20 +11,24 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -37,6 +42,7 @@ import org.wordpress.android.util.validateEmail
 fun AddSubscribersScreen(
     onSubmit: (List<String>) -> Unit,
     onCancel: () -> Unit,
+    showProgress: State<Boolean>,
     modifier: Modifier = Modifier,
 ) {
     var entry by remember { mutableStateOf("") }
@@ -86,23 +92,34 @@ fun AddSubscribersScreen(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            OutlinedButton(
-                onClick = onCancel,
-                modifier = Modifier.weight(1f)
+        if (showProgress.value) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
             ) {
-                Text(stringResource(id = android.R.string.cancel))
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp)
+                )
             }
-
-            Button(
-                onClick = { onSubmit(parseEntry(entry)) },
-                enabled = isValidEntry,
-                modifier = Modifier.weight(1f)
+        } else {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Text(stringResource(id = R.string.send))
+                OutlinedButton(
+                    onClick = onCancel,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(id = android.R.string.cancel))
+                }
+
+                Button(
+                    onClick = { onSubmit(parseEntry(entry)) },
+                    enabled = isValidEntry,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(id = R.string.send))
+                }
             }
         }
     }
@@ -128,7 +145,8 @@ private fun AddSubscribersScreenPreview() {
     AppThemeM3 {
         AddSubscribersScreen(
             onSubmit = {},
-            onCancel = {}
+            onCancel = {},
+            showProgress = remember { mutableStateOf(false) }
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -129,7 +129,7 @@ private fun isValidEntry(entry: String): Boolean {
 }
 
 private fun parseEntry(entry: String): List<String> {
-    return entry.split(",").map { it.trim() }
+    return entry.split(",").map { it.trim() }.filter { it.isNotEmpty() }
 }
 
 @Preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -55,42 +55,34 @@ fun AddSubscribersScreen(
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
-        Row(
+        OutlinedTextField(
+            value = entry,
+            onValueChange = {
+                entry = it
+                isValidEntry = isValidEntry(entry)
+            },
+            label = {
+                Text(stringResource(id = R.string.subscribers_add_email_hint))
+            },
+            keyboardOptions = KeyboardOptions.Default.copy(
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    onSubmit(parseEntry(entry))
+                }
+            ),
             modifier = modifier.fillMaxWidth()
-        ) {
-            OutlinedTextField(
-                value = entry,
-                onValueChange = {
-                    entry = it
-                    isValidEntry = isValidEntry(entry)
-                },
-                label = {
-                    Text(stringResource(id = R.string.subscribers_add_email_hint))
-                },
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    imeAction = ImeAction.Done
-                ),
-                keyboardActions = KeyboardActions(
-                    onDone = {
-                        onSubmit(parseEntry(entry))
-                    }
-                ),
-                modifier = modifier.fillMaxWidth()
-            )
-        }
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Row(
-            modifier = modifier.fillMaxWidth()
-        ) {
-            Text(
-                text = stringResource(id = R.string.subscribers_add_disclosure),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
+        Text(
+            text = stringResource(id = R.string.subscribers_add_disclosure),
+            style = MaterialTheme.typography.bodyMedium
+        )
 
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(16.dp))
 
         if (showProgress.value) {
             Box(

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -40,6 +40,7 @@ fun AddSubscribersScreen(
     modifier: Modifier = Modifier,
 ) {
     var entry by remember { mutableStateOf("") }
+    var isValidEntry by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier
@@ -55,6 +56,7 @@ fun AddSubscribersScreen(
                 value = entry,
                 onValueChange = {
                     entry = it
+                    isValidEntry = isValidEntry(entry)
                 },
                 label = {
                     Text(stringResource(id = R.string.subscribers_add_email_hint))
@@ -64,9 +66,7 @@ fun AddSubscribersScreen(
                 ),
                 keyboardActions = KeyboardActions(
                     onDone = {
-                        if (isValidEntry(entry)) {
-                            onSubmit(parseEntry(entry))
-                        }
+                        onSubmit(parseEntry(entry))
                     }
                 ),
                 modifier = modifier.fillMaxWidth()
@@ -99,7 +99,7 @@ fun AddSubscribersScreen(
 
             Button(
                 onClick = { onSubmit(parseEntry(entry)) },
-                enabled = entry.isNotEmpty(),
+                enabled = isValidEntry,
                 modifier = Modifier.weight(1f)
             ) {
                 Text(stringResource(id = R.string.send))

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -120,7 +120,7 @@ fun AddSubscribersScreen(
 private fun isValidEntry(entry: String): Boolean {
     parseEntry(entry).forEach {
         if (!validateEmail(it)) {
-            return true
+            return false
         }
     }
     return true

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersScreen.kt
@@ -20,6 +20,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -35,7 +39,8 @@ fun AddSubscribersScreen(
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var entry = ""
+    var entry by remember { mutableStateOf("") }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -47,7 +52,7 @@ fun AddSubscribersScreen(
             modifier = modifier.fillMaxWidth()
         ) {
             OutlinedTextField(
-                value = "",
+                value = entry,
                 onValueChange = {
                     entry = it
                 },

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersViewModel.kt
@@ -4,13 +4,17 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.wordpress.android.R
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.ToastUtilsWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import rs.wordpress.api.kotlin.WpComApiClient
 import rs.wordpress.api.kotlin.WpRequestResult
@@ -22,8 +26,10 @@ import javax.inject.Named
 
 @HiltViewModel
 class AddSubscribersViewModel @Inject constructor(
+    @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val appLogWrapper: AppLogWrapper,
+    private val toastUtilsWrapper: ToastUtilsWrapper,
 ) : ScopedViewModel(bgDispatcher) {
     @Inject
     @Named(IO_THREAD)
@@ -50,7 +56,24 @@ class AddSubscribersViewModel @Inject constructor(
         return selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
     }
 
-    suspend fun addSubscribers(emails: List<String>): Result<Boolean> = withContext(ioDispatcher) {
+    fun onSubmitClick(
+        emails: List<String>,
+        onSuccess: () -> Unit
+    ) {
+        launch(bgDispatcher) {
+            val result = addSubscribers(emails)
+            launch(mainDispatcher) {
+                if (result.isSuccess) {
+                    toastUtilsWrapper.showToast(R.string.subscribers_add_success)
+                    onSuccess()
+                } else {
+                    toastUtilsWrapper.showToast(R.string.subscribers_add_failed)
+                }
+            }
+        }
+    }
+
+    private suspend fun addSubscribers(emails: List<String>): Result<Boolean> = withContext(ioDispatcher) {
         val params = AddSubscribersParams(
             emails = emails
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/AddSubscribersViewModel.kt
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.subscribers
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.modules.BG_THREAD
+import org.wordpress.android.modules.IO_THREAD
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.viewmodel.ScopedViewModel
+import rs.wordpress.api.kotlin.WpComApiClient
+import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.AddSubscribersParams
+import uniffi.wp_api.WpAuthentication
+import uniffi.wp_api.WpAuthenticationProvider
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class AddSubscribersViewModel @Inject constructor(
+    @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
+    private val appLogWrapper: AppLogWrapper,
+) : ScopedViewModel(bgDispatcher) {
+    @Inject
+    @Named(IO_THREAD)
+    lateinit var ioDispatcher: CoroutineDispatcher
+
+    @Inject
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+
+    @Inject
+    lateinit var accountStore: AccountStore
+
+    private val _showProgress = MutableStateFlow(false)
+    val showProgress = _showProgress.asStateFlow()
+
+    private val wpComApiClient: WpComApiClient by lazy {
+        WpComApiClient(
+            WpAuthenticationProvider.staticWithAuth(
+                WpAuthentication.Bearer(token = accountStore.accessToken!!)
+            )
+        )
+    }
+
+    private fun siteId(): Long {
+        return selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
+    }
+
+    suspend fun addSubscribers(emails: List<String>): Result<Boolean> = withContext(ioDispatcher) {
+        val params = AddSubscribersParams(
+            emails = emails
+        )
+
+        _showProgress.value = true
+        try {
+            val response = wpComApiClient.request { requestBuilder ->
+                requestBuilder.subscribers().addSubscribers(
+                    wpComSiteId = siteId().toULong(),
+                    params = params
+                )
+            }
+
+            when (response) {
+                is WpRequestResult.Success -> {
+                    // the backend may return HTTP 200 even when no subscribers were added, so verify there's
+                    // a valid uploadId before assuming success
+                    if (response.response.data.uploadId == 0.toULong()) {
+                        appLogWrapper.d(AppLog.T.MAIN, "No subscribers added")
+                        return@withContext Result.failure(Exception("No subscribers added"))
+                    } else {
+                        appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
+                        return@withContext Result.success(true)
+                    }
+                }
+
+                else -> {
+                    val error = (response as? WpRequestResult.WpError)?.errorMessage
+                    appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
+                    return@withContext Result.failure(Exception(error))
+                }
+            }
+        } finally {
+            _showProgress.value = false
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.subscribers
 
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -201,8 +202,19 @@ class SubscribersActivity : BaseAppCompatActivity() {
                             onSubmit = { emails ->
                                 lifecycleScope.launch {
                                     val result = viewModel.addSubscribers(emails)
-                                    if (result) {
+                                    if (result.isSuccess) {
+                                        Toast.makeText(
+                                            this@SubscribersActivity,
+                                            getString(R.string.subscribers_add_success),
+                                            Toast.LENGTH_SHORT
+                                        ).show()
                                         navController.navigateUp()
+                                    } else {
+                                        Toast.makeText(
+                                            this@SubscribersActivity,
+                                            getString(R.string.subscribers_add_failed),
+                                            Toast.LENGTH_LONG
+                                        ).show()
                                     }
                                 }
                             },

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -57,6 +58,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
         List,
         Detail,
         Plan,
+        AddSubscribers
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
@@ -81,6 +83,16 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                 Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back))
                             }
                         },
+                        actions = {
+                            IconButton(onClick = {
+                                navController.navigate(route = SubscriberScreen.AddSubscribers.name)
+                            }) {
+                                Icon(
+                                    imageVector = Icons.Default.Add,
+                                    contentDescription = stringResource(R.string.subscribers_add_subscribers)
+                                )
+                            }
+                        }
                     )
                 },
             ) { contentPadding ->
@@ -179,6 +191,10 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                 }
                             }
                         }
+                    }
+
+                    composable(route = SubscriberScreen.AddSubscribers.name) {
+                        titleState.value = stringResource(R.string.subscribers_add_subscribers)
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -203,10 +203,15 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                 lifecycleScope.launch {
                                     val result = viewModel.addSubscribers(emails)
                                     if (result.isSuccess) {
+                                        val toastMsg = if (emails.size > 1) {
+                                            getString(R.string.subscribers_add_success_plural, emails.size)
+                                        } else {
+                                            getString(R.string.subscribers_add_success_singular)
+                                        }
                                         Toast.makeText(
                                             this@SubscribersActivity,
-                                            getString(R.string.subscribers_add_success),
-                                            Toast.LENGTH_SHORT
+                                            toastMsg,
+                                            Toast.LENGTH_LONG
                                         ).show()
                                         navController.navigateUp()
                                     } else {
@@ -219,6 +224,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                 }
                             },
                             onCancel = { navController.navigateUp() },
+                            showProgress = viewModel.showAddSubscribersProgress.collectAsState(),
                             modifier = Modifier.padding(contentPadding)
                         )
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -40,6 +40,8 @@ import uniffi.wp_api.Subscriber
 @AndroidEntryPoint
 class SubscribersActivity : BaseAppCompatActivity() {
     private val viewModel by viewModels<SubscribersViewModel>()
+    private val addSubscribersViewModel by viewModels<AddSubscribersViewModel>()
+
     private lateinit var composeView: ComposeView
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,6 +73,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
         val navController = rememberNavController()
         val listTitle = stringResource(R.string.subscribers)
         val titleState = remember { mutableStateOf(listTitle) }
+        val showAddSubscribersButtonState = remember { mutableStateOf(true) }
 
         AppThemeM3 {
             Scaffold(
@@ -89,13 +92,15 @@ class SubscribersActivity : BaseAppCompatActivity() {
                             }
                         },
                         actions = {
-                            IconButton(onClick = {
-                                navController.navigate(route = SubscriberScreen.AddSubscribers.name)
-                            }) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = stringResource(R.string.subscribers_add_subscribers)
-                                )
+                            if (showAddSubscribersButtonState.value) {
+                                IconButton(onClick = {
+                                    navController.navigate(route = SubscriberScreen.AddSubscribers.name)
+                                }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Add,
+                                        contentDescription = stringResource(R.string.subscribers_add_subscribers)
+                                    )
+                                }
                             }
                         }
                     )
@@ -107,6 +112,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                 ) {
                     composable(route = SubscriberScreen.List.name) {
                         titleState.value = listTitle
+                        showAddSubscribersButtonState.value = true
                         ShowListScreen(
                             navController,
                             modifier = Modifier.padding(contentPadding)
@@ -119,7 +125,8 @@ class SubscribersActivity : BaseAppCompatActivity() {
                             if (userId != null) {
                                 viewModel.getSubscriber(userId)?.let { subscriber ->
                                     titleState.value = subscriber.displayNameOrEmail()
-                                    ShowSubscriberDetailScreen(
+                                    showAddSubscribersButtonState.value = false
+                                        ShowSubscriberDetailScreen(
                                         subscriber = subscriber,
                                         navController = navController,
                                         modifier = Modifier.padding(contentPadding)
@@ -138,6 +145,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                     subscriber.plans?.let { plans ->
                                         if (planIndex in plans.indices) {
                                             titleState.value = plans[planIndex].title
+                                            showAddSubscribersButtonState.value = false
                                             SubscriberPlanScreen(
                                                 plan = plans[planIndex],
                                                 modifier = Modifier.padding(contentPadding)
@@ -151,7 +159,8 @@ class SubscribersActivity : BaseAppCompatActivity() {
 
                     composable(route = SubscriberScreen.AddSubscribers.name) {
                         titleState.value = stringResource(R.string.subscribers_add_subscribers)
-                        ShowAddSubscribersScreen(
+                        showAddSubscribersButtonState.value = false
+                            ShowAddSubscribersScreen(
                             navController = navController,
                             modifier = Modifier.padding(contentPadding)
                         )
@@ -242,7 +251,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
         AddSubscribersScreen(
             onSubmit = { emails ->
                 lifecycleScope.launch {
-                    val result = viewModel.addSubscribers(emails)
+                    val result = addSubscribersViewModel.addSubscribers(emails)
                     if (result.isSuccess) {
                         val toastMsg = if (emails.size > 1) {
                             getString(R.string.subscribers_add_success_plural, emails.size)
@@ -265,7 +274,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                 }
             },
             onCancel = { navController.navigateUp() },
-            showProgress = viewModel.showAddSubscribersProgress.collectAsState(),
+            showProgress = addSubscribersViewModel.showProgress.collectAsState(),
             modifier = modifier
         )
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.subscribers
 
 import android.os.Build
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -22,13 +21,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
@@ -126,7 +123,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                                 viewModel.getSubscriber(userId)?.let { subscriber ->
                                     titleState.value = subscriber.displayNameOrEmail()
                                     showAddSubscribersButtonState.value = false
-                                        ShowSubscriberDetailScreen(
+                                    ShowSubscriberDetailScreen(
                                         subscriber = subscriber,
                                         navController = navController,
                                         modifier = Modifier.padding(contentPadding)
@@ -160,7 +157,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
                     composable(route = SubscriberScreen.AddSubscribers.name) {
                         titleState.value = stringResource(R.string.subscribers_add_subscribers)
                         showAddSubscribersButtonState.value = false
-                            ShowAddSubscribersScreen(
+                        ShowAddSubscribersScreen(
                             navController = navController,
                             modifier = Modifier.padding(contentPadding)
                         )
@@ -250,28 +247,12 @@ class SubscribersActivity : BaseAppCompatActivity() {
     ) {
         AddSubscribersScreen(
             onSubmit = { emails ->
-                lifecycleScope.launch {
-                    val result = addSubscribersViewModel.addSubscribers(emails)
-                    if (result.isSuccess) {
-                        val toastMsg = if (emails.size > 1) {
-                            getString(R.string.subscribers_add_success_plural, emails.size)
-                        } else {
-                            getString(R.string.subscribers_add_success_singular)
-                        }
-                        Toast.makeText(
-                            this@SubscribersActivity,
-                            toastMsg,
-                            Toast.LENGTH_LONG
-                        ).show()
+                addSubscribersViewModel.onSubmitClick(
+                    emails = emails,
+                    onSuccess = {
                         navController.navigateUp()
-                    } else {
-                        Toast.makeText(
-                            this@SubscribersActivity,
-                            getString(R.string.subscribers_add_failed),
-                            Toast.LENGTH_LONG
-                        ).show()
                     }
-                }
+                )
             },
             onCancel = { navController.navigateUp() },
             showProgress = addSubscribersViewModel.showProgress.collectAsState(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -70,6 +71,7 @@ class SubscribersActivity : BaseAppCompatActivity() {
         val navController = rememberNavController()
         val listTitle = stringResource(R.string.subscribers)
         val titleState = remember { mutableStateOf(listTitle) }
+
         AppThemeM3 {
             Scaffold(
                 topBar = {
@@ -105,39 +107,8 @@ class SubscribersActivity : BaseAppCompatActivity() {
                 ) {
                     composable(route = SubscriberScreen.List.name) {
                         titleState.value = listTitle
-                        DataViewScreen(
-                            uiState = viewModel.uiState.collectAsState(),
-                            items = viewModel.items.collectAsState(),
-                            supportedFilters = viewModel.getSupportedFilters(),
-                            currentFilter = viewModel.itemFilter.collectAsState().value,
-                            supportedSorts = viewModel.getSupportedSorts(),
-                            currentSort = viewModel.itemSortBy.collectAsState().value,
-                            errorMessage = viewModel.errorMessage.collectAsState().value,
-                            onRefresh = {
-                                viewModel.onRefreshData()
-                            },
-                            onFetchMore = {
-                                viewModel.onFetchMoreData()
-                            },
-                            onSearchQueryChange = { query ->
-                                viewModel.onSearchQueryChange(query)
-                            },
-                            onItemClick = { item ->
-                                viewModel.onItemClick(item)
-                                (item.data as? Subscriber)?.let { subscriber ->
-                                    navController.currentBackStackEntry?.savedStateHandle?.set(
-                                        key = KEY_USER_ID,
-                                        value = subscriber.userId
-                                    )
-                                    navController.navigate(route = SubscriberScreen.Detail.name)
-                                }
-                            },
-                            onFilterClick = { filter ->
-                                viewModel.onFilterClick(filter)
-                            },
-                            onSortClick = { sort ->
-                                viewModel.onSortClick(sort)
-                            },
+                        ShowListScreen(
+                            navController,
                             modifier = Modifier.padding(contentPadding)
                         )
                     }
@@ -148,28 +119,10 @@ class SubscribersActivity : BaseAppCompatActivity() {
                             if (userId != null) {
                                 viewModel.getSubscriber(userId)?.let { subscriber ->
                                     titleState.value = subscriber.displayNameOrEmail()
-                                    SubscriberDetailScreen(
+                                    ShowSubscriberDetailScreen(
                                         subscriber = subscriber,
-                                        onEmailClick = { email ->
-                                            onEmailClick(email)
-                                        },
-                                        onUrlClick = { url ->
-                                            onUrlClick(url)
-                                        },
-                                        onPlanClick = { planIndex ->
-                                            navController.currentBackStackEntry?.savedStateHandle?.set(
-                                                key = KEY_USER_ID,
-                                                value = userId
-                                            )
-                                            // plans don't have a unique id, so we use the index to identify them
-                                            navController.currentBackStackEntry?.savedStateHandle?.set(
-                                                key = KEY_PLAN_INDEX,
-                                                value = planIndex
-                                            )
-                                            navController.navigate(route = SubscriberScreen.Plan.name)
-                                        },
-                                        modifier = Modifier.padding(contentPadding),
-                                        subscriberStats = viewModel.subscriberStats.collectAsState()
+                                        navController = navController,
+                                        modifier = Modifier.padding(contentPadding)
                                     )
                                 }
                             }
@@ -198,39 +151,123 @@ class SubscribersActivity : BaseAppCompatActivity() {
 
                     composable(route = SubscriberScreen.AddSubscribers.name) {
                         titleState.value = stringResource(R.string.subscribers_add_subscribers)
-                        AddSubscribersScreen(
-                            onSubmit = { emails ->
-                                lifecycleScope.launch {
-                                    val result = viewModel.addSubscribers(emails)
-                                    if (result.isSuccess) {
-                                        val toastMsg = if (emails.size > 1) {
-                                            getString(R.string.subscribers_add_success_plural, emails.size)
-                                        } else {
-                                            getString(R.string.subscribers_add_success_singular)
-                                        }
-                                        Toast.makeText(
-                                            this@SubscribersActivity,
-                                            toastMsg,
-                                            Toast.LENGTH_LONG
-                                        ).show()
-                                        navController.navigateUp()
-                                    } else {
-                                        Toast.makeText(
-                                            this@SubscribersActivity,
-                                            getString(R.string.subscribers_add_failed),
-                                            Toast.LENGTH_LONG
-                                        ).show()
-                                    }
-                                }
-                            },
-                            onCancel = { navController.navigateUp() },
-                            showProgress = viewModel.showAddSubscribersProgress.collectAsState(),
+                        ShowAddSubscribersScreen(
+                            navController = navController,
                             modifier = Modifier.padding(contentPadding)
                         )
                     }
                 }
             }
         }
+    }
+
+    @Composable
+    private fun ShowListScreen(
+        navController: NavHostController,
+        modifier: Modifier
+    ) {
+        DataViewScreen(
+            uiState = viewModel.uiState.collectAsState(),
+            items = viewModel.items.collectAsState(),
+            supportedFilters = viewModel.getSupportedFilters(),
+            currentFilter = viewModel.itemFilter.collectAsState().value,
+            supportedSorts = viewModel.getSupportedSorts(),
+            currentSort = viewModel.itemSortBy.collectAsState().value,
+            errorMessage = viewModel.errorMessage.collectAsState().value,
+            onRefresh = {
+                viewModel.onRefreshData()
+            },
+            onFetchMore = {
+                viewModel.onFetchMoreData()
+            },
+            onSearchQueryChange = { query ->
+                viewModel.onSearchQueryChange(query)
+            },
+            onItemClick = { item ->
+                viewModel.onItemClick(item)
+                (item.data as? Subscriber)?.let { subscriber ->
+                    navController.currentBackStackEntry?.savedStateHandle?.set(
+                        key = KEY_USER_ID,
+                        value = subscriber.userId
+                    )
+                    navController.navigate(route = SubscriberScreen.Detail.name)
+                }
+            },
+            onFilterClick = { filter ->
+                viewModel.onFilterClick(filter)
+            },
+            onSortClick = { sort ->
+                viewModel.onSortClick(sort)
+            },
+            modifier = modifier
+        )
+    }
+
+    @Composable
+    private fun ShowSubscriberDetailScreen(
+        subscriber: Subscriber,
+        navController: NavHostController,
+        modifier: Modifier
+    ) {
+        SubscriberDetailScreen(
+            subscriber = subscriber,
+            onEmailClick = { email ->
+                onEmailClick(email)
+            },
+            onUrlClick = { url ->
+                onUrlClick(url)
+            },
+            onPlanClick = { planIndex ->
+                navController.currentBackStackEntry?.savedStateHandle?.set(
+                    key = KEY_USER_ID,
+                    value = subscriber.userId
+                )
+                // plans don't have a unique id, so we use the index to identify them
+                navController.currentBackStackEntry?.savedStateHandle?.set(
+                    key = KEY_PLAN_INDEX,
+                    value = planIndex
+                )
+                navController.navigate(route = SubscriberScreen.Plan.name)
+            },
+            modifier = modifier,
+            subscriberStats = viewModel.subscriberStats.collectAsState()
+        )
+    }
+
+    @Composable
+    private fun ShowAddSubscribersScreen(
+        navController: NavHostController,
+        modifier: Modifier
+    ) {
+        AddSubscribersScreen(
+            onSubmit = { emails ->
+                lifecycleScope.launch {
+                    val result = viewModel.addSubscribers(emails)
+                    if (result.isSuccess) {
+                        val toastMsg = if (emails.size > 1) {
+                            getString(R.string.subscribers_add_success_plural, emails.size)
+                        } else {
+                            getString(R.string.subscribers_add_success_singular)
+                        }
+                        Toast.makeText(
+                            this@SubscribersActivity,
+                            toastMsg,
+                            Toast.LENGTH_LONG
+                        ).show()
+                        navController.navigateUp()
+                    } else {
+                        Toast.makeText(
+                            this@SubscribersActivity,
+                            getString(R.string.subscribers_add_failed),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+                }
+            },
+            onCancel = { navController.navigateUp() },
+            showProgress = viewModel.showAddSubscribersProgress.collectAsState(),
+            modifier = modifier
+        )
     }
 
     private fun onEmailClick(email: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -21,10 +21,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.compose.theme.AppThemeM3
@@ -195,6 +197,18 @@ class SubscribersActivity : BaseAppCompatActivity() {
 
                     composable(route = SubscriberScreen.AddSubscribers.name) {
                         titleState.value = stringResource(R.string.subscribers_add_subscribers)
+                        AddSubscribersScreen(
+                            onSubmit = { emails ->
+                                lifecycleScope.launch {
+                                    val result = viewModel.addSubscribers(emails)
+                                    if (result) {
+                                        navController.navigateUp()
+                                    }
+                                }
+                            },
+                            onCancel = { navController.navigateUp() },
+                            modifier = Modifier.padding(contentPadding)
+                        )
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -200,13 +200,19 @@ class SubscribersViewModel @Inject constructor(
 
             when (response) {
                 is WpRequestResult.Success -> {
-                    appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
-                    return@withContext Result.success(true)
+                    // the backend may return HTTP 200 even when no subscribers were added, so verify there's
+                    // a valid uploadId before assuming success
+                    if (response.response.data.uploadId == 0.toULong()) {
+                        appLogWrapper.d(AppLog.T.MAIN, "No subscribers added")
+                        return@withContext Result.failure(Exception("No subscribers added"))
+                    } else {
+                        appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
+                        return@withContext Result.success(true)
+                    }
                 }
 
                 else -> {
                     val error = (response as? WpRequestResult.WpError)?.errorMessage
-                    onError((response as? WpRequestResult.WpError)?.errorMessage)
                     appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
                     return@withContext Result.failure(Exception(error))
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -18,7 +18,6 @@ import org.wordpress.android.ui.dataview.DataViewItemImage
 import org.wordpress.android.ui.dataview.DataViewViewModel
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
-import uniffi.wp_api.AddSubscribersParams
 import uniffi.wp_api.IndividualSubscriberStats
 import uniffi.wp_api.IndividualSubscriberStatsParams
 import uniffi.wp_api.ListSubscribersSortField
@@ -39,9 +38,6 @@ class SubscribersViewModel @Inject constructor(
 ) {
     private val _subscriberStats = MutableStateFlow<IndividualSubscriberStats?>(null)
     val subscriberStats = _subscriberStats.asStateFlow()
-
-    private val _showAddSubscribersProgress = MutableStateFlow(false)
-    val showAddSubscribersProgress = _showAddSubscribersProgress.asStateFlow()
 
     private var statsJob: Job? = null
 
@@ -182,44 +178,6 @@ class SubscribersViewModel @Inject constructor(
             ),
             data = subscriber
         )
-    }
-
-    suspend fun addSubscribers(emails: List<String>): Result<Boolean> = withContext(ioDispatcher) {
-        val params = AddSubscribersParams(
-            emails = emails
-        )
-
-        _showAddSubscribersProgress.value = true
-        try {
-            val response = wpComApiClient.request { requestBuilder ->
-                requestBuilder.subscribers().addSubscribers(
-                    wpComSiteId = siteId().toULong(),
-                    params = params
-                )
-            }
-
-            when (response) {
-                is WpRequestResult.Success -> {
-                    // the backend may return HTTP 200 even when no subscribers were added, so verify there's
-                    // a valid uploadId before assuming success
-                    if (response.response.data.uploadId == 0.toULong()) {
-                        appLogWrapper.d(AppLog.T.MAIN, "No subscribers added")
-                        return@withContext Result.failure(Exception("No subscribers added"))
-                    } else {
-                        appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
-                        return@withContext Result.success(true)
-                    }
-                }
-
-                else -> {
-                    val error = (response as? WpRequestResult.WpError)?.errorMessage
-                    appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
-                    return@withContext Result.failure(Exception(error))
-                }
-            }
-        } finally {
-            _showAddSubscribersProgress.value = false
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.dataview.DataViewItemImage
 import org.wordpress.android.ui.dataview.DataViewViewModel
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.AddSubscribersParams
 import uniffi.wp_api.IndividualSubscriberStats
 import uniffi.wp_api.IndividualSubscriberStatsParams
 import uniffi.wp_api.ListSubscribersSortField
@@ -178,6 +179,31 @@ class SubscribersViewModel @Inject constructor(
             ),
             data = subscriber
         )
+    }
+
+    suspend fun addSubscriber(email: String, displayName: String): Boolean = withContext(ioDispatcher) {
+        val params = AddSubscribersParams(
+            emails = listOf(email),
+        )
+
+        val response = wpComApiClient.request { requestBuilder ->
+            requestBuilder.subscribers().addSubscribers(
+                wpComSiteId = siteId().toULong(),
+                params = params
+            )
+        }
+
+        when (response) {
+            is WpRequestResult.Success -> {
+                appLogWrapper.d(AppLog.T.MAIN, "Successfully added subscriber: $email")
+                return@withContext true
+            }
+            else -> {
+                onError((response as? WpRequestResult.WpError)?.errorMessage)
+                appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
+                return@withContext false
+            }
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -40,6 +40,9 @@ class SubscribersViewModel @Inject constructor(
     private val _subscriberStats = MutableStateFlow<IndividualSubscriberStats?>(null)
     val subscriberStats = _subscriberStats.asStateFlow()
 
+    private val _showAddSubscribersProgress = MutableStateFlow(false)
+    val showAddSubscribersProgress = _showAddSubscribersProgress.asStateFlow()
+
     private var statsJob: Job? = null
 
     @Inject
@@ -186,24 +189,30 @@ class SubscribersViewModel @Inject constructor(
             emails = emails
         )
 
-        val response = wpComApiClient.request { requestBuilder ->
-            requestBuilder.subscribers().addSubscribers(
-                wpComSiteId = siteId().toULong(),
-                params = params
-            )
-        }
+        _showAddSubscribersProgress.value = true
+        try {
+            val response = wpComApiClient.request { requestBuilder ->
+                requestBuilder.subscribers().addSubscribers(
+                    wpComSiteId = siteId().toULong(),
+                    params = params
+                )
+            }
 
-        when (response) {
-            is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
-                return@withContext Result.success(true)
+            when (response) {
+                is WpRequestResult.Success -> {
+                    appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
+                    return@withContext Result.success(true)
+                }
+
+                else -> {
+                    val error = (response as? WpRequestResult.WpError)?.errorMessage
+                    onError((response as? WpRequestResult.WpError)?.errorMessage)
+                    appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
+                    return@withContext Result.failure(Exception(error))
+                }
             }
-            else -> {
-                val error = (response as? WpRequestResult.WpError)?.errorMessage
-                onError((response as? WpRequestResult.WpError)?.errorMessage)
-                appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
-                return@withContext Result.failure(Exception(error))
-            }
+        } finally {
+            _showAddSubscribersProgress.value = false
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -181,9 +181,9 @@ class SubscribersViewModel @Inject constructor(
         )
     }
 
-    suspend fun addSubscriber(email: String, displayName: String): Boolean = withContext(ioDispatcher) {
+    suspend fun addSubscribers(emails: List<String>): Boolean = withContext(ioDispatcher) {
         val params = AddSubscribersParams(
-            emails = listOf(email),
+            emails = emails
         )
 
         val response = wpComApiClient.request { requestBuilder ->
@@ -195,7 +195,7 @@ class SubscribersViewModel @Inject constructor(
 
         when (response) {
             is WpRequestResult.Success -> {
-                appLogWrapper.d(AppLog.T.MAIN, "Successfully added subscriber: $email")
+                appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
                 return@withContext true
             }
             else -> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -181,7 +181,7 @@ class SubscribersViewModel @Inject constructor(
         )
     }
 
-    suspend fun addSubscribers(emails: List<String>): Boolean = withContext(ioDispatcher) {
+    suspend fun addSubscribers(emails: List<String>): Result<Boolean> = withContext(ioDispatcher) {
         val params = AddSubscribersParams(
             emails = emails
         )
@@ -196,12 +196,13 @@ class SubscribersViewModel @Inject constructor(
         when (response) {
             is WpRequestResult.Success -> {
                 appLogWrapper.d(AppLog.T.MAIN, "Successfully added ${emails.size} subscribers")
-                return@withContext true
+                return@withContext Result.success(true)
             }
             else -> {
+                val error = (response as? WpRequestResult.WpError)?.errorMessage
                 onError((response as? WpRequestResult.WpError)?.errorMessage)
                 appLogWrapper.e(AppLog.T.MAIN, "Failed to add subscriber: $response")
-                return@withContext false
+                return@withContext Result.failure(Exception(error))
             }
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5029,7 +5029,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_add_disclosure">
         By clicking Send you represent that you\'ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
     </string>
-    <string name="subscribers_add_success">Successfully added subscribers</string>
+    <string name="subscribers_add_success_singular">Successfully added subscriber</string>
+    <string name="subscribers_add_success_plural">Successfully added %d subscribers</string>
     <string name="subscribers_add_failed">Failed to add subscribers</string>
 
     <!-- Application Password authentication -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5029,6 +5029,8 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_add_disclosure">
         By clicking Send you represent that you\'ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
     </string>
+    <string name="subscribers_add_success">Successfully added subscribers</string>
+    <string name="subscribers_add_failed">Failed to add subscribers</string>
 
     <!-- Application Password authentication -->
     <string name="application_password_credentials_stored">Application password credentials stored for %1$s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5024,6 +5024,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_renewal_info">Renewal information</string>
     <string name="subscribers_renewal_interval">Renewal interval</string>
     <string name="subscribers_gift_content_description">Gift</string>
+    <string name="subscribers_add_subscribers">Add subscribers</string>
 
     <!-- Application Password authentication -->
     <string name="application_password_credentials_stored">Application password credentials stored for %1$s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5027,10 +5027,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_add_subscribers">Add subscribers</string>
     <string name="subscribers_add_email_hint">name@example.com</string>
     <string name="subscribers_add_disclosure">
-        By clicking Send you represent that you've obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
+        By clicking Send you represent that you\'ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
     </string>
-    <string name="subscribers_add_success_singular">Successfully added subscriber</string>
-    <string name="subscribers_add_success_plural">Successfully added %d subscribers</string>
+    <string name="subscribers_add_success">Successfully added subscribers</string>
     <string name="subscribers_add_failed">Failed to add subscribers</string>
 
     <!-- Application Password authentication -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5027,7 +5027,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_add_subscribers">Add subscribers</string>
     <string name="subscribers_add_email_hint">name@example.com</string>
     <string name="subscribers_add_disclosure">
-        By clicking Send you represent that you\'ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
+        By clicking Send you represent that you've obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
     </string>
     <string name="subscribers_add_success_singular">Successfully added subscriber</string>
     <string name="subscribers_add_success_plural">Successfully added %d subscribers</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5025,6 +5025,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="subscribers_renewal_interval">Renewal interval</string>
     <string name="subscribers_gift_content_description">Gift</string>
     <string name="subscribers_add_subscribers">Add subscribers</string>
+    <string name="subscribers_add_email_hint">name@example.com</string>
+    <string name="subscribers_add_disclosure">
+        By clicking Send you represent that you\'ve obtained the appropriate consent to email each person. Spam complaints or high bounce rate from your subscribers may lead to action against your account.
+    </string>
 
     <!-- Application Password authentication -->
     <string name="application_password_credentials_stored">Application password credentials stored for %1$s</string>


### PR DESCRIPTION
This PR updates the subscribers features to enable adding subscribers. I followed the wording of the iOS app, and like iOS a comma-separated list of email addresses can be entered.

Note that instead of using `SubscribersViewModel` as the list, detail, and plan screens do, I opted to create a new `AddSubscribersViewModel` for this feature.

**To test:**
* My Site > Subscribers
* Note the plus button at top of the subscriber list screen only appears for that screen
* Tap the plus button
* Note that the submit button is only enabled when valid email(s) are entered
* Tap Submit
* Note the toast stating that the subscribers were added, and that you're returned to the subscriber list screen


https://github.com/user-attachments/assets/5280c3f0-face-4a5e-8649-5086a23e49d3

