### PR TITLE
Fix: Login Analitycs Tracker failing because of the lack of initialisation in an Application Password case

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/LoginSiteApplicationPasswordFragment.kt
@@ -87,6 +87,8 @@ class LoginSiteApplicationPasswordFragment : LoginBaseFormFragment<LoginListener
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        mAnalyticsListener.trackUrlFormViewed()
+
         requireActivity().setTitle(R.string.site_address_login_title)
         this.siteAddressInput = view.findViewById(R.id.login_site_address_row)
         siteAddressInput?.addTextChangedListener(this)


### PR DESCRIPTION
## Description
This PR is fixing an error with the flow initialization inside `LoginAnalyticsTracker` when using Application Password inside MySites selection screen. The bug was causing the app to crash in build varient (to warn the developers), but prod users are nto affected. We are just missing that event, but fortunately is not used yet.

To properly track the login steps we need to initialise the track flow, but we were missing it. Other parts should not be affected.

We are initialising the flow in the same way it is done for its homonym for XML-RPC

PR were the bug was discovered: https://github.com/wordpress-mobile/WordPress-Android/pull/22001#issuecomment-3053644616

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

1. Log into a regular site
2. Enable Application Password feature
3. Go to MySites selection screem
4. Add a new self-hosted site
- [x] Verify you can add it correctly


https://github.com/user-attachments/assets/1c4914b5-2b04-488f-b81d-2601130af1ca



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->