### PR TITLE
Revert AGP to `8.7.3`

### DIFF
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -76,11 +76,6 @@
     <issue id="ObsoleteSdkInt">
         <ignore path="**/generated/ksp/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
     </issue>
-    <issue id="UseRequiresApi">
-        <ignore path="**/generated/ksp/**/org/wordpress/android/ui/main/Hilt_WPMainNavigationView.java" />
-    </issue>
-    <!-- TODO: Enable this rule once all dependencies are updated to support 16KB page size alignment -->
-    <issue id="Aligned16KB" severity="warning" />
     <issue id="IconDensities" severity="warning" /> <!--    fluxc-->
     <!-- INTEROPERABILITY -->
     <!-- TODO: https://github.com/wordpress-mobile/WordPress-Android/pull/21430 -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,9 @@ android.enableR8.fullMode=false
 
 # Dependency Analysis Plugin
 dependency.analysis.android.ignored.variants=release,wordpressVanillaDebug,wordpressVanillaRelease,wordpressWasabiDebug,wordpressWasabiRelease,wordpressJalapenoRelease,jetpackVanillaDebug,jetpackVanillaRelease,jetpackWasabiDebug,jetpackWasabiRelease,jetpackJalapenoRelease
+
+# Use lint from AGP 8.8.1
+# The lint shipped with currently used AGP (8.7.3) combined with androidx.lifecycle 2.9.0 crashes
+# https://issuetracker.google.com/issues/418014548
+# Remove this after bumping AGP to 8.8.1 or higher
+android.experimental.lint.version=8.8.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = '8.11.0'
+agp = '8.7.3'
 airbnb-lottie = '6.6.7'
 android-desugar = '2.1.5'
 android-installreferrer = '2.2'


### PR DESCRIPTION
See [this discussion](https://github.com/wordpress-mobile/WordPress-Android/pull/22043#issuecomment-3136738098) for the reason.