### PR TITLE
Feature: Application Password info dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -45,7 +45,11 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                             }
                         )
                     }
-                    ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Info -> TODO()
+                    ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Info -> {
+                        ApplicationPasswordInfoDialog(
+                            onConfirm = { viewModel.confirmApplicationPasswordInfo() }
+                        )
+                    }
                     ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.None -> {
                         // Stub
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -48,6 +48,7 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                     }
                     ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Info -> {
                         ApplicationPasswordInfoDialog(
+                            onDismiss = { viewModel.dismissApplicationPasswordInfo() },
                             onConfirm = { viewModel.confirmApplicationPasswordInfo() }
                         )
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -31,7 +31,8 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                 when (applicationPasswordDialogState) {
                     is ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable -> {
                         ApplicationPasswordOffConfirmationDialog(
-                            affectedSites = (applicationPasswordDialogState as ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable).affectedSites,
+                            affectedSites = (applicationPasswordDialogState as
+                                    ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable).affectedSites,
                             onDismiss = { viewModel.dismissDisableApplicationPassword() },
                             onConfirm = { viewModel.confirmDisableApplicationPassword() },
                             onContactSupport = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -31,7 +31,7 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                 when (applicationPasswordDialogState) {
                     is ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable -> {
                         ApplicationPasswordOffConfirmationDialog(
-                            affectedSites = (applicationPasswordDialogState as ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable).affectedSits,
+                            affectedSites = (applicationPasswordDialogState as ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable).affectedSites,
                             onDismiss = { viewModel.dismissDisableApplicationPassword() },
                             onConfirm = { viewModel.confirmDisableApplicationPassword() },
                             onContactSupport = {
@@ -55,7 +55,7 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
                     }
                 }
 
-                // Only sho other dialogs if we are not showing the Application Password one
+                // Only show other dialogs if we are not showing the Application Password one
                 if (applicationPasswordDialogState is ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.None
                     && showDialog.value) {
                     FeedbackDialog(

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesActivity.kt
@@ -24,26 +24,36 @@ class ExperimentalFeaturesActivity : BaseAppCompatActivity() {
         setContent {
             AppThemeM3 {
                 val features by viewModel.switchStates.collectAsStateWithLifecycle()
-                val disableApplicationPasswordDialog by
-                viewModel.disableApplicationPasswordDialogState.collectAsStateWithLifecycle()
+                val applicationPasswordDialogState by
+                viewModel.applicationPasswordDialogState.collectAsStateWithLifecycle()
                 val showDialog = remember { mutableStateOf(false) }
 
-                if (disableApplicationPasswordDialog > 0) {
-                    ApplicationPasswordOffConfirmationDialog(
-                        affectedSites = disableApplicationPasswordDialog,
-                        onDismiss = { viewModel.dismissDisableApplicationPassword() },
-                        onConfirm = { viewModel.confirmDisableApplicationPassword() },
-                        onContactSupport = {
-                            val intent = SupportWebViewActivity.createIntent(
-                                context = this,
-                                origin = HelpActivity.Origin.UNKNOWN,
-                                selectedSite = null,
-                                extraSupportTags = null
-                            )
-                            this.startActivity(intent)
-                        }
-                    )
-                } else if (showDialog.value) {
+                when (applicationPasswordDialogState) {
+                    is ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable -> {
+                        ApplicationPasswordOffConfirmationDialog(
+                            affectedSites = (applicationPasswordDialogState as ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Disable).affectedSits,
+                            onDismiss = { viewModel.dismissDisableApplicationPassword() },
+                            onConfirm = { viewModel.confirmDisableApplicationPassword() },
+                            onContactSupport = {
+                                val intent = SupportWebViewActivity.createIntent(
+                                    context = this,
+                                    origin = HelpActivity.Origin.UNKNOWN,
+                                    selectedSite = null,
+                                    extraSupportTags = null
+                                )
+                                this.startActivity(intent)
+                            }
+                        )
+                    }
+                    ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.Info -> TODO()
+                    ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.None -> {
+                        // Stub
+                    }
+                }
+
+                // Only sho other dialogs if we are not showing the Application Password one
+                if (applicationPasswordDialogState is ExperimentalFeaturesViewModel.ApplicationPasswordDialogState.None
+                    && showDialog.value) {
                     FeedbackDialog(
                         onDismiss = { showDialog.value = false },
                         onSendFeedback = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -27,7 +27,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -230,6 +233,8 @@ fun ApplicationPasswordInfoDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
+    var showMore by remember { mutableStateOf(false) }
+
     AlertDialog(
         onDismissRequest = {},
         icon = {
@@ -255,18 +260,32 @@ fun ApplicationPasswordInfoDialog(
                 Text(
                     text = stringResource(R.string.application_password_info_description_1),
                 )
-                Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(
-                    text = stringResource(R.string.application_password_info_description_2),
-                )
-                Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(
-                    text = stringResource(R.string.application_password_info_description_3),
-                )
-                Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(
-                    text = stringResource(R.string.application_password_info_description_4),
-                )
+
+                if (!showMore) {
+                    Spacer(modifier = Modifier.height(Margin.Medium.value))
+                    Text(
+                        text = stringResource(R.string.learn_more),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        textDecoration = TextDecoration.Underline,
+                        modifier = Modifier
+                            .clickable { showMore = true }
+                            .padding(vertical = Margin.Small.value)
+                    )
+                } else {
+                    Spacer(modifier = Modifier.height(Margin.Medium.value))
+                    Text(
+                        text = stringResource(R.string.application_password_info_description_2),
+                    )
+                    Spacer(modifier = Modifier.height(Margin.Medium.value))
+                    Text(
+                        text = stringResource(R.string.application_password_info_description_3),
+                    )
+                    Spacer(modifier = Modifier.height(Margin.Medium.value))
+                    Text(
+                        text = stringResource(R.string.application_password_info_description_4),
+                    )
+                }
             }
         },
         confirmButton = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -160,7 +162,20 @@ fun ApplicationPasswordOffConfirmationDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.application_password_disable_feature_title)) },
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(Margin.ExtraLarge.value)
+            )
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.application_password_disable_feature_title),
+                textAlign = TextAlign.Center
+            )
+                },
         text = {
             Column {
                 Text(
@@ -216,23 +231,52 @@ fun ApplicationPasswordInfoDialog(
 ) {
     AlertDialog(
         onDismissRequest = {},
-        title = { Text(text = stringResource(R.string.application_password_info_title)) },
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(Margin.ExtraLarge.value)
+            )
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.application_password_info_title),
+                textAlign = TextAlign.Center
+            )
+        },
         text = {
             Column(
-                modifier = Modifier.verticalScroll(rememberScrollState())
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(vertical = Margin.Small.value)
             ) {
-                Text(text = stringResource(R.string.application_password_info_description_1))
+                Text(
+                    text = stringResource(R.string.application_password_info_description_1),
+                )
                 Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(text = stringResource(R.string.application_password_info_description_2))
+                Text(
+                    text = stringResource(R.string.application_password_info_description_2),
+                )
                 Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(text = stringResource(R.string.application_password_info_description_3))
+                Text(
+                    text = stringResource(R.string.application_password_info_description_3),
+                )
                 Spacer(modifier = Modifier.height(Margin.Medium.value))
-                Text(text = stringResource(R.string.application_password_info_description_4))
+                Text(
+                    text = stringResource(R.string.application_password_info_description_4),
+                )
             }
-               },
+        },
         confirmButton = {
-            Button(onClick = onConfirm) {
-                Text(text = stringResource(R.string.got_it))
+            Button(
+                onClick = onConfirm,
+                modifier = Modifier.padding(horizontal = Margin.Small.value)
+            ) {
+                Text(
+                    text = stringResource(R.string.got_it),
+                    style = MaterialTheme.typography.labelLarge
+                )
             }
         },
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -233,7 +234,7 @@ fun ApplicationPasswordInfoDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    var showMore by remember { mutableStateOf(false) }
+    var showMore by rememberSaveable { mutableStateOf(false) }
 
     AlertDialog(
         onDismissRequest = {},

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -206,6 +206,22 @@ fun ApplicationPasswordOffConfirmationDialog(
     )
 }
 
+@Composable
+fun ApplicationPasswordInfoDialog(
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text(text = stringResource(R.string.application_password_info_title)) },
+        text = { Text(text = stringResource(R.string.application_password_info_description)) },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(text = stringResource(R.string.got_it))
+            }
+        },
+    )
+}
+
 @Preview
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -227,6 +227,7 @@ fun ApplicationPasswordOffConfirmationDialog(
 
 @Composable
 fun ApplicationPasswordInfoDialog(
+    onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
     AlertDialog(
@@ -269,14 +270,13 @@ fun ApplicationPasswordInfoDialog(
             }
         },
         confirmButton = {
-            Button(
-                onClick = onConfirm,
-                modifier = Modifier.padding(horizontal = Margin.Small.value)
-            ) {
-                Text(
-                    text = stringResource(R.string.got_it),
-                    style = MaterialTheme.typography.labelLarge
-                )
+            Button(onClick = onConfirm) {
+                Text(text = stringResource(R.string.enable))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.cancel))
             }
         },
     )

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -213,7 +213,14 @@ fun ApplicationPasswordInfoDialog(
     AlertDialog(
         onDismissRequest = {},
         title = { Text(text = stringResource(R.string.application_password_info_title)) },
-        text = { Text(text = stringResource(R.string.application_password_info_description)) },
+        text = {
+            Column {
+                Text(text = stringResource(R.string.application_password_info_description_1))
+                Text(text = stringResource(R.string.application_password_info_description_2))
+                Text(text = stringResource(R.string.application_password_info_description_3))
+                Text(text = stringResource(R.string.application_password_info_description_4))
+            }
+               },
         confirmButton = {
             Button(onClick = onConfirm) {
                 Text(text = stringResource(R.string.got_it))

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesScreen.kt
@@ -4,7 +4,11 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
@@ -214,10 +218,15 @@ fun ApplicationPasswordInfoDialog(
         onDismissRequest = {},
         title = { Text(text = stringResource(R.string.application_password_info_title)) },
         text = {
-            Column {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
                 Text(text = stringResource(R.string.application_password_info_description_1))
+                Spacer(modifier = Modifier.height(Margin.Medium.value))
                 Text(text = stringResource(R.string.application_password_info_description_2))
+                Spacer(modifier = Modifier.height(Margin.Medium.value))
                 Text(text = stringResource(R.string.application_password_info_description_3))
+                Spacer(modifier = Modifier.height(Margin.Medium.value))
                 Text(text = stringResource(R.string.application_password_info_description_4))
             }
                },

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -29,8 +29,10 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     private val _switchStates = MutableStateFlow<Map<Feature, Boolean>>(emptyMap())
     val switchStates: StateFlow<Map<Feature, Boolean>> = _switchStates.asStateFlow()
 
-    private val _applicationPasswordDialogState = MutableStateFlow<ApplicationPasswordDialogState>(ApplicationPasswordDialogState.None)
-    val applicationPasswordDialogState: StateFlow<ApplicationPasswordDialogState> = _applicationPasswordDialogState.asStateFlow()
+    private val _applicationPasswordDialogState =
+        MutableStateFlow<ApplicationPasswordDialogState>(ApplicationPasswordDialogState.None)
+    val applicationPasswordDialogState: StateFlow<ApplicationPasswordDialogState> =
+        _applicationPasswordDialogState.asStateFlow()
 
     init {
         val initialStates = Feature.entries

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -54,20 +54,20 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         // Since FluxC has not way to access the experimental features, this is a workaround to remove the
         // Application Password credentials when the feature is disabled to avoid FluxC to use them.
         // See the logic in [SiteModelExtensions.kt] and how it can not access to the feature flag
-        if (feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE && enabled.not()) {
-            val affectedSites = applicationPasswordLoginHelper.getApplicationPasswordSitesCount()
-            if (affectedSites > 0) {
-                _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Disable(affectedSites)
-            } else {
-                confirmDisableApplicationPassword()
-            }
-        } else {
-            _switchStates.update { currentStates ->
-                currentStates.toMutableMap().apply {
-                    this[feature] = enabled
-                    experimentalFeatures.setEnabled(feature, enabled)
+        if (feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE) {
+            if (enabled) {
+                _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Info
+                setFeatureSwitchState(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
+            }  else {
+                val affectedSites = applicationPasswordLoginHelper.getApplicationPasswordSitesCount()
+                if (affectedSites > 0) {
+                    _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Disable(affectedSites)
+                } else {
+                    confirmDisableApplicationPassword()
                 }
             }
+        } else {
+            setFeatureSwitchState(feature, enabled)
         }
     }
 
@@ -78,12 +78,7 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     @Suppress("TooGenericExceptionCaught")
     fun confirmDisableApplicationPassword() {
         _applicationPasswordDialogState.value = ApplicationPasswordDialogState.None
-        _switchStates.update { currentStates ->
-            currentStates.toMutableMap().apply {
-                this[Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE] = false
-                experimentalFeatures.setEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
-            }
-        }
+        setFeatureSwitchState(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
 
         viewModelScope.launch {
             try {
@@ -98,6 +93,18 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
                     AppLog.T.DB,
                     "Error when trying to remove Application Password credentials: ${exception.stackTrace}"
                 )
+            }
+        }
+    }
+
+    private fun setFeatureSwitchState(
+        feature: Feature,
+        enabled: Boolean
+    ) {
+        _switchStates.update { currentStates ->
+            currentStates.toMutableMap().apply {
+                this[feature] = enabled
+                experimentalFeatures.setEnabled(feature, enabled)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -128,6 +128,6 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         /**
          * Dialog representing the disable feature state, and the affected sites if any.
          */
-        data class Disable(val affectedSits: Int) : ApplicationPasswordDialogState()
+        data class Disable(val affectedSites: Int) : ApplicationPasswordDialogState()
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -97,6 +97,11 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         }
     }
 
+    fun confirmApplicationPasswordInfo() {
+        _applicationPasswordDialogState.value = ApplicationPasswordDialogState.None
+        setFeatureSwitchState(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
+    }
+
     private fun setFeatureSwitchState(
         feature: Feature,
         enabled: Boolean

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -59,7 +59,6 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         if (feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE) {
             if (enabled) {
                 _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Info
-                setFeatureSwitchState(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
             }  else {
                 val affectedSites = applicationPasswordLoginHelper.getApplicationPasswordSitesCount()
                 if (affectedSites > 0) {
@@ -97,6 +96,11 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    fun dismissApplicationPasswordInfo() {
+        _applicationPasswordDialogState.value = ApplicationPasswordDialogState.None
+        setFeatureSwitchState(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
     }
 
     fun confirmApplicationPasswordInfo() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -29,8 +29,8 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     private val _switchStates = MutableStateFlow<Map<Feature, Boolean>>(emptyMap())
     val switchStates: StateFlow<Map<Feature, Boolean>> = _switchStates.asStateFlow()
 
-    private val _disableApplicationPasswordDialogState = MutableStateFlow(0)
-    val disableApplicationPasswordDialogState: StateFlow<Int> = _disableApplicationPasswordDialogState.asStateFlow()
+    private val _applicationPasswordDialogState = MutableStateFlow<ApplicationPasswordDialogState>(ApplicationPasswordDialogState.None)
+    val applicationPasswordDialogState: StateFlow<ApplicationPasswordDialogState> = _applicationPasswordDialogState.asStateFlow()
 
     init {
         val initialStates = Feature.entries
@@ -57,7 +57,7 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
         if (feature == Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE && enabled.not()) {
             val affectedSites = applicationPasswordLoginHelper.getApplicationPasswordSitesCount()
             if (affectedSites > 0) {
-                _disableApplicationPasswordDialogState.value = affectedSites
+                _applicationPasswordDialogState.value = ApplicationPasswordDialogState.Disable(affectedSites)
             } else {
                 confirmDisableApplicationPassword()
             }
@@ -72,12 +72,12 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
     }
 
     fun dismissDisableApplicationPassword() {
-        _disableApplicationPasswordDialogState.value = 0
+        _applicationPasswordDialogState.value = ApplicationPasswordDialogState.None
     }
 
     @Suppress("TooGenericExceptionCaught")
     fun confirmDisableApplicationPassword() {
-        _disableApplicationPasswordDialogState.value = 0
+        _applicationPasswordDialogState.value = ApplicationPasswordDialogState.None
         _switchStates.update { currentStates ->
             currentStates.toMutableMap().apply {
                 this[Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE] = false
@@ -100,5 +100,22 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    sealed class ApplicationPasswordDialogState {
+        /**
+         * No dialog
+         */
+        data object None : ApplicationPasswordDialogState()
+
+        /**
+         * General info dialog
+         */
+        data object Info : ApplicationPasswordDialogState()
+
+        /**
+         * Dialog representing the disable feature state, and the affected sites if any.
+         */
+        data class Disable(val affectedSits: Int) : ApplicationPasswordDialogState()
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5034,7 +5034,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling application password will remove your login info from %1$s sites.</string>
     <string name="application_password_info_title">Application Passwords</string>
-    <string name="application_password_info_description_1">Application passwords are a more secure way for this app to access your site content without using your actual account password.</string>
+    <string name="application_password_info_description_1">Application passwords are a secure way for apps to access your site without using your account password.</string>
     <string name="application_password_info_description_2">When you add sites to the app, application passwords will be created automatically as needed.</string>
     <string name="application_password_info_description_3">You can view and manage these passwords in your user profile within your WordPress site\'s admin panel.</string>
     <string name="application_password_info_description_4">Please note that revoking application passwords used by the app will terminate the app\'s access to your site. Be cautious when revoking application passwords created by the app.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -976,7 +976,7 @@
     <string name="experimental_subscribers_feature">Experimental subscribers</string>
     <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
     <string name="experimental_application_password_feature">Application Password log in</string>
-    <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites.</string>
+    <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5033,7 +5033,10 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password </string>
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling application password will remove your login info from %1$s sites.</string>
-    <string name="application_password_info_title">About Application Passwords</string>
-    <string name="application_password_info_description">Application Passwords description</string>
+    <string name="application_password_info_title">Application Passwords</string>
+    <string name="application_password_info_description_1">Application passwords are a more secure way for this app to access your site content without using your actual account password.</string>
+    <string name="application_password_info_description_2">When you add sites to the app, application passwords will be created automatically as needed.</string>
+    <string name="application_password_info_description_3">You can view and manage these passwords in your user profile within your WordPress site\'s admin panel.</string>
+    <string name="application_password_info_description_4">Please note that revoking application passwords used by the app will terminate the app\'s access to your site. Be cautious when revoking application passwords created by the app.</string>
     <string name="got_it">Got it</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5033,4 +5033,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password </string>
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling application password will remove your login info from %1$s sites.</string>
+    <string name="application_password_info_title">About Application Passwords</string>
+    <string name="application_password_info_description">Application Passwords description</string>
+    <string name="got_it">Got it</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5038,5 +5038,5 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_info_description_2">When you add sites to the app, application passwords will be created automatically as needed.</string>
     <string name="application_password_info_description_3">You can view and manage these passwords in your user profile within your WordPress site\'s admin panel.</string>
     <string name="application_password_info_description_4">Please note that revoking application passwords used by the app will terminate the app\'s access to your site. Be cautious when revoking application passwords created by the app.</string>
-    <string name="got_it">Got it</string>
+    <string name="enable">Enable</string>
 </resources>

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
@@ -16,6 +16,7 @@ import org.wordpress.android.BuildConfig
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeaturesViewModel.ApplicationPasswordDialogState
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.config.GutenbergKitFeature
 
@@ -156,30 +157,31 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `dismissDisableApplicationPassword sets dialog state to false`() = test {
+    fun `dismissDisableApplicationPassword sets dialog state to none`() = test {
         createViewModel()
         whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
         // Simulate dialog being shown
         viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
-        assertThat(viewModel.disableApplicationPasswordDialogState.value).isEqualTo(1)
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.Disable(1))
         // Dismiss
         viewModel.dismissDisableApplicationPassword()
-        assertThat(viewModel.disableApplicationPasswordDialogState.value).isEqualTo(0)
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.None)
     }
 
     @Test
-    fun `confirmDisableApplicationPassword disables feature, removes credentials, and sets dialog state to false`() =
+    fun `confirmDisableApplicationPassword disables feature, removes credentials, and sets dialog state to none`() =
         test {
             createViewModel()
             whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
             // Simulate dialog being shown
             viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
-            assertThat(viewModel.disableApplicationPasswordDialogState.value).isEqualTo(1)
+            assertThat(viewModel.applicationPasswordDialogState.value)
+                .isEqualTo(ApplicationPasswordDialogState.Disable(1))
             // Confirm
             viewModel.confirmDisableApplicationPassword()
             advanceUntilIdle()
             // Dialog should be dismissed
-            assertThat(viewModel.disableApplicationPasswordDialogState.value).isEqualTo(0)
+            assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.None)
             // Feature should be disabled
             assertThat(viewModel.switchStates.value[Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE]).isFalse()
             // Credentials should be removed
@@ -193,10 +195,22 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
             whenever(applicationPasswordLoginHelper.getApplicationPasswordSitesCount()).thenReturn(1)
             viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, false)
             // Dialog should be shown
-            assertThat(viewModel.disableApplicationPasswordDialogState.value).isEqualTo(1)
+            assertThat(viewModel.applicationPasswordDialogState.value)
+                .isEqualTo(ApplicationPasswordDialogState.Disable(1))
             // Credentials should not be removed yet
             verify(applicationPasswordLoginHelper, never()).removeAllApplicationPasswordCredentials()
         }
+
+    @Test
+    fun `onFeatureToggled on for application password shows info dialog`() = test {
+        createViewModel()
+        // Simulate dialog being shown
+        viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.Info)
+        // Dismiss
+        viewModel.confirmApplicationPasswordInfo()
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.None)
+    }
 
     private fun createViewModel() {
         viewModel = ExperimentalFeaturesViewModel(

--- a/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModelTest.kt
@@ -202,13 +202,24 @@ class ExperimentalFeaturesViewModelTest : BaseUnitTest() {
         }
 
     @Test
-    fun `onFeatureToggled on for application password shows info dialog`() = test {
+    fun `onFeatureToggled on for application password shows info dialog and enable`() = test {
         createViewModel()
         // Simulate dialog being shown
         viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
         assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.Info)
         // Dismiss
         viewModel.confirmApplicationPasswordInfo()
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.None)
+    }
+
+    @Test
+    fun `onFeatureToggled on for application password shows info dialog and keep dioabled`() = test {
+        createViewModel()
+        // Simulate dialog being shown
+        viewModel.onFeatureToggled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
+        assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.Info)
+        // Dismiss
+        viewModel.dismissApplicationPasswordInfo()
         assertThat(viewModel.applicationPasswordDialogState.value).isEqualTo(ApplicationPasswordDialogState.None)
     }
 


### PR DESCRIPTION
## Description
This PR is crating an informative Application Password dialog for when the feature is enabled.

I've followed [how it was done on iOS and used the same strings](https://github.com/wordpress-mobile/WordPress-iOS/pull/24684). I think theuy are a bit long tough. So, if you have any suggestion about them is welcome :) 

## Testing instructions
1. Go to experimental features screen
2. Enable/disale Application Password
- [ ] Verify the dialogs look ok

https://github.com/user-attachments/assets/4da911d7-9246-4b70-9304-4d0f48424b30


<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->