### PR TITLE
Fix subscriber pull-to-refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewScreen.kt
@@ -73,8 +73,8 @@ fun DataViewScreen(
     onFetchMore: () -> Unit,
     modifier: Modifier = Modifier,
     errorMessage: String? = null,
+    refreshState: State<Boolean>
 ) {
-    val refreshState = remember { mutableStateOf(false) }
     val pullToRefreshState = rememberPullToRefreshState()
 
     PullToRefreshBox(
@@ -492,6 +492,7 @@ private fun LoadedPreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -514,6 +515,7 @@ private fun LoadingPreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -536,6 +538,7 @@ private fun EmptyPreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -558,6 +561,7 @@ private fun EmptySearchPreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -580,6 +584,7 @@ private fun OfflinePreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -602,6 +607,7 @@ private fun ErrorPreview() {
         onFilterClick = { },
         onSortClick = { },
         onSortOrderClick = { },
+        refreshState = remember { mutableStateOf(false) }
     )
 }
 
@@ -610,5 +616,4 @@ private val dummyDropdownItems = listOf(
         id = 0L,
         titleRes = R.string.filter
     ),
-
-    )
+)

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -122,6 +122,7 @@ open class DataViewViewModel @Inject constructor(
                     sortBy = _itemSortBy.value,
                 )
                 if (uiState.value == DataViewUiState.ERROR) {
+                    _refreshState.value = false
                     return@launch
                 }
 
@@ -140,9 +141,11 @@ open class DataViewViewModel @Inject constructor(
                 } else {
                     updateUiState(DataViewUiState.LOADED)
                 }
+                _refreshState.value = false
             }
         } else {
             updateUiState(DataViewUiState.OFFLINE)
+            _refreshState.value = false
         }
     }
 
@@ -158,7 +161,6 @@ open class DataViewViewModel @Inject constructor(
             appLogWrapper.d(AppLog.T.MAIN, "$logTag onRefreshData")
             _refreshState.value = true
             fetchData()
-            _refreshState.value = false
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -64,6 +64,9 @@ open class DataViewViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage = _errorMessage.asStateFlow()
 
+    private val _refreshState = MutableStateFlow(false)
+    val refreshState = _refreshState.asStateFlow()
+
     private val debouncedQuery = MutableStateFlow("")
     private var searchQuery: String = ""
     private var page = 0
@@ -153,7 +156,9 @@ open class DataViewViewModel @Inject constructor(
         if (_uiState.value == DataViewUiState.LOADED) {
             resetPaging()
             appLogWrapper.d(AppLog.T.MAIN, "$logTag onRefreshData")
+            _refreshState.value = true
             fetchData()
+            _refreshState.value = false
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -104,13 +104,16 @@ open class DataViewViewModel @Inject constructor(
         return selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
     }
 
-    private fun fetchData() {
+    private fun fetchData(isRefreshing: Boolean = false) {
         if (networkUtilsWrapper.isNetworkAvailable()) {
             val isLoadingMore = page > 0
             if (isLoadingMore) {
                 updateUiState(DataViewUiState.LOADING_MORE)
             } else {
                 updateUiState(DataViewUiState.LOADING)
+            }
+            if (isRefreshing) {
+                _refreshState.value = true
             }
 
             launch {
@@ -145,7 +148,6 @@ open class DataViewViewModel @Inject constructor(
             }
         } else {
             updateUiState(DataViewUiState.OFFLINE)
-            _refreshState.value = false
         }
     }
 
@@ -159,8 +161,7 @@ open class DataViewViewModel @Inject constructor(
         if (_uiState.value == DataViewUiState.LOADED) {
             resetPaging()
             appLogWrapper.d(AppLog.T.MAIN, "$logTag onRefreshData")
-            _refreshState.value = true
-            fetchData()
+            fetchData(isRefreshing = true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersActivity.kt
@@ -209,7 +209,8 @@ class SubscribersActivity : BaseAppCompatActivity() {
             onSortOrderClick = { order ->
                 viewModel.onSortOrderClick(order)
             },
-            modifier = modifier
+            modifier = modifier,
+            refreshState = viewModel.refreshState.collectAsState()
         )
     }
 


### PR DESCRIPTION
Prior to this PR, after a pull-to-refresh the refresh indicator would never disappear. This PR resolves this by moving the refresh state to the view model.

To test, simply perform a PTR on the subscriber list and note the indicator doesn't hang around.


https://github.com/user-attachments/assets/b845eae4-d924-459d-9fc7-699961b3bc77

