### PR TITLE
Make subscribers feature flag available to all

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -719,13 +719,8 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentBlogSubscribers(@NonNull Context context) {
-        // for now we only show the subscribers screen for debug users since it's very much a WIP
-        if (BuildConfig.DEBUG) {
-            Intent intent = new Intent(context, SubscribersActivity.class);
-            context.startActivity(intent);
-        } else {
-            ToastUtils.showToast(context, R.string.coming_soon, ToastUtils.Duration.LONG);
-        }
+        Intent intent = new Intent(context, SubscribersActivity.class);
+        context.startActivity(intent);
     }
 
     public static void viewCurrentBlogPeople(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import org.wordpress.android.BuildConfig
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -44,10 +43,7 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     private fun shouldShowFeature(feature: Feature): Boolean {
-        // only show subscribers in debug builds
-        return if (BuildConfig.DEBUG.not() && feature == Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
-            false
-        } else if (gutenbergKitFeature.isEnabled()) {
+        return if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR
         } else {
             feature != Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -974,7 +974,7 @@
     <string name="experimental_features_feedback_dialog_message">Are you willing to share feedback on the experimental editor?</string>
     <string name="experimental_features_feedback_dialog_decline">Not now</string>
     <string name="experimental_subscribers_feature">Experimental subscribers</string>
-    <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers (work in progress)</string>
+    <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
     <string name="experimental_application_password_feature">Application Password log in</string>
     <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites.</string>
 


### PR DESCRIPTION
During development, the subscribers experimental feature flag was only available in debug builds. Although there's still some work left for subscribers, we're far enough along that we can enable the experimental feature flag for all users.

To test, run a release build and verify that the subscribers feature flag is visible and the subscribers feature works as expected.