### PR TITLE
Jetpack Connection cleanup

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -851,7 +851,7 @@
 
         <!-- Jetpack connection -->
         <activity
-            android:name=".ui.jetpackconnection.JetpackConnectionActivity"
+            android:name=".ui.jetpackrestconnection.JetpackRestConnectionActivity"
             android:theme="@style/WordPress.NoActionBar" />
 
         <!-- Domain Management -->

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackconnection/JetpackConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackconnection/JetpackConnectionViewModel.kt
@@ -326,8 +326,7 @@ class JetpackConnectionViewModel @Inject constructor(
          */
         @Suppress("Unused")
         fun canInitiateJetpackConnection(site: SiteModel): Boolean {
-            return site.isSelfHostedAdmin 
-                && site.isApplicationPasswordsSupported
+            return site.isUsingSelfHostedRestApi
                 && !site.applicationPasswordsAuthorizeUrl.isNullOrEmpty()
                 && !site.wpApiRestUrl.isNullOrEmpty()
                 && !site.isJetpackConnected

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackconnection/JetpackConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackconnection/JetpackConnectionViewModel.kt
@@ -319,15 +319,12 @@ class JetpackConnectionViewModel @Inject constructor(
 
         /**
          * Requirements:
-         * - Self-hosted site, and
-         * - The site is authenticated with application password, and
+         * - Self-hosted site authenticated with application password, and
          * - the site isn't already connected to Jetpack, and
          * - Jetpack is not installed or the installed jetpack version is 14.2 or above
          */
-        @Suppress("Unused")
         fun canInitiateJetpackConnection(site: SiteModel): Boolean {
             return site.isUsingSelfHostedRestApi
-                && !site.applicationPasswordsAuthorizeUrl.isNullOrEmpty()
                 && !site.wpApiRestUrl.isNullOrEmpty()
                 && !site.isJetpackConnected
                 && (!site.isJetpackInstalled || checkMinimalVersion(site.jetpackVersion, LIMIT_VERSION))

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jetpackconnection
+package org.wordpress.android.ui.jetpackrestconnection
 
 import android.content.Context
 import android.content.Intent
@@ -15,13 +15,13 @@ import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.util.extensions.setContent
 
 @AndroidEntryPoint
-class JetpackConnectionActivity : BaseAppCompatActivity() {
-    private val viewModel: JetpackConnectionViewModel by viewModels()
+class JetpackRestConnectionActivity : BaseAppCompatActivity() {
+    private val viewModel: JetpackRestConnectionViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            JetpackConnectionScreen(
+            JetpackRestConnectionScreen(
                 currentStep = viewModel.currentStep.collectAsState(),
                 stepStates = viewModel.stepStates.collectAsState(),
                 buttonType = viewModel.buttonType.collectAsState(),
@@ -33,8 +33,8 @@ class JetpackConnectionActivity : BaseAppCompatActivity() {
         lifecycleScope.launch {
             viewModel.uiEvent.filterNotNull().collect { event ->
                 when (event) {
-                    JetpackConnectionViewModel.UiEvent.Close -> finish()
-                    JetpackConnectionViewModel.UiEvent.ShowCancelConfirmation -> showCancelConfirmationDialog()
+                    JetpackRestConnectionViewModel.UiEvent.Close -> finish()
+                    JetpackRestConnectionViewModel.UiEvent.ShowCancelConfirmation -> showCancelConfirmationDialog()
                 }
             }
         }
@@ -42,8 +42,8 @@ class JetpackConnectionActivity : BaseAppCompatActivity() {
 
     private fun showCancelConfirmationDialog() {
         MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.jetpack_connection_cancel_title)
-            .setMessage(R.string.jetpack_connection_cancel_message)
+            .setTitle(R.string.jetpack_rest_connection_cancel_title)
+            .setMessage(R.string.jetpack_rest_connection_cancel_message)
             .setPositiveButton(R.string.yes) { _, _ -> viewModel.onCancelConfirmed() }
             .setNegativeButton(R.string.no) { _, _ -> viewModel.onCancelDismissed() }
             .setCancelable(false)
@@ -53,6 +53,6 @@ class JetpackConnectionActivity : BaseAppCompatActivity() {
     companion object {
         @JvmStatic
         fun createIntent(context: Context) =
-            Intent(context, JetpackConnectionActivity::class.java)
+            Intent(context, JetpackRestConnectionActivity::class.java)
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
@@ -128,11 +128,31 @@ private data class StepConfig(
 )
 
 private val stepConfigs = listOf(
-    StepConfig(ConnectionStep.LoginWpCom, R.string.jetpack_rest_connection_step_login_wpcom, Icons.Default.AccountCircle),
-    StepConfig(ConnectionStep.InstallJetpack, R.string.jetpack_rest_connection_step_install_jetpack, Icons.Default.Build),
-    StepConfig(ConnectionStep.ConnectSite, R.string.jetpack_rest_connection_step_connect_site, Icons.Default.Home),
-    StepConfig(ConnectionStep.ConnectWpCom, R.string.jetpack_rest_connection_step_connect_wpcom, Icons.Default.Settings),
-    StepConfig(ConnectionStep.Finalize, R.string.jetpack_rest_connection_step_finalize, Icons.Default.CheckCircle)
+    StepConfig(
+        step = ConnectionStep.LoginWpCom,
+        titleRes = R.string.jetpack_rest_connection_step_login_wpcom,
+        icon = Icons.Default.AccountCircle
+    ),
+    StepConfig(
+        step = ConnectionStep.InstallJetpack,
+        titleRes = R.string.jetpack_rest_connection_step_install_jetpack,
+        icon = Icons.Default.Build
+    ),
+    StepConfig(
+        step = ConnectionStep.ConnectSite,
+        titleRes = R.string.jetpack_rest_connection_step_connect_site,
+        icon = Icons.Default.Home
+    ),
+    StepConfig(
+        step = ConnectionStep.ConnectWpCom,
+        titleRes = R.string.jetpack_rest_connection_step_connect_wpcom,
+        icon = Icons.Default.Settings
+    ),
+    StepConfig(
+        step = ConnectionStep.Finalize,
+        titleRes = R.string.jetpack_rest_connection_step_finalize,
+        icon = Icons.Default.CheckCircle
+    )
 )
 
 @Composable

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jetpackconnection
+package org.wordpress.android.ui.jetpackrestconnection
 
 import android.content.Context
 import android.content.res.Configuration
@@ -53,14 +53,14 @@ import androidx.compose.ui.unit.dp
 import org.wordpress.android.R
 import org.wordpress.android.ui.compose.components.ScreenWithTopAppBarM3
 import org.wordpress.android.ui.compose.components.buttons.PrimaryButtonM3
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel.ButtonType
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel.ConnectionStatus
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel.ConnectionStep
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel.ErrorType
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel.StepState
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ButtonType
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStatus
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStep
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ErrorType
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.StepState
 
 @Composable
-fun JetpackConnectionScreen(
+fun JetpackRestConnectionScreen(
     currentStep: State<ConnectionStep?>,
     stepStates: State<Map<ConnectionStep, StepState>>,
     buttonType: State<ButtonType?>,
@@ -68,7 +68,7 @@ fun JetpackConnectionScreen(
     onRetryClick: () -> Unit = {}
 ) {
     ScreenWithTopAppBarM3(
-        titleRes = R.string.jetpack_connection_setup_title,
+        titleRes = R.string.jetpack_rest_connection_setup_title,
         onCloseClick = onCloseClick,
         content = {
             Column {
@@ -128,11 +128,11 @@ private data class StepConfig(
 )
 
 private val stepConfigs = listOf(
-    StepConfig(ConnectionStep.LoginWpCom, R.string.jetpack_connection_step_login_wpcom, Icons.Default.AccountCircle),
-    StepConfig(ConnectionStep.InstallJetpack, R.string.jetpack_connection_step_install_jetpack, Icons.Default.Build),
-    StepConfig(ConnectionStep.ConnectSite, R.string.jetpack_connection_step_connect_site, Icons.Default.Home),
-    StepConfig(ConnectionStep.ConnectWpCom, R.string.jetpack_connection_step_connect_wpcom, Icons.Default.Settings),
-    StepConfig(ConnectionStep.Finalize, R.string.jetpack_connection_step_finalize, Icons.Default.CheckCircle)
+    StepConfig(ConnectionStep.LoginWpCom, R.string.jetpack_rest_connection_step_login_wpcom, Icons.Default.AccountCircle),
+    StepConfig(ConnectionStep.InstallJetpack, R.string.jetpack_rest_connection_step_install_jetpack, Icons.Default.Build),
+    StepConfig(ConnectionStep.ConnectSite, R.string.jetpack_rest_connection_step_connect_site, Icons.Default.Home),
+    StepConfig(ConnectionStep.ConnectWpCom, R.string.jetpack_rest_connection_step_connect_wpcom, Icons.Default.Settings),
+    StepConfig(ConnectionStep.Finalize, R.string.jetpack_rest_connection_step_finalize, Icons.Default.CheckCircle)
 )
 
 @Composable
@@ -244,11 +244,11 @@ private fun ConnectionStepContent(
 
 private fun getErrorText(context: Context, errorType: ErrorType): String {
     @StringRes val messageRes = when (errorType) {
-        is ErrorType.JetpackAlreadyInstalled -> R.string.jetpack_connection_error_jetpack_already_installed
-        is ErrorType.Timeout -> R.string.jetpack_connection_error_timeout
-        is ErrorType.Offline -> R.string.jetpack_connection_error_offline
-        is ErrorType.Unknown -> R.string.jetpack_connection_error_unknown
-        is ErrorType.FailedToConnectWpCom -> R.string.jetpack_connection_error_wpcom
+        is ErrorType.JetpackAlreadyInstalled -> R.string.jetpack_rest_connection_error_jetpack_already_installed
+        is ErrorType.Timeout -> R.string.jetpack_rest_connection_error_timeout
+        is ErrorType.Offline -> R.string.jetpack_rest_connection_error_offline
+        is ErrorType.Unknown -> R.string.jetpack_rest_connection_error_unknown
+        is ErrorType.FailedToConnectWpCom -> R.string.jetpack_rest_connection_error_wpcom
     }
     val baseMessage = context.getString(messageRes)
     return errorType.message?.let { "$baseMessage: $it" } ?: baseMessage
@@ -271,7 +271,7 @@ private fun ConnectionStepStatusIndicator(
         ConnectionStatus.Completed -> {
             Icon(
                 imageVector = Icons.Default.Check,
-                contentDescription = stringResource(R.string.jetpack_connection_status_completed),
+                contentDescription = stringResource(R.string.jetpack_rest_connection_status_completed),
                 modifier = Modifier.size(20.dp),
                 tint = MaterialTheme.colorScheme.primary
             )
@@ -280,7 +280,7 @@ private fun ConnectionStepStatusIndicator(
         ConnectionStatus.Failed -> {
             Icon(
                 imageVector = Icons.Default.Warning,
-                contentDescription = stringResource(R.string.jetpack_connection_status_failed),
+                contentDescription = stringResource(R.string.jetpack_rest_connection_status_failed),
                 modifier = Modifier.size(20.dp),
                 tint = MaterialTheme.colorScheme.error
             )
@@ -294,10 +294,10 @@ private fun ConnectionStepStatusIndicator(
 
 @Composable
 private fun getStatusText(status: ConnectionStatus): String = when (status) {
-    ConnectionStatus.NotStarted -> stringResource(R.string.jetpack_connection_status_not_started)
-    ConnectionStatus.InProgress -> stringResource(R.string.jetpack_connection_status_in_progress)
-    ConnectionStatus.Completed -> stringResource(R.string.jetpack_connection_status_completed)
-    ConnectionStatus.Failed -> stringResource(R.string.jetpack_connection_status_failed)
+    ConnectionStatus.NotStarted -> stringResource(R.string.jetpack_rest_connection_status_not_started)
+    ConnectionStatus.InProgress -> stringResource(R.string.jetpack_rest_connection_status_in_progress)
+    ConnectionStatus.Completed -> stringResource(R.string.jetpack_rest_connection_status_completed)
+    ConnectionStatus.Failed -> stringResource(R.string.jetpack_rest_connection_status_failed)
 }
 
 @Composable
@@ -388,7 +388,7 @@ private data class ConnectionStepStyle(
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
-private fun JetpackConnectionScreenPreview() {
+private fun JetpackRestConnectionScreenPreview() {
     val currentStep = remember { mutableStateOf(ConnectionStep.ConnectSite) }
     val stepStates = remember {
         mutableStateOf(
@@ -406,7 +406,7 @@ private fun JetpackConnectionScreenPreview() {
     }
     val buttonType = remember { mutableStateOf<ButtonType?>(ButtonType.Done) }
 
-    JetpackConnectionScreen(
+    JetpackRestConnectionScreen(
         currentStep = currentStep,
         stepStates = stepStates,
         buttonType = buttonType,

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.jetpackconnection
+package org.wordpress.android.ui.jetpackrestconnection
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @HiltViewModel
-class JetpackConnectionViewModel @Inject constructor(
+class JetpackRestConnectionViewModel @Inject constructor(
     @Named(UI_THREAD) mainDispatcher: CoroutineDispatcher,
     @Named(BG_THREAD) private val bgDispatcher: CoroutineDispatcher,
     private val selectedSiteRepository: SelectedSiteRepository,
@@ -312,7 +312,7 @@ class JetpackConnectionViewModel @Inject constructor(
     }
 
     companion object {
-        private const val TAG = "JetpackConnectionViewModel"
+        private const val TAG = "JetpackRestConnectionViewModel"
         private const val LIMIT_VERSION = "14.2"
         private const val STEP_TIMEOUT_MS = 30000L // 30 seconds timeout per step
         private const val STEP_DELAY_MS = 2000L
@@ -323,7 +323,7 @@ class JetpackConnectionViewModel @Inject constructor(
          * - the site isn't already connected to Jetpack, and
          * - Jetpack is not installed or the installed jetpack version is 14.2 or above
          */
-        fun canInitiateJetpackConnection(site: SiteModel): Boolean {
+        fun canInitiateJetpackRestConnection(site: SiteModel): Boolean {
             return site.isUsingSelfHostedRestApi
                 && !site.wpApiRestUrl.isNullOrEmpty()
                 && !site.isJetpackConnected

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -94,7 +94,6 @@ import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsRemind
 import org.wordpress.android.ui.bloggingreminders.BloggingReminderUtils;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.deeplinks.DeepLinkOpenWebLinksWithJetpackHelper;
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionActivity;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureFullScreenOverlayFragment;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil;
 import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalOverlayUtil.JetpackFeatureCollectionOverlaySource;
@@ -519,10 +518,6 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         if (savedInstanceState != null) {
             mIsChangingConfiguration = savedInstanceState.getBoolean(ARG_IS_CHANGING_CONFIGURATION, false);
         }
-
-        // TODO remove this
-        Intent intent = JetpackConnectionActivity.createIntent(this);
-        startActivity(intent);
     }
 
     private void initBackPressHandler() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -41,7 +41,7 @@ class ExperimentalFeatures @Inject constructor(
             R.string.experimental_application_password_feature_description
         ),
         EXPERIMENTAL_JETPACK_REST_CONNECTION(
-            "experimental_jetpack_connection",
+            "experimental_jetpack_rest_connection",
             R.string.experimental_jetpack_rest_connection,
             R.string.experimental_jetpack_rest_connection_description
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeatures.kt
@@ -40,10 +40,10 @@ class ExperimentalFeatures @Inject constructor(
             R.string.experimental_application_password_feature,
             R.string.experimental_application_password_feature_description
         ),
-        EXPERIMENTAL_JETPACK_CONNECTION(
+        EXPERIMENTAL_JETPACK_REST_CONNECTION(
             "experimental_jetpack_connection",
-            R.string.experimental_jetpack_connection,
-            R.string.experimental_jetpack_connection_description
+            R.string.experimental_jetpack_rest_connection,
+            R.string.experimental_jetpack_rest_connection_description
         );
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/experimentalfeatures/ExperimentalFeaturesViewModel.kt
@@ -47,7 +47,7 @@ internal class ExperimentalFeaturesViewModel @Inject constructor(
 
     private fun shouldShowFeature(feature: Feature): Boolean {
         // Only show Jetpack Connection feature in debug builds
-        return if (feature == Feature.EXPERIMENTAL_JETPACK_CONNECTION) {
+        return if (feature == Feature.EXPERIMENTAL_JETPACK_REST_CONNECTION) {
             BuildConfig.DEBUG
         } else if (gutenbergKitFeature.isEnabled()) {
             feature != Feature.EXPERIMENTAL_BLOCK_EDITOR

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -18,7 +18,11 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.ui.JetpackConnectionSource.STATS
 import org.wordpress.android.ui.JetpackConnectionWebViewActivity
 import org.wordpress.android.ui.WPWebViewActivity
+import org.wordpress.android.ui.jetpackconnection.JetpackConnectionActivity
+import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel
 import org.wordpress.android.ui.main.BaseAppCompatActivity
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T.API
 import org.wordpress.android.util.WPUrlUtils
@@ -38,6 +42,12 @@ class StatsConnectJetpackActivity : BaseAppCompatActivity() {
 
     @Inject
     lateinit var mDispatcher: Dispatcher
+
+    @Inject
+    lateinit var mExperimentalFeatures: ExperimentalFeatures
+
+    @Inject
+    lateinit var mSelectedSiteRepository: SelectedSiteRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -123,6 +133,19 @@ class StatsConnectJetpackActivity : BaseAppCompatActivity() {
     }
 
     private fun startJetpackConnectionFlow(siteModel: SiteModel) {
+        // if the experimental Jetpack REST Connection feature is enabled and this site is able to use it, launch
+        // the experimental flow instead of the old web-based one
+        if (mExperimentalFeatures.isEnabled(ExperimentalFeatures.Feature.EXPERIMENTAL_JETPACK_CONNECTION)) {
+            mSelectedSiteRepository.getSelectedSite()?.let { site ->
+                if (JetpackConnectionViewModel.canInitiateJetpackConnection(site)) {
+                    val intent = JetpackConnectionActivity.createIntent(this)
+                    startActivity(intent)
+                    finish()
+                    return
+                }
+            }
+        }
+
         mIsJetpackConnectStarted = true
         JetpackConnectionWebViewActivity
             .startJetpackConnectionFlow(this, STATS, siteModel, mAccountStore.hasAccessToken())

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConnectJetpackActivity.kt
@@ -18,8 +18,8 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.ui.JetpackConnectionSource.STATS
 import org.wordpress.android.ui.JetpackConnectionWebViewActivity
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionActivity
-import org.wordpress.android.ui.jetpackconnection.JetpackConnectionViewModel
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionActivity
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
@@ -135,10 +135,10 @@ class StatsConnectJetpackActivity : BaseAppCompatActivity() {
     private fun startJetpackConnectionFlow(siteModel: SiteModel) {
         // if the experimental Jetpack REST Connection feature is enabled and this site is able to use it, launch
         // the experimental flow instead of the old web-based one
-        if (mExperimentalFeatures.isEnabled(ExperimentalFeatures.Feature.EXPERIMENTAL_JETPACK_CONNECTION)) {
+        if (mExperimentalFeatures.isEnabled(ExperimentalFeatures.Feature.EXPERIMENTAL_JETPACK_REST_CONNECTION)) {
             mSelectedSiteRepository.getSelectedSite()?.let { site ->
-                if (JetpackConnectionViewModel.canInitiateJetpackConnection(site)) {
-                    val intent = JetpackConnectionActivity.createIntent(this)
+                if (JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)) {
+                    val intent = JetpackRestConnectionActivity.createIntent(this)
                     startActivity(intent)
                     finish()
                     return

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -977,8 +977,8 @@
     <string name="experimental_subscribers_feature_description">View and manage newsletter subscribers</string>
     <string name="experimental_application_password_feature">Application Password log in</string>
     <string name="experimental_application_password_feature_description">Enable Application Password to log into self-hosted sites</string>
-    <string name="experimental_jetpack_connection">Experimental Jetpack Connection</string>
-    <string name="experimental_jetpack_connection_description">Enable experimental Jetpack Connection flow</string>
+    <string name="experimental_jetpack_rest_connection">Experimental Jetpack REST Connection</string>
+    <string name="experimental_jetpack_rest_connection_description">Enable experimental Jetpack REST Connection flow</string>
 
     <!-- Debug settings -->
     <string name="preference_open_debug_settings" translatable="false">Debug Settings</string>
@@ -1006,25 +1006,25 @@
     <string name="content_description_people_looking_charts">People looking at graphs and charts</string>
     <string name="jetpack_connection_terms_and_conditions">By setting up Jetpack you agree to our %1$sterms and conditions%2$s</string>
 
-    <!-- Jetpack Connection Screen -->
-    <string name="jetpack_connection_title">Jetpack Connection</string>
-    <string name="jetpack_connection_setup_title">Setting up Jetpack</string>
-    <string name="jetpack_connection_step_login_wpcom">Login to WordPress.com</string>
-    <string name="jetpack_connection_step_install_jetpack">Install Jetpack Plugin</string>
-    <string name="jetpack_connection_step_connect_site">Connect Your Site</string>
-    <string name="jetpack_connection_step_connect_wpcom">Connect to WordPress.com</string>
-    <string name="jetpack_connection_step_finalize">Finalize Setup</string>
-    <string name="jetpack_connection_status_not_started">Not started</string>
-    <string name="jetpack_connection_status_in_progress">In progress…</string>
-    <string name="jetpack_connection_status_completed">Completed</string>
-    <string name="jetpack_connection_status_failed">Failed</string>
-    <string name="jetpack_connection_cancel_title">Cancel Jetpack Setup?</string>
-    <string name="jetpack_connection_cancel_message">The Jetpack connection process is in progress. Are you sure you want to cancel?</string>
-    <string name="jetpack_connection_error_jetpack_already_installed">Jetpack is already installed</string>
-    <string name="jetpack_connection_error_timeout">Timed out</string>
-    <string name="jetpack_connection_error_unknown" translatable="false">@string/error_generic</string>
-    <string name="jetpack_connection_error_offline" translatable="false">@string/no_network_title</string>
-    <string name="jetpack_connection_error_wpcom">Unable to connect to WordPress.com</string>
+    <!-- Jetpack REST Connection Screen -->
+    <string name="jetpack_rest_connection_title">Jetpack Connection</string>
+    <string name="jetpack_rest_connection_setup_title">Setting up Jetpack</string>
+    <string name="jetpack_rest_connection_step_login_wpcom">Login to WordPress.com</string>
+    <string name="jetpack_rest_connection_step_install_jetpack">Install Jetpack Plugin</string>
+    <string name="jetpack_rest_connection_step_connect_site">Connect Your Site</string>
+    <string name="jetpack_rest_connection_step_connect_wpcom">Connect to WordPress.com</string>
+    <string name="jetpack_rest_connection_step_finalize">Finalize Setup</string>
+    <string name="jetpack_rest_connection_status_not_started">Not started</string>
+    <string name="jetpack_rest_connection_status_in_progress">In progress…</string>
+    <string name="jetpack_rest_connection_status_completed">Completed</string>
+    <string name="jetpack_rest_connection_status_failed">Failed</string>
+    <string name="jetpack_rest_connection_cancel_title">Cancel Jetpack Setup?</string>
+    <string name="jetpack_rest_connection_cancel_message">The Jetpack connection process is in progress. Are you sure you want to cancel?</string>
+    <string name="jetpack_rest_connection_error_jetpack_already_installed">Jetpack is already installed</string>
+    <string name="jetpack_rest_connection_error_timeout">Timed out</string>
+    <string name="jetpack_rest_connection_error_unknown" translatable="false">@string/error_generic</string>
+    <string name="jetpack_rest_connection_error_offline" translatable="false">@string/no_network_title</string>
+    <string name="jetpack_rest_connection_error_wpcom">Unable to connect to WordPress.com</string>
 
     <!-- Stats refresh -->
     <string name="stats_no_data_yet">No data yet</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1008,7 +1008,7 @@
 
     <!-- Jetpack REST Connection Screen -->
     <string name="jetpack_rest_connection_title">Jetpack Connection</string>
-    <string name="jetpack_rest_connection_setup_title">Setting up Jetpack</string>
+    <string name="jetpack_rest_connection_setup_title">Setting up Jetpack (Simulated)</string>
     <string name="jetpack_rest_connection_step_login_wpcom">Login to WordPress.com</string>
     <string name="jetpack_rest_connection_step_install_jetpack">Install Jetpack Plugin</string>
     <string name="jetpack_rest_connection_step_connect_site">Connect Your Site</string>


### PR DESCRIPTION
This PR makes the following changes to the Jetpack Connection project in preparation for the feature branch to be merged (since we will be relying on [a feature flag](https://github.com/wordpress-mobile/WordPress-Android/pull/22100) instead of a feature branch):

- Fixed an issue with translating re-used strings 
- Rely on `SiteModel.isUsingSelfHostedRestApi` to determine whether the feature is supported for a site
- Removed starting the simulated flow from the main activity
- Added starting the simulated flow from stats when applicable
- Renamed feature from "Jetpack Connection" to "Jetpack Rest Connection" to avoid confusion with the existing web-based Jetpack Connection flow (the majority of changes in the PR come from this)
- Added "(Simulated)" to the simulated flow screen to make it clear nothing is actually happening to the site

**To test**
- Enable the Experimental Application Password and Jetpack Connection features
- Create a Jurassic Ninja site without the Jetpack plugin
- Add the site to the app
- My Site > Stats > Install Jetpack
- Note that the simulated flow is shown

https://github.com/user-attachments/assets/57089bdd-640e-4cb9-9142-d1525927ccbe


