### PR TITLE
Added no deprecated APIs and no reflection to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,8 @@ WordPress/src/main/java/org/wordpress/android/
 - **Android Lint**: Built-in Android static analysis
 - **Line Length**: 120 characters max
 - **No FIXME**: Use TODO instead of FIXME in committed code
+- **No Deprecated APIs**: Avoid using deprecated methods and classes in new code
+- **No Reflection**: Avoid using reflection in new code; prefer type-safe alternatives
 
 ### Development Workflow
 - Default development flavor: `jetpackWasabi` (Jetpack app with beta suffix)


### PR DESCRIPTION
This small PR updates `CLAUDE.md` with these two additions:

```
- **No Deprecated APIs**: Avoid using deprecated methods and classes in new code
- **No Reflection**: Avoid using reflection in new code; prefer type-safe alternatives
```

I felt this was necessary because Claude sometimes resorted to both of the above, the latter especially when generating tests. After I added these two items, I verified that Claude understood them:

<img width="1503" height="210" alt="claude-respionse" src="https://github.com/user-attachments/assets/4a10a236-c8c3-45dc-b7b3-c9cec5f63125" />
