### PR TITLE
[Cleanup] Completely Remove `stories-android` from the Codebase

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
+++ b/WordPress/src/androidTest/java/org/wordpress/android/e2e/pages/MySitesPage.kt
@@ -56,7 +56,7 @@ class MySitesPage {
 
         WPSupportUtils.clickOn(R.id.fab_button)
         if (WPSupportUtils.isElementDisplayed(MaterialR.id.design_bottom_sheet)) {
-            // If Stories are enabled, FAB opens a bottom sheet with options - select the 'Blog post' option
+            // If enabled, FAB opens a bottom sheet with options - select the 'Blog post' option
             WPSupportUtils.clickOn(Espresso.onView(ViewMatchers.withText(R.string.my_site_bottom_sheet_add_post)))
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -20,7 +20,6 @@ public class RequestCodes {
     public static final int STOCK_MEDIA_PICKER_MULTI_SELECT = 1201;
     public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT = 1202;
     public static final int STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK = 1203;
-    public static final int STORIES_PHOTO_PICKER = 1204;
     public static final int SITE_ICON_PICKER = 1205;
     public static final int SHOW_LOGIN_EPILOGUE_AND_RETURN = 1300;
     public static final int SHOW_SIGNUP_EPILOGUE_AND_RETURN = 1301;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1474,7 +1474,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                     getNotificationsListFragment().onActivityResult(requestCode, resultCode, data);
                 }
                 break;
-            case RequestCodes.STORIES_PHOTO_PICKER:
             case RequestCodes.PHOTO_PICKER:
             case RequestCodes.DOMAIN_REGISTRATION:
                 passOnActivityResultToMySiteFragment(requestCode, resultCode, data);

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -258,7 +258,6 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                     }
                 }
             }
-            RequestCodes.STORIES_PHOTO_PICKER,
             UCrop.REQUEST_CROP -> {
                 if (resultCode == UCrop.RESULT_ERROR) {
                     AppLog.e(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -3004,7 +3004,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             RequestCodes.MULTI_SELECT_MEDIA_PICKER,
             RequestCodes.SINGLE_SELECT_MEDIA_PICKER,
             RequestCodes.PHOTO_PICKER,
-            RequestCodes.STORIES_PHOTO_PICKER,
             RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT,
             RequestCodes.MEDIA_LIBRARY,
             RequestCodes.PICTURE_LIBRARY,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostEditorAnalyticsSession.java
@@ -54,8 +54,7 @@ public class PostEditorAnalyticsSession implements Serializable {
         GUTENBERG,
         GUTENBERG_KIT,
         CLASSIC,
-        HTML,
-        WP_STORIES_CREATOR
+        HTML
     }
 
     public enum Outcome {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -223,7 +223,6 @@
     <!-- Delete Media -->
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
-    <string name="cannot_retry_deleted_media_item_fatal">Media has been removed. Try re-creating your Story.</string>
     <string name="media_empty_list">You don\'t have any media</string>
     <string name="media_empty_search_list">No media matching your search</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
@@ -2505,7 +2504,6 @@
     <string name="my_site_bottom_sheet_title">Add new</string>
     <string name="my_site_bottom_sheet_add_post">Blog post</string>
     <string name="my_site_bottom_sheet_add_page">Site page</string>
-    <string name="my_site_bottom_sheet_add_story">Story post</string>
     <string name="my_site_quick_actions_title">Quick Links</string>
     <string name="my_site_bottom_sheet_add_post_from_audio">Post from audio</string>
 
@@ -3616,7 +3614,6 @@
 
     <string name="create_post_fab_tooltip">Create a post</string>
     <string name="create_page_fab_tooltip">Create a page</string>
-    <string name="create_post_story_fab_tooltip">Create a post or story</string>
 
     <!-- Site Creation -->
     <string name="new_site_creation_screen_title_general">Create Site</string>
@@ -3752,7 +3749,6 @@
     <string name="prepublishing_nudges_toolbar_title_publish">Publish Date</string>
     <string name="prepublishing_tags_description">Tags help tell readers what a post is about</string>
     <string name="prepublishing_nudges_home_tags_not_set">Not set</string>
-    <string name="prepublishing_nudges_story_title_hint">Give your story a title</string>
     <string name="prepublishing_nudges_home_categories_not_set">Not set</string>
     <string name="prepublishing_nudges_toolbar_title_categories">Categories</string>
     <string name="prepublishing_nudges_toolbar_title_add_categories">Add New Category</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModelTest.kt
@@ -685,23 +685,6 @@ class MediaPickerViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `camera FAB is not shown in stories when selected items`() = test {
-        whenever(resourceProvider.getString(R.string.cab_selected)).thenReturn("%d selected")
-        setupViewModel(listOf(firstItem), buildMediaPickerSetup(true, setOf(IMAGE, VIDEO)))
-
-        selectItem(0)
-
-        assertStoriesFabIsHidden()
-    }
-
-    @Test
-    fun `camera FAB is not shown when no stories`() = test {
-        setupViewModel(listOf(firstItem), buildMediaPickerSetup(true, setOf(IMAGE, VIDEO), HIDDEN))
-
-        assertStoriesFabIsHidden()
-    }
-
-    @Test
     fun `empty state is emitted when no items in picker`() = test {
         setupViewModel(null, singleSelectMediaPickerSetup, numberOfStates = 1)
 
@@ -1012,12 +995,6 @@ class MediaPickerViewModelTest : BaseUnitTest() {
         defaultSearchView = false,
         title = R.string.wp_media_title
     )
-
-    private fun assertStoriesFabIsHidden() {
-        uiStates.last().fabUiModel.let { model ->
-            assertThat(model.show).isEqualTo(false)
-        }
-    }
 
     private fun assertPartialMediaAccessUi(isVisible: Boolean = false) {
         uiStates.last().isPartialMediaAccessPromptVisible.let {

--- a/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/viewmodel/main/WPMainActivityViewModelTest.kt
@@ -382,17 +382,6 @@ class WPMainActivityViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `new post action is triggered from FAB when no full access to content if stories unavailable`() {
-        startViewModelWithDefaultParameters()
-        viewModel.onFabClicked(
-            site = initSite(hasFullAccessToContent = false, isWpcomOrJpSite = false),
-            page = PageType.MY_SITE
-        )
-        assertThat(viewModel.isBottomSheetShowing.value).isNull()
-        assertThat(viewModel.createAction.value).isEqualTo(CREATE_NEW_POST)
-    }
-
-    @Test
     fun `bottom sheet is visualized when user has full access to content and has 2 options`() {
         whenever(mainCreateSheetHelper.canCreatePage(any(), any())).thenReturn(false)
         startViewModelWithDefaultParameters()

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -149,10 +149,8 @@
     <ID>NestedBlockDepth:AllTimeWidgetBlockListViewModel.kt$AllTimeWidgetBlockListViewModel$override fun onDataSetChanged(context: Context)</ID>
     <ID>NestedBlockDepth:AllTimeWidgetListViewModel.kt$AllTimeWidgetListViewModel$fun onDataSetChanged(onError: (appWidgetId: Int) -> Unit)</ID>
     <ID>NestedBlockDepth:CreatePageListItemActionsUseCase.kt$CreatePageListItemActionsUseCase$fun setupPageActions( listType: PageListType, uploadUiState: PostUploadUiState, siteModel: SiteModel, remoteId: Long ): Set&lt;Action></ID>
-    <ID>NestedBlockDepth:LoadStoryFromStoriesPrefsUseCase.kt$LoadStoryFromStoriesPrefsUseCase$private fun loadOrReCreateStoryFromStoriesPrefs(site: SiteModel, mediaIds: ArrayList&lt;String>): ReCreateStoryResult</ID>
     <ID>NestedBlockDepth:PublicizeErrorDialogFragment.kt$PublicizeErrorDialogFragment$override fun onCreateDialog(savedInstanceState: Bundle?): Dialog</ID>
     <ID>NestedBlockDepth:PublishNotificationReceiverViewModel.kt$PublishNotificationReceiverViewModel$fun loadNotification(notificationId: Int): NotificationUiModel?</ID>
-    <ID>NestedBlockDepth:StoriesPrefs.kt$StoriesPrefs$private fun checkSlideOriginalBackgroundMediaExists(storyFrameItem: StoryFrameItem?): Boolean</ID>
     <ID>NestedBlockDepth:StoryComposerActivity.kt$StoryComposerActivity$override fun onStorySaveButtonPressed()</ID>
     <ID>NestedBlockDepth:StoryComposerActivity.kt$StoryComposerActivity$private fun buildStoryMediaFileDataListFromStoryFrameIndexes( storyIndex: StoryIndex ): ArrayList&lt;StoryMediaFileData></ID>
     <ID>NestedBlockDepth:TodayWidgetBlockListViewModel.kt$TodayWidgetBlockListViewModel$override fun onDataSetChanged(context: Context)</ID>
@@ -168,7 +166,6 @@
     <ID>ReturnCount:FeaturedImageHelper.kt$FeaturedImageHelper$fun queueFeaturedImageForUpload( localPostId: Int, site: SiteModel, uri: Uri, mimeType: String? ): EnqueueFeaturedImageResult</ID>
     <ID>ReturnCount:FollowedBlogsProvider.kt$FollowedBlogsProvider$fun getAllFollowedBlogs(query: String?): List&lt;PreferenceModel></ID>
     <ID>ReturnCount:ImageManager.kt$ImageManager$ private fun Context?.isAvailable(): Boolean</ID>
-    <ID>ReturnCount:LoadStoryFromStoriesPrefsUseCase.kt$LoadStoryFromStoriesPrefsUseCase$fun areAllStorySlidesEditable(site: SiteModel, mediaIds: ArrayList&lt;String>): Boolean</ID>
     <ID>ReturnCount:MediaPickerAdapterDiffCallback.kt$MediaPickerAdapterDiffCallback$override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any?</ID>
     <ID>ReturnCount:PageListViewModel.kt$PageListViewModel$private fun getFeaturedImageUrl(featuredImageId: Long): String?</ID>
     <ID>ReturnCount:PageParentFragment.kt$PageParentFragment$override fun onOptionsItemSelected(item: MenuItem): Boolean</ID>
@@ -181,9 +178,6 @@
     <ID>ReturnCount:PublishNotificationReceiverViewModel.kt$PublishNotificationReceiverViewModel$fun loadNotification(notificationId: Int): NotificationUiModel?</ID>
     <ID>ReturnCount:ReaderSiteNotificationsUseCase.kt$ReaderSiteNotificationsUseCase$suspend fun toggleNotification( blogId: Long, feedId: Long ): SiteNotificationState</ID>
     <ID>ReturnCount:RemotePreviewLogicHelper.kt$RemotePreviewLogicHelper$fun runPostPreviewLogic( activity: Activity, site: SiteModel, post: PostImmutableModel, helperFunctions: RemotePreviewHelperFunctions ): PreviewLogicOperationResult</ID>
-    <ID>ReturnCount:StoriesMediaPickerResultHandler.kt$StoriesMediaPickerResultHandler$@Deprecated("Use rather the other handle method and the live data navigation.") fun handleMediaPickerResultForStories( data: Intent, activity: Activity?, selectedSite: SiteModel?, source: PagePostCreationSourcesDetail ): Boolean</ID>
-    <ID>ReturnCount:StoriesMediaPickerResultHandler.kt$StoriesMediaPickerResultHandler$private fun buildNavigationAction( data: Intent, selectedSite: SiteModel, source: PagePostCreationSourcesDetail ): SiteNavigationAction?</ID>
-    <ID>ReturnCount:StoriesPrefs.kt$StoriesPrefs$private fun checkSlideOriginalBackgroundMediaExists(storyFrameItem: StoryFrameItem?): Boolean</ID>
     <ID>ReturnCount:UploadActionUseCase.kt$UploadActionUseCase$fun getAutoUploadAction(post: PostImmutableModel, site: SiteModel): UploadAction</ID>
     <ID>ReturnCount:WPEditTextWithChipsOutlined.kt$WPEditTextWithChipsOutlined$private fun endsWithDelimiter(string: String): Boolean</ID>
     <ID>ReturnCount:WPEditTextWithChipsOutlined.kt$WPEditTextWithChipsOutlined$private fun removeDelimiterFromItemIfPresent(item: String?): String?</ID>

--- a/config/gradle/included_builds.gradle
+++ b/config/gradle/included_builds.gradle
@@ -56,17 +56,6 @@ if (localBuilds.exists()) {
         }
     }
 
-    if (ext.has("localStoriesAndroidPath")) {
-        includeBuild(ext.localStoriesAndroidPath) {
-            dependencySubstitution {
-                println "Substituting stories-android with the local build"
-                substitute module("$gradle.ext.storiesAndroidPath") using project(':stories')
-                substitute module("$gradle.ext.storiesAndroidMp4ComposePath") using project(':mp4compose')
-                substitute module("$gradle.ext.storiesAndroidPhotoEditorPath") using project(':photoeditor')
-            }
-        }
-    }
-
     if (ext.has("localAztecAndroidPath")) {
         includeBuild(ext.localAztecAndroidPath) {
             dependencySubstitution {

--- a/docs/test_instructions_per_dependency_update.md
+++ b/docs/test_instructions_per_dependency_update.md
@@ -412,7 +412,7 @@ Step.3:
     <summary>1. In app reviews</summary>
 
 - Perform a clean install.
-- Publish three (`AppReviewManager.TARGET_COUNT_POST_PUBLISHED + 1`) new posts or stories.
+- Publish three (`AppReviewManager.TARGET_COUNT_POST_PUBLISHED + 1`) new posts.
 - Verify that there are no crashes.
 
 </details>


### PR DESCRIPTION
Partially Closes: [AINFRA-898](https://linear.app/a8c/issue/AINFRA-898)
Related: [SA#746](https://github.com/Automattic/stories-android/pull/746)

## Description

<!-- Describe the changes, why they are needed, and how they address the issue -->

This change completely removes `stories-android` from the codebase.

PS: Obviously there could be still lots of 'story' related references within the codebase that could be removed, but this change at least deals with all 'stories' related references and (hopefully) removes them all.

---

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

1. Verify that all the CI checks are successful.
2. (Optional) Smoke test both apps, Jetpack and WordPress, with/without composite builds, and verify everything is working as expected.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->