### PR TITLE
Fix media settings toolbar

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -398,7 +398,7 @@
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"
             android:label="@string/media_settings_screen_title"
-            android:theme="@style/WordPress.NoActionBar.TranslucentStatus" />
+            android:theme="@style/WordPress.NoActionBar" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.install.JetpackF
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallActivity
 import org.wordpress.android.ui.main.feedbackform.FeedbackFormActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
-import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity
@@ -106,7 +105,6 @@ private val excludedActivities = listOf(
     SupportWebViewActivity::class.java.name,
 
     // these are excluded because they explicitly enable edge-to-edge
-    MediaSettingsActivity::class.java.name,
     ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.install.JetpackF
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallActivity
 import org.wordpress.android.ui.main.feedbackform.FeedbackFormActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
+import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity
@@ -104,7 +105,8 @@ private val excludedActivities = listOf(
     SubscribersActivity::class.java.name,
     SupportWebViewActivity::class.java.name,
 
-    // this is excluded because it explicitly enables edge-to-edge
+    // these are excluded because they explicitly enable edge-to-edge
+    MediaSettingsActivity::class.java.name,
     ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -330,8 +330,6 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
         ImageView imgScrim = findViewById(R.id.image_gradient_scrim);
         imgScrim.getLayoutParams().height = toolbarHeight * 3;
 
-        adjustToolbar();
-
         // tap to show full screen view (not supported for documents)
         if (!isDocument()) {
             View.OnClickListener listener = v -> showFullScreen();
@@ -517,19 +515,6 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
         overridePendingTransition(R.anim.do_nothing, R.anim.activity_slide_out_to_bottom);
     }
 
-    /*
-     * adjust the toolbar so it doesn't overlap the status bar
-     */
-    @SuppressLint({"InternalInsetResource", "DiscouragedApi"})
-    private void adjustToolbar() {
-        int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            int statusHeight = getResources().getDimensionPixelSize(resourceId);
-            View toolbar = findViewById(R.id.toolbar);
-            toolbar.getLayoutParams().height += statusHeight;
-            toolbar.setPadding(0, statusHeight, 0, 0);
-        }
-    }
 
     private boolean shouldShowFab() {
         // fab only shows for images

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -111,6 +111,7 @@ import static org.wordpress.android.editor.EditorImageMetaData.ARG_EDITOR_IMAGE_
 
 public class MediaSettingsActivity extends BaseAppCompatActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback {
+    private static final int TOOLBAR_HEIGHT_MULTIPLIER = 3;
     private static final String ARG_MEDIA_LOCAL_ID = "media_local_id";
     private static final String ARG_ID_LIST = "id_list";
     private static final String ARG_DELETE_MEDIA_DIALOG_VISIBLE = "delete_media_dialog_visible";
@@ -328,7 +329,7 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
         // set the height of the gradient scrim that appears atop the image
         int toolbarHeight = DisplayUtils.getActionBarHeight(this);
         ImageView imgScrim = findViewById(R.id.image_gradient_scrim);
-        imgScrim.getLayoutParams().height = toolbarHeight * 3;
+        imgScrim.getLayoutParams().height = toolbarHeight * TOOLBAR_HEIGHT_MULTIPLIER;
 
         // tap to show full screen view (not supported for documents)
         if (!isDocument()) {

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -4,20 +4,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="false"
+    android:fitsSystemWindows="true"
     android:focusableInTouchMode="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="false">
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="false"
+            android:fitsSystemWindows="true"
             app:expandedTitleMarginEnd="64dp"
             app:expandedTitleMarginStart="48dp"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -361,7 +361,7 @@
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@android:style/Animation</item>
     </style>
-    
+
     <style name="WordPress.TransparentDialog" parent="WordPress.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
@@ -476,12 +476,6 @@
     </style>
 
     <style name="MediaSettings" />
-
-    <style name="WordPress.NoActionBar.TranslucentStatus" parent="WordPress.NoActionBar">
-        <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:statusBarColor">@android:color/white</item>
-        <item name="android:windowLightStatusBar">false</item>
-    </style>
 
     <style name="MediaSettings.Divider">
         <item name="android:background">?android:attr/listDivider</item>


### PR DESCRIPTION
Fixes CMM-593

This PR fixes an issue with `MediaSettingsActivity` that caused the toolbar to appear too low. This also restores the status bar, which was hidden despite the activity not being edge-to-edge or fullscreen.

**To test**
* My Site > Media
* Tap a photo
* Verify that the toolbar appears in the correct position

Before & After shots below:

<img width="808" height="829" alt="before-and-after" src="https://github.com/user-attachments/assets/5caf2286-b483-42a3-a47a-370103acf82f" />
