### PR TITLE
Implement GutenbergKit ViewModel Architecture

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -90,6 +90,7 @@ import org.wordpress.android.ui.posts.AddCategoryFragment;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostPublishSettingsFragment;
 import org.wordpress.android.ui.posts.EditPostSettingsFragment;
+import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment;
 import org.wordpress.android.ui.posts.HistoryListFragment;
 import org.wordpress.android.ui.posts.PostDatePickerDialogFragment;
 import org.wordpress.android.ui.posts.PostListFragment;
@@ -271,6 +272,8 @@ public interface AppComponent {
     void inject(EditPostActivity object);
 
     void inject(EditPostSettingsFragment object);
+
+    void inject(GutenbergKitEditorFragment object);
 
     void inject(PostSettingsListDialogFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.posts.EditPostAuthViewModel;
 import org.wordpress.android.ui.posts.EditPostPublishSettingsViewModel;
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel;
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel;
+import org.wordpress.android.ui.posts.GutenbergKitViewModel;
 import org.wordpress.android.ui.posts.navigation.EditPostNavigationViewModel;
 import org.wordpress.android.ui.posts.EditPostSettingsViewModel;
 import org.wordpress.android.ui.posts.PostListMainViewModel;
@@ -306,6 +307,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(EditPostSettingsViewModel.class)
     abstract ViewModel editPostSettingsViewModel(EditPostSettingsViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(GutenbergKitViewModel.class)
+    abstract ViewModel gutenbergKitViewModel(GutenbergKitViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -76,6 +76,7 @@ import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
+import org.wordpress.android.ui.posts.editor.GutenbergKitSettings
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergPropsBuilder
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
@@ -2632,7 +2633,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             )
         }
 
-        private fun createGutenbergKitSettings(isWpCom: Boolean): MutableMap<String, Any?> {
+        private fun createGutenbergKitSettings(isWpCom: Boolean): GutenbergKitSettings {
             val postType = if (editPostRepository.isPage) "page" else "post"
             val siteURL = siteModel.url
             val siteApiRoot = if (isWpCom) "https://public-api.wordpress.com/"
@@ -2640,28 +2641,27 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             // Use the application password for self-hosted sites when available
             val authHeader = if (isWpCom) "Bearer ${accountStore.accessToken}" else "Basic "
             val siteApiNamespace = if (isWpCom)
-                arrayOf("sites/${site.siteId}/", "sites/${UrlUtils.removeScheme(siteURL)}/")
-                else arrayOf()
+                listOf("sites/${site.siteId}/", "sites/${UrlUtils.removeScheme(siteURL)}/")
+                else emptyList()
 
             val languageString = perAppLocaleManager.getCurrentLocaleLanguageCode()
             val wpcomLocaleSlug = languageString.replace("_", "-").lowercase()
 
-            return mutableMapOf(
-                "postId" to editPostRepository.getPost()?.remotePostId?.toInt(),
-                "postType" to postType,
-                "postTitle" to editPostRepository.getPost()?.title,
-                "postContent" to editPostRepository.getPost()?.content,
-                "siteURL" to siteURL,
-                "siteApiRoot" to siteApiRoot,
-                "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
-                "authHeader" to authHeader,
-                "siteApiNamespace" to siteApiNamespace,
-                "themeStyles" to experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES),
-                // Limited to Simple sites until application passwords are supported
-                "plugins" to (gutenbergKitPluginsFeature.isEnabled() && site.isWPCom),
-                "locale" to wpcomLocaleSlug,
-                "cookies" to editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
-                "webViewGlobals" to listOf(
+            return GutenbergKitSettings(
+                postId = editPostRepository.getPost()?.remotePostId?.toInt(),
+                postType = postType,
+                postTitle = editPostRepository.getPost()?.title,
+                postContent = editPostRepository.getPost()?.content,
+                siteURL = siteURL,
+                siteApiRoot = siteApiRoot,
+                namespaceExcludedPaths = listOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
+                authHeader = authHeader,
+                siteApiNamespace = siteApiNamespace,
+                themeStyles = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES),
+                plugins = gutenbergKitPluginsFeature.isEnabled() && site.isWPCom,
+                locale = wpcomLocaleSlug,
+                cookies = editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
+                webViewGlobals = listOf(
                     WebViewGlobal(
                         "_currentSiteType",
                         when {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -76,7 +76,6 @@ import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
-import org.wordpress.android.ui.posts.GutenbergKitSettings
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergPropsBuilder
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -76,7 +76,7 @@ import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
-import org.wordpress.android.ui.posts.editor.GutenbergKitSettings
+import org.wordpress.android.ui.posts.GutenbergKitSettings
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergPropsBuilder
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -434,6 +434,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private lateinit var editPostSettingsViewModel: EditPostSettingsViewModel
     private lateinit var prepublishingViewModel: PrepublishingViewModel
     private lateinit var editPostAuthViewModel: EditPostAuthViewModel
+    private lateinit var gutenbergKitViewModel: GutenbergKitViewModel
 
     private lateinit var siteModel: SiteModel
 
@@ -646,6 +647,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         editPostSettingsViewModel = ViewModelProvider(this, viewModelFactory)[EditPostSettingsViewModel::class.java]
         prepublishingViewModel = ViewModelProvider(this, viewModelFactory)[PrepublishingViewModel::class.java]
         editPostAuthViewModel = ViewModelProvider(this, viewModelFactory)[EditPostAuthViewModel::class.java]
+        gutenbergKitViewModel = ViewModelProvider(this, viewModelFactory)[GutenbergKitViewModel::class.java]
     }
 
     private fun initializeSiteModel(savedInstanceState: Bundle?): Boolean {
@@ -2607,13 +2609,17 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             val gutenbergWebViewAuthorizationData = createGutenbergWebViewAuthorizationData(isWpCom)
             val settings = createGutenbergKitSettings(isWpCom)
 
-            return GutenbergKitEditorFragment.newInstance(
+            val fragment = GutenbergKitEditorFragment.newInstance(
                 getContext(),
                 isNewPost,
                 gutenbergWebViewAuthorizationData,
                 jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
-                settings
             )
+
+            // Set settings in ViewModel for fragment to observe
+            gutenbergKitViewModel.updateEditorSettings(settings)
+
+            return fragment
         }
 
         private fun createGutenbergWebViewAuthorizationData(isWpCom: Boolean): GutenbergWebViewAuthorizationData {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitViewModel.kt
@@ -3,8 +3,30 @@ package org.wordpress.android.ui.posts
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import org.wordpress.android.ui.posts.editor.GutenbergKitSettings
+import org.wordpress.gutenberg.WebViewGlobal
+import java.io.Serializable
 import javax.inject.Inject
+
+data class GutenbergKitSettings(
+    val postId: Int? = null,
+    val postType: String,
+    val postTitle: String? = null,
+    val postContent: String? = null,
+    val siteURL: String,
+    val siteApiRoot: String,
+    val namespaceExcludedPaths: List<String> = emptyList(),
+    val authHeader: String,
+    val siteApiNamespace: List<String> = emptyList(),
+    val themeStyles: Boolean = false,
+    val plugins: Boolean = false,
+    val locale: String,
+    val cookies: Map<String, String> = emptyMap(),
+    val webViewGlobals: List<WebViewGlobal> = emptyList()
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
 
 /**
  * ViewModel for managing GutenbergKit editor settings and state.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitViewModel.kt
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.posts
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import org.wordpress.android.ui.posts.editor.GutenbergKitSettings
+import javax.inject.Inject
+
+/**
+ * ViewModel for managing GutenbergKit editor settings and state.
+ * Handles communication between EditPostActivity and GutenbergKitEditorFragment.
+ */
+class GutenbergKitViewModel @Inject constructor() : ViewModel() {
+    private val _editorSettings = MutableLiveData<GutenbergKitSettings>()
+    val editorSettings: LiveData<GutenbergKitSettings> = _editorSettings
+
+    /**
+     * Updates the editor settings. Called by EditPostActivity when creating the fragment.
+     */
+    fun updateEditorSettings(settings: GutenbergKitSettings) {
+        _editorSettings.value = settings
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -69,7 +69,11 @@ data class GutenbergKitSettings(
     val locale: String,
     val cookies: Map<String, String> = emptyMap(),
     val webViewGlobals: List<WebViewGlobal> = emptyList()
-) : Serializable
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}
 
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
     EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -54,30 +54,11 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.ui.posts.GutenbergKitSettings
 import org.wordpress.android.ui.posts.GutenbergKitViewModel
 import org.wordpress.android.WordPress
 import javax.inject.Inject
 
-data class GutenbergKitSettings(
-    val postId: Int? = null,
-    val postType: String,
-    val postTitle: String? = null,
-    val postContent: String? = null,
-    val siteURL: String,
-    val siteApiRoot: String,
-    val namespaceExcludedPaths: List<String> = emptyList(),
-    val authHeader: String,
-    val siteApiNamespace: List<String> = emptyList(),
-    val themeStyles: Boolean = false,
-    val plugins: Boolean = false,
-    val locale: String,
-    val cookies: Map<String, String> = emptyMap(),
-    val webViewGlobals: List<WebViewGlobal> = emptyList()
-) : Serializable {
-    companion object {
-        private const val serialVersionUID: Long = 1L
-    }
-}
 
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
     EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -54,6 +54,23 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
+data class GutenbergKitSettings(
+    val postId: Int? = null,
+    val postType: String,
+    val postTitle: String? = null,
+    val postContent: String? = null,
+    val siteURL: String,
+    val siteApiRoot: String,
+    val namespaceExcludedPaths: List<String> = emptyList(),
+    val authHeader: String,
+    val siteApiNamespace: List<String> = emptyList(),
+    val themeStyles: Boolean = false,
+    val plugins: Boolean = false,
+    val locale: String,
+    val cookies: Map<String, String> = emptyMap(),
+    val webViewGlobals: List<WebViewGlobal> = emptyList()
+) : Serializable
+
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
     EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,
     GutenbergNetworkConnectionListener {
@@ -88,8 +105,8 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
         if (arguments != null) {
-            @Suppress("UNCHECKED_CAST", "DEPRECATION")
-            settings = requireArguments().getSerializable(ARG_GUTENBERG_KIT_SETTINGS) as Map<String, Any?>?
+            @Suppress("DEPRECATION")
+            settings = requireArguments().getSerializable(ARG_GUTENBERG_KIT_SETTINGS) as GutenbergKitSettings?
         }
 
         // request dependency injection. Do this after setting min/max dimensions
@@ -216,17 +233,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
             throw ClassCastException("$activity must implement ${T::class.simpleName}: $e")
         }
     }
-
-    // Type-safe settings accessors
-    private inline fun <reified T> Map<String, Any?>.getSetting(key: String): T? = this[key] as? T
-    private inline fun <reified T> Map<String, Any?>.getSettingOrDefault(key: String, default: T): T =
-        getSetting(key) ?: default
-
-    private fun Map<String, Any?>.getStringArray(key: String): Array<String> =
-        getSetting<Array<String?>>(key)?.asSequence()?.filterNotNull()?.toList()?.toTypedArray() ?: emptyArray()
-
-    private fun Map<String, Any?>.getWebViewGlobals(key: String): List<WebViewGlobal> =
-        getSetting<List<WebViewGlobal>>(key) ?: emptyList()
 
     // View extension functions
     private fun View?.setVisibleOrGone(visible: Boolean) {
@@ -517,39 +523,31 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     }
 
     private fun buildEditorConfiguration(editorSettings: String): EditorConfiguration {
-        val settingsMap = settings!!
+        val kitSettings = settings!!
 
-        return settingsMap.run {
-            val postId = getSetting<Int>("postId").let { if (it == 0) -1 else it }
-            val siteURL = getSetting<String>("siteURL")
-            val siteApiRoot = getSetting<String>("siteApiRoot")
-            val siteApiNamespace = getStringArray("siteApiNamespace")
-            val firstNamespace = siteApiNamespace.firstOrNull() ?: ""
-            val editorAssetsEndpoint = "${siteApiRoot}wpcom/v2/${firstNamespace}editor-assets"
-            val cookies = getSetting<Map<String, String>>("cookies") ?: emptyMap()
-            val namespaceExcludedPaths = getStringArray("namespaceExcludedPaths")
-            val webViewGlobals = getWebViewGlobals("webViewGlobals")
+        val postId = kitSettings.postId?.let { if (it == 0) -1 else it }
+        val firstNamespace = kitSettings.siteApiNamespace.firstOrNull() ?: ""
+        val editorAssetsEndpoint = "${kitSettings.siteApiRoot}wpcom/v2/${firstNamespace}editor-assets"
 
-            EditorConfiguration.Builder()
-                .setTitle(getSetting<String>("postTitle") ?: "")
-                .setContent(getSetting<String>("postContent") ?: "")
-                .setPostId(postId)
-                .setPostType(getSetting<String>("postType"))
-                .setThemeStyles(getSettingOrDefault("themeStyles", false))
-                .setPlugins(getSettingOrDefault("plugins", false))
-                .setSiteApiRoot(getSetting<String>("siteApiRoot") ?: "")
-                .setSiteApiNamespace(siteApiNamespace)
-                .setNamespaceExcludedPaths(namespaceExcludedPaths)
-                .setAuthHeader(getSetting<String>("authHeader") ?: "")
-                .setWebViewGlobals(webViewGlobals)
-                .setEditorSettings(editorSettings)
-                .setLocale(getSetting<String>("locale"))
-                .setEditorAssetsEndpoint(editorAssetsEndpoint)
-                .setCachedAssetHosts(setOf("s0.wp.com", UrlUtils.getHost(siteURL)))
-                .setEnableAssetCaching(true)
-                .setCookies(cookies)
-                .build()
-        }
+        return EditorConfiguration.Builder()
+            .setTitle(kitSettings.postTitle ?: "")
+            .setContent(kitSettings.postContent ?: "")
+            .setPostId(postId)
+            .setPostType(kitSettings.postType)
+            .setThemeStyles(kitSettings.themeStyles)
+            .setPlugins(kitSettings.plugins)
+            .setSiteApiRoot(kitSettings.siteApiRoot)
+            .setSiteApiNamespace(kitSettings.siteApiNamespace.toTypedArray())
+            .setNamespaceExcludedPaths(kitSettings.namespaceExcludedPaths.toTypedArray())
+            .setAuthHeader(kitSettings.authHeader)
+            .setWebViewGlobals(kitSettings.webViewGlobals)
+            .setEditorSettings(editorSettings)
+            .setLocale(kitSettings.locale)
+            .setEditorAssetsEndpoint(editorAssetsEndpoint)
+            .setCachedAssetHosts(setOf("s0.wp.com", UrlUtils.getHost(kitSettings.siteURL)))
+            .setEnableAssetCaching(true)
+            .setCookies(kitSettings.cookies)
+            .build()
     }
 
     override fun showNotice(message: String?) {
@@ -594,20 +592,20 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
         private const val CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101
         private const val CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102
 
-        private var settings: Map<String, Any?>? = null
+        private var settings: GutenbergKitSettings? = null
 
         fun newInstance(
             context: Context,
             isNewPost: Boolean,
             webViewAuthorizationData: GutenbergWebViewAuthorizationData?,
             jetpackFeaturesEnabled: Boolean,
-            settings: Map<String, Any?>?
+            settings: GutenbergKitSettings?
         ): GutenbergKitEditorFragment {
             val fragment = GutenbergKitEditorFragment()
             val args = Bundle()
             args.putBoolean(ARG_IS_NEW_POST, isNewPost)
             args.putBoolean(ARG_JETPACK_FEATURES_ENABLED, jetpackFeaturesEnabled)
-            args.putSerializable(ARG_GUTENBERG_KIT_SETTINGS, settings as Serializable?)
+            args.putSerializable(ARG_GUTENBERG_KIT_SETTINGS, settings)
             fragment.setArguments(args)
             val db = getDatabase(context)
             GutenbergKitEditorFragment.settings = settings

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -53,6 +53,10 @@ import org.wordpress.gutenberg.Media
 import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
+import androidx.lifecycle.ViewModelProvider
+import org.wordpress.android.ui.posts.GutenbergKitViewModel
+import org.wordpress.android.WordPress
+import javax.inject.Inject
 
 data class GutenbergKitSettings(
     val postId: Int? = null,
@@ -78,6 +82,9 @@ data class GutenbergKitSettings(
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
     EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,
     GutenbergNetworkConnectionListener {
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    private lateinit var gutenbergKitViewModel: GutenbergKitViewModel
+
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -91,11 +98,28 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     private var isEditorDidMount = false
     private var rootView: View? = null
 
+    // Access settings through ViewModel
+    private val settings: GutenbergKitSettings?
+        get() = if (::gutenbergKitViewModel.isInitialized) {
+            gutenbergKitViewModel.editorSettings.value
+        } else {
+            null
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         ProfilingUtils.start("Visual Editor Startup")
         ProfilingUtils.split("EditorFragment.onCreate")
+
+        // Trigger dependency injection
+        (requireActivity().applicationContext as WordPress).component().inject(this)
+
+        // Initialize shared ViewModel (same scope as Activity) - after DI is complete
+        gutenbergKitViewModel = ViewModelProvider(
+            requireActivity(),
+            viewModelFactory
+        )[GutenbergKitViewModel::class.java]
 
         if (savedInstanceState != null) {
             isHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED)
@@ -108,11 +132,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
-        if (arguments != null) {
-            @Suppress("DEPRECATION")
-            settings = requireArguments().getSerializable(ARG_GUTENBERG_KIT_SETTINGS) as GutenbergKitSettings?
-        }
-
         // request dependency injection. Do this after setting min/max dimensions
         if (activity is EditorFragmentActivity) {
             (activity as EditorFragmentActivity).initializeEditorFragment()
@@ -591,28 +610,22 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
         private const val ARG_GUTENBERG_WEB_VIEW_AUTH_DATA = "param_gutenberg_web_view_auth_data"
         const val ARG_FEATURED_IMAGE_ID: String = "featured_image_id"
         const val ARG_JETPACK_FEATURES_ENABLED: String = "jetpack_features_enabled"
-        const val ARG_GUTENBERG_KIT_SETTINGS: String = "gutenberg_kit_settings"
 
         private const val CAPTURE_PHOTO_PERMISSION_REQUEST_CODE = 101
         private const val CAPTURE_VIDEO_PERMISSION_REQUEST_CODE = 102
-
-        private var settings: GutenbergKitSettings? = null
 
         fun newInstance(
             context: Context,
             isNewPost: Boolean,
             webViewAuthorizationData: GutenbergWebViewAuthorizationData?,
             jetpackFeaturesEnabled: Boolean,
-            settings: GutenbergKitSettings?
         ): GutenbergKitEditorFragment {
             val fragment = GutenbergKitEditorFragment()
             val args = Bundle()
             args.putBoolean(ARG_IS_NEW_POST, isNewPost)
             args.putBoolean(ARG_JETPACK_FEATURES_ENABLED, jetpackFeaturesEnabled)
-            args.putSerializable(ARG_GUTENBERG_KIT_SETTINGS, settings)
             fragment.setArguments(args)
             val db = getDatabase(context)
-            GutenbergKitEditorFragment.settings = settings
             db?.addParcel(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, webViewAuthorizationData)
             return fragment
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -50,15 +50,12 @@ import org.wordpress.gutenberg.GutenbergView.TitleAndContentCallback
 import org.wordpress.gutenberg.GutenbergWebViewPool.getPreloadedWebView
 import org.wordpress.gutenberg.GutenbergWebViewPool.recycleWebView
 import org.wordpress.gutenberg.Media
-import org.wordpress.gutenberg.WebViewGlobal
-import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 import androidx.lifecycle.ViewModelProvider
 import org.wordpress.android.ui.posts.GutenbergKitSettings
 import org.wordpress.android.ui.posts.GutenbergKitViewModel
 import org.wordpress.android.WordPress
 import javax.inject.Inject
-
 
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
     EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitViewModelTest.kt
@@ -1,0 +1,40 @@
+package org.wordpress.android.ui.posts
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+
+@ExperimentalCoroutinesApi
+class GutenbergKitViewModelTest : BaseUnitTest() {
+    private lateinit var viewModel: GutenbergKitViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = GutenbergKitViewModel()
+    }
+
+    @Test
+    fun `updateEditorSettings stores and exposes settings correctly`() = test {
+        // Arrange
+        val testSettings = GutenbergKitSettings(
+            postId = 123,
+            postType = "post",
+            postTitle = "Test Post",
+            postContent = "Test content",
+            siteURL = "https://example.com",
+            siteApiRoot = "https://example.com/wp-json",
+            authHeader = "Bearer token123",
+            locale = "en"
+        )
+
+        // Act
+        viewModel.updateEditorSettings(testSettings)
+
+        // Assert
+        assertThat(viewModel.editorSettings.value).isEqualTo(testSettings)
+        assertThat(viewModel.editorSettings.value?.postId).isEqualTo(123)
+        assertThat(viewModel.editorSettings.value?.postTitle).isEqualTo("Test Post")
+    }
+}


### PR DESCRIPTION
## Summary
Replaces static variable pattern in `GutenbergKitEditorFragment` with proper `ViewModel` architecture to improve state management and prevent memory leaks.

## Key Changes
- **Create `GutenbergKitViewModel`** with dependency injection
- **Replace static settings variable** with `ViewModel`-based state management
- **Add Dagger injection support** for `GutenbergKitEditorFragment`

## Technical Benefits
- **Memory leak prevention**: Eliminates static variables that retain references
- **Lifecycle awareness**: Proper state management that survives configuration changes
- **Modern architecture**: Follows Android `ViewModel` best practices