### PR TITLE
Enable application password experimental feature for all users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 
 26.0
 -----
-
+* [**] Added Application Password login experimental feature
 
 25.9
 -----

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -47,9 +47,6 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         // only show subscribers in debug builds
         return if (BuildConfig.DEBUG.not() && feature == Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
             false
-        } else if (BuildConfig.DEBUG.not() && feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE) {
-            // only show application password in debug builds
-            false
         } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR
         } else {


### PR DESCRIPTION
## Description
This PR is enabling the Application Password experimental feature toggle to all users

Note that this PR is targeting `release/26.0`

## Testing instructions
Just check the code to verify the impacted toggle is not affected by visibility anymore.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->