### PR TITLE
Update expected JDK version for remote build caching to `21.0.6`

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -142,7 +142,7 @@ def checkForRemoteBuildCacheOptimizedExperience() {
     assertSecretsApplied()
     assertDeveloperPropertiesMatch("${rootDir}/libs/login/developer.properties")
     assertDeveloperPropertiesMatch("${rootDir}/libs/fluxc/developer.properties")
-    assertJava17Amazon()
+    assertJava21Amazon()
 }
 
 def assertDeveloperPropertiesMatch(String developerPropertiesPath) {
@@ -166,9 +166,9 @@ def assertSecretsApplied() {
     }
 }
 
-boolean assertJava17Amazon() {
+boolean assertJava21Amazon() {
     def version = System.getProperty("java.version")
-    def expectedVersion = "17.0.14"
+    def expectedVersion = "21.0.6"
     def vendor = System.getProperty("java.vendor")
 
     if (!(version.contains(expectedVersion) && vendor.toLowerCase().contains("amazon"))) {


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/WordPress-Android/pull/22038 and addresses these comments: [1](https://github.com/wordpress-mobile/WordPress-Android/pull/22038#issuecomment-3100948512), [2](https://github.com/wordpress-mobile/WordPress-Android/pull/22038#issuecomment-3102180028).

@ParaskP7 My local setup doesn't currently support remote build caching. Can you please double check that it's working as intended with this PR? If there are any issues, please feel free to push to this branch directly.