### PR TITLE
Deprecating isApplicationPasswordsSupported in favor of isUsingSelfHostedRestApi

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1176,7 +1176,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     }
 
     /**
-     * Deprecated
+     * @deprecated
      * Use isUsingSelfHostedRestApi() to know if Application Password is supported and set
      */
     @Deprecated

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -104,11 +104,17 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Nullable
     @Column(name = "API_REST_USERNAME")
     private String mApiRestUsernameEncrypted;
+    /**
+     * This field is populated by decrypting {mApiRestUsernameEncrypted} at runtime when reading the field form the DB
+     */
     @Nullable
     private String mApiRestUsernamePlain;
     @Nullable
     @Column(name = "API_REST_PASSWORD")
     private String mApiRestPasswordEncrypted;
+    /**
+     * This field is populated by decrypting {mApiRestUsernameEncrypted} at runtime when reading the field form the DB
+     */
     @Nullable
     private String mApiRestPasswordPlain;
     @Nullable
@@ -1169,6 +1175,11 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mApplicationPasswordsAuthorizeUrl = applicationPasswordsAuthorizeUrl;
     }
 
+    /**
+     * Deprecated
+     * Use isUsingSelfHostedRestApi() to know if Application Password is supported and set
+     */
+    @Deprecated
     public boolean isApplicationPasswordsSupported() {
         return mApplicationPasswordsAuthorizeUrl != null && !mApplicationPasswordsAuthorizeUrl.isEmpty();
     }

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -105,7 +105,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column(name = "API_REST_USERNAME")
     private String mApiRestUsernameEncrypted;
     /**
-     * This field is populated by decrypting {mApiRestUsernameEncrypted} at runtime when reading the field form the DB
+     * This field is populated by decrypting {mApiRestUsernameEncrypted} at runtime when reading the field from the DB
      */
     @Nullable
     private String mApiRestUsernamePlain;
@@ -113,7 +113,7 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
     @Column(name = "API_REST_PASSWORD")
     private String mApiRestPasswordEncrypted;
     /**
-     * This field is populated by decrypting {mApiRestUsernameEncrypted} at runtime when reading the field form the DB
+     * This field is populated by decrypting {mApiRestPasswordEncrypted} at runtime when reading the field from the DB
      */
     @Nullable
     private String mApiRestPasswordPlain;

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/model/SiteModel.java
@@ -1175,15 +1175,6 @@ public class SiteModel extends Payload<BaseNetworkError> implements Identifiable
         mApplicationPasswordsAuthorizeUrl = applicationPasswordsAuthorizeUrl;
     }
 
-    /**
-     * @deprecated
-     * Use isUsingSelfHostedRestApi() to know if Application Password is supported and set
-     */
-    @Deprecated
-    public boolean isApplicationPasswordsSupported() {
-        return mApplicationPasswordsAuthorizeUrl != null && !mApplicationPasswordsAuthorizeUrl.isEmpty();
-    }
-
     public int getPublishedStatus() {
         return mPublishedStatus;
     }


### PR DESCRIPTION
## Description
There seems to be an old function to check if the Application Password was being used, but it's not integrated at all in the new flow.
I checked the code and tried to remove it, but it seems that it was introduced by Woo, and there are some Woo references, although it's not used in our project. 
On the other hand, because of previous interactions, it looks like they are copying our FluxC changes into their project, so in order not to break anything there, I'm just deprecating the function in favor of the new one.

## Testing instructions
Jus check the code

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->