### PR TITLE
Fix: proper Application Password authentication scheme for Wordpress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/UnifiedLoginTracker.kt
@@ -133,7 +133,8 @@ class UnifiedLoginTracker
         LOGIN_PASSWORD("login_password"),
         LOGIN_SITE_ADDRESS("login_site_address"),
         SIGNUP("signup"),
-        GOOGLE_SIGNUP("google_signup")
+        GOOGLE_SIGNUP("google_signup"),
+        APPLICATION_PASSWORD("application_password")
     }
 
     enum class Step(val value: String) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.wordpress.android.R
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.accounts.UnifiedLoginTracker
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.util.ToastUtils
@@ -24,6 +25,9 @@ import javax.inject.Inject
 class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    @Inject
+    lateinit var unifiedLoginTracker: UnifiedLoginTracker
 
     private var viewModel: ApplicationPasswordLoginViewModel? = null
 
@@ -69,8 +73,10 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
         if (navigationActionData.isError) {
             ActivityLauncher.showMainActivity(this)
         } else if (navigationActionData.showSiteSelector) {
+            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.name)
             ActivityLauncher.showMainActivityAndLoginEpilogue(this, navigationActionData.oldSitesIDs, false)
         } else if (navigationActionData.showPostSignupInterstitial) {
+            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.name)
             ActivityLauncher.showPostSignupInterstitial(this)
         } else {
             val mainActivityIntent = Intent(this, WPMainActivity::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginActivity.kt
@@ -73,10 +73,10 @@ class ApplicationPasswordLoginActivity: BaseAppCompatActivity() {
         if (navigationActionData.isError) {
             ActivityLauncher.showMainActivity(this)
         } else if (navigationActionData.showSiteSelector) {
-            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.name)
+            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.value)
             ActivityLauncher.showMainActivityAndLoginEpilogue(this, navigationActionData.oldSitesIDs, false)
         } else if (navigationActionData.showPostSignupInterstitial) {
-            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.name)
+            unifiedLoginTracker.setFlow(UnifiedLoginTracker.Flow.APPLICATION_PASSWORD.value)
             ActivityLauncher.showPostSignupInterstitial(this)
         } else {
             val mainActivityIntent = Intent(this, WPMainActivity::class.java)

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts.applicationpassword
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -145,12 +144,10 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
-        Log.d("CHANGE_TAG", "Receiving onsite changed event")
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
             if (site == null) {
-                Log.d("CHANGE_TAG", "Receiving onsite changed event error")
                 appLogWrapper.e(AppLog.T.MAIN, "Site not found for URL: ${currentUrlLogin?.siteUrl}")
                 _onFinishedEvent.emit(
                     NavigationActionData(
@@ -162,7 +159,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                     )
                 )
             } else {
-                Log.d("CHANGE_TAG", "Open sites: ${siteStore.hasSite() && oldSitesIDs?.contains(site.id) == false}")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = siteStore.hasSite() && oldSitesIDs?.contains(site.id) == false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -14,7 +14,6 @@ import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
-import org.wordpress.android.fluxc.store.SiteStore.OnProfileFetched
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.login.util.SiteUtils

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -161,7 +161,8 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             } else {
                 _onFinishedEvent.emit(
                     NavigationActionData(
-                        showSiteSelector = siteStore.hasSite() && oldSitesIDs?.contains(site.id) == false,
+                        showSiteSelector = siteStore.hasSite() &&
+                                oldSitesIDs?.contains(site.id) != true, // null or false
                         showPostSignupInterstitial = !siteStore.hasSite()
                                 && appPrefsWrapper.shouldShowPostSignupInterstitial,
                         siteUrl = currentUrlLogin?.siteUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts.applicationpassword
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -80,17 +81,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             // Store credentials if the site already exists
             val credentialsStored = storeCredentials(urlLogin)
             // If the site already exists, we can skip fetching it again
-            if (credentialsStored) {
-                _onFinishedEvent.emit(
-                    NavigationActionData(
-                        showSiteSelector = false,
-                        showPostSignupInterstitial = false,
-                        siteUrl = urlLogin.siteUrl,
-                        oldSitesIDs = oldSitesIDs,
-                        isError = false
-                    )
-                )
-            } else {
+            if (!credentialsStored) {
                 fetchSites(
                     urlLogin.user.orEmpty(),
                     urlLogin.password.orEmpty(),
@@ -155,11 +146,13 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
-        val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
-        val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-        if (site == null) {
-            appLogWrapper.e(AppLog.T.MAIN, "Site not found for URL: ${currentUrlLogin?.siteUrl}")
-            viewModelScope.launch {
+        Log.d("CHANGE_TAG", "Receiving onsite changed event")
+        viewModelScope.launch {
+            val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
+            val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
+            if (site == null) {
+                Log.d("CHANGE_TAG", "Receiving onsite changed event error")
+                appLogWrapper.e(AppLog.T.MAIN, "Site not found for URL: ${currentUrlLogin?.siteUrl}")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,
@@ -169,26 +162,19 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
                         isError = true
                     )
                 )
-            }
-        } else {
-            dispatcher.dispatch(SiteActionBuilder.newFetchProfileXmlRpcAction(site))
-        }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.BACKGROUND)
-    fun onProfileFetched(event: OnProfileFetched) {
-        viewModelScope.launch {
-            _onFinishedEvent.emit(
-                NavigationActionData(
-                    showSiteSelector = siteStore.hasSite(),
-                    showPostSignupInterstitial = !siteStore.hasSite()
-                            && appPrefsWrapper.shouldShowPostSignupInterstitial,
-                    siteUrl = event.site.url,
-                    oldSitesIDs = oldSitesIDs,
-                    isError = false
+            } else {
+                Log.d("CHANGE_TAG", "Open sites: ${siteStore.hasSite() && oldSitesIDs?.contains(site.id) == false}")
+                _onFinishedEvent.emit(
+                    NavigationActionData(
+                        showSiteSelector = siteStore.hasSite() && oldSitesIDs?.contains(site.id) == false,
+                        showPostSignupInterstitial = !siteStore.hasSite()
+                                && appPrefsWrapper.shouldShowPostSignupInterstitial,
+                        siteUrl = currentUrlLogin?.siteUrl,
+                        oldSitesIDs = oldSitesIDs,
+                        isError = false
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -181,14 +181,14 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             return if (authorizationUrl.isNullOrEmpty()) {
                 authorizationUrl.orEmpty()
             } else {
-                val appName: String?
-                val successUrl: String?
+                val appName: String
+                val successUrl: String
                 if (buildConfigWrapper.isJetpackApp) {
-                    appName = "android-jetpack-client"
-                    successUrl = "jetpack://app-pass-authorize"
+                    appName = ANDROID_JETPACK_CLIENT
+                    successUrl = JETPACK_SUCCESS_URL
                 } else {
-                    appName = "android-wordpress-client"
-                    successUrl = "wordpress://app-pass-authorize"
+                    appName = ANDROID_WORDPRESS_CLIENT
+                    successUrl = WORDPRESS_SUCCESS_URL
                 }
                 authorizationUrl.toUri().buildUpon().apply {
                     appendQueryParameter("app_name", appName)
@@ -196,6 +196,13 @@ class ApplicationPasswordLoginHelper @Inject constructor(
                 }.build().toString()
             }
         }
+    }
+
+    companion object {
+        private const val ANDROID_JETPACK_CLIENT = "android-jetpack-client"
+        private const val ANDROID_WORDPRESS_CLIENT = "android-wordpress-client"
+        private const val JETPACK_SUCCESS_URL = "jetpack://app-pass-authorize"
+        private const val WORDPRESS_SUCCESS_URL = "wordpress://app-pass-authorize"
     }
 
     data class UriLogin(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -164,7 +164,10 @@ class ApplicationPasswordLoginHelper @Inject constructor(
     /**
      * This class is created to wrap the Uri calls and let us unit test the login helper
      */
-    class UriLoginWrapper @Inject constructor(private val apiRootUrlCache: ApiRootUrlCache) {
+    class UriLoginWrapper @Inject constructor(
+        private val apiRootUrlCache: ApiRootUrlCache,
+        private val buildConfigWrapper: BuildConfigWrapper,
+        ) {
         fun parseUriLogin(url: String): UriLogin {
             val uri = url.toUri()
             val siteUrl = UrlUtils.normalizeUrl(uri.getQueryParameter("site_url"))
@@ -178,9 +181,18 @@ class ApplicationPasswordLoginHelper @Inject constructor(
             return if (authorizationUrl.isNullOrEmpty()) {
                 authorizationUrl.orEmpty()
             } else {
+                val appName: String?
+                val successUrl: String?
+                if (buildConfigWrapper.isJetpackApp) {
+                    appName = "android-jetpack-client"
+                    successUrl = "jetpack://app-pass-authorize"
+                } else {
+                    appName = "android-wordpress-client"
+                    successUrl = "wordpress://app-pass-authorize"
+                }
                 authorizationUrl.toUri().buildUpon().apply {
-                    appendQueryParameter("app_name", "android-jetpack-client")
-                    appendQueryParameter("success_url", "jetpack://app-pass-authorize")
+                    appendQueryParameter("app_name", appName)
+                    appendQueryParameter("success_url", successUrl)
                 }.build().toString()
             }
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -64,32 +64,6 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `given intent rawData, when setup site and able to store credentials, then emit ok`() = runTest {
-        // Given
-        val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
-            showSiteSelector = false,
-            showPostSignupInterstitial = false,
-            siteUrl = urlLogin.siteUrl,
-            oldSitesIDs = null,
-            isError = false
-        )
-        whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(true)
-
-        // When
-        viewModel.onFinishedEvent.test {
-            viewModel.setupSite(rawData)
-
-            // Then
-            val finishedEvent = awaitItem()
-            assertEquals(expectedResult, finishedEvent)
-            verify(applicationPasswordLoginHelper, times(1))
-                .storeApplicationPasswordCredentialsFrom(eq(urlLogin))
-            verify(selfHostedEndpointFinder, times(0)).verifyOrDiscoverXMLRPCEndpoint(any())
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `given empty rawData, when setup site, then emit error`() = runTest {
         // Given
         val emptyRawData = ""
@@ -209,6 +183,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with site selector`() =
         runTest {
             // Given
+            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = true,
@@ -218,6 +193,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(true)
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
@@ -226,9 +202,10 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
-                viewModel.onProfileFetched(
-                    SiteStore.OnProfileFetched(
-                        SiteModel().apply { url = urlLogin.siteUrl }
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(
+                        rowsAffected = 1,
+                        updatedSites = listOf(SiteModel())
                     )
                 )
 
@@ -244,6 +221,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no site selector nor interstitial`() =
         runTest {
             // Given
+            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = false,
@@ -253,6 +231,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(false)
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
@@ -261,9 +240,10 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
-                viewModel.onProfileFetched(
-                    SiteStore.OnProfileFetched(
-                        SiteModel().apply { url = urlLogin.siteUrl }
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(
+                        rowsAffected = 1,
+                        updatedSites = listOf(testSite)
                     )
                 )
 
@@ -279,6 +259,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no interstitial by sites`() =
         runTest {
             // Given
+            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = true,
@@ -288,6 +269,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 isError = false
             )
             whenever(siteStore.hasSite()).thenReturn(true)
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
                 .thenReturn(xmlRpcEndpoint)
@@ -296,9 +278,10 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
-                viewModel.onProfileFetched(
-                    SiteStore.OnProfileFetched(
-                        SiteModel().apply { url = urlLogin.siteUrl }
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(
+                        rowsAffected = 1,
+                        updatedSites = listOf(SiteModel())
                     )
                 )
 
@@ -314,6 +297,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no interstitial by preferences`() =
         runTest {
             // Given
+            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = false,
@@ -322,6 +306,7 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
                 oldSitesIDs = null,
                 isError = false
             )
+            whenever(siteStore.sites).thenReturn(listOf(testSite))
             whenever(appPrefsWrapper.shouldShowPostSignupInterstitial).thenReturn(false)
             whenever(applicationPasswordLoginHelper.storeApplicationPasswordCredentialsFrom(eq(urlLogin))).thenReturn(false)
             whenever(selfHostedEndpointFinder.verifyOrDiscoverXMLRPCEndpoint(urlLogin.siteUrl!!))
@@ -331,9 +316,10 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
             viewModel.onFinishedEvent.test {
                 viewModel.setupSite(rawData)
                 // Mock onSiteChanged event
-                viewModel.onProfileFetched(
-                    SiteStore.OnProfileFetched(
-                        SiteModel().apply { url = urlLogin.siteUrl }
+                viewModel.onSiteChanged(
+                    SiteStore.OnSiteChanged(
+                        rowsAffected = 1,
+                        updatedSites = listOf(testSite)
                     )
                 )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelperTest.kt
@@ -169,14 +169,14 @@ class ApplicationPasswordLoginHelperTest : BaseUnitTest() {
 
     @Test
     fun `appendParamsToRestAuthorizationUrl with null authorizationUrl returns empty string`() {
-        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache)
+        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache, buildConfigWrapper)
             .appendParamsToRestAuthorizationUrl(null)
         assertEquals("", result)
     }
 
     @Test
     fun `appendParamsToRestAuthorizationUrl with empty authorizationUrl returns empty string`() {
-        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache)
+        val result = ApplicationPasswordLoginHelper.UriLoginWrapper(apiRootUrlCache, buildConfigWrapper)
             .appendParamsToRestAuthorizationUrl("")
         assertEquals("", result)
     }


### PR DESCRIPTION
## Description
This PR is using the proper scheme for Application Password authentication when the build is Wordpress instead of Jeppack

## Testing instructions

1. Run the WordPress version
2. Log into a self-hosted site
3. Enable Authentication Password feature
4. Go to My Site screen and log in using the Application Password card
- [ ] Verify the flow works as expected

1. Run the Jetpack version
2. log into a self-hosted site
3. Enable Authentication Password feature
4. Go to My Site screen and log in using the Application Password card
- [ ] Verify the flow works as expected


https://github.com/user-attachments/assets/f49e3c43-4b35-40a7-8445-05ac7f7c0c69



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->