### PR TITLE
Hide subscribers from the WordPress app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.experimentalfeatures
 
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.R
 import org.wordpress.android.ui.prefs.AppPrefsWrapper
 import javax.inject.Inject
@@ -7,7 +8,16 @@ import javax.inject.Inject
 class ExperimentalFeatures @Inject constructor(
     private val appPrefsWrapper: AppPrefsWrapper
 ) {
-    fun isEnabled(feature: Feature) : Boolean {
+    fun isEnabled(feature: Feature): Boolean {
+        // Experimental subscribers feature is only available in the Jetpack app but was originally available
+        // in the WordPress app, so if this is the WordPress app make sure to disable it. This can be dropped
+        // a few releases down the road (code written July 17, 2025)
+        if (feature == Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE &&
+            !BuildConfig.IS_JETPACK_APP &&
+            appPrefsWrapper.getExperimentalFeatureConfig(feature.prefKey)
+        ) {
+            setEnabled(feature, false)
+        }
         return appPrefsWrapper.getExperimentalFeatureConfig(feature.prefKey)
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.wordpress.android.BuildConfig
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.utils.AppLogWrapper
@@ -43,7 +44,9 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     private fun shouldShowFeature(feature: Feature): Boolean {
-        return if (gutenbergKitFeature.isEnabled()) {
+        return if (feature == Feature.EXPERIMENTAL_SUBSCRIBERS_FEATURE) {
+            BuildConfig.IS_JETPACK_APP
+        } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR
         } else {
             feature != Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR


### PR DESCRIPTION
This PR removes the subscribers feature from WPAndroid as per this discussion: p1752760775615149/1752756864.520159-slack-C04PWEZSYFL

Note this will remain in draft until we hear we should do this from a lead.

**To test:**

* Run JPAndroid and verify subscribers is available
* Run WPAndroid and verify subscribers is not available