### PR TITLE
Storing api root url from discovery process

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -108,7 +108,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 credentialsStored
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.stackTrace}")
+            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.message}")
             false
         }
     }
@@ -137,7 +137,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Error storing credentials: ${e.stackTrace}")
+            appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.message}")
             emitErrorFetching(urlLogin)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -108,7 +108,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 credentialsStored
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.message}")
+            appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.stackTraceToString()}")
             false
         }
     }
@@ -137,7 +137,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 )
             }
         } catch (e: Exception) {
-            appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.message}")
+            appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.stackTraceToString()}")
             emitErrorFetching(urlLogin)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnProfileFetched
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
-import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.login.util.SiteUtils
 import org.wordpress.android.modules.IO_THREAD
@@ -112,7 +111,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ComplexCondition")
     private suspend fun fetchSites(
         username: String,
         password: String,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -92,7 +92,12 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     )
                 )
             } else {
-                fetchSites(urlLogin.user.orEmpty(), urlLogin.password.orEmpty(), urlLogin.siteUrl.orEmpty())
+                fetchSites(
+                    urlLogin.user.orEmpty(),
+                    urlLogin.password.orEmpty(),
+                    urlLogin.siteUrl.orEmpty(),
+                    urlLogin.apiRootUrl.orEmpty()
+                )
             }
         }
     }
@@ -108,9 +113,14 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun fetchSites(username: String, password: String, siteUrl: String) = withContext(ioDispatcher) {
+    private suspend fun fetchSites(
+        username: String,
+        password: String,
+        siteUrl: String,
+        apiRootUrl: String
+        ) = withContext(ioDispatcher) {
         try {
-            if (username.isEmpty() || password.isEmpty() || siteUrl.isEmpty()) {
+            if (username.isEmpty() || password.isEmpty() || siteUrl.isEmpty() || apiRootUrl.isEmpty()) {
                 appLogWrapper.e(AppLog.T.MAIN, "Cannot fetch sites for credential storing: UriLogin is empty")
                 emitErrorFetching(siteUrl)
             } else {
@@ -118,10 +128,11 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(siteUrl)
                 dispatcher.dispatch(
                     SiteActionBuilder.newFetchSitesXmlRpcFromApplicationPasswordAction(
-                        RefreshSitesXMLRPCPayload(
+                        SiteStore.RefreshSitesXMLRPCApplicationPasswordCredentialsPayload(
                             username = username,
                             password = password,
                             url = xmlRpcEndpoint,
+                            apiRootUrl = apiRootUrl,
                         )
                     )
                 )

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -77,8 +77,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                 return@launch
             }
             val urlLogin = applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(rawData)
+            currentUrlLogin = urlLogin
             // Store credentials if the site already exists
-            val credentialsStored = storeCredentials(rawData)
+            val credentialsStored = storeCredentials(urlLogin)
             // If the site already exists, we can skip fetching it again
             if (credentialsStored) {
                 _onFinishedEvent.emit(
@@ -91,22 +92,15 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     )
                 )
             } else {
-                fetchSites(urlLogin)
-                currentUrlLogin = urlLogin
+                fetchSites(urlLogin.user.orEmpty(), urlLogin.password.orEmpty(), urlLogin.siteUrl.orEmpty())
             }
         }
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun storeCredentials(rawData: String): Boolean = withContext(ioDispatcher) {
+    private suspend fun storeCredentials(urlLogin: UriLogin): Boolean = withContext(ioDispatcher) {
         try {
-            if (rawData.isEmpty()) {
-                appLogWrapper.e(AppLog.T.DB, "Cannot store credentials: rawData is empty")
-                false
-            } else {
-                val credentialsStored = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)
-                credentialsStored
-            }
+            applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(urlLogin)
         } catch (e: Exception) {
             appLogWrapper.e(AppLog.T.DB, "Error storing credentials: ${e.stackTraceToString()}")
             false
@@ -114,23 +108,19 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun fetchSites(
-        urlLogin: UriLogin
-    ) = withContext(ioDispatcher) {
+    private suspend fun fetchSites(username: String, password: String, siteUrl: String) = withContext(ioDispatcher) {
         try {
-            if (urlLogin.user.isNullOrEmpty() ||
-                urlLogin.password.isNullOrEmpty() ||
-                urlLogin.siteUrl.isNullOrEmpty()) {
-                appLogWrapper.e(AppLog.T.MAIN, "Cannot store credentials: rawData is empty")
-                emitErrorFetching(urlLogin)
+            if (username.isEmpty() || password.isEmpty() || siteUrl.isEmpty()) {
+                appLogWrapper.e(AppLog.T.MAIN, "Cannot fetch sites for credential storing: UriLogin is empty")
+                emitErrorFetching(siteUrl)
             } else {
                 val xmlRpcEndpoint =
-                    selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl)
+                    selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(siteUrl)
                 dispatcher.dispatch(
                     SiteActionBuilder.newFetchSitesXmlRpcFromApplicationPasswordAction(
                         RefreshSitesXMLRPCPayload(
-                            username = urlLogin.user,
-                            password = urlLogin.password,
+                            username = username,
+                            password = password,
                             url = xmlRpcEndpoint,
                         )
                     )
@@ -138,15 +128,15 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             }
         } catch (e: Exception) {
             appLogWrapper.e(AppLog.T.API, "Error fetching sites: ${e.stackTraceToString()}")
-            emitErrorFetching(urlLogin)
+            emitErrorFetching(siteUrl)
         }
     }
 
-    private suspend fun emitErrorFetching(urlLogin: UriLogin) =  _onFinishedEvent.emit(
+    private suspend fun emitErrorFetching(siteUrl: String) =  _onFinishedEvent.emit(
         NavigationActionData(
             showSiteSelector = false,
             showPostSignupInterstitial = false,
-            siteUrl = urlLogin.siteUrl,
+            siteUrl = siteUrl,
             oldSitesIDs = oldSitesIDs,
             isError = true
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCache.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCache.kt
@@ -13,6 +13,9 @@ class ApiRootUrlCache @Inject constructor() {
     private val cache = mutableMapOf<String, String>()
 
     fun put(key: String, value: String) {
+        if (key.isEmpty() || value.isEmpty()) {
+            return
+        }
         cache[key] = value
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCache.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCache.kt
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.accounts.login
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory cache to store and retrieve the ApiRootUrl between the login discovery process and the final store step
+ * This cache is necessary because between those states we are interrupting the code flow by calling external intents
+ * so we need a place to safely store the data
+ */
+@Singleton
+class ApiRootUrlCache @Inject constructor() {
+    private val cache = mutableMapOf<String, String>()
+
+    fun put(key: String, value: String) {
+        cache[key] = value
+    }
+
+    fun get(key: String): String? {
+        return cache[key]
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -31,6 +31,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
+    private val apiRootUrlCache: ApiRootUrlCache
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -46,10 +47,12 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         when (val urlDiscoveryResult = wpLoginClient.apiDiscovery(siteUrl)) {
             is ApiDiscoveryResult.Success -> {
                 val authorizationUrl = urlDiscoveryResult.success.applicationPasswordsAuthenticationUrl.url()
+                // Store the ApiRootUrl for use it after the login
+                apiRootUrlCache.put(UrlUtils.normalizeUrl(siteUrl), urlDiscoveryResult.success.apiRootUrl.url())
                 val authorizationUrlComplete =
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
                 Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete" +
-                        " API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl}")
+                        " API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl.url()}")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
             }
@@ -72,44 +75,39 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     }
 
     @Suppress("ReturnCount")
-    suspend fun storeApplicationPasswordCredentialsFrom(url: String): Boolean {
-        if (url.isEmpty() || url == processedAppPasswordData) {
+    suspend fun storeApplicationPasswordCredentialsFrom(urlLogin: UriLogin): Boolean {
+        if (urlLogin.apiRootUrl == null ||
+            urlLogin.user.isNullOrEmpty() ||
+            urlLogin.password.isNullOrEmpty() ||
+            urlLogin.siteUrl == null ||
+            urlLogin.siteUrl == processedAppPasswordData
+            ) {
             return false
         }
 
         return withContext(bgDispatcher) {
-            val uriLogin = uriLoginWrapper.parseUriLogin(url)
-
-            if (uriLogin.user.isNullOrEmpty() || uriLogin.password.isNullOrEmpty() ) {
-                false
-            } else {
-                val normalizedUrl = UrlUtils.normalizeUrl(uriLogin.siteUrl)
-                val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
-                if (site != null) {
-                    // Get the current apiRootUrl
-                    val urlDiscoveryResult = wpLoginClient.apiDiscovery(normalizedUrl)
-                    site.apply {
-                        apiRestUsernameEncrypted = ""
-                        apiRestPasswordEncrypted = ""
-                        apiRestUsernameIV = ""
-                        apiRestPasswordIV = ""
-                        apiRestUsernamePlain = uriLogin.user
-                        apiRestPasswordPlain = uriLogin.password
-                        if (urlDiscoveryResult is ApiDiscoveryResult.Success) {
-                            wpApiRestUrl = urlDiscoveryResult.success.apiRootUrl.url()
-                        }
-                    }
-                    dispatcherWrapper.insertOrUpdateSite(site)
-                    uriLogin.siteUrl?.let { trackSuccessful(it) }
-                    processedAppPasswordData = url // Save locally to avoid duplicated calls
-                    true
-                } else {
-                    appLogWrapper.e(
-                        AppLog.T.DB,
-                        "WP_RS: Cannot save application password credentials for: ${uriLogin.siteUrl}"
-                    )
-                    false
+            val normalizedUrl = UrlUtils.normalizeUrl(urlLogin.siteUrl)
+            val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
+            if (site != null) {
+                site.apply {
+                    apiRestUsernameEncrypted = ""
+                    apiRestPasswordEncrypted = ""
+                    apiRestUsernameIV = ""
+                    apiRestPasswordIV = ""
+                    apiRestUsernamePlain = urlLogin.user
+                    apiRestPasswordPlain = urlLogin.password
+                    wpApiRestUrl = urlLogin.apiRootUrl
                 }
+                dispatcherWrapper.insertOrUpdateSite(site)
+                urlLogin.siteUrl?.let { trackSuccessful(it) }
+                processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
+                true
+            } else {
+                appLogWrapper.e(
+                    AppLog.T.DB,
+                    "WP_RS: Cannot save application password credentials for: ${urlLogin.siteUrl}"
+                )
+                false
             }
         }
     }
@@ -163,14 +161,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     /**
      * This class is created to wrap the Uri calls and let us unit test the login helper
      */
-    class UriLoginWrapper @Inject constructor() {
+    class UriLoginWrapper @Inject constructor(private val apiRootUrlCache: ApiRootUrlCache) {
         fun parseUriLogin(url: String): UriLogin {
             val uri = url.toUri()
-            return UriLogin(
-                uri.getQueryParameter("site_url"),
-                uri.getQueryParameter("user_login"),
-                uri.getQueryParameter("password")
-            )
+            val siteUrl = UrlUtils.normalizeUrl(uri.getQueryParameter("site_url"))
+            val userLogin = uri.getQueryParameter("user_login")
+            val password = uri.getQueryParameter("password")
+            val apiRootUrl = apiRootUrlCache.get(siteUrl)
+            return UriLogin(siteUrl, userLogin, password, apiRootUrl)
         }
 
         fun appendParamsToRestAuthorizationUrl(authorizationUrl: String?): String {
@@ -188,7 +186,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     data class UriLogin(
         val siteUrl: String?,
         val user: String?,
-        val password: String?
+        val password: String?,
+        val apiRootUrl: String?
     )
 
     // We need to wrap the dispatcher because tests are failing due to the actions not having a proper equals method

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -31,7 +31,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private val buildConfigWrapper: BuildConfigWrapper,
     private val wpLoginClient: WpLoginClient,
     private val appLogWrapper: AppLogWrapper,
-    private val apiRootUrlCache: ApiRootUrlCache
+    private val apiRootUrlCache: ApiRootUrlCache,
+    private val discoverSuccessWrapper: DiscoverSuccessWrapper
 ) {
     private var processedAppPasswordData: String? = null
 
@@ -46,13 +47,15 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     private suspend fun getAuthorizationUrlCompleteInternal(siteUrl: String): String = withContext(bgDispatcher) {
         when (val urlDiscoveryResult = wpLoginClient.apiDiscovery(siteUrl)) {
             is ApiDiscoveryResult.Success -> {
-                val authorizationUrl = urlDiscoveryResult.success.applicationPasswordsAuthenticationUrl.url()
+                val authorizationUrl =
+                    discoverSuccessWrapper.getApplicationPasswordsAuthenticationUrl(urlDiscoveryResult)
+                val apiRootUrl = discoverSuccessWrapper.getApiRootUrl(urlDiscoveryResult)
                 // Store the ApiRootUrl for use it after the login
-                apiRootUrlCache.put(UrlUtils.normalizeUrl(siteUrl), urlDiscoveryResult.success.apiRootUrl.url())
+                apiRootUrlCache.put(UrlUtils.normalizeUrl(siteUrl), apiRootUrl)
                 val authorizationUrlComplete =
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
                 Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete" +
-                        " API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl.url()}")
+                        " API_ROOT_URL $apiRootUrl")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
             }
@@ -99,7 +102,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     wpApiRestUrl = urlLogin.apiRootUrl
                 }
                 dispatcherWrapper.insertOrUpdateSite(site)
-                urlLogin.siteUrl?.let { trackSuccessful(it) }
+                trackSuccessful(urlLogin.siteUrl)
                 processedAppPasswordData = urlLogin.siteUrl // Save locally to avoid duplicated calls
                 true
             } else {
@@ -198,5 +201,12 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 SiteActionBuilder.newUpdateSiteAction(site)
             )
         }
+    }
+
+    class DiscoverSuccessWrapper @Inject constructor() {
+        fun getApiRootUrl(successObject: ApiDiscoveryResult.Success) = successObject.success.apiRootUrl.url()
+
+        fun getApplicationPasswordsAuthenticationUrl(successObject: ApiDiscoveryResult.Success) =
+            successObject.success.applicationPasswordsAuthenticationUrl.url()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -6,7 +6,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
+import org.wordpress.android.fluxc.Dispatcher
+import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
@@ -22,7 +27,8 @@ private const val SUCCESS_TAG = "success"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val siteSqlUtils: SiteSqlUtils,
+    private val dispatcher: Dispatcher,
+    private val siteStore: SiteStore,
     private val uriLoginWrapper: UriLoginWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
     private val wpLoginClient: WpLoginClient,
@@ -79,7 +85,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 false
             } else {
                 val normalizedUrl = UrlUtils.normalizeUrl(uriLogin.siteUrl)
-                val site = siteSqlUtils.getSites().firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
+                val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
                 if (site != null) {
                     site.apply {
                         apiRestUsernameEncrypted = ""
@@ -89,7 +95,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         apiRestUsernamePlain = uriLogin.user
                         apiRestPasswordPlain = uriLogin.password
                     }
-                    siteSqlUtils.insertOrUpdateSite(site)
+                    insertOrUpdateSite(site)
                     uriLogin.siteUrl?.let { trackSuccessful(it) }
                     processedAppPasswordData = url // Save locally to avoid duplicated calls
                     true
@@ -102,6 +108,12 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun insertOrUpdateSite(site: SiteModel) {
+        dispatcher.dispatch(
+            SiteActionBuilder.newUpdateSiteAction(site)
+        )
     }
 
     private fun trackSuccessful(siteUrl: String) {
@@ -129,7 +141,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
      */
     suspend fun removeAllApplicationPasswordCredentials(): Int {
         return withContext(bgDispatcher) {
-            val sites = siteSqlUtils.getSites()
+            val sites = siteStore.sites
             val affectedSites = sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
             sites.forEach { site ->
                 site.apply {
@@ -140,15 +152,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     apiRestUsernameIV = ""
                     apiRestPasswordIV = ""
                 }
-                siteSqlUtils.insertOrUpdateSite(site)
+                insertOrUpdateSite(site)
             }
             affectedSites
         }
     }
 
     fun getApplicationPasswordSitesCount(): Int {
-        val sites = siteSqlUtils.getSites()
-        return sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
+        return siteStore.sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -49,7 +49,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 val authorizationUrlComplete =
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
                 Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete" +
-                        "API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl}")
+                        " API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl}")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
             }
@@ -191,7 +191,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         val password: String?
     )
 
-    // We need to wrap the dispatcher because tests are failing sue to the actions not having a proper equals method
+    // We need to wrap the dispatcher because tests are failing due to the actions not having a proper equals method
     // so, every action is returning false when compared with the one we want to test
     class DispatcherWrapper @Inject constructor(private val dispatcher: Dispatcher) {
         fun insertOrUpdateSite(site: SiteModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -50,7 +50,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 val authorizationUrl = urlDiscoveryResult.success.applicationPasswordsAuthenticationUrl.url()
                 val authorizationUrlComplete =
                     uriLoginWrapper.appendParamsToRestAuthorizationUrl(authorizationUrl)
-                Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete")
+                Log.d("WP_RS", "Found authorization for $siteUrl URL: $authorizationUrlComplete" +
+                        "API_ROOT_URL ${urlDiscoveryResult.success.apiRootUrl}")
                 AnalyticsTracker.track(Stat.BACKGROUND_REST_AUTODISCOVERY_SUCCESSFUL)
                 authorizationUrlComplete
             }
@@ -87,6 +88,8 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 val normalizedUrl = UrlUtils.normalizeUrl(uriLogin.siteUrl)
                 val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) ==  normalizedUrl}
                 if (site != null) {
+                    // Get the current apiRootUrl
+                    val urlDiscoveryResult = wpLoginClient.apiDiscovery(normalizedUrl)
                     site.apply {
                         apiRestUsernameEncrypted = ""
                         apiRestPasswordEncrypted = ""
@@ -94,6 +97,9 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                         apiRestPasswordIV = ""
                         apiRestUsernamePlain = uriLogin.user
                         apiRestPasswordPlain = uriLogin.password
+                        if (urlDiscoveryResult is ApiDiscoveryResult.Success) {
+                            wpApiRestUrl = urlDiscoveryResult.success.apiRootUrl.url()
+                        }
                     }
                     insertOrUpdateSite(site)
                     uriLogin.siteUrl?.let { trackSuccessful(it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -74,7 +74,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         return ""
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ComplexCondition")
     suspend fun storeApplicationPasswordCredentialsFrom(urlLogin: UriLogin): Boolean {
         if (urlLogin.apiRootUrl == null ||
             urlLogin.user.isNullOrEmpty() ||

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -9,9 +9,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.BG_THREAD
 import org.wordpress.android.util.AppLog
@@ -27,7 +25,7 @@ private const val SUCCESS_TAG = "success"
 
 class ApplicationPasswordLoginHelper @Inject constructor(
     @param:Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
-    private val dispatcher: Dispatcher,
+    private val dispatcherWrapper: DispatcherWrapper,
     private val siteStore: SiteStore,
     private val uriLoginWrapper: UriLoginWrapper,
     private val buildConfigWrapper: BuildConfigWrapper,
@@ -101,7 +99,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                             wpApiRestUrl = urlDiscoveryResult.success.apiRootUrl.url()
                         }
                     }
-                    insertOrUpdateSite(site)
+                    dispatcherWrapper.insertOrUpdateSite(site)
                     uriLogin.siteUrl?.let { trackSuccessful(it) }
                     processedAppPasswordData = url // Save locally to avoid duplicated calls
                     true
@@ -114,12 +112,6 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }
             }
         }
-    }
-
-    private fun insertOrUpdateSite(site: SiteModel) {
-        dispatcher.dispatch(
-            SiteActionBuilder.newUpdateSiteAction(site)
-        )
     }
 
     private fun trackSuccessful(siteUrl: String) {
@@ -158,7 +150,7 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                     apiRestUsernameIV = ""
                     apiRestPasswordIV = ""
                 }
-                insertOrUpdateSite(site)
+                dispatcherWrapper.insertOrUpdateSite(site)
             }
             affectedSites
         }
@@ -198,4 +190,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         val user: String?,
         val password: String?
     )
+
+    // We need to wrap the dispatcher because tests are failing sue to the actions not having a proper equals method
+    // so, every action is returning false when compared with the one we want to test
+    class DispatcherWrapper @Inject constructor(private val dispatcher: Dispatcher) {
+        fun insertOrUpdateSite(site: SiteModel) {
+            dispatcher.dispatch(
+                SiteActionBuilder.newUpdateSiteAction(site)
+            )
+        }
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -46,7 +46,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     private lateinit var viewModel: ApplicationPasswordLoginViewModel
 
     private val rawData = "url=callback?site_url=https://example.com&user_login=user&password=pass"
-    private val urlLogin = ApplicationPasswordLoginHelper.UriLogin("https://example.com", "user", "pass")
+    private val urlLogin = ApplicationPasswordLoginHelper.UriLogin("https://example.com", "user", "pass", "https://example.com/json")
 
     @Before
     fun setUp() {
@@ -73,7 +73,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             oldSitesIDs = null,
             isError = false
         )
-        whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(true)
+        whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(true)
 
         // When
         viewModel.onFinishedEvent.test {
@@ -83,7 +83,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             val finishedEvent = awaitItem()
             assertEquals(expectedResult, finishedEvent)
             verify(applicationPasswordLoginHelper, times(1))
-                .storeApplicationPasswordCredentialsFrom(rawData)
+                .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
             verify(selfHostedEndpointFinder, times(0)).verifyOrDiscoverXMLRPCEndpoint(any())
             cancelAndIgnoreRemainingEvents()
         }
@@ -109,7 +109,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             val finishedEvent = awaitItem()
             assertEquals(expectedResult, finishedEvent)
             verify(applicationPasswordLoginHelper, times(0))
-                .storeApplicationPasswordCredentialsFrom(rawData)
+                .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
             verify(selfHostedEndpointFinder, times(0)).verifyOrDiscoverXMLRPCEndpoint(any())
             cancelAndIgnoreRemainingEvents()
         }
@@ -129,7 +129,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             )
             whenever(applicationPasswordLoginHelper.getSiteUrlLoginFromRawData(malformedRawData))
                 .thenReturn(
-                    ApplicationPasswordLoginHelper.UriLogin("", "", "")
+                    ApplicationPasswordLoginHelper.UriLogin("", "", "", "")
                 )
 
             // When
@@ -155,7 +155,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 oldSitesIDs = null,
                 isError = true
             )
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(any())).thenThrow(RuntimeException())
 
             // When
@@ -182,7 +182,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 oldSitesIDs = null,
                 isError = true
             )
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -218,7 +218,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(true)
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -253,7 +253,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(false)
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -288,7 +288,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(true)
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 
@@ -323,7 +323,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(false)
-            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(rawData)).thenReturn(false)
+            whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCacheTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApiRootUrlCacheTest.kt
@@ -1,0 +1,116 @@
+package org.wordpress.android.ui.accounts.login
+
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ApiRootUrlCacheTest {
+    private lateinit var apiRootUrlCache: ApiRootUrlCache
+
+    @Before
+    fun setUp() {
+        apiRootUrlCache = ApiRootUrlCache()
+    }
+
+    @Test
+    fun `put and get returns correct value`() {
+        val key = "test-site.com"
+        val value = "https://test-site.com/wp-json/"
+
+        apiRootUrlCache.put(key, value)
+
+        assertEquals(value, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `get returns null for non-existent key`() {
+        val result = apiRootUrlCache.get("non-existent-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `put overwrites existing value`() {
+        val key = "test-site.com"
+        val originalValue = "https://test-site.com/wp-json/"
+        val newValue = "https://test-site.com/api/"
+
+        apiRootUrlCache.put(key, originalValue)
+        apiRootUrlCache.put(key, newValue)
+
+        assertEquals(newValue, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `cache can store multiple entries`() {
+        val key1 = "site1.com"
+        val value1 = "https://site1.com/wp-json/"
+        val key2 = "site2.com"
+        val value2 = "https://site2.com/wp-json/"
+        val key3 = "site3.com"
+        val value3 = "https://site3.com/api/"
+
+        apiRootUrlCache.put(key1, value1)
+        apiRootUrlCache.put(key2, value2)
+        apiRootUrlCache.put(key3, value3)
+
+        assertEquals(value1, apiRootUrlCache.get(key1))
+        assertEquals(value2, apiRootUrlCache.get(key2))
+        assertEquals(value3, apiRootUrlCache.get(key3))
+    }
+
+    @Test
+    fun `cache doesn't handle empty string values`() {
+        val key = "empty-site.com"
+        val value = ""
+
+        apiRootUrlCache.put(key, value)
+
+        assertEquals(null, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `cache doesn't handle empty string keys`() {
+        val key = ""
+        val value = "https://site1.com/wp-json/"
+
+        apiRootUrlCache.put(key, value)
+
+        assertEquals(null, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `cache handles special characters in keys`() {
+        val key = "test-site.com/subdir?param=value"
+        val value = "https://test-site.com/subdir/wp-json/"
+
+        apiRootUrlCache.put(key, value)
+
+        assertEquals(value, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `cache handles special characters in values`() {
+        val key = "test-site.com"
+        val value = "https://test-site.com/wp-json/?auth=token&user=test@email.com"
+
+        apiRootUrlCache.put(key, value)
+
+        assertEquals(value, apiRootUrlCache.get(key))
+    }
+
+    @Test
+    fun `cache is case sensitive for keys`() {
+        val keyLowerCase = "test-site.com"
+        val keyUpperCase = "TEST-SITE.COM"
+        val value1 = "https://test-site.com/wp-json/"
+        val value2 = "https://TEST-SITE.COM/wp-json/"
+
+        apiRootUrlCache.put(keyLowerCase, value1)
+        apiRootUrlCache.put(keyUpperCase, value2)
+
+        assertEquals(value1, apiRootUrlCache.get(keyLowerCase))
+        assertEquals(value2, apiRootUrlCache.get(keyUpperCase))
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.BuildConfigWrapper
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
@@ -38,7 +38,10 @@ private const val TEST_URL_AUTH_SUFFIX = "?app_name=android-jetpack-client&succe
 @ExperimentalCoroutinesApi
 class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
      @Mock
-     lateinit var siteSqlUtils: SiteSqlUtils
+     lateinit var dispatcherWrapper: ApplicationPasswordLoginHelper.DispatcherWrapper
+
+     @Mock
+     lateinit var siteStore: SiteStore
 
      @Mock
      lateinit var uriLoginWrapper: ApplicationPasswordLoginHelper.UriLoginWrapper
@@ -69,7 +72,8 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
         MockitoAnnotations.openMocks(this)
         applicationPasswordLoginHelper = ApplicationPasswordLoginHelper(
             testDispatcher(),
-            siteSqlUtils,
+            dispatcherWrapper,
+            siteStore,
             uriLoginWrapper,
             buildConfigWrapper,
             wpLoginClient,
@@ -152,26 +156,26 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
                 apiRestUsernameEncrypted = TEST_USER
                 apiRestPasswordEncrypted = TEST_PASSWORD
             }
-        whenever(siteSqlUtils.getSites()).thenReturn(listOf(siteModel))
+        whenever(siteStore.sites).thenReturn(listOf(siteModel))
 
         val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
 
         assertTrue(result)
-        verify(siteSqlUtils).getSites()
-        verify(siteSqlUtils).insertOrUpdateSite(eq(siteModel))
+        verify(siteStore).sites
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(siteModel))
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with valid data but not matching site does not store credentials`() =
         runTest {
             val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser&password=testpassword"
-            whenever(siteSqlUtils.getSites()).thenReturn(listOf())
+            whenever(siteStore.sites).thenReturn(listOf())
 
             val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
 
             assertFalse(result)
-            verify(siteSqlUtils).getSites()
-            verify(siteSqlUtils, times(0)).insertOrUpdateSite(any())
+            verify(siteStore).sites
+            verify(dispatcherWrapper, times(0)).insertOrUpdateSite(any())
         }
 
     @Test
@@ -256,12 +260,12 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
 
     @Test
     fun `removeAllApplicationPasswordCredentials with no sites completes without errors`() = runTest {
-        whenever(siteSqlUtils.getSites()).thenReturn(emptyList())
+        whenever(siteStore.sites).thenReturn(emptyList())
 
         applicationPasswordLoginHelper.removeAllApplicationPasswordCredentials()
 
-        verify(siteSqlUtils).getSites()
-        verify(siteSqlUtils, times(0)).insertOrUpdateSite(any())
+        verify(siteStore).sites
+        verify(dispatcherWrapper, times(0)).insertOrUpdateSite(any())
     }
 
     @Test
@@ -276,12 +280,12 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             apiRestUsernameIV = "user_iv"
             apiRestPasswordIV = "password_iv"
         }
-        whenever(siteSqlUtils.getSites()).thenReturn(listOf(site))
+        whenever(siteStore.sites).thenReturn(listOf(site))
 
         applicationPasswordLoginHelper.removeAllApplicationPasswordCredentials()
 
-        verify(siteSqlUtils).getSites()
-        verify(siteSqlUtils).insertOrUpdateSite(eq(site))
+        verify(siteStore).sites
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(site))
 
         // Verify all password fields are cleared
         assertEquals("", site.apiRestUsernamePlain)
@@ -319,14 +323,14 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             url = "http://site3.com"
             // This site has no credentials set
         }
-        whenever(siteSqlUtils.getSites()).thenReturn(listOf(site1, site2, site3))
+        whenever(siteStore.sites).thenReturn(listOf(site1, site2, site3))
 
         applicationPasswordLoginHelper.removeAllApplicationPasswordCredentials()
 
-        verify(siteSqlUtils).getSites()
-        verify(siteSqlUtils).insertOrUpdateSite(eq(site1))
-        verify(siteSqlUtils).insertOrUpdateSite(eq(site2))
-        verify(siteSqlUtils).insertOrUpdateSite(eq(site3))
+        verify(siteStore).sites
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(site1))
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(site2))
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(site3))
 
         // Verify all password fields are cleared for all sites
         listOf(site1, site2, site3).forEach { site ->
@@ -350,11 +354,11 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             apiRestUsernamePlain = TEST_USER
             apiRestPasswordPlain = TEST_PASSWORD
         }
-        whenever(siteSqlUtils.getSites()).thenReturn(listOf(site))
+        whenever(siteStore.sites).thenReturn(listOf(site))
 
         applicationPasswordLoginHelper.removeAllApplicationPasswordCredentials()
 
-        verify(siteSqlUtils).insertOrUpdateSite(eq(site))
+        verify(dispatcherWrapper).insertOrUpdateSite(eq(site))
 
         // Verify non-password fields are preserved
         assertEquals(1, site.id)

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -17,6 +17,8 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.DiscoverSuccessWrapper
+import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper.UriLogin
 import org.wordpress.android.util.BuildConfigWrapper
 import rs.wordpress.api.kotlin.ApiDiscoveryResult
 import rs.wordpress.api.kotlin.WpLoginClient
@@ -31,12 +33,14 @@ import kotlin.test.assertTrue
 private const val TEST_URL = "http://test.com"
 private const val TEST_USER = "testuser"
 private const val TEST_PASSWORD = "testpassword"
+private const val TEST_API_ROOT_URL = "http://test.com/json"
 
 private const val TEST_URL_AUTH = "https://www.test.com/auth"
 private const val TEST_URL_AUTH_SUFFIX = "?app_name=android-jetpack-client&success_url=callback://callback"
 
 @ExperimentalCoroutinesApi
 class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
+    val testUriLogin = UriLogin(TEST_URL, TEST_USER, TEST_PASSWORD, TEST_API_ROOT_URL)
      @Mock
      lateinit var dispatcherWrapper: ApplicationPasswordLoginHelper.DispatcherWrapper
 
@@ -64,6 +68,11 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Mock
     lateinit var emptyAuthParsedUrl: ParsedUrl
 
+    @Mock
+    lateinit var discoverSuccessWrapper: DiscoverSuccessWrapper
+
+    private val apiRootUrlCache: ApiRootUrlCache = ApiRootUrlCache()
+
 
     private lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
@@ -77,80 +86,61 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             uriLoginWrapper,
             buildConfigWrapper,
             wpLoginClient,
-            appLogWrapper
+            appLogWrapper,
+            apiRootUrlCache,
+            discoverSuccessWrapper
         )
-        whenever(uriLoginWrapper.parseUriLogin(any()))
-            .thenReturn(
-                ApplicationPasswordLoginHelper.UriLogin(TEST_URL, TEST_USER, TEST_PASSWORD)
-            )
         whenever(uriLoginWrapper.appendParamsToRestAuthorizationUrl(any()))
             .thenReturn("$TEST_URL_AUTH$TEST_URL_AUTH_SUFFIX")
-
-        whenever(authParsedUrl.url()).thenReturn(TEST_URL_AUTH)
-        whenever(emptyAuthParsedUrl.url()).thenReturn("")
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with empty data returns false`() = runTest {
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom("")
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(
+            UriLogin("", "", "", "")
+        )
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with same data returns false`() = runTest {
-        val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser&password=testpassword"
-        applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with null user name returns false`() = runTest {
-        whenever(uriLoginWrapper.parseUriLogin(any()))
-            .thenReturn(
-                ApplicationPasswordLoginHelper.UriLogin(TEST_URL, null, TEST_PASSWORD)
-            )
-        val data = "jetpack://app-pass-authorize?site_url=http://test.com&password=testpasswordr"
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with missing user name returns false`() = runTest {
-        whenever(uriLoginWrapper.parseUriLogin(any()))
-            .thenReturn(
-                ApplicationPasswordLoginHelper.UriLogin(TEST_URL, "", TEST_PASSWORD)
-            )
-        val data = "jetpack://app-pass-authorize?site_url=http://test.com&password=testpasswordr"
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with null password returns false`() = runTest {
-        whenever(uriLoginWrapper.parseUriLogin(any()))
-            .thenReturn(
-                ApplicationPasswordLoginHelper.UriLogin(TEST_URL, TEST_USER, null)
-            )
-        val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser"
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with missing password returns false`() = runTest {
-        whenever(uriLoginWrapper.parseUriLogin(any()))
-            .thenReturn(
-                ApplicationPasswordLoginHelper.UriLogin(TEST_URL, TEST_USER, "")
-            )
-        val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser"
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `storeApplicationPasswordCredentialsFrom with empty api root url returns false`() = runTest {
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
         assertFalse(result)
     }
 
     @Test
     fun `storeApplicationPasswordCredentialsFrom with valid data stores credentials`() = runTest {
-            val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser&password=testpassword"
             val siteModel = SiteModel().apply {
                 url = TEST_URL
                 apiRestUsernameEncrypted = TEST_USER
@@ -158,7 +148,7 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
             }
         whenever(siteStore.sites).thenReturn(listOf(siteModel))
 
-        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+        val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
         assertTrue(result)
         verify(siteStore).sites
@@ -168,10 +158,9 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
     @Test
     fun `storeApplicationPasswordCredentialsFrom with valid data but not matching site does not store credentials`() =
         runTest {
-            val data = "jetpack://app-pass-authorize?site_url=http://test.com&user_login=testuser&password=testpassword"
             whenever(siteStore.sites).thenReturn(listOf())
 
-            val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(data)
+            val result = applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(testUriLogin)
 
             assertFalse(result)
             verify(siteStore).sites
@@ -180,29 +169,33 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
 
     @Test
     fun `appendParamsToRestAuthorizationUrl with null authorizationUrl returns empty string`() {
-        val result = ApplicationPasswordLoginHelper.UriLoginWrapper().appendParamsToRestAuthorizationUrl(null)
+        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache)
+            .appendParamsToRestAuthorizationUrl(null)
         assertEquals("", result)
     }
 
     @Test
     fun `appendParamsToRestAuthorizationUrl with empty authorizationUrl returns empty string`() {
-        val result = ApplicationPasswordLoginHelper.UriLoginWrapper().appendParamsToRestAuthorizationUrl("")
+        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache)
+            .appendParamsToRestAuthorizationUrl("")
         assertEquals("", result)
     }
 
     @Test
     fun `given proper site, when api discovery is success, then return discovery url`() = runTest {
-        whenever(wpLoginClient.apiDiscovery(eq(TEST_URL)))
-            .thenReturn(
-                ApiDiscoveryResult.Success(
-                    AutoDiscoveryAttemptSuccess(
-                        ParsedUrl(Pointer.createConstant(1)),
-                        ParsedUrl(Pointer.createConstant(1)),
-                        wpApiDetails,
-                        authParsedUrl
-                    )
-                )
+        val apiDiscoveryResult = ApiDiscoveryResult.Success(
+            AutoDiscoveryAttemptSuccess(
+                ParsedUrl(Pointer.createConstant(1)),
+                ParsedUrl(Pointer.createConstant(1)),
+                wpApiDetails,
+                authParsedUrl
             )
+        )
+        whenever(discoverSuccessWrapper.getApplicationPasswordsAuthenticationUrl(eq(apiDiscoveryResult)))
+            .thenReturn(TEST_URL_AUTH)
+        whenever(discoverSuccessWrapper.getApiRootUrl(eq(apiDiscoveryResult)))
+            .thenReturn(TEST_API_ROOT_URL)
+        whenever(wpLoginClient.apiDiscovery(eq(TEST_URL))).thenReturn(apiDiscoveryResult)
 
         val result = applicationPasswordLoginHelper.getAuthorizationUrlComplete(TEST_URL)
 
@@ -233,8 +226,6 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
                     )
                 )
             )
-        whenever(uriLoginWrapper.appendParamsToRestAuthorizationUrl(any()))
-            .thenReturn("")
 
         val result = applicationPasswordLoginHelper.getAuthorizationUrlComplete(TEST_URL)
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/action/SiteAction.java
@@ -36,6 +36,7 @@ import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferPayl
 import org.wordpress.android.fluxc.store.SiteStore.InitiateAutomatedTransferResponsePayload;
 import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.QuickStartCompletedResponsePayload;
+import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCApplicationPasswordCredentialsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsPayload;
 import org.wordpress.android.fluxc.store.SiteStore.SuggestDomainsResponsePayload;
@@ -51,7 +52,7 @@ public enum SiteAction implements IAction {
     FETCH_SITES,
     @Action(payloadType = RefreshSitesXMLRPCPayload.class)
     FETCH_SITES_XML_RPC,
-    @Action(payloadType = RefreshSitesXMLRPCPayload.class)
+    @Action(payloadType = RefreshSitesXMLRPCApplicationPasswordCredentialsPayload.class)
     FETCH_SITES_XML_RPC_FROM_APPLICATION_PASSWORD,
     @Action(payloadType = FetchWPAPISitePayload.class)
     FETCH_SITE_WP_API,

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
@@ -59,7 +59,7 @@ class SiteXMLRPCClient @Inject constructor(
         add(request)
     }
 
-    suspend fun fetchSitesFromApplicationPassword(xmlrpcUrl: String, username: String, password: String): SitesModel {
+    suspend fun fetchSitesFromApplicationPassword(xmlrpcUrl: String, apiRootUrl: String, username: String, password: String): SitesModel {
         val sites = fetchSites(xmlrpcUrl, username, password)
         // If fetched from Application Password, we need to be sure we are not storing the regular credentials
         sites.sites.forEach { site ->
@@ -67,6 +67,7 @@ class SiteXMLRPCClient @Inject constructor(
             site.password = ""
             site.apiRestUsernamePlain = username
             site.apiRestPasswordPlain = password
+            site.wpApiRestUrl = apiRootUrl
         }
         return sites
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/site/SiteXMLRPCClient.kt
@@ -59,7 +59,12 @@ class SiteXMLRPCClient @Inject constructor(
         add(request)
     }
 
-    suspend fun fetchSitesFromApplicationPassword(xmlrpcUrl: String, apiRootUrl: String, username: String, password: String): SitesModel {
+    suspend fun fetchSitesFromApplicationPassword(
+        xmlrpcUrl: String,
+        apiRootUrl: String,
+        username: String,
+        password: String
+    ): SitesModel {
         val sites = fetchSites(xmlrpcUrl, username, password)
         // If fetched from Application Password, we need to be sure we are not storing the regular credentials
         sites.sites.forEach { site ->

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -171,6 +171,13 @@ open class SiteStore @Inject constructor(
         @JvmField val url: String = ""
     ) : Payload<BaseNetworkError>()
 
+    data class RefreshSitesXMLRPCApplicationPasswordCredentialsPayload(
+        @JvmField val username: String = "",
+        @JvmField val password: String = "",
+        @JvmField val url: String = "",
+        @JvmField val apiRootUrl: String = "",
+    ) : Payload<BaseNetworkError>()
+
     data class FetchWPAPISitePayload(
         val url: String,
         val username: String? = null,
@@ -1330,7 +1337,7 @@ open class SiteStore @Inject constructor(
             }
             FETCH_SITES_XML_RPC_FROM_APPLICATION_PASSWORD ->
                 coroutineEngine.launch(T.MAIN, this, "Fetch XMLRPC sites from Application Password") {
-                    emitChange(fetchSitesXmlRpcFromApplicationPassword(action.payload as RefreshSitesXMLRPCPayload))
+                    emitChange(fetchSitesXmlRpcFromApplicationPassword(action.payload as RefreshSitesXMLRPCApplicationPasswordCredentialsPayload))
             }
             FETCH_SITE_WP_API -> coroutineEngine.launch(T.MAIN, this, "Fetch WPAPI Site") {
                 emitChange(fetchWPAPISite(action.payload as FetchWPAPISitePayload))
@@ -1449,10 +1456,10 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    suspend fun fetchSitesXmlRpcFromApplicationPassword(payload: RefreshSitesXMLRPCPayload): OnSiteChanged {
+    suspend fun fetchSitesXmlRpcFromApplicationPassword(payload: RefreshSitesXMLRPCApplicationPasswordCredentialsPayload): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
             updateSites(
-                siteXMLRPCClient.fetchSitesFromApplicationPassword(payload.url, payload.username, payload.password)
+                siteXMLRPCClient.fetchSitesFromApplicationPassword(payload.url, payload.apiRootUrl,payload.username, payload.password)
             )
         }
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/SiteStore.kt
@@ -1337,7 +1337,9 @@ open class SiteStore @Inject constructor(
             }
             FETCH_SITES_XML_RPC_FROM_APPLICATION_PASSWORD ->
                 coroutineEngine.launch(T.MAIN, this, "Fetch XMLRPC sites from Application Password") {
-                    emitChange(fetchSitesXmlRpcFromApplicationPassword(action.payload as RefreshSitesXMLRPCApplicationPasswordCredentialsPayload))
+                    emitChange(fetchSitesXmlRpcFromApplicationPassword(
+                        action.payload as RefreshSitesXMLRPCApplicationPasswordCredentialsPayload)
+                    )
             }
             FETCH_SITE_WP_API -> coroutineEngine.launch(T.MAIN, this, "Fetch WPAPI Site") {
                 emitChange(fetchWPAPISite(action.payload as FetchWPAPISitePayload))
@@ -1456,10 +1458,17 @@ open class SiteStore @Inject constructor(
         }
     }
 
-    suspend fun fetchSitesXmlRpcFromApplicationPassword(payload: RefreshSitesXMLRPCApplicationPasswordCredentialsPayload): OnSiteChanged {
+    suspend fun fetchSitesXmlRpcFromApplicationPassword(
+        payload: RefreshSitesXMLRPCApplicationPasswordCredentialsPayload
+    ): OnSiteChanged {
         return coroutineEngine.withDefaultContext(T.API, this, "Fetch sites") {
             updateSites(
-                siteXMLRPCClient.fetchSitesFromApplicationPassword(payload.url, payload.apiRootUrl,payload.username, payload.password)
+                siteXMLRPCClient.fetchSitesFromApplicationPassword(
+                    payload.url,
+                    payload.apiRootUrl,
+                    payload.username,
+                    payload.password
+                )
             )
         }
     }


### PR DESCRIPTION
## Description
This PR stores the API_ROOT_URL from the discovery process in advance of waiting for the sites fetch to get it.
This is done this way to be sure we are using the result from the RS discovery in cases where there is no access to the current XML-RPC endpoints.
In addition, some refactor has been done and now we are using SiteStore directly instead of some SQL calls.

## Testing instructions

1. Log into a self-hosted site
2. Enable Application Password and follow the login process
- [ ] Verify it works as expected
- [ ] Open the DB -> SiteModel and verify the credential fields and the `WP_API_REST_URL` one are filled
<img width="1306" height="170" alt="Screenshot 2025-07-10 at 13 03 36" src="https://github.com/user-attachments/assets/108bd697-356f-4e54-a165-1ec1da87f6ae" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->