### PR TITLE
Fix Missing `POST_NOTIFICATIONS` Permission Checks for Android 13+

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -105,7 +105,8 @@ public class GCMMessageHandler {
                               NotificationsUtilsWrapper notificationsUtilsWrapper,
                               NotificationManagerWrapper notificationManagerWrapper) {
         mActiveNotificationsMap = new ArrayMap<>();
-        mNotificationHelper = new NotificationHelper(this, systemNotificationsTracker, notificationsUtilsWrapper, notificationManagerWrapper);
+        mNotificationHelper = new NotificationHelper(this, systemNotificationsTracker, notificationsUtilsWrapper,
+                notificationManagerWrapper);
     }
 
     synchronized void rebuildAndUpdateNotificationsOnSystemBarForThisNote(Context context,

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageHandler.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
@@ -101,9 +102,10 @@ public class GCMMessageHandler {
     private final NotificationHelper mNotificationHelper;
 
     @Inject GCMMessageHandler(SystemNotificationsTracker systemNotificationsTracker,
-                              NotificationsUtilsWrapper notificationsUtilsWrapper) {
+                              NotificationsUtilsWrapper notificationsUtilsWrapper,
+                              NotificationManagerWrapper notificationManagerWrapper) {
         mActiveNotificationsMap = new ArrayMap<>();
-        mNotificationHelper = new NotificationHelper(this, systemNotificationsTracker, notificationsUtilsWrapper);
+        mNotificationHelper = new NotificationHelper(this, systemNotificationsTracker, notificationsUtilsWrapper, notificationManagerWrapper);
     }
 
     synchronized void rebuildAndUpdateNotificationsOnSystemBarForThisNote(Context context,
@@ -273,13 +275,16 @@ public class GCMMessageHandler {
         private SystemNotificationsTracker mSystemNotificationsTracker;
 
         private NotificationsUtilsWrapper mNotificationsUtilsWrapper;
+        private NotificationManagerWrapper mNotificationManagerWrapper;
 
         NotificationHelper(GCMMessageHandler gCMMessageHandler,
                            SystemNotificationsTracker systemNotificationsTracker,
-                           NotificationsUtilsWrapper notificationsUtilsWrapper) {
+                           NotificationsUtilsWrapper notificationsUtilsWrapper,
+                           NotificationManagerWrapper notificationManagerWrapper) {
             mGCMMessageHandler = gCMMessageHandler;
             mSystemNotificationsTracker = systemNotificationsTracker;
             mNotificationsUtilsWrapper = notificationsUtilsWrapper;
+            mNotificationManagerWrapper = notificationManagerWrapper;
         }
 
         void handleDefaultPush(Context context, @NonNull Bundle data, long wpcomUserId) {
@@ -839,8 +844,7 @@ public class GCMMessageHandler {
                         | PendingIntent.FLAG_IMMUTABLE
                 );
                 builder.setContentIntent(pendingIntent);
-                NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-                notificationManager.notify(pushId, builder.build());
+                mNotificationManagerWrapper.notify(pushId, builder.build());
                 mSystemNotificationsTracker.trackShownNotification(notificationType);
             }
         }
@@ -1084,8 +1088,7 @@ public class GCMMessageHandler {
                             context, AUTH_PUSH_NOTIFICATION_ID, notificationType);
             builder.setDeleteIntent(pendingDeleteIntent);
 
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-            notificationManager.notify(AUTH_PUSH_NOTIFICATION_ID, builder.build());
+            mNotificationManagerWrapper.notify(AUTH_PUSH_NOTIFICATION_ID, builder.build());
             mSystemNotificationsTracker.trackShownNotification(notificationType);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -1,11 +1,16 @@
 package org.wordpress.android.push;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.content.ContextCompat;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AppLog;
 
 import static org.wordpress.android.push.NotificationPushIds.ACTIONS_PROGRESS_NOTIFICATION_ID;
 
@@ -44,6 +49,15 @@ public class NativeNotificationsUtils {
             builder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
         }
         builder.setProgress(0, 0, intermediateMessage);
+
+        // Check for POST_NOTIFICATIONS permission on Android 13+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) 
+                != PackageManager.PERMISSION_GRANTED) {
+                AppLog.w(AppLog.T.NOTIFS, "POST_NOTIFICATIONS permission not granted, skipping notification with id: " + pushId);
+                return;
+            }
+        }
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
         notificationManager.notify(pushId, builder.build());

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -51,13 +51,12 @@ public class NativeNotificationsUtils {
         builder.setProgress(0, 0, intermediateMessage);
 
         // Check for POST_NOTIFICATIONS permission on Android 13+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
-                != PackageManager.PERMISSION_GRANTED) {
-                AppLog.w(AppLog.T.NOTIFS,
-                        "POST_NOTIFICATIONS permission not granted, skipping notification with id: " + pushId);
-                return;
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+            && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+               != PackageManager.PERMISSION_GRANTED) {
+            AppLog.w(AppLog.T.NOTIFS,
+                    "POST_NOTIFICATIONS permission not granted, skipping notification with id: " + pushId);
+            return;
         }
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -52,9 +52,10 @@ public class NativeNotificationsUtils {
 
         // Check for POST_NOTIFICATIONS permission on Android 13+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) 
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
                 != PackageManager.PERMISSION_GRANTED) {
-                AppLog.w(AppLog.T.NOTIFS, "POST_NOTIFICATIONS permission not granted, skipping notification with id: " + pushId);
+                AppLog.w(AppLog.T.NOTIFS,
+                        "POST_NOTIFICATIONS permission not granted, skipping notification with id: " + pushId);
                 return;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationManagerWrapper.kt
@@ -22,13 +22,13 @@ class NotificationManagerWrapper @Inject constructor(private val context: Contex
         }
 
         // Check for POST_NOTIFICATIONS permission on Android 13+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
-                != PackageManager.PERMISSION_GRANTED
-            ) {
-                AppLog.w(T.NOTIFS, "POST_NOTIFICATIONS permission not granted, skipping notification with id: $id")
-                return
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            AppLog.w(T.NOTIFS, "POST_NOTIFICATIONS permission not granted, skipping notification with id: $id")
+            return
         }
 
         NotificationManagerCompat.from(context).notify(id, notification)

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationManagerWrapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationManagerWrapper.kt
@@ -1,12 +1,38 @@
 package org.wordpress.android.ui.notifications
 
+import android.Manifest
 import android.app.Notification
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T
 import javax.inject.Inject
 
-class NotificationManagerWrapper
-@Inject constructor(private val context: Context) {
+class NotificationManagerWrapper @Inject constructor(private val context: Context) {
     fun areNotificationsEnabled() = NotificationManagerCompat.from(context).areNotificationsEnabled()
-    fun notify(id: Int, notification: Notification) = NotificationManagerCompat.from(context).notify(id, notification)
+
+    fun notify(id: Int, notification: Notification) {
+        // Check if notifications are enabled at system level first
+        if (!areNotificationsEnabled()) {
+            AppLog.d(T.NOTIFS, "Notifications disabled by user, skipping notification with id: $id")
+            return
+        }
+
+        // Check for POST_NOTIFICATIONS permission on Android 13+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED
+            ) {
+                AppLog.w(T.NOTIFS, "POST_NOTIFICATIONS permission not granted, skipping notification with id: $id")
+                return
+            }
+        }
+
+        NotificationManagerCompat.from(context).notify(id, notification)
+    }
+
+    fun cancel(id: Int) = NotificationManagerCompat.from(context).cancel(id)
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishNotificationReceiver.kt
@@ -4,12 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import org.wordpress.android.R
 import org.wordpress.android.WordPress
 import org.wordpress.android.push.NotificationType
 import org.wordpress.android.push.NotificationsProcessingService
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import javax.inject.Inject
 
@@ -22,6 +22,9 @@ class PublishNotificationReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var jetpackFeatureRemovalPhaseHelper: JetpackFeatureRemovalPhaseHelper
+
+    @Inject
+    lateinit var notificationManagerWrapper: NotificationManagerWrapper
 
     override fun onReceive(context: Context, intent: Intent) {
         (context.applicationContext as WordPress).component().inject(this)
@@ -47,7 +50,7 @@ class PublishNotificationReceiver : BroadcastReceiver() {
                     )
                 )
                 .build()
-            NotificationManagerCompat.from(context).notify(notificationId, notificationCompat)
+            notificationManagerWrapper.notify(notificationId, notificationCompat)
             systemNotificationsTracker.trackShownNotification(notificationType)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/quickstart/QuickStartReminderReceiver.java
@@ -9,7 +9,6 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -22,6 +21,7 @@ import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.mysite.MySiteViewModel;
 import org.wordpress.android.ui.mysite.SelectedSiteRepository;
 import org.wordpress.android.ui.mysite.cards.quickstart.QuickStartRepository;
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 
 import javax.inject.Inject;
@@ -42,6 +42,7 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
     @Inject QuickStartTracker mQuickStartTracker;
 
     @Inject JetpackFeatureRemovalPhaseHelper mJetpackFeatureRemovalPhaseHelper;
+    @Inject NotificationManagerWrapper mNotificationManagerWrapper;
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -93,7 +94,6 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
                 PendingIntent.getActivity(context, NotificationPushIds.QUICK_START_REMINDER_NOTIFICATION_ID,
                         resultIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
-        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
         Notification notification = new NotificationCompat.Builder(context,
                 context.getString(R.string.notification_channel_reminder_id))
                 .setSmallIcon(R.drawable.ic_app_white_24dp)
@@ -108,7 +108,7 @@ public class QuickStartReminderReceiver extends BroadcastReceiver {
                                 notificationType))
                 .build();
 
-        notificationManager.notify(NotificationPushIds.QUICK_START_REMINDER_NOTIFICATION_ID, notification);
+        mNotificationManagerWrapper.notify(NotificationPushIds.QUICK_START_REMINDER_NOTIFICATION_ID, notification);
         mQuickStartTracker.track(Stat.QUICK_START_NOTIFICATION_SENT);
         mSystemNotificationsTracker.trackShownNotification(notificationType);
     }

--- a/WordPress/src/main/java/org/wordpress/android/workers/WordPressWorkersFactory.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/WordPressWorkersFactory.kt
@@ -4,6 +4,7 @@ import androidx.work.DelegatingWorkerFactory
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.support.ZendeskHelper
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.ui.uploads.UploadStarter
 import org.wordpress.android.util.UploadWorker
 import org.wordpress.android.workers.notification.local.LocalNotificationHandlerFactory
@@ -26,13 +27,14 @@ class WordPressWorkersFactory @Inject constructor(
     weeklyRoundupNotifier: WeeklyRoundupNotifier,
     promptReminderNotifier: PromptReminderNotifier,
     accountStore: AccountStore,
-    zendeskHelper: ZendeskHelper
+    zendeskHelper: ZendeskHelper,
+    notificationManagerWrapper: NotificationManagerWrapper
 ) : DelegatingWorkerFactory() {
     init {
         addFactory(UploadWorker.Factory(uploadStarter, siteStore))
-        addFactory(LocalNotificationWorker.Factory(localNotificationHandlerFactory))
+        addFactory(LocalNotificationWorker.Factory(localNotificationHandlerFactory, notificationManagerWrapper))
         addFactory(ReminderWorker.Factory(reminderScheduler, reminderNotifier, promptReminderNotifier))
-        addFactory(WeeklyRoundupWorker.Factory(weeklyRoundupNotifier))
+        addFactory(WeeklyRoundupWorker.Factory(weeklyRoundupNotifier, notificationManagerWrapper))
         addFactory(GCMRegistrationWorker.Factory(accountStore, zendeskHelper))
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/notification/local/LocalNotificationWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/notification/local/LocalNotificationWorker.kt
@@ -85,7 +85,12 @@ class LocalNotificationWorker(
             workerParameters: WorkerParameters
         ): ListenableWorker? {
             return if (workerClassName == LocalNotificationWorker::class.java.name) {
-                LocalNotificationWorker(appContext, workerParameters, localNotificationHandlerFactory, notificationManagerWrapper)
+                LocalNotificationWorker(
+                    appContext,
+                    workerParameters,
+                    localNotificationHandlerFactory,
+                    notificationManagerWrapper
+                )
             } else {
                 null
             }

--- a/WordPress/src/main/java/org/wordpress/android/workers/notification/local/LocalNotificationWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/notification/local/LocalNotificationWorker.kt
@@ -3,7 +3,6 @@ package org.wordpress.android.workers.notification.local
 import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -12,12 +11,14 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import org.wordpress.android.R
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.workers.notification.local.LocalNotification.Type
 
 class LocalNotificationWorker(
     val context: Context,
     params: WorkerParameters,
-    private val localNotificationHandlerFactory: LocalNotificationHandlerFactory
+    private val localNotificationHandlerFactory: LocalNotificationHandlerFactory,
+    private val notificationManagerWrapper: NotificationManagerWrapper
 ) : CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
         val id = inputData.getInt(ID, -1)
@@ -27,7 +28,7 @@ class LocalNotificationWorker(
 
         val localNotificationHandler = localNotificationHandlerFactory.buildLocalNotificationHandler(type)
         if (localNotificationHandler.shouldShowNotification()) {
-            NotificationManagerCompat.from(context).notify(id, localNotificationBuilder(id).build())
+            notificationManagerWrapper.notify(id, localNotificationBuilder(id).build())
             localNotificationHandler.onNotificationShown()
         }
 
@@ -75,7 +76,8 @@ class LocalNotificationWorker(
     }
 
     class Factory(
-        private val localNotificationHandlerFactory: LocalNotificationHandlerFactory
+        private val localNotificationHandlerFactory: LocalNotificationHandlerFactory,
+        private val notificationManagerWrapper: NotificationManagerWrapper
     ) : WorkerFactory() {
         override fun createWorker(
             appContext: Context,
@@ -83,7 +85,7 @@ class LocalNotificationWorker(
             workerParameters: WorkerParameters
         ): ListenableWorker? {
             return if (workerClassName == LocalNotificationWorker::class.java.name) {
-                LocalNotificationWorker(appContext, workerParameters, localNotificationHandlerFactory)
+                LocalNotificationWorker(appContext, workerParameters, localNotificationHandlerFactory, notificationManagerWrapper)
             } else {
                 null
             }

--- a/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotificationManager.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/reminder/ReminderNotificationManager.kt
@@ -1,13 +1,14 @@
 package org.wordpress.android.workers.reminder
 
 import android.content.Context
-import androidx.core.app.NotificationManagerCompat
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import javax.inject.Inject
 
 class ReminderNotificationManager @Inject constructor(
-    private val context: Context
+    private val context: Context,
+    private val notificationManagerWrapper: NotificationManagerWrapper
 ) {
     fun notify(id: Int, notification: ReminderNotification) {
-        NotificationManagerCompat.from(context).notify(id, notification.asNotificationCompatBuilder(context).build())
+        notificationManagerWrapper.notify(id, notification.asNotificationCompatBuilder(context).build())
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupWorker.kt
+++ b/WordPress/src/main/java/org/wordpress/android/workers/weeklyroundup/WeeklyRoundupWorker.kt
@@ -1,15 +1,16 @@
 package org.wordpress.android.workers.weeklyroundup
 
 import android.content.Context
-import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.coroutineScope
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 
 class WeeklyRoundupWorker(
     val context: Context,
     val notifier: WeeklyRoundupNotifier,
+    val notificationManagerWrapper: NotificationManagerWrapper,
     workerParameters: WorkerParameters
 ) : CoroutineWorker(context, workerParameters) {
     override suspend fun doWork(): Result = coroutineScope {
@@ -23,19 +24,19 @@ class WeeklyRoundupWorker(
     }
 
     private fun showNotification(notification: WeeklyRoundupNotification) {
-        NotificationManagerCompat.from(context)
-            .notify(notification.id, notification.asNotificationCompatBuilder(context).build())
+        notificationManagerWrapper.notify(notification.id, notification.asNotificationCompatBuilder(context).build())
     }
 
     class Factory(
-        private val notifier: WeeklyRoundupNotifier
+        private val notifier: WeeklyRoundupNotifier,
+        private val notificationManagerWrapper: NotificationManagerWrapper
     ) : WorkerFactory() {
         override fun createWorker(
             appContext: Context,
             workerClassName: String,
             workerParameters: WorkerParameters
         ) = if (workerClassName == WeeklyRoundupWorker::class.java.name) {
-            WeeklyRoundupWorker(appContext, notifier, workerParameters)
+            WeeklyRoundupWorker(appContext, notifier, notificationManagerWrapper, workerParameters)
         } else {
             null
         }

--- a/WordPress/src/test/java/org/wordpress/android/push/NotificationHelperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/push/NotificationHelperTest.kt
@@ -12,6 +12,7 @@ import org.wordpress.android.push.GCMMessageHandler.PUSH_TYPE_COMMENT
 import org.wordpress.android.push.GCMMessageHandler.PUSH_ARG_MSG
 import org.wordpress.android.push.GCMMessageHandler.PUSH_ARG_TITLE
 import org.wordpress.android.push.GCMMessageService.PUSH_ARG_NOTE_ID
+import org.wordpress.android.ui.notifications.NotificationManagerWrapper
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
 import kotlin.test.assertEquals
@@ -23,8 +24,13 @@ class NotificationHelperTest : BaseUnitTest() {
     private val systemNotificationsTracker: SystemNotificationsTracker = mock()
     private val gcmMessageHandler: GCMMessageHandler = mock()
     private val notificationsUtilsWrapper = mock<NotificationsUtilsWrapper>()
-    private val notificationHelper =
-        GCMMessageHandler.NotificationHelper(gcmMessageHandler, systemNotificationsTracker, notificationsUtilsWrapper)
+    private val notificationManagerWrapper = mock<NotificationManagerWrapper>()
+    private val notificationHelper = GCMMessageHandler.NotificationHelper(
+        gcmMessageHandler,
+        systemNotificationsTracker,
+        notificationsUtilsWrapper,
+        notificationManagerWrapper
+    )
 
     @Test
     fun `WHEN a PN that is a comment has a message argument THEN then the message is used as title`() {


### PR DESCRIPTION
## Summary
Resolves 9 lint errors for `NotificationManagerCompat.notify()` calls by implementing proper runtime permission checking for the `POST_NOTIFICATIONS` permission required on Android 13+.

## Changes

### Enhanced NotificationManagerWrapper
- Added runtime permission check for `POST_NOTIFICATIONS` on Android 13+ (API 33)
- Added system-level notification enabled check using `areNotificationsEnabled()`
- Graceful handling with logging when permission is not granted (preserves existing Android behavior)
- Added `cancel()` method for completeness

### Updated Notification Call Sites
**Dependency Injection approach** (preferred):
- `ReminderNotificationManager.kt` - Use injected wrapper
- `WeeklyRoundupWorker.kt` - Added wrapper to constructor and factory
- `PublishNotificationReceiver.kt` - Added wrapper injection via `@Inject`
- `LocalNotificationWorker.kt` - Added wrapper to constructor and factory  
- `GCMMessageHandler.java` - Added wrapper to constructor and `NotificationHelper`
- `QuickStartReminderReceiver.java` - Added wrapper injection via `@Inject`

**Direct permission checking** (for static utilities):
- `NativeNotificationsUtils.java` - Added inline permission checking for static methods

### Infrastructure Updates
- `WordPressWorkersFactory.kt` - Added `NotificationManagerWrapper` parameter and pass to worker factories

## Behavior Preservation
**This implementation follows Android's recommended approach**: According to [Android 13 documentation](https://developer.android.com/develop/ui/views/notifications/notification-permission), apps should check the `POST_NOTIFICATIONS` permission before calling `notify()` rather than relying on system behavior when permission is denied. While the documentation doesn't specify exact runtime behavior without permission, it's clear that "your app can't send notifications unless it qualifies for an exemption." Our implementation adds explicit permission checking and logging to handle this gracefully and provide visibility to developers. The lint warnings encourage this defensive programming approach.