### PR TITLE
Drop sorting subscribers by email

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -56,11 +56,11 @@ class SubscribersViewModel @Inject constructor(
     override fun getSupportedFilters(): List<DataViewDropdownItem> {
         return listOf(
             DataViewDropdownItem(
-                id = ID_FILTER_EMAIL,
+                id = SubscriberFilterType.Email.id,
                 titleRes = R.string.subscribers_filter_email_subscription
             ),
             DataViewDropdownItem(
-                id = ID_FILTER_READER,
+                id = SubscriberFilterType.Reader.id,
                 titleRes = R.string.subscribers_filter_reader_subscription
             )
         )
@@ -69,11 +69,11 @@ class SubscribersViewModel @Inject constructor(
     override fun getSupportedSorts(): List<DataViewDropdownItem> {
         return listOf(
             DataViewDropdownItem(
-                id = ID_SORT_DATE,
+                id = SubscriberSortType.DateSubscribed.id,
                 titleRes = R.string.subscribers_sort_date
             ),
             DataViewDropdownItem(
-                id = ID_SORT_NAME,
+                id = SubscriberSortType.Name.id,
                 titleRes = R.string.subscribers_sort_name
             ),
         )
@@ -111,16 +111,16 @@ class SubscribersViewModel @Inject constructor(
     ): List<DataViewItem> = withContext(ioDispatcher) {
         val filterType = filter?.let {
             when (it.id) {
-                ID_FILTER_EMAIL -> SubscriberType.EmailSubscriber
-                ID_FILTER_READER -> SubscriberType.ReaderSubscriber
+                SubscriberFilterType.Email.id -> SubscriberType.EmailSubscriber
+                SubscriberFilterType.Reader.id -> SubscriberType.ReaderSubscriber
                 else -> null
             }
         }
 
         val sortType = sortBy?.let {
             when (it.id) {
-                ID_SORT_DATE -> ListSubscribersSortField.DATE_SUBSCRIBED
-                ID_SORT_NAME -> ListSubscribersSortField.DISPLAY_NAME
+                SubscriberSortType.DateSubscribed.id -> ListSubscribersSortField.DATE_SUBSCRIBED
+                SubscriberSortType.Name.id -> ListSubscribersSortField.DISPLAY_NAME
                 else -> null
             }
         }
@@ -297,13 +297,17 @@ class SubscribersViewModel @Inject constructor(
         _uiEvent.value = null
     }
 
+    private enum class SubscriberSortType(val id: Long) {
+        DateSubscribed(1L),
+        Name(2L)
+    }
+
+    private enum class SubscriberFilterType(val id: Long) {
+        Email(1L),
+        Reader(2L)
+    }
+
     companion object {
-        private const val ID_FILTER_EMAIL = 1L
-        private const val ID_FILTER_READER = 2L
-
-        private const val ID_SORT_DATE = 1L
-        private const val ID_SORT_NAME = 2L
-
         fun Subscriber.displayNameOrEmail() = displayName.ifEmpty { emailAddress }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -73,10 +73,6 @@ class SubscribersViewModel @Inject constructor(
                 titleRes = R.string.subscribers_sort_date
             ),
             DataViewDropdownItem(
-                id = ID_SORT_EMAIL,
-                titleRes = R.string.subscribers_sort_email
-            ),
-            DataViewDropdownItem(
                 id = ID_SORT_NAME,
                 titleRes = R.string.subscribers_sort_name
             ),
@@ -125,7 +121,6 @@ class SubscribersViewModel @Inject constructor(
             when (it.id) {
                 ID_SORT_DATE -> ListSubscribersSortField.DATE_SUBSCRIBED
                 ID_SORT_NAME -> ListSubscribersSortField.DISPLAY_NAME
-                ID_SORT_EMAIL -> ListSubscribersSortField.EMAIL_ADDRESS
                 else -> null
             }
         }
@@ -307,8 +302,7 @@ class SubscribersViewModel @Inject constructor(
         private const val ID_FILTER_READER = 2L
 
         private const val ID_SORT_DATE = 1L
-        private const val ID_SORT_EMAIL = 2L
-        private const val ID_SORT_NAME = 3L
+        private const val ID_SORT_NAME = 2L
 
         fun Subscriber.displayNameOrEmail() = displayName.ifEmpty { emailAddress }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4995,7 +4995,6 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <!-- Subscribers -->
     <string name="subscribers_filter_email_subscription">Email subscription</string>
     <string name="subscribers_filter_reader_subscription">Reader subscription</string>
-    <string name="subscribers_sort_email">Email</string>
     <string name="subscribers_sort_date">Date subscribed</string>
     <string name="subscribers_sort_name">Name</string>
     <string name="subscribers_empty">There are no subscribers</string>


### PR DESCRIPTION
This PR drops the option to sort the subscriber list by email address. We don't display the email address in the list so it didn't make sense to sort by it. I also took Copilot's advice and changed the sort (and filter) types to an enum (as @adalpari suggested on a previous review).

To test, tap the sort icon above the subscriber list and verify that only "Date subscribed" and "Name" are available options.

![sort](https://github.com/user-attachments/assets/45ac0e1e-17a2-4edd-bc5e-709b0b1fead8)
