### PR TITLE
Hide the user filter if the subscribers experimental feature is enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -467,6 +467,10 @@ public class FilteredRecyclerView extends RelativeLayout {
         mSearchSuggestionsRecyclerView.setAdapter(searchSuggestionAdapter);
     }
 
+    public void hideAppBarLayout() {
+        mAppBarLayout.setVisibility(GONE);
+    }
+
     public void showAppBarLayout() {
         mAppBarLayout.setVisibility(VISIBLE);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -42,6 +42,8 @@ import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.mysite.jetpackbadge.JetpackPoweredBottomSheetFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures;
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature;
 import org.wordpress.android.ui.utils.UiHelpers;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.WPAvatarUtils;
@@ -69,6 +71,7 @@ public class PeopleListFragment extends Fragment {
     @Inject ImageManager mImageManager;
     @Inject JetpackBrandingUtils mJetpackBrandingUtils;
     @Inject UiHelpers mUiHelpers;
+    @Inject ExperimentalFeatures mExperimentalFeatures;
 
     public static PeopleListFragment newInstance(SiteModel site) {
         PeopleListFragment peopleListFragment = new PeopleListFragment();
@@ -135,6 +138,13 @@ public class PeopleListFragment extends Fragment {
         mFilteredRecyclerView.setToolbarLeftAndRightPadding(
                 getResources().getDimensionPixelSize(R.dimen.margin_filter_spinner),
                 getResources().getDimensionPixelSize(R.dimen.margin_none));
+
+        // if the subscribers feature is enabled, hide the filter spinner and set the default filter
+        if (mExperimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)) {
+            mFilteredRecyclerView.hideAppBarLayout();
+            mPeopleListFilter = PeopleListFilter.TEAM;
+            AppPrefs.setPeopleListFilter(mPeopleListFilter);
+        }
 
         mFilteredRecyclerView.setFilterListener(new FilteredRecyclerView.FilterListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -139,7 +139,8 @@ public class PeopleListFragment extends Fragment {
                 getResources().getDimensionPixelSize(R.dimen.margin_filter_spinner),
                 getResources().getDimensionPixelSize(R.dimen.margin_none));
 
-        // if the subscribers feature is enabled, hide the filter spinner and set the default filter
+        // If the subscribers feature flag is enabled, hide the filter spinner and set the default filter.
+        // Once the subscribers feature is released to everyone, we can remove the filter entirely.
         if (mExperimentalFeatures.isEnabled(Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE)) {
             mFilteredRecyclerView.hideAppBarLayout();
             mPeopleListFilter = PeopleListFilter.TEAM;


### PR DESCRIPTION
One of the tasks of the subscriber feature is to remove the filter at the top of the Users screen, as was done [on iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/24513). In this PR, the filter is hidden when the experimental subscribers feature is enabled. Once we remove the feature flag, we can remove the filter entirely.

**To test:**
- Disable the subscribers experimental feature
- Verify that the filter on the Users screen is available:
<img width="392" height="193" alt="userfilter" src="https://github.com/user-attachments/assets/0662bb2f-7512-4fb5-a496-0284046332bb" />

- Enable the subscribers experimental feature
- Verify the filter on the Users screen no longer appears

<img width="392" height="140" alt="users" src="https://github.com/user-attachments/assets/c6469152-1bc9-4fa6-8582-53b3f4f01f3f" />



