### PR TITLE
Fix: application password card being shown after success authentication

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -141,7 +141,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
     )
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings("unused", "ComplexCondition")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -11,7 +11,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -148,7 +147,7 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-            if (event.rowsAffected < 1 || site == null || areBadCredentials(site)) {
+            if (event.rowsAffected < 1 || site == null || applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
                 appLogWrapper.e(AppLog.T.MAIN, "Site not found or credentials are empty.")
                 _onFinishedEvent.emit(
                     NavigationActionData(
@@ -174,9 +173,6 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             }
         }
     }
-
-    private fun areBadCredentials(site: SiteModel) =
-        site.apiRestUsernamePlain.isNullOrEmpty() || site.apiRestPasswordPlain.isNullOrEmpty()
 
     data class NavigationActionData(
         val showSiteSelector: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -11,6 +11,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.discovery.SelfHostedEndpointFinder
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged
@@ -141,14 +142,13 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         )
     )
 
-    @SuppressWarnings("unused", "ComplexCondition")
+    @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     fun onSiteChanged(event: OnSiteChanged) {
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-            if (event.rowsAffected < 1 || site == null ||
-                site.apiRestUsernamePlain.isNullOrEmpty() || site.apiRestPasswordPlain.isNullOrEmpty()) {
+            if (event.rowsAffected < 1 || site == null || areBadCredentials(site)) {
                 appLogWrapper.e(AppLog.T.MAIN, "Site not found or credentials are empty.")
                 _onFinishedEvent.emit(
                     NavigationActionData(
@@ -174,6 +174,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
             }
         }
     }
+
+    private fun areBadCredentials(site: SiteModel) =
+        site.apiRestUsernamePlain.isNullOrEmpty() || site.apiRestPasswordPlain.isNullOrEmpty()
 
     data class NavigationActionData(
         val showSiteSelector: Boolean,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModel.kt
@@ -147,8 +147,9 @@ class ApplicationPasswordLoginViewModel @Inject constructor(
         viewModelScope.launch {
             val currentNormalizedUrl = UrlUtils.normalizeUrl(currentUrlLogin?.siteUrl)
             val site = siteStore.sites.firstOrNull { UrlUtils.normalizeUrl(it.url) == currentNormalizedUrl }
-            if (site == null) {
-                appLogWrapper.e(AppLog.T.MAIN, "Site not found for URL: ${currentUrlLogin?.siteUrl}")
+            if (event.rowsAffected < 1 || site == null ||
+                site.apiRestUsernamePlain.isNullOrEmpty() || site.apiRestPasswordPlain.isNullOrEmpty()) {
+                appLogWrapper.e(AppLog.T.MAIN, "Site not found or credentials are empty.")
                 _onFinishedEvent.emit(
                     NavigationActionData(
                         showSiteSelector = false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/ApplicationPasswordLoginHelper.kt
@@ -161,6 +161,9 @@ class ApplicationPasswordLoginHelper @Inject constructor(
         return siteStore.sites.count { !it.apiRestUsernameEncrypted.isNullOrEmpty() }
     }
 
+    fun siteHasBadCredentials(site: SiteModel) =
+        site.apiRestUsernamePlain.isNullOrEmpty() || site.apiRestPasswordPlain.isNullOrEmpty()
+
     /**
      * This class is created to wrap the Uri calls and let us unit test the login helper
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.mysite.MySiteCardAndItem.Card.QuickLinksItem.QuickLinkItem
@@ -21,7 +22,7 @@ import javax.inject.Inject
 
 class ApplicationPasswordViewModelSlice @Inject constructor(
     private val applicationPasswordLoginHelper: ApplicationPasswordLoginHelper,
-    private val siteSqlUtils: SiteSqlUtils,
+    private val siteStore: SiteStore,
     private val experimentalFeatures: ExperimentalFeatures,
 ) {
     lateinit var scope: CoroutineScope
@@ -68,7 +69,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
 
         scope.launch {
             // If the site is already authorized, no need to run the discovery
-            val storedSite = siteSqlUtils.getSiteWithLocalId(site.localId())
+            val storedSite = siteStore.sites.firstOrNull { it.localId() == site.localId() }
             if (storedSite != null &&
                 !storedSite.apiRestUsernameEncrypted.isNullOrEmpty() &&
                 !storedSite.apiRestPasswordEncrypted.isNullOrEmpty()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.SiteSqlUtils
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
@@ -52,10 +51,10 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
     private fun buildApplicationPasswordDiscovery(site: SiteModel) {
         scope.launch {
             // If the site is already authorized, no need to run the discovery
-            val storedSite = siteStore.sites.firstOrNull { it.localId() == site.localId() }
+            val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
             if (storedSite != null &&
-                !storedSite.apiRestUsernameEncrypted.isNullOrEmpty() &&
-                !storedSite.apiRestPasswordEncrypted.isNullOrEmpty()
+                !storedSite.apiRestUsernamePlain.isNullOrEmpty() &&
+                !storedSite.apiRestPasswordPlain.isNullOrEmpty()
                 ) {
                 uiModelMutable.postValue(null)
                 return@launch

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -52,10 +52,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
         scope.launch {
             // If the site is already authorized, no need to run the discovery
             val storedSite = siteStore.sites.firstOrNull { it.id == site.id }
-            if (storedSite != null &&
-                !storedSite.apiRestUsernamePlain.isNullOrEmpty() &&
-                !storedSite.apiRestPasswordPlain.isNullOrEmpty()
-                ) {
+            if (storedSite != null && !applicationPasswordLoginHelper.siteHasBadCredentials(site)) {
                 uiModelMutable.postValue(null)
                 return@launch
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -27,8 +27,6 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
 ) {
     lateinit var scope: CoroutineScope
 
-    private val siteURLCache = mutableMapOf<String, String>()
-
     fun initialize(scope: CoroutineScope) {
         this.scope = scope
     }
@@ -52,21 +50,6 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
         experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE)
 
     private fun buildApplicationPasswordDiscovery(site: SiteModel) {
-        // Check if the site URL is already cached
-        val cachedValue = siteURLCache[site.url]
-        if (cachedValue == null) {
-            // No cached value, set to null until get a response
-            uiModelMutable.postValue(null)
-        } else {
-            // If cached value is empty, it means the site has no authentication URL
-            if (cachedValue.isEmpty()) {
-                uiModelMutable.postValue(null)
-            } else {
-                postAuthenticationUrl(cachedValue)
-            }
-            return
-        }
-
         scope.launch {
             // If the site is already authorized, no need to run the discovery
             val storedSite = siteStore.sites.firstOrNull { it.localId() == site.localId() }
@@ -80,10 +63,8 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
             val authorizationUrlComplete = applicationPasswordLoginHelper.getAuthorizationUrlComplete(site.url)
             if (authorizationUrlComplete.isEmpty()) {
                 uiModelMutable.postValue(null)
-                siteURLCache[site.url] = ""
             } else {
                 postAuthenticationUrl(authorizationUrlComplete)
-                siteURLCache[site.url] = authorizationUrlComplete
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSlice.kt
@@ -57,6 +57,7 @@ class ApplicationPasswordViewModelSlice @Inject constructor(
                 !storedSite.apiRestUsernameEncrypted.isNullOrEmpty() &&
                 !storedSite.apiRestPasswordEncrypted.isNullOrEmpty()
                 ) {
+                uiModelMutable.postValue(null)
                 return@launch
             }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/applicationpassword/ApplicationPasswordLoginViewModelTest.kt
@@ -47,6 +47,11 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
 
     private val rawData = "url=callback?site_url=https://example.com&user_login=user&password=pass"
     private val urlLogin = ApplicationPasswordLoginHelper.UriLogin("https://example.com", "user", "pass", "https://example.com/json")
+    private val testSite = SiteModel().apply {
+        apiRestUsernamePlain = urlLogin.user
+        apiRestPasswordPlain = urlLogin.password
+        url = urlLogin.siteUrl
+    }
 
     @Before
     fun setUp() {
@@ -183,7 +188,6 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with site selector`() =
         runTest {
             // Given
-            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = true,
@@ -221,7 +225,6 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no site selector nor interstitial`() =
         runTest {
             // Given
-            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = false,
@@ -259,7 +262,6 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no interstitial by sites`() =
         runTest {
             // Given
-            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = true,
@@ -297,7 +299,6 @@ class ApplicationPasswordLoginViewModelTest : BaseUnitTest() {
     fun `given intent rawData, when setup site and not able to store credentials but store fetch, then emit ok with no interstitial by preferences`() =
         runTest {
             // Given
-            val testSite = SiteModel().apply { url = urlLogin.siteUrl }
             val xmlRpcEndpoint = "https://example.com/xmlrpc.php"
             val expectedResult = ApplicationPasswordLoginViewModel.NavigationActionData(
                 showSiteSelector = false,

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/applicationpassword/ApplicationPasswordViewModelSliceTest.kt
@@ -16,7 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.fluxc.persistence.SiteSqlUtils
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.mysite.MySiteCardAndItem
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
@@ -36,7 +36,7 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
     lateinit var applicationPasswordLoginHelper: ApplicationPasswordLoginHelper
 
     @Mock
-    lateinit var siteSqlUtils: SiteSqlUtils
+    lateinit var siteStore: SiteStore
 
     @Mock
     lateinit var experimentalFeatures: ExperimentalFeatures
@@ -53,7 +53,7 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
 
         applicationPasswordViewModelSlice = ApplicationPasswordViewModelSlice(
             applicationPasswordLoginHelper,
-            siteSqlUtils,
+            siteStore,
             experimentalFeatures,
         ).apply {
             initialize(testScope())
@@ -97,51 +97,21 @@ class ApplicationPasswordViewModelSliceTest : BaseUnitTest() {
 
     @Test
     fun `given site already authenticated, when calling api discovery, then show no card`() = runTest {
-        whenever(siteSqlUtils.getSiteWithLocalId(eq(siteTest.localId()))
-        ).thenReturn(SiteModel().apply {
-            apiRestUsernameEncrypted = "user"
-            apiRestPasswordEncrypted = "password"
-        })
+        whenever(siteStore.sites)
+        .thenReturn(
+            listOf(
+                SiteModel().apply {
+                    id = siteTest.id
+                    apiRestUsernamePlain = "user"
+                    apiRestPasswordPlain = "password"
+                }
+            )
+        )
 
         applicationPasswordViewModelSlice.buildCard(siteTest)
 
         assertNull(applicationPasswordCard)
-        verify(siteSqlUtils).getSiteWithLocalId(eq(siteTest.localId()))
+        verify(siteStore).sites
         verify(applicationPasswordLoginHelper, times(0)).getAuthorizationUrlComplete(any())
     }
-
-    @Test
-    fun `given site url cached, when calling api discovery, then show card but don't call api discovery`() = runTest {
-        whenever(applicationPasswordLoginHelper.getAuthorizationUrlComplete(eq(TEST_URL)))
-            .thenReturn("$TEST_URL_AUTH$TEST_URL_AUTH_SUFFIX")
-
-        // Add site to the cache
-        applicationPasswordViewModelSlice.buildCard(siteTest)
-
-        // call function again
-        applicationPasswordViewModelSlice.buildCard(siteTest)
-
-        assertNotNull(applicationPasswordCard)
-        verify(siteSqlUtils).getSiteWithLocalId(eq(siteTest.localId()))
-        verify(applicationPasswordLoginHelper, times(1))
-            .getAuthorizationUrlComplete(any()) // only called once
-    }
-
-    @Test
-    fun `given site with empty cached, when calling api discovery, then don't show card nor call api discovery`() =
-        runTest {
-            whenever(applicationPasswordLoginHelper.getAuthorizationUrlComplete(eq(TEST_URL)))
-                .thenReturn("")
-
-            // Add site tp the cache
-            applicationPasswordViewModelSlice.buildCard(siteTest)
-
-            // call function again
-            applicationPasswordViewModelSlice.buildCard(siteTest)
-
-            assertNull(applicationPasswordCard)
-            verify(siteSqlUtils).getSiteWithLocalId(eq(siteTest.localId()))
-            verify(applicationPasswordLoginHelper, times(1))
-                .getAuthorizationUrlComplete(any()) // only called once
-        }
 }


### PR DESCRIPTION
## Description
This PR is trying to fix a problem with the Application Password card reappearing inside MySite screen after actually log in using the Application Password flow. Reported here: https://github.com/wordpress-mobile/WordPress-Android/pull/22016#issuecomment-3074260727

The issue seems to be happening after some changes (improvements) in the Application Password flow related to the `SiteStore` and the `SiteSqlUtils ` usage. Since this is not a 100% reproducible issue, I've tackled some key points that could be contributing to a race condition:

1. Double-check the site credentials when onSiteChanged is called inside the login flow
2. Replace `SiteSqlUtils` with `SiteStore` inside the card construction
3. Remove an in-memory cache I created when working with the `siteSqlUtils ` that is not necessary anymore and could lead into data corruption
4. Other minor improvements, like setting the card to null for recycled cases

## Testing instructions

1. Log into a self-hosted site
2. Enable Application Password feature
3. Log in with Application Password using the MySite card
- [ ] Verify the flow works as expected, and you don't see the card anymore


https://github.com/user-attachments/assets/fde33d16-5b6c-4fcd-ac76-25b5e019b260


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->