### PR TITLE
Dependabot should ignore `encryptedlogging` updates due our custom versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,7 @@ updates:
       - dependency-name: "com.automattic.tracks:crashlogging"
       - dependency-name: "rs.wordpress.api:android"
       - dependency-name: "com.gravatar:gravatar"
+      - dependency-name: "com.automattic:encryptedlogging"
       # Ignore dependencies that were added only to address security vulnerabilities of transitive WireMock dependencies
       - dependency-name: "org.eclipse.jetty:jetty-webapp"
       - dependency-name: "com.fasterxml.jackson.core:jackson-databind"


### PR DESCRIPTION
As explained in the line `36` of this diff:

> Our libraries that are stored in S3 have a custom versioning scheme which doesn't work with dependapot.