### PR TITLE
Jetpack connect start button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
@@ -25,7 +25,7 @@ class JetpackRestConnectionActivity : BaseAppCompatActivity() {
                 currentStep = viewModel.currentStep.collectAsState(),
                 stepStates = viewModel.stepStates.collectAsState(),
                 buttonType = viewModel.buttonType.collectAsState(),
-
+                onStartClick = viewModel::onStartClick,
                 onCloseClick = viewModel::onCloseClick,
                 onRetryClick = viewModel::onRetryClick
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionActivity.kt
@@ -25,6 +25,7 @@ class JetpackRestConnectionActivity : BaseAppCompatActivity() {
                 currentStep = viewModel.currentStep.collectAsState(),
                 stepStates = viewModel.stepStates.collectAsState(),
                 buttonType = viewModel.buttonType.collectAsState(),
+
                 onCloseClick = viewModel::onCloseClick,
                 onRetryClick = viewModel::onRetryClick
             )

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
@@ -64,6 +64,7 @@ fun JetpackRestConnectionScreen(
     currentStep: State<ConnectionStep?>,
     stepStates: State<Map<ConnectionStep, StepState>>,
     buttonType: State<ButtonType?>,
+    onStartClick: () -> Unit = {},
     onCloseClick: () -> Unit = {},
     onRetryClick: () -> Unit = {}
 ) {
@@ -86,6 +87,7 @@ fun JetpackRestConnectionScreen(
                 ) {
                     JetpackConnectionButton(
                         buttonType = buttonType.value,
+                        onStartClick = onStartClick,
                         onDoneClick = onCloseClick,
                         onRetryClick = onRetryClick
                     )
@@ -98,12 +100,14 @@ fun JetpackRestConnectionScreen(
 @Composable
 private fun JetpackConnectionButton(
     buttonType: ButtonType?,
+    onStartClick: () -> Unit = {},
     onDoneClick: () -> Unit,
     onRetryClick: () -> Unit
 ) {
     val (labelRes, onClick) = when (buttonType) {
         ButtonType.Done -> R.string.label_done_button to onDoneClick
         ButtonType.Retry -> R.string.retry to onRetryClick
+        ButtonType.Start -> R.string.jetpack_rest_connection_button_start to onStartClick
         null -> return
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionScreen.kt
@@ -107,7 +107,7 @@ private fun JetpackConnectionButton(
     val (labelRes, onClick) = when (buttonType) {
         ButtonType.Done -> R.string.label_done_button to onDoneClick
         ButtonType.Retry -> R.string.retry to onRetryClick
-        ButtonType.Start -> R.string.jetpack_rest_connection_button_start to onStartClick
+        ButtonType.Start -> R.string.start to onStartClick
         null -> return
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -52,14 +52,13 @@ class JetpackRestConnectionViewModel @Inject constructor(
     // TODO Inject or initialize this properly when the actual implementation is ready
     private var jetpackConnectionClient: JetpackConnectionClient? = null
 
-    init {
-        // startConnectionJob()
-    }
-
     private fun startConnectionJob(fromStep: ConnectionStep? = null) {
         val stepInfo = fromStep?.let { " from step: $it" } ?: ""
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection job$stepInfo")
+
         _buttonType.value = null
+        _uiEvent.value = null
+
         job?.cancel()
         job = launch {
             startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -175,8 +174,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            _buttonType.value = null
-            _uiEvent.value = null
             startConnectionJob(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -53,12 +53,13 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private var jetpackConnectionClient: JetpackConnectionClient? = null
 
     init {
-        startConnectionJob()
+        // startConnectionJob()
     }
 
     private fun startConnectionJob(fromStep: ConnectionStep? = null) {
         val stepInfo = fromStep?.let { " from step: $it" } ?: ""
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection job$stepInfo")
+        _buttonType.value = null
         job?.cancel()
         job = launch {
             startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -133,6 +134,11 @@ class JetpackRestConnectionViewModel @Inject constructor(
             }
             else -> {}
         }
+    }
+
+    fun onStartClick() {
+        appLogWrapper.d(AppLog.T.API, "$TAG: Start clicked")
+        startConnectionJob()
     }
 
     fun onCloseClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -36,7 +36,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val _uiEvent = MutableStateFlow<UiEvent?>(null)
     val uiEvent = _uiEvent
 
-    private val _buttonType = MutableStateFlow<ButtonType?>(null)
+    private val _buttonType = MutableStateFlow<ButtonType?>(ButtonType.Start)
     val buttonType = _buttonType
 
     data class StepState(
@@ -307,6 +307,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     }
 
     sealed class ButtonType {
+        data object Start : ButtonType()
         data object Done : ButtonType()
         data object Retry : ButtonType()
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="sort_by">Sort by</string>
     <string name="ascending">Ascending</string>
     <string name="descending">Descending</string>
+    <string name="start">Start</string>
 
     <string name="button_not_now">Not now</string>
     <string name="button_skip">Skip</string>
@@ -1025,7 +1026,6 @@
     <string name="jetpack_rest_connection_error_unknown" translatable="false">@string/error_generic</string>
     <string name="jetpack_rest_connection_error_offline" translatable="false">@string/no_network_title</string>
     <string name="jetpack_rest_connection_error_wpcom">Unable to connect to WordPress.com</string>
-    <string name="jetpack_rest_connection_button_start">Connect your site</string>
 
     <!-- Stats refresh -->
     <string name="stats_no_data_yet">No data yet</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1011,9 +1011,9 @@
     <string name="jetpack_rest_connection_setup_title">Setting up Jetpack (Simulated)</string>
     <string name="jetpack_rest_connection_step_login_wpcom">Login to WordPress.com</string>
     <string name="jetpack_rest_connection_step_install_jetpack">Install Jetpack Plugin</string>
-    <string name="jetpack_rest_connection_step_connect_site">Connect Your Site</string>
+    <string name="jetpack_rest_connection_step_connect_site">Connect your site</string>
     <string name="jetpack_rest_connection_step_connect_wpcom">Connect to WordPress.com</string>
-    <string name="jetpack_rest_connection_step_finalize">Finalize Setup</string>
+    <string name="jetpack_rest_connection_step_finalize">Finalize setup</string>
     <string name="jetpack_rest_connection_status_not_started">Not started</string>
     <string name="jetpack_rest_connection_status_in_progress">In progress…</string>
     <string name="jetpack_rest_connection_status_completed">Completed</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1010,7 +1010,7 @@
     <string name="jetpack_rest_connection_title">Jetpack Connection</string>
     <string name="jetpack_rest_connection_setup_title">Setting up Jetpack (Simulated)</string>
     <string name="jetpack_rest_connection_step_login_wpcom">Login to WordPress.com</string>
-    <string name="jetpack_rest_connection_step_install_jetpack">Install Jetpack Plugin</string>
+    <string name="jetpack_rest_connection_step_install_jetpack">Install Jetpack plugin</string>
     <string name="jetpack_rest_connection_step_connect_site">Connect your site</string>
     <string name="jetpack_rest_connection_step_connect_wpcom">Connect to WordPress.com</string>
     <string name="jetpack_rest_connection_step_finalize">Finalize setup</string>
@@ -1025,6 +1025,7 @@
     <string name="jetpack_rest_connection_error_unknown" translatable="false">@string/error_generic</string>
     <string name="jetpack_rest_connection_error_offline" translatable="false">@string/no_network_title</string>
     <string name="jetpack_rest_connection_error_wpcom">Unable to connect to WordPress.com</string>
+    <string name="jetpack_rest_connection_button_start">Connect your site</string>
 
     <!-- Stats refresh -->
     <string name="stats_no_data_yet">No data yet</string>


### PR DESCRIPTION
This small PR adds a "Start" button to the connection flow. I added this after noticing that on iOS the flow isn't started right away but instead after clicking a button:

<img width="242" height="1043" alt="iOS" src="https://github.com/user-attachments/assets/1c7c9b1c-f31b-45a3-abe5-8d3f9f129855" />

Note, however, that I didn't copy the wording from iOS because "Connect your site" is too similar to the "Connect to your site" title in step 3. Instead, I just used "Start," which seems clear enough:

<img width="297" height="628" alt="android" src="https://github.com/user-attachments/assets/0c8a3546-5787-4be8-adad-bea11600223e" />

