### PR TITLE
Save subscriber sort by, sort order, and filter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -1,5 +1,8 @@
 package org.wordpress.android.ui.dataview
 
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -8,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.withContext
+import org.wordpress.android.WordPress.Companion.getContext
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.IO_THREAD
@@ -72,6 +76,10 @@ open class DataViewViewModel @Inject constructor(
     private var page = INITIAL_PAGE
     private var canLoadMore = true
 
+    private fun prefs(): SharedPreferences {
+        return PreferenceManager.getDefaultSharedPreferences(getContext())
+    }
+
     // TODO this is strictly for wp.com sites, we'll need different auth for self-hosted
     val wpComApiClient: WpComApiClient by lazy {
         WpComApiClient(
@@ -84,8 +92,7 @@ open class DataViewViewModel @Inject constructor(
     init {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag init")
         launch {
-            _itemSortBy.value = getDefaultSort()
-
+            restorePrefs()
             fetchData()
 
             debouncedQuery
@@ -102,6 +109,27 @@ open class DataViewViewModel @Inject constructor(
 
     fun siteId(): Long {
         return selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
+    }
+
+    private fun restorePrefs() {
+        val prefs = prefs()
+
+        val sortOrdinal = prefs.getInt(getPrefKeyName(PrefKey.SORT_ORDER), -1)
+        if (sortOrdinal > -1) {
+            _sortOrder.value = WpApiParamOrder.entries.toTypedArray()[sortOrdinal]
+        }
+
+        val sortById = prefs.getLong(getPrefKeyName(PrefKey.SORT_BY), -1)
+        if (sortById > -1) {
+            _itemSortBy.value = getSupportedSorts().firstOrNull { it.id == sortById }
+        } else {
+            _itemSortBy.value = getDefaultSort()
+        }
+
+        val filterId = prefs.getLong(getPrefKeyName(PrefKey.FILTER), -1)
+        if (filterId > -1) {
+            _itemFilter.value = getSupportedFilters().firstOrNull { it.id == filterId }
+        }
     }
 
     private fun fetchData(isRefreshing: Boolean = false) {
@@ -176,18 +204,26 @@ open class DataViewViewModel @Inject constructor(
     fun onFilterClick(filter: DataViewDropdownItem?) {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag onFilterClick: $filter")
         resetPaging()
+        val keyName = getPrefKeyName(PrefKey.FILTER)
         // clear the filter if it's already selected
-        _itemFilter.value = if (filter == _itemFilter.value) {
-            null
+        if (filter == _itemFilter.value || filter == null) {
+            _itemFilter.value = null
+            prefs().edit { remove(keyName) }
         } else {
-            filter
+            _itemFilter.value = filter
+            prefs().edit { putLong(keyName, filter.id) }
         }
         fetchData()
+    }
+
+    private fun getPrefKeyName(prefKey: PrefKey) : String {
+        return "${logTag}_${prefKey.name}"
     }
 
     fun onSortClick(sort: DataViewDropdownItem) {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag onSortClick: $sort")
         if (sort != _itemSortBy.value) {
+            prefs().edit { putLong(getPrefKeyName(PrefKey.SORT_BY), sort.id) }
             _itemSortBy.value = sort
             resetPaging()
             fetchData()
@@ -197,6 +233,7 @@ open class DataViewViewModel @Inject constructor(
     fun onSortOrderClick(order: WpApiParamOrder) {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag onSortOrderClick: $order")
         if (order != _sortOrder.value) {
+            prefs().edit { putInt(getPrefKeyName(PrefKey.SORT_ORDER), order.ordinal) }
             _sortOrder.value = order
             resetPaging()
             fetchData()
@@ -272,6 +309,12 @@ open class DataViewViewModel @Inject constructor(
 
     private val logTag
         get() = this::class.java.simpleName
+
+    private enum class PrefKey {
+        SORT_ORDER,
+        SORT_BY,
+        FILTER,
+    }
 
     companion object {
         private const val SEARCH_DELAY_MS = 500L

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -111,6 +111,9 @@ open class DataViewViewModel @Inject constructor(
         return selectedSiteRepository.getSelectedSite()?.siteId ?: 0L
     }
 
+    /**
+     * Restores the sort order, sort by, and filter from saved preferences
+     */
     private fun restorePrefs() {
         val prefs = prefs()
 
@@ -216,6 +219,10 @@ open class DataViewViewModel @Inject constructor(
         fetchData()
     }
 
+    /**
+     * Returns the name of the preference key for the given [prefKey]. This relies on
+     * the [logTag] so descendants will have unique names for each key.
+     */
     private fun getPrefKeyName(prefKey: PrefKey) : String {
         return "${logTag}_${prefKey.name}"
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -75,10 +75,6 @@ open class DataViewViewModel @Inject constructor(
     private var page = INITIAL_PAGE
     private var canLoadMore = true
 
-    private fun prefs(): SharedPreferences {
-        return sharedPrefs
-    }
-
     // TODO this is strictly for wp.com sites, we'll need different auth for self-hosted
     val wpComApiClient: WpComApiClient by lazy {
         WpComApiClient(
@@ -114,23 +110,21 @@ open class DataViewViewModel @Inject constructor(
      * Restores the sort order, sort by, and filter from saved preferences
      */
     private fun restorePrefs() {
-        val prefs = prefs()
-
-        val sortOrdinal = prefs.getInt(getPrefKeyName(PrefKey.SORT_ORDER), -1)
+        val sortOrdinal = sharedPrefs.getInt(getPrefKeyName(PrefKey.SORT_ORDER), -1)
         if (sortOrdinal > -1) {
             WpApiParamOrder.entries.toTypedArray().getOrNull(sortOrdinal)?.let {
                 _sortOrder.value = it
             }
         }
 
-        val sortById = prefs.getLong(getPrefKeyName(PrefKey.SORT_BY), -1)
+        val sortById = sharedPrefs.getLong(getPrefKeyName(PrefKey.SORT_BY), -1)
         if (sortById > -1) {
             _itemSortBy.value = getSupportedSorts().firstOrNull { it.id == sortById }
         } else {
             _itemSortBy.value = getDefaultSort()
         }
 
-        val filterId = prefs.getLong(getPrefKeyName(PrefKey.FILTER), -1)
+        val filterId = sharedPrefs.getLong(getPrefKeyName(PrefKey.FILTER), -1)
         if (filterId > -1) {
             _itemFilter.value = getSupportedFilters().firstOrNull { it.id == filterId }
         }
@@ -212,10 +206,10 @@ open class DataViewViewModel @Inject constructor(
         // clear the filter if it's already selected
         if (filter == _itemFilter.value || filter == null) {
             _itemFilter.value = null
-            prefs().edit { remove(keyName) }
+            sharedPrefs.edit { remove(keyName) }
         } else {
             _itemFilter.value = filter
-            prefs().edit { putLong(keyName, filter.id) }
+            sharedPrefs.edit { putLong(keyName, filter.id) }
         }
         fetchData()
     }
@@ -231,7 +225,7 @@ open class DataViewViewModel @Inject constructor(
     fun onSortClick(sort: DataViewDropdownItem) {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag onSortClick: $sort")
         if (sort != _itemSortBy.value) {
-            prefs().edit { putLong(getPrefKeyName(PrefKey.SORT_BY), sort.id) }
+            sharedPrefs.edit { putLong(getPrefKeyName(PrefKey.SORT_BY), sort.id) }
             _itemSortBy.value = sort
             resetPaging()
             fetchData()
@@ -241,7 +235,7 @@ open class DataViewViewModel @Inject constructor(
     fun onSortOrderClick(order: WpApiParamOrder) {
         appLogWrapper.d(AppLog.T.MAIN, "$logTag onSortOrderClick: $order")
         if (order != _sortOrder.value) {
-            prefs().edit { putInt(getPrefKeyName(PrefKey.SORT_ORDER), order.ordinal) }
+            sharedPrefs.edit { putInt(getPrefKeyName(PrefKey.SORT_ORDER), order.ordinal) }
             _sortOrder.value = order
             resetPaging()
             fetchData()

--- a/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/dataview/DataViewViewModel.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.dataview
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -11,7 +10,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.withContext
-import org.wordpress.android.WordPress.Companion.getContext
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.modules.IO_THREAD
@@ -36,6 +34,7 @@ import javax.inject.Named
 open class DataViewViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     private val appLogWrapper: AppLogWrapper,
+    private val sharedPrefs: SharedPreferences,
 ) : ScopedViewModel(mainDispatcher) {
     @Inject
     lateinit var networkUtilsWrapper: NetworkUtilsWrapper
@@ -77,7 +76,7 @@ open class DataViewViewModel @Inject constructor(
     private var canLoadMore = true
 
     private fun prefs(): SharedPreferences {
-        return PreferenceManager.getDefaultSharedPreferences(getContext())
+        return sharedPrefs
     }
 
     // TODO this is strictly for wp.com sites, we'll need different auth for self-hosted
@@ -119,7 +118,9 @@ open class DataViewViewModel @Inject constructor(
 
         val sortOrdinal = prefs.getInt(getPrefKeyName(PrefKey.SORT_ORDER), -1)
         if (sortOrdinal > -1) {
-            _sortOrder.value = WpApiParamOrder.entries.toTypedArray()[sortOrdinal]
+            WpApiParamOrder.entries.toTypedArray().getOrNull(sortOrdinal)?.let {
+                _sortOrder.value = it
+            }
         }
 
         val sortById = prefs.getLong(getPrefKeyName(PrefKey.SORT_BY), -1)

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -34,7 +34,7 @@ class SubscribersViewModel @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
 ) : DataViewViewModel(
     mainDispatcher = mainDispatcher,
-    appLogWrapper = appLogWrapper
+    appLogWrapper = appLogWrapper,
 ) {
     private val _subscriberStats = MutableStateFlow<IndividualSubscriberStats?>(null)
     val subscriberStats = _subscriberStats.asStateFlow()

--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.subscribers
 
+import android.content.SharedPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -32,9 +33,11 @@ import javax.inject.Named
 class SubscribersViewModel @Inject constructor(
     @Named(UI_THREAD) private val mainDispatcher: CoroutineDispatcher,
     private val appLogWrapper: AppLogWrapper,
+    sharedPrefs: SharedPreferences,
 ) : DataViewViewModel(
     mainDispatcher = mainDispatcher,
     appLogWrapper = appLogWrapper,
+    sharedPrefs = sharedPrefs
 ) {
     private val _subscriberStats = MutableStateFlow<IndividualSubscriberStats?>(null)
     val subscriberStats = _subscriberStats.asStateFlow()


### PR DESCRIPTION
This PR updates the subscribers feature so the sort by, sort order, and filter are stored in shared preferences and restored when the view model is initialized.

To test, verify that those three items are retained between sessions.