### PR TITLE
Fix `RecyclerView` Position Handling in ReaderCommentAdapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -292,7 +292,12 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             return;
         }
 
-        final ReaderComment comment = getItem(position);
+        int currentPosition = holder.getBindingAdapterPosition();
+        if (currentPosition == RecyclerView.NO_POSITION) {
+            return;
+        }
+        
+        ReaderComment comment = getItem(currentPosition);
         if (comment == null) {
             return;
         }
@@ -316,13 +321,19 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             View.OnClickListener authorListener = new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    ReaderActivityLauncher.showReaderBlogPreview(
-                            view.getContext(),
-                            comment.authorBlogId,
-                            mPost.isFollowedByCurrentUser,
-                            ReaderTracker.SOURCE_COMMENT,
-                            mReaderTracker
-                    );
+                    int authorCurrentPosition = commentHolder.getBindingAdapterPosition();
+                    if (authorCurrentPosition == RecyclerView.NO_POSITION) return;
+
+                    ReaderComment currentComment = getItem(authorCurrentPosition);
+                    if (currentComment != null && currentComment.hasAuthorBlogId()) {
+                        ReaderActivityLauncher.showReaderBlogPreview(
+                                view.getContext(),
+                                currentComment.authorBlogId,
+                                mPost.isFollowedByCurrentUser,
+                                ReaderTracker.SOURCE_COMMENT,
+                                mReaderTracker
+                        );
+                    }
                 }
             };
             commentHolder.mAuthorContainer.setOnClickListener(authorListener);
@@ -382,17 +393,30 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
                 menuPopup.setAnchorView(commentHolder.mActionButton);
                 menuPopup.setModal(true);
                 menuPopup.setOnItemClickListener((parent, view, position1, id) -> {
-                    mCommentMenuActionListener
-                            .onCommentMenuItemTapped(comment, actions.get(position1).getType());
+                    int menuCurrentPosition = commentHolder.getBindingAdapterPosition();
+                    if (menuCurrentPosition != RecyclerView.NO_POSITION) {
+                        ReaderComment currentComment = getItem(menuCurrentPosition);
+                        if (currentComment != null) {
+                            mCommentMenuActionListener
+                                    .onCommentMenuItemTapped(currentComment, actions.get(position1).getType());
+                        }
+                    }
                     menuPopup.dismiss();
                 });
                 menuPopup.show();
             });
         } else {
             commentHolder.mActionButton.setImageResource(R.drawable.ic_share_white_24dp);
-            commentHolder.mActionButtonContainer.setOnClickListener(
-                    v -> mCommentMenuActionListener
-                            .onCommentMenuItemTapped(comment, ReaderCommentMenuActionType.SHARE));
+            commentHolder.mActionButtonContainer.setOnClickListener(v -> {
+                int shareCurrentPosition = commentHolder.getBindingAdapterPosition();
+                if (shareCurrentPosition != RecyclerView.NO_POSITION) {
+                    ReaderComment currentComment = getItem(shareCurrentPosition);
+                    if (currentComment != null) {
+                        mCommentMenuActionListener
+                                .onCommentMenuItemTapped(currentComment, ReaderCommentMenuActionType.SHARE);
+                    }
+                }
+            });
         }
 
         // show indentation spacer for comments with parents and indent it based on comment level
@@ -441,8 +465,12 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             commentHolder.mReplyView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (mReplyListener != null) {
-                        mReplyListener.onRequestReply(comment.commentId);
+                    int replyCurrentPosition = commentHolder.getBindingAdapterPosition();
+                    if (replyCurrentPosition == RecyclerView.NO_POSITION) return;
+
+                    ReaderComment currentComment = getItem(replyCurrentPosition);
+                    if (currentComment != null && mReplyListener != null) {
+                        mReplyListener.onRequestReply(currentComment.commentId);
                     }
                 }
             });
@@ -461,11 +489,11 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             }
         }
 
-        showLikeStatus(commentHolder, position);
+        showLikeStatus(commentHolder);
 
         // if we're nearing the end of the comments and we know more exist on the server,
         // fire request to load more
-        if (mMoreCommentsExist && mDataRequestedListener != null && (position >= getItemCount() - NUM_HEADERS)) {
+        if (mMoreCommentsExist && mDataRequestedListener != null && (currentPosition >= getItemCount() - NUM_HEADERS)) {
             mDataRequestedListener.onRequestData();
         }
     }
@@ -495,7 +523,12 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
     }
 
-    private void showLikeStatus(final CommentHolder holder, int position) {
+    private void showLikeStatus(final CommentHolder holder) {
+        int position = holder.getBindingAdapterPosition();
+        if (position == RecyclerView.NO_POSITION) {
+            return;
+        }
+
         ReaderComment comment = getItem(position);
         if (comment == null) {
             return;
@@ -515,8 +548,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
                 holder.mCountLikes.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        int clickedPosition = holder.getBindingAdapterPosition();
-                        toggleLike(v.getContext(), holder, clickedPosition);
+                        toggleLike(v.getContext(), holder);
                     }
                 });
             }
@@ -526,8 +558,13 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
     }
 
-    private void toggleLike(Context context, CommentHolder holder, int position) {
+    private void toggleLike(Context context, CommentHolder holder) {
         if (!NetworkUtils.checkConnection(context)) {
+            return;
+        }
+
+        int position = holder.getBindingAdapterPosition();
+        if (position == RecyclerView.NO_POSITION) {
             return;
         }
 
@@ -548,7 +585,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         ReaderComment updatedComment = ReaderCommentTable.getComment(comment.blogId, comment.postId, comment.commentId);
         if (updatedComment != null) {
             mComments.set(position - NUM_HEADERS, updatedComment);
-            showLikeStatus(holder, position);
+            showLikeStatus(holder);
         }
 
         mReaderTracker.trackPost(isAskingToLike

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -296,7 +296,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         if (currentPosition == RecyclerView.NO_POSITION) {
             return;
         }
-        
+
         ReaderComment comment = getItem(currentPosition);
         if (comment == null) {
             return;
@@ -316,32 +316,26 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         String avatarUrl = WPAvatarUtils.rewriteAvatarUrl(comment.getAuthorAvatar(), mAvatarSz);
         mImageManager.loadIntoCircle(commentHolder.mImgAvatar, ImageType.AVATAR, avatarUrl);
 
-        // tapping avatar or author name opens blog preview
-        if (comment.hasAuthorBlogId()) {
-            View.OnClickListener authorListener = new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    int authorCurrentPosition = commentHolder.getBindingAdapterPosition();
-                    if (authorCurrentPosition == RecyclerView.NO_POSITION) return;
+        View.OnClickListener authorListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                int authorCurrentPosition = commentHolder.getBindingAdapterPosition();
+                if (authorCurrentPosition == RecyclerView.NO_POSITION) return;
 
-                    ReaderComment currentComment = getItem(authorCurrentPosition);
-                    if (currentComment != null && currentComment.hasAuthorBlogId()) {
-                        ReaderActivityLauncher.showReaderBlogPreview(
-                                view.getContext(),
-                                currentComment.authorBlogId,
-                                mPost.isFollowedByCurrentUser,
-                                ReaderTracker.SOURCE_COMMENT,
-                                mReaderTracker
-                        );
-                    }
+                ReaderComment currentComment = getItem(authorCurrentPosition);
+                // tapping avatar or author name opens blog preview
+                if (currentComment != null && currentComment.hasAuthorBlogId()) {
+                    ReaderActivityLauncher.showReaderBlogPreview(
+                            view.getContext(),
+                            currentComment.authorBlogId,
+                            mPost.isFollowedByCurrentUser,
+                            ReaderTracker.SOURCE_COMMENT,
+                            mReaderTracker
+                    );
                 }
-            };
-            commentHolder.mAuthorContainer.setOnClickListener(authorListener);
-            commentHolder.mAuthorContainer.setOnClickListener(authorListener);
-        } else {
-            commentHolder.mAuthorContainer.setOnClickListener(null);
-            commentHolder.mAuthorContainer.setOnClickListener(null);
-        }
+            }
+        };
+        commentHolder.mAuthorContainer.setOnClickListener(authorListener);
 
         // author name uses different color for comments from the post's author
         if (comment.authorId == mPost.authorId) {


### PR DESCRIPTION
## Summary
Fixes RecyclerView lint warning "Do not treat position as fixed" in `ReaderCommentAdapter.java` by properly handling adapter positions in `onBindViewHolder()` and click listeners.

## Changes
- **Initial data access**: Replace direct `position` parameter usage with `holder.getBindingAdapterPosition()` 
- **Click listeners**: Update all click listeners (author, reply, action buttons) to get fresh position data instead of capturing stale comment objects
- **Position validation**: Add proper `RecyclerView.NO_POSITION` checks throughout the method
- **Variable naming**: Use unique variable names to avoid compilation conflicts (`authorCurrentPosition`, `replyCurrentPosition`, etc.)
- **Author click logic**: Always attach author click listener and validate `hasAuthorBlogId()` at tap time with fresh data instead of conditionally at bind time

## Technical Details
The RecyclerView lint rule enforces that adapter positions should not be treated as fixed since RecyclerView data can change between when `onBindViewHolder()` is called and when click handlers execute. This fix ensures we always work with current, valid positions rather than potentially stale data.

The key changes ensure that:
1. No direct usage of the `position` parameter from method signature
2. All position lookups use `holder.getBindingAdapterPosition()` with proper validation
3. Comment objects are retrieved fresh in click handlers rather than captured from binding time
4. Click listener attachment is consistent across all handlers - always attach, validate data at tap time

## Testing
- Builds without RecyclerView lint errors
- Comment interactions (like, reply, author clicks) work correctly with dynamic data changes
- Author clicks properly handle cases where blog ID availability changes between bind and tap time
