### PR TITLE
Add navigation abstraction layer to `EditPostActivity`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -256,6 +256,8 @@ import org.wordpress.android.util.image.ImageType
 import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.viewmodel.storage.StorageUtilsViewModel
+import org.wordpress.android.ui.posts.navigation.EditPostNavigationViewModel
+import org.wordpress.android.ui.posts.navigation.EditPostDestination
 import org.wordpress.android.widgets.AppReviewManager.incrementInteractions
 import org.wordpress.android.widgets.WPSnackbar.Companion.make
 import org.wordpress.android.widgets.WPViewPager
@@ -430,6 +432,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
     @Inject lateinit var editorBloggingPromptsViewModel: EditorBloggingPromptsViewModel
     @Inject lateinit var editorJetpackSocialViewModel: EditorJetpackSocialViewModel
+    @Inject lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
 
     private lateinit var siteModel: SiteModel
 
@@ -545,6 +548,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         isLandingEditor = intent.extras?.getBoolean(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR) ?: false
 
         refreshMobileEditorFromSiteSetting()
+
+        // Initialize navigation state management
+        initializeNavigation()
 
         // Initialize editor settings and UI components based on the siteModel
         setupEditor()
@@ -948,6 +954,84 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     override fun onSettingsSaved() { /* No Op */ }
     override fun onCredentialsValidated(error: Exception?) { /* No Op */ }
+
+    /**
+     * Initialize navigation state management for the edit post flow.
+     */
+    private fun initializeNavigation() {
+        AppLog.d(AppLog.T.POSTS, "EditPostActivity: Initializing navigation state management")
+
+        // Observe navigation events to update ViewPager position
+        editPostNavigationViewModel.navigationEvents.observe(this) { event ->
+            event.getContentIfNotHandled()?.let { destination ->
+                AppLog.d(AppLog.T.POSTS, "EditPostActivity: Handling navigation event to $destination")
+                updateViewPagerPosition(destination)
+            }
+        }
+
+        // Observe current destination changes for UI updates
+        editPostNavigationViewModel.currentDestination.observe(this) { destination ->
+            AppLog.d(AppLog.T.POSTS, "EditPostActivity: Current destination changed to $destination")
+            updateUIForDestination(destination)
+        }
+    }
+
+    /**
+     * Updates ViewPager position based on navigation destination.
+     */
+    private fun updateViewPagerPosition(destination: EditPostDestination) {
+        val targetPage = when (destination) {
+            EditPostDestination.Editor -> PAGE_CONTENT
+            EditPostDestination.Settings -> PAGE_SETTINGS
+            EditPostDestination.PublishSettings -> PAGE_PUBLISH_SETTINGS
+            EditPostDestination.History -> PAGE_HISTORY
+        }
+
+        viewPager?.let { pager ->
+            if (pager.currentItem != targetPage) {
+                AppLog.d(AppLog.T.POSTS, "EditPostActivity: Moving ViewPager from ${pager.currentItem} to $targetPage")
+                pager.currentItem = targetPage
+            }
+        }
+    }
+
+    /**
+     * Updates UI elements based on current navigation destination.
+     */
+    private fun updateUIForDestination(destination: EditPostDestination) {
+        when (destination) {
+            EditPostDestination.Editor -> {
+                title = SiteUtils.getSiteNameOrHomeURL(siteModel)
+                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                toolbar?.setBackgroundResource(R.drawable.tab_layout_background)
+            }
+
+            EditPostDestination.Settings -> {
+                setTitle(if (editPostRepository.isPage) R.string.page_settings else R.string.post_settings)
+                editorPhotoPicker?.hidePhotoPicker()
+                appBarLayout?.liftOnScrollTargetViewId = R.id.settings_fragment_root
+                toolbar?.background = null
+            }
+
+            EditPostDestination.PublishSettings -> {
+                setTitle(R.string.publish_date)
+                editorPhotoPicker?.hidePhotoPicker()
+                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                toolbar?.background = null
+            }
+
+            EditPostDestination.History -> {
+                setTitle(R.string.history_title)
+                editorPhotoPicker?.hidePhotoPicker()
+                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                toolbar?.background = null
+            }
+        }
+
+        // Refresh options menu as visibility may change based on destination
+        invalidateOptionsMenu()
+    }
+
     private fun setupViewPager() {
         // Set up the ViewPager with the sections adapter.
         viewPager = findViewById(R.id.pager)
@@ -1405,12 +1489,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Suppress("LongMethod", "CyclomaticComplexMethod", "SwallowedException")
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        var showMenuItems = true
-        viewPager?.let {
-            if (it.currentItem > PAGE_CONTENT) {
-                showMenuItems = false
-            }
-        }
+        val currentDestination = editPostNavigationViewModel.currentDestination.value ?: EditPostDestination.default()
+        val showMenuItems = currentDestination == EditPostDestination.Editor
 
         val undoItem = menu.findItem(R.id.menu_undo_action)
         val redoItem = menu.findItem(R.id.menu_redo_action)
@@ -1455,8 +1535,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             if (primaryAction != null) {
                 primaryAction.setTitle(primaryActionText)
                 primaryAction.setVisible(
-                    (viewPager != null) && (viewPager?.currentItem != PAGE_HISTORY
-                            ) && (viewPager?.currentItem != PAGE_PUBLISH_SETTINGS)
+                    currentDestination != EditPostDestination.History &&
+                    currentDestination != EditPostDestination.PublishSettings
                 )
             }
         }
@@ -1531,25 +1611,22 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun handleBackPressed(): Boolean {
-        viewPager?.let { pager ->
-            when {
-                pager.currentItem == PAGE_PUBLISH_SETTINGS -> {
-                    pager.currentItem = PAGE_SETTINGS
-                    invalidateOptionsMenu()
+        when {
+            editorPhotoPicker?.isPhotoPickerShowing() == true -> {
+                editorPhotoPicker?.hidePhotoPicker()
+            }
+            editPostNavigationViewModel.canNavigateBack() -> {
+                // Handle navigation-specific logic before navigating
+                val currentDest = editPostNavigationViewModel.currentDestination.value
+                if (currentDest == EditPostDestination.Settings) {
+                    editorFragment?.setFeaturedImageId(editPostRepository.featuredImageId)
                 }
-                pager.currentItem > PAGE_CONTENT -> {
-                    if (pager.currentItem == PAGE_SETTINGS) {
-                        editorFragment?.setFeaturedImageId(editPostRepository.featuredImageId)
-                    }
-                    pager.currentItem = PAGE_CONTENT
-                    invalidateOptionsMenu()
-                }
-                editorPhotoPicker?.isPhotoPickerShowing() == true -> {
-                    editorPhotoPicker?.hidePhotoPicker()
-                }
-                else -> {
-                    savePostAndOptionallyFinish(doFinish = true, forceSave = false)
-                }
+
+                // Let the navigation ViewModel handle the back navigation
+                editPostNavigationViewModel.handleBackNavigation()
+            }
+            else -> {
+                savePostAndOptionallyFinish(doFinish = true, forceSave = false)
             }
         }
         return true
@@ -1618,7 +1695,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             if (itemId == R.id.menu_history) {
                 AnalyticsTracker.track(Stat.REVISIONS_LIST_VIEWED)
                 ActivityUtils.hideKeyboard(this)
-                viewPager?.currentItem = PAGE_HISTORY
+                editPostNavigationViewModel.navigateTo(EditPostDestination.History)
             } else if (itemId == R.id.menu_preview_post) {
                 if (!showPreview()) {
                     return false
@@ -1626,7 +1703,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             } else if (itemId == R.id.menu_post_settings) {
                 editPostSettingsFragment?.refreshViews()
                 ActivityUtils.hideKeyboard(this)
-                viewPager?.currentItem = PAGE_SETTINGS
+                editPostNavigationViewModel.navigateTo(EditPostDestination.Settings)
             } else if (itemId == R.id.menu_secondary_action) {
                 return performSecondaryAction()
             } else if (itemId == R.id.menu_html_mode) {
@@ -2265,7 +2342,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun showPrepublishingNudgeBottomSheet() {
-        viewPager?.currentItem = PAGE_CONTENT
+        editPostNavigationViewModel.navigateTo(EditPostDestination.Editor)
         ActivityUtils.hideKeyboard(this)
         val delayMs = PREPUBLISHING_NUDGE_BOTTOM_SHEET_DELAY
         showPrepublishingBottomSheetRunnable?.let {
@@ -3107,7 +3184,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun handleHistoryDetail() {
         if (dB?.hasParcel(KEY_REVISION) == true) {
-            viewPager?.currentItem = PAGE_CONTENT
+            editPostNavigationViewModel.navigateTo(EditPostDestination.Editor)
             revision = dB?.getParcel(KEY_REVISION, parcelableCreator())
             Handler().postDelayed(
                 { loadRevision() },
@@ -3340,7 +3417,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun onEditPostPublishedSettingsClick() {
-        viewPager?.currentItem = PAGE_PUBLISH_SETTINGS
+        editPostNavigationViewModel.navigateTo(EditPostDestination.PublishSettings)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1023,7 +1023,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             EditPostDestination.History -> {
                 setTitle(R.string.history_title)
                 editorPhotoPicker?.hidePhotoPicker()
-                appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
+                appBarLayout?.liftOnScrollTargetViewId = R.id.empty_recycler_view
                 toolbar?.background = null
             }
         }
@@ -1039,34 +1039,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         viewPager?.offscreenPageLimit = OFFSCREEN_PAGE_LIMIT
         viewPager?.setPagingEnabled(false)
 
-        // When swiping between different sections, select the corresponding tab. We can also use ActionBar.Tab#select()
-        // to do this if we have a reference to the Tab.
-        viewPager?.clearOnPageChangeListeners()
-        viewPager?.addOnPageChangeListener(object : SimpleOnPageChangeListener() {
-            override fun onPageSelected(position: Int) {
-                invalidateOptionsMenu()
-                if (position == PAGE_CONTENT) {
-                    title = SiteUtils.getSiteNameOrHomeURL(siteModel)
-                    appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
-                    toolbar?.setBackgroundResource(R.drawable.tab_layout_background)
-                } else if (position == PAGE_SETTINGS) {
-                    setTitle(if (editPostRepository.isPage) R.string.page_settings else R.string.post_settings)
-                    editorPhotoPicker?.hidePhotoPicker()
-                    appBarLayout?.liftOnScrollTargetViewId = R.id.settings_fragment_root
-                    toolbar?.background = null
-                } else if (position == PAGE_PUBLISH_SETTINGS) {
-                    setTitle(R.string.publish_date)
-                    editorPhotoPicker?.hidePhotoPicker()
-                    appBarLayout?.setLiftOnScrollTargetViewIdAndRequestLayout(View.NO_ID)
-                    toolbar?.background = null
-                } else if (position == PAGE_HISTORY) {
-                    setTitle(R.string.history_title)
-                    editorPhotoPicker?.hidePhotoPicker()
-                    appBarLayout?.liftOnScrollTargetViewId = R.id.empty_recycler_view
-                    toolbar?.background = null
-                }
-            }
-        })
+        // UI updates are now handled by the navigation system in updateUIForDestination()
+        // ViewPager is only used for displaying content, not managing navigation state
     }
 
     @Suppress("LongMethod")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -40,7 +40,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.LiveData
-import androidx.viewpager.widget.ViewPager.SimpleOnPageChangeListener
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostDestination.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostDestination.kt
@@ -1,0 +1,35 @@
+package org.wordpress.android.ui.posts.navigation
+
+/**
+ * Represents the available destinations in the Edit Post flow.
+ * Provides type-safe navigation between different screens in the post editing interface.
+ */
+sealed class EditPostDestination {
+    /**
+     * The main editor screen where users write and edit post content.
+     */
+    object Editor : EditPostDestination()
+
+    /**
+     * The settings screen for configuring post metadata, categories, tags, etc.
+     */
+    object Settings : EditPostDestination()
+
+    /**
+     * The publish settings screen for scheduling and publish options.
+     */
+    object PublishSettings : EditPostDestination()
+
+    /**
+     * The post history/revisions screen showing previous versions.
+     */
+    object History : EditPostDestination()
+
+    companion object {
+        /**
+         * Returns the default destination for the Edit Post flow.
+         * Used as a fallback when navigation state is unclear.
+         */
+        fun default(): EditPostDestination = Editor
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostNavigationViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostNavigationViewModel.kt
@@ -1,0 +1,59 @@
+package org.wordpress.android.ui.posts.navigation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.viewmodel.Event
+import javax.inject.Inject
+
+/**
+ * ViewModel responsible for managing navigation state in the Edit Post flow.
+ * Provides centralized navigation state management and type-safe navigation events.
+ */
+class EditPostNavigationViewModel @Inject constructor() : ViewModel() {
+    private val _currentDestination = MutableLiveData(EditPostDestination.default())
+    val currentDestination: LiveData<EditPostDestination> = _currentDestination
+
+    private val _navigationEvents = MutableLiveData<Event<EditPostDestination>>()
+    val navigationEvents: LiveData<Event<EditPostDestination>> = _navigationEvents
+
+    fun navigateTo(destination: EditPostDestination) {
+        AppLog.d(
+            AppLog.T.POSTS,
+            "EditPostNavigationViewModel: navigating from ${_currentDestination.value} to $destination"
+        )
+        _currentDestination.value = destination
+        _navigationEvents.value = Event(destination)
+    }
+
+    fun canNavigateBack(): Boolean {
+        val canNavigate = (_currentDestination.value ?: EditPostDestination.default()) != EditPostDestination.Editor
+        AppLog.d(AppLog.T.POSTS, "EditPostNavigationViewModel: canNavigateBack() = $canNavigate")
+        return canNavigate
+    }
+
+    fun handleBackNavigation(): Boolean {
+        // Use Elvis operator since _currentDestination is initialized and should never be null,
+        // but LiveData.value is nullable by design. Use default destination as fallback.
+        val currentDest = _currentDestination.value ?: EditPostDestination.default()
+        AppLog.d(AppLog.T.POSTS, "EditPostNavigationViewModel: handleBackNavigation() from $currentDest")
+
+        return when (currentDest) {
+            EditPostDestination.PublishSettings -> {
+                navigateTo(EditPostDestination.Settings)
+                true
+            }
+
+            EditPostDestination.Settings, EditPostDestination.History -> {
+                navigateTo(EditPostDestination.Editor)
+                true
+            }
+
+            EditPostDestination.Editor -> {
+                // Let activity handle back press (exit)
+                false
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostNavigator.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/navigation/EditPostNavigator.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.posts.navigation
+
+/**
+ * Interface for handling navigation between different screens in the Edit Post flow.
+ * Provides abstraction over the underlying navigation implementation.
+ */
+interface EditPostNavigator {
+    /**
+     * Navigate to the specified destination.
+     */
+    fun navigateTo(destination: EditPostDestination)
+
+    /**
+     * Get the currently active destination.
+     */
+    fun getCurrentDestination(): EditPostDestination
+
+    /**
+     * Check if back navigation is possible from current destination.
+     */
+    fun canNavigateBack(): Boolean
+
+    /**
+     * Handle back navigation. Returns true if navigation was handled, false otherwise.
+     */
+    fun navigateBack(): Boolean
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/navigation/EditPostNavigationViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/navigation/EditPostNavigationViewModelTest.kt
@@ -1,0 +1,200 @@
+package org.wordpress.android.ui.posts.navigation
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.viewmodel.Event
+
+@ExperimentalCoroutinesApi
+class EditPostNavigationViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: EditPostNavigationViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = EditPostNavigationViewModel()
+    }
+
+    @Test
+    fun `should initialize with default destination`() {
+        // Verify initial state
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+    }
+
+    @Test
+    fun `should update current destination when navigateTo is called`() {
+        // When navigating to settings
+        viewModel.navigateTo(EditPostDestination.Settings)
+
+        // Then current destination should be updated
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Settings)
+    }
+
+    @Test
+    fun `should emit navigation event when navigateTo is called`() {
+        // Given
+        var capturedEvent: Event<EditPostDestination>? = null
+        viewModel.navigationEvents.observeForever { capturedEvent = it }
+
+        // When
+        viewModel.navigateTo(EditPostDestination.History)
+
+        // Then
+        assertThat(capturedEvent).isNotNull
+        assertThat(capturedEvent!!.peekContent()).isEqualTo(EditPostDestination.History)
+    }
+
+    @Test
+    fun `should emit new event for each navigation call`() {
+        // Given
+        val capturedEvents = mutableListOf<Event<EditPostDestination>>()
+        viewModel.navigationEvents.observeForever { capturedEvents.add(it) }
+
+        // When
+        viewModel.navigateTo(EditPostDestination.Settings)
+        viewModel.navigateTo(EditPostDestination.PublishSettings)
+
+        // Then
+        assertThat(capturedEvents).hasSize(2)
+        assertThat(capturedEvents[0].peekContent()).isEqualTo(EditPostDestination.Settings)
+        assertThat(capturedEvents[1].peekContent()).isEqualTo(EditPostDestination.PublishSettings)
+    }
+
+    @Test
+    fun `canNavigateBack should return false when on Editor`() {
+        // Given - initialized on Editor by default
+
+        // When/Then
+        assertThat(viewModel.canNavigateBack()).isFalse
+    }
+
+    @Test
+    fun `canNavigateBack should return true when on Settings`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.Settings)
+
+        // When/Then
+        assertThat(viewModel.canNavigateBack()).isTrue
+    }
+
+    @Test
+    fun `canNavigateBack should return true when on PublishSettings`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.PublishSettings)
+
+        // When/Then
+        assertThat(viewModel.canNavigateBack()).isTrue
+    }
+
+    @Test
+    fun `canNavigateBack should return true when on History`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.History)
+
+        // When/Then
+        assertThat(viewModel.canNavigateBack()).isTrue
+    }
+
+    @Test
+    fun `handleBackNavigation should return false when on Editor`() {
+        // Given - initialized on Editor by default
+
+        // When
+        val handled = viewModel.handleBackNavigation()
+
+        // Then
+        assertThat(handled).isFalse
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+    }
+
+    @Test
+    fun `handleBackNavigation should navigate from Settings to Editor`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.Settings)
+
+        // When
+        val handled = viewModel.handleBackNavigation()
+
+        // Then
+        assertThat(handled).isTrue
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+    }
+
+    @Test
+    fun `handleBackNavigation should navigate from History to Editor`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.History)
+
+        // When
+        val handled = viewModel.handleBackNavigation()
+
+        // Then
+        assertThat(handled).isTrue
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+    }
+
+    @Test
+    fun `handleBackNavigation should navigate from PublishSettings to Settings`() {
+        // Given
+        viewModel.navigateTo(EditPostDestination.PublishSettings)
+
+        // When
+        val handled = viewModel.handleBackNavigation()
+
+        // Then
+        assertThat(handled).isTrue
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Settings)
+    }
+
+    @Test
+    fun `should emit navigation events during back navigation`() {
+        // Given
+        val capturedEvents = mutableListOf<Event<EditPostDestination>>()
+        viewModel.navigationEvents.observeForever { capturedEvents.add(it) }
+        viewModel.navigateTo(EditPostDestination.PublishSettings)
+        capturedEvents.clear() // Clear the initial navigation event
+
+        // When
+        viewModel.handleBackNavigation()
+
+        // Then
+        assertThat(capturedEvents).hasSize(1)
+        assertThat(capturedEvents[0].peekContent()).isEqualTo(EditPostDestination.Settings)
+    }
+
+    @Test
+    fun `should handle navigation flow through multiple destinations`() {
+        // Test the complete navigation flow: Editor -> Settings -> PublishSettings -> Settings -> Editor
+
+        // Start at Editor (default)
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+        assertThat(viewModel.canNavigateBack()).isFalse
+
+        // Navigate to Settings
+        viewModel.navigateTo(EditPostDestination.Settings)
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Settings)
+        assertThat(viewModel.canNavigateBack()).isTrue
+
+        // Navigate to PublishSettings
+        viewModel.navigateTo(EditPostDestination.PublishSettings)
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.PublishSettings)
+        assertThat(viewModel.canNavigateBack()).isTrue
+
+        // Navigate back to Settings
+        var handled = viewModel.handleBackNavigation()
+        assertThat(handled).isTrue
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Settings)
+
+        // Navigate back to Editor
+        handled = viewModel.handleBackNavigation()
+        assertThat(handled).isTrue
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+        assertThat(viewModel.canNavigateBack()).isFalse
+
+        // Try to navigate back from Editor (should not be handled)
+        handled = viewModel.handleBackNavigation()
+        assertThat(handled).isFalse
+        assertThat(viewModel.currentDestination.value).isEqualTo(EditPostDestination.Editor)
+    }
+}


### PR DESCRIPTION
## Summary
Replaces direct ViewPager manipulation with a testable navigation abstraction layer.

## Changes
- **EditPostDestination**: Type-safe sealed class for navigation targets
- **EditPostNavigationViewModel**: Centralized navigation state with LiveData
- **EditPostNavigator**: Interface for future implementation flexibility
- **Integration**: Updated EditPostActivity to use navigation abstraction
- **Tests**: Comprehensive unit tests covering all navigation scenarios

## Benefits
- Navigation logic is now testable and centralized
- Maintains full backward compatibility with existing ViewPager
- Enables future migration to ViewPager2/Navigation Component
- Clear separation between navigation logic and UI concerns

## Testing Instructions
1. Open EditPostActivity and navigate between Editor/Settings/PublishSettings/History tabs
2. Verify back navigation works correctly (PublishSettings → Settings → Editor)
3. Confirm menu items show/hide appropriately based on current tab
4. Test that UI updates (titles, toolbar styling) work as before