### PR TITLE
Media settings: Hide status bar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/BaseAppCompatActivity.kt
@@ -24,6 +24,7 @@ import org.wordpress.android.ui.jetpackplugininstall.fullplugin.install.JetpackF
 import org.wordpress.android.ui.jetpackplugininstall.remoteplugin.JetpackRemoteInstallActivity
 import org.wordpress.android.ui.main.feedbackform.FeedbackFormActivity
 import org.wordpress.android.ui.media.MediaPreviewActivity
+import org.wordpress.android.ui.media.MediaSettingsActivity
 import org.wordpress.android.ui.mysite.menu.MenuActivity
 import org.wordpress.android.ui.mysite.personalization.PersonalizationActivity
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity
@@ -103,6 +104,7 @@ private val excludedActivities = listOf(
     SupportWebViewActivity::class.java.name,
 
     // these are excluded because they explicitly enable edge-to-edge
+    MediaSettingsActivity::class.java.name,
     ReaderPostPagerActivity::class.java.name,
 
     // these are excluded and use the NoEdgeToEdge style to avoid the keyboard overlapping

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -23,7 +23,6 @@ import android.os.Environment;
 import android.os.Handler;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
-import android.util.AttributeSet;
 import android.view.HapticFeedbackConstants;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -351,15 +350,14 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
             });
             ViewExtensionsKt.redirectContextClickToLongPressListener(mFabView);
         }
+
+        enableEdgeToEdge();
     }
 
-    @Override
-    @Nullable
-    public View onCreateView(
-            @NonNull String name,
-            @NonNull Context context,
-            @NonNull AttributeSet attrs) {
-        // enable full screen for Android 33+
+    /**
+     * Hide status bar on API 33+
+     */
+    private void enableEdgeToEdge() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             Window window = getWindow();
             window.setDecorFitsSystemWindows(false);
@@ -370,7 +368,6 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
                     WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             );
         }
-        return super.onCreateView(name, context, attrs);
     }
 
     private boolean isMediaFromEditor() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -355,7 +355,7 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
     }
 
     /**
-     * Hide status bar on API 33+
+     * Enable edge-to-edge API 33+, but only hide the status bar and not the navigation bar
      */
     private void enableEdgeToEdge() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -23,11 +23,13 @@ import android.os.Environment;
 import android.os.Handler;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
+import android.util.AttributeSet;
 import android.view.HapticFeedbackConstants;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -49,6 +51,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.appbar.CollapsingToolbarLayout;
@@ -347,6 +351,26 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
             });
             ViewExtensionsKt.redirectContextClickToLongPressListener(mFabView);
         }
+    }
+
+    @Override
+    @Nullable
+    public View onCreateView(
+            @NonNull String name,
+            @NonNull Context context,
+            @NonNull AttributeSet attrs) {
+        // enable full screen for Android 33+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Window window = getWindow();
+            window.setDecorFitsSystemWindows(false);
+            WindowInsetsControllerCompat controller =
+                    new WindowInsetsControllerCompat(window, window.getDecorView());
+            controller.hide(WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.navigationBars());
+            controller.setSystemBarsBehavior(
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+        }
+        return super.onCreateView(name, context, attrs);
     }
 
     private boolean isMediaFromEditor() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -365,7 +365,7 @@ public class MediaSettingsActivity extends BaseAppCompatActivity
             window.setDecorFitsSystemWindows(false);
             WindowInsetsControllerCompat controller =
                     new WindowInsetsControllerCompat(window, window.getDecorView());
-            controller.hide(WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.navigationBars());
+            controller.hide(WindowInsetsCompat.Type.statusBars());
             controller.setSystemBarsBehavior(
                     WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             );

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -4,20 +4,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
+    android:fitsSystemWindows="false"
     android:focusableInTouchMode="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="false">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsing_toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
+            android:fitsSystemWindows="false"
             app:expandedTitleMarginEnd="64dp"
             app:expandedTitleMarginStart="48dp"
             app:layout_scrollFlags="scroll|exitUntilCollapsed">


### PR DESCRIPTION
While working on #22052 it occurred to me that `MediaSettingsActivity` would look better if the image was flushed to the top of the screen instead of below the status bar. So, this PR updates `MediaSettingsActivity` to hide the status bar on API 33+.

**To test**
* Use an API 33+ device
* My Site > Media
* Tap a photo
* Ensure the image wraps to the top of the display
* Repeat using a pre-API 33 device and verify it still looks correct (albeit with the status bar showing)

Before & after shots below:

<img width="600" alt="before" src="https://github.com/user-attachments/assets/bcbe4ed4-3b84-4dae-9db6-6754d00d7dca" />
