### PR TITLE
Drop user filter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -209,7 +209,6 @@ public class PeopleListFragment extends Fragment {
                         mFilteredRecyclerView.setToolbarScrollFlags(0);
                         return "";
                     case GENERIC_ERROR:
-                    case PERMISSION_ERROR:
                         switch (mPeopleListFilter) {
                             case TEAM:
                                 return getString(R.string.error_fetch_users_list);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -58,7 +58,7 @@ import javax.inject.Inject;
 
 /**
  * Note that this fragment relies on [FilteredRecyclerView] but in July 2025 we
- * hide the filter in the XML layout because it's no longer needed due to the
+ * hid the filter in the XML layout because it's no longer needed due to the
  * separate "Subscribers" feature. At some point we'll likely want to remove
  * all the filtering logic from this fragment but for now it's kept intact.
  */

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -41,7 +41,6 @@ import org.wordpress.android.ui.ActionableEmptyView;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.WPAvatarUtils;
@@ -57,6 +56,12 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+/**
+ * Note that this fragment relies on [FilteredRecyclerView] but in July 2025 we
+ * hide the filter in the XML layout because it's no longer needed due to the
+ * separate "Subscribers" feature. At some point we'll likely want to remove
+ * all the filtering logic from this fragment but for now it's kept intact.
+ */
 public class PeopleListFragment extends Fragment {
     private SiteModel mSite;
     private OnPersonSelectedListener mOnPersonSelectedListener;
@@ -156,14 +161,7 @@ public class PeopleListFragment extends Fragment {
 
             @Override
             public FilterCriteria onRecallSelection() {
-                mPeopleListFilter = AppPrefs.getPeopleListFilter();
-
-                // if viewers is not available for this blog, set the filter to TEAM
-                if (mPeopleListFilter == PeopleListFilter.VIEWERS && !isPrivate) {
-                    mPeopleListFilter = PeopleListFilter.TEAM;
-                    AppPrefs.setPeopleListFilter(mPeopleListFilter);
-                }
-                return mPeopleListFilter;
+                return PeopleListFilter.TEAM;
             }
 
             @Override
@@ -175,7 +173,6 @@ public class PeopleListFragment extends Fragment {
             public void onFilterSelected(int position, FilterCriteria criteria) {
                 AnalyticsTracker.track(Stat.PEOPLE_MANAGEMENT_FILTER_CHANGED);
                 mPeopleListFilter = (PeopleListFilter) criteria;
-                AppPrefs.setPeopleListFilter(mPeopleListFilter);
             }
 
             @Override
@@ -211,6 +208,7 @@ public class PeopleListFragment extends Fragment {
                         mFilteredRecyclerView.setToolbarScrollFlags(0);
                         return "";
                     case GENERIC_ERROR:
+                    case PERMISSION_ERROR:
                         switch (mPeopleListFilter) {
                             case TEAM:
                                 return getString(R.string.error_fetch_users_list);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -101,6 +101,7 @@ public class PeopleListFragment extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mPeopleListFilter = PeopleListFilter.TEAM;
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -17,7 +17,6 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.JetpackCapability;
 import org.wordpress.android.fluxc.store.QuickStartStore.QuickStartTask;
-import org.wordpress.android.models.PeopleListFilter;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
@@ -89,9 +88,6 @@ public class AppPrefs {
 
         // index of the last active item in Stats activity
         STATS_ITEM_INDEX,
-
-        // index of the last active people list filter in People Management activity
-        PEOPLE_LIST_FILTER_INDEX,
 
         // selected site in the main activity
         SELECTED_SITE_LOCAL_ID,
@@ -495,26 +491,6 @@ public class AppPrefs {
 
     public static void setReaderSubsPageTitle(String pageTitle) {
         setString(DeletablePrefKey.READER_SUBS_PAGE_TITLE, pageTitle);
-    }
-
-    public static PeopleListFilter getPeopleListFilter() {
-        int idx = getInt(DeletablePrefKey.PEOPLE_LIST_FILTER_INDEX);
-        PeopleListFilter[] values = PeopleListFilter.values();
-        if (values.length < idx) {
-            return values[0];
-        } else {
-            return values[idx];
-        }
-    }
-
-    public static void setPeopleListFilter(PeopleListFilter peopleListFilter) {
-        if (peopleListFilter != null) {
-            setInt(DeletablePrefKey.PEOPLE_LIST_FILTER_INDEX, peopleListFilter.ordinal());
-        } else {
-            prefs().edit()
-                   .remove(DeletablePrefKey.PEOPLE_LIST_FILTER_INDEX.name())
-                   .apply();
-        }
     }
 
     // Store the version code of the app. Used to check it the app was upgraded.

--- a/WordPress/src/main/res/layout/people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/people_list_fragment.xml
@@ -39,7 +39,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            android:scrollbars="vertical" />
+            android:scrollbars="vertical"
+            app:wpHideAppBarLayout="true" />
 
         <ProgressBar
             android:id="@+id/progress_footer"


### PR DESCRIPTION
To [match iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/24513), this PR hides the filter from the users (people) screen and always shows `TEAM` users.

Note this screen relies on `FilteredRecyclerView` which requires logic related to filtering. I've left this intact for now because rewriting this screen to use a regular `RecyclerView` would require a significant rewrite, and I didn't think we'd want to delay the "Subscribers" feature in order to do that.

To test, go to the users screen and verify that there's no filter at the top left.

<img width="392" height="829" alt="users" src="https://github.com/user-attachments/assets/01d8e89b-d60c-4683-b29e-af648528c11f" />
