### PR TITLE
Replace `PrepublishingBottomSheetListener` with `ViewModel` Communication

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -192,7 +192,6 @@ import org.wordpress.android.ui.posts.editor.media.EditorMediaListener
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment.Companion.newInstance
 import org.wordpress.android.ui.posts.prepublishing.home.usecases.PublishPostImmediatelyUseCase
-import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingBottomSheetListener
 import org.wordpress.android.ui.posts.reactnative.ReactNativeRequestHandler
 import org.wordpress.android.ui.posts.services.AztecImageLoader
 import org.wordpress.android.ui.posts.services.AztecVideoLoader
@@ -255,6 +254,7 @@ import org.wordpress.android.viewmodel.Event
 import org.wordpress.android.viewmodel.helpers.ToastMessageHolder
 import org.wordpress.android.viewmodel.storage.StorageUtilsViewModel
 import org.wordpress.android.ui.posts.navigation.EditPostNavigationViewModel
+import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel
 import org.wordpress.android.ui.posts.navigation.EditPostDestination
 import org.wordpress.android.widgets.AppReviewManager.incrementInteractions
 import org.wordpress.android.widgets.WPSnackbar.Companion.make
@@ -278,7 +278,7 @@ import kotlin.math.max
 class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, EditorImageSettingsListener,
     EditorImagePreviewListener, EditorEditMediaListener, EditorDragAndDropListener, EditorFragmentListener,
     ActivityCompat.OnRequestPermissionsResultCallback, PhotoPickerListener, EditorPhotoPickerListener,
-    EditorMediaListener, EditPostActivityHook, HistoryItemClickInterface, PrepublishingBottomSheetListener,
+    EditorMediaListener, EditPostActivityHook, HistoryItemClickInterface,
     PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger, SiteSettingsListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
@@ -431,7 +431,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     @Inject lateinit var editorJetpackSocialViewModel: EditorJetpackSocialViewModel
     private lateinit var editPostNavigationViewModel: EditPostNavigationViewModel
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
-    @Inject lateinit var editPostAuthViewModel: EditPostAuthViewModel
+    private lateinit var prepublishingViewModel: PrepublishingViewModel
+    private lateinit var editPostAuthViewModel: EditPostAuthViewModel
 
     private lateinit var siteModel: SiteModel
 
@@ -642,6 +643,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private fun initializeViewModels() {
         editPostNavigationViewModel = ViewModelProvider(this, viewModelFactory)[EditPostNavigationViewModel::class.java]
         editPostSettingsViewModel = ViewModelProvider(this, viewModelFactory)[EditPostSettingsViewModel::class.java]
+        prepublishingViewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
+        editPostAuthViewModel = ViewModelProvider(this, viewModelFactory)[EditPostAuthViewModel::class.java]
     }
 
     private fun initializeSiteModel(savedInstanceState: Bundle?): Boolean {
@@ -1200,6 +1203,18 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 clearFeaturedImage()
             }
         }
+
+        // Observe prepublishing submit button events
+        prepublishingViewModel.triggerOnSubmitButtonClickedListener.observe(this) { event ->
+            event.getContentIfNotHandled()?.let { publishPost ->
+                AppLog.d(AppLog.T.POSTS, "EditPostActivity: Handling prepublishing submit event")
+                uploadPost(publishPost)
+                if (publishPost) {
+                    incrementInteractions(Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE)
+                }
+            }
+        }
+
     }
 
     private fun initializePostObject() {
@@ -2367,12 +2382,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
 
-    override fun onSubmitButtonClicked(publishPost: Boolean) {
-        uploadPost(publishPost)
-        if (publishPost) {
-            incrementInteractions(Stat.APP_REVIEWS_EVENT_INCREMENTED_BY_PUBLISHING_POST_OR_PAGE)
-        }
-    }
 
     private fun uploadPost(publishPost: Boolean) {
         updateAndSavePostAsyncOnEditorExit(object : OnPostUpdatedFromUIListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1214,7 +1214,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 }
             }
         }
-
     }
 
     private fun initializePostObject() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
@@ -41,7 +41,6 @@ import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeFragme
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType
 import org.wordpress.android.ui.posts.prepublishing.home.PublishPost
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingActionClickedListener
-import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingBottomSheetListener
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingScreenClosedListener
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingSocialViewModelProvider
 import org.wordpress.android.ui.posts.prepublishing.publishsettings.PrepublishingPublishSettingsFragment
@@ -69,7 +68,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     private lateinit var viewModel: PrepublishingViewModel
     private lateinit var keyboardResizeViewUtil: KeyboardResizeViewUtil
 
-    private var prepublishingBottomSheetListener: PrepublishingBottomSheetListener? = null
 
     private var jetpackSocialViewModel: EditorJetpackSocialViewModel? = null
     private lateinit var editShareMessageActivityResultLauncher: ActivityResultLauncher<Intent>
@@ -81,11 +79,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        prepublishingBottomSheetListener = if (context is PrepublishingBottomSheetListener) {
-            context
-        } else {
-            throw RuntimeException("$context must implement PrepublishingBottomSheetListener")
-        }
 
         editShareMessageActivityResultLauncher = registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
@@ -99,11 +92,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
                 }
             }
         }
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        prepublishingBottomSheetListener = null
     }
 
     override fun onCreateView(
@@ -179,7 +167,7 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     private fun initViewModel(savedInstanceState: Bundle?) {
-        viewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
+        viewModel = ViewModelProvider(requireActivity(), viewModelFactory)[PrepublishingViewModel::class.java]
 
         viewModel.navigationTarget.observeEvent(this) { navigationState ->
             navigateToScreen(navigationState)
@@ -189,9 +177,6 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
             dismiss()
         }
 
-        viewModel.triggerOnSubmitButtonClickedListener.observeEvent(this) { publishPost ->
-            prepublishingBottomSheetListener?.onSubmitButtonClicked(publishPost)
-        }
 
         viewModel.dismissKeyboard.observeEvent(this) {
             ActivityUtils.hideKeyboardForced(view)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
@@ -118,7 +118,7 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
             viewModelFactory
         )[PrepublishingCategoriesViewModel::class.java]
         parentViewModel = ViewModelProvider(
-            requireParentFragment(),
+            requireActivity(),
             viewModelFactory
         )[PrepublishingViewModel::class.java]
         startObserving()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/addcategory/PrepublishingAddCategoryFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/addcategory/PrepublishingAddCategoryFragment.kt
@@ -137,7 +137,7 @@ class PrepublishingAddCategoryFragment : Fragment(R.layout.prepublishing_add_cat
             viewModelFactory
         )[PrepublishingAddCategoryViewModel::class.java]
         parentViewModel = ViewModelProvider(
-            requireParentFragment(),
+            requireActivity(),
             viewModelFactory
         )[PrepublishingViewModel::class.java]
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/social/PrepublishingSocialFragment.kt
@@ -55,7 +55,7 @@ class PrepublishingSocialFragment : Fragment(R.layout.prepublishing_social_fragm
 
     private fun setupViewModels() {
         parentViewModel = ViewModelProvider(
-            requireParentFragment(),
+            requireActivity(),
             viewModelFactory
         )[PrepublishingViewModel::class.java]
 


### PR DESCRIPTION
## Summary
This PR eliminates the `PrepublishingBottomSheetListener` interface dependency from `EditPostActivity` as part of preparing for Navigation Component migration. It replaces callback-based fragment communication with proper ViewModel patterns following modern Android architecture guidelines.

## Problem Statement
- `EditPostActivity` implemented `PrepublishingBottomSheetListener` interface, creating tight coupling
- `PrepublishingBottomSheetFragment` used fragment-scoped `PrepublishingViewModel`, causing separate instances
- Interface-based communication prevents Navigation Component adoption
- Fragment recreation after dismissal showed blank screens due to ViewModel scoping issues

## Solution
Replace interface communication with activity-scoped `PrepublishingViewModel` shared between activity and fragments, enabling proper event-based communication while maintaining correct fragment lifecycle behavior.

## Changes Made

### Core Architecture Changes
- ✅ Remove `PrepublishingBottomSheetListener` interface implementation from `EditPostActivity`
- ✅ Add `PrepublishingViewModel` to `EditPostActivity.initializeViewModels()` with activity scope
- ✅ Update `PrepublishingBottomSheetFragment` to use `requireActivity()` scope for ViewModel
- ✅ Replace interface callback with `ViewModel.triggerOnSubmitButtonClickedListener` observation

### ViewModel Scoping Fixes
- ✅ Fix `PrepublishingCategoriesFragment` to use activity-scoped parent ViewModel
- ✅ Fix `PrepublishingAddCategoryFragment` to use activity-scoped parent ViewModel  
- ✅ Fix `PrepublishingSocialFragment` to use activity-scoped parent ViewModel

### State Management Improvements
- ✅ Replace generic `isStarted` flag with semantic `tagsFetched` flag
- ✅ Improve `start()` method logic to handle both configuration changes and fragment recreation
- ✅ Ensure dismissal + reopen resets to HOME screen while config changes preserve current screen

## Files Modified
- `EditPostActivity.kt` - Remove interface, add ViewModel observation
- `PrepublishingBottomSheetFragment.kt` - Use activity-scoped ViewModel, remove interface casting
- `PrepublishingViewModel.kt` - Improve initialization logic and state management
- `PrepublishingCategoriesFragment.kt` - Fix ViewModel scoping
- `PrepublishingAddCategoryFragment.kt` - Fix ViewModel scoping
- `PrepublishingSocialFragment.kt` - Fix ViewModel scoping

## Testing Instructions

### 1. Basic Functionality
- [x] Open post editor
- [x] Tap publish button to open prepublishing sheet
- [x] Verify HOME screen shows with publish options
- [x] Tap "Publish" button and verify post publishes correctly

### 2. Fragment Recreation - Dismissal + Reopen
- [x] Open prepublishing sheet (should show HOME)
- [x] Navigate to Categories screen
- [x] Tap outside sheet to dismiss
- [x] Reopen prepublishing sheet
- [x] **Expected**: Shows HOME screen (not Categories)

### 3. Configuration Changes - Screen Rotation
- [x] Open prepublishing sheet (should show HOME)
- [x] Navigate to Categories screen
- [x] Rotate device
- [x] **Expected**: Still shows Categories screen (preserved state)
- [x] Navigate to Tags screen
- [x] Rotate device again
- [x] **Expected**: Still shows Tags screen

### 4. Child Fragment Navigation
- [x] Open prepublishing sheet
- [x] Navigate through different screens (Categories, Tags, Social, Publish Settings)
- [x] Verify all screens load correctly
- [x] Verify back navigation works properly
- [x] Test category selection and tag editing functionality

### 5. Publishing Flow
- [x] Open prepublishing sheet
- [x] Modify categories/tags/settings
- [x] Tap "Publish" button
- [x] Verify post publishes with correct metadata
- [x] Verify sheet closes after publishing
- [x] Test both "Save as Draft" and "Publish" options