### PR TITLE
Migrate Remaining `EditPostActivity` Direct Launches to `EditorLauncher`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -402,7 +402,7 @@ public class ActivityLauncher {
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         Intent mainActivityIntent = getMainActivityInNewStack(context);
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
             .isPage(false)
             .build();
 
@@ -418,7 +418,7 @@ public class ActivityLauncher {
         TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
         Intent mainActivityIntent = getMainActivityInNewStack(context);
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .postLocalId(localPostId)
                 .isPage(false)
                 .build();
@@ -462,7 +462,7 @@ public class ActivityLauncher {
             site.getSiteId()
         );
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .reblogPostTitle(post.getTitle())
                 .reblogPostQuote(post.getExcerpt())
                 .reblogPostImage(post.getFeaturedImage())
@@ -988,7 +988,7 @@ public class ActivityLauncher {
             return;
         }
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
             .isPage(false)
             .isPromo(isPromo)
             .source(source)
@@ -1007,7 +1007,7 @@ public class ActivityLauncher {
             final int promptId,
             final EntryPoint entryPoint
     ) {
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .isPage(false)
                 .isPromo(isPromo)
                 .source(source)
@@ -1047,7 +1047,7 @@ public class ActivityLauncher {
             return;
         }
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .postLocalId(post.getId())
                 .loadAutoSaveRevision(false)
                 .build();
@@ -1063,10 +1063,10 @@ public class ActivityLauncher {
             return;
         }
 
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
-            .postLocalId(post.getId())
-            .loadAutoSaveRevision(loadAutoSaveRevision)
-            .build();
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
+                .postLocalId(post.getId())
+                .loadAutoSaveRevision(loadAutoSaveRevision)
+                .build();
 
         Intent editorIntent = EditorLauncher.getInstance().createEditorIntent(activity, params);
         activity.startActivityForResult(editorIntent, RequestCodes.EDIT_POST);
@@ -1094,7 +1094,7 @@ public class ActivityLauncher {
 
     public static void editPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site,
                                          int pageLocalId, boolean loadAutoSaveRevision) {
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .postLocalId(pageLocalId)
                 .loadAutoSaveRevision(loadAutoSaveRevision)
                 .isPage(true)
@@ -1111,7 +1111,7 @@ public class ActivityLauncher {
 
     public static void editLandingPageForResult(@NonNull Fragment fragment, @NonNull SiteModel site, int homeLocalId,
                                                 boolean isNewSite) {
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
                 .postLocalId(homeLocalId)
                 .loadAutoSaveRevision(false)
                 .isPage(true)
@@ -1139,14 +1139,14 @@ public class ActivityLauncher {
             @Nullable String template,
             @NonNull PagePostCreationSourcesDetail source
     ) {
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
-            .isPage(true)
-            .isPromo(false)
-            .pageTitle(title)
-            .pageContent(content)
-            .pageTemplate(template)
-            .source(source)
-            .build();
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
+                .isPage(true)
+                .isPromo(false)
+                .pageTitle(title)
+                .pageContent(content)
+                .pageTemplate(template)
+                .source(source)
+                .build();
 
         Intent intent = EditorLauncher.getInstance().createEditorIntent(activity, params);
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
@@ -1159,7 +1159,7 @@ public class ActivityLauncher {
             @NonNull String content,
             @Nullable String template,
             @NonNull PagePostCreationSourcesDetail source) {
-        EditorLauncherParams params = new EditorLauncherParams.Builder(site)
+        EditorLauncherParams params = EditorLauncherParams.Builder.forSite(site)
             .isPage(true)
             .isPromo(false)
             .pageTitle(title)

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -35,8 +35,9 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.main.BaseAppCompatActivity;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorLauncher;
+import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -140,12 +141,15 @@ public class AddQuickPressShortcutActivity extends BaseAppCompatActivity {
                     ToastUtils.showToast(AddQuickPressShortcutActivity.this, R.string.quickpress_add_error,
                             ToastUtils.Duration.LONG);
                 } else {
-                    Intent shortcutIntent = new Intent(getApplicationContext(), EditPostActivity.class);
+                    EditorLauncherParams params =
+                            EditorLauncherParams.Builder.forQuickPressBlogId(siteIds[position]).isQuickPress(true)
+                                                        .build();
+
+                    Intent shortcutIntent =
+                            EditorLauncher.getInstance().createEditorIntent(getApplicationContext(), params);
                     shortcutIntent.setAction(Intent.ACTION_MAIN);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    shortcutIntent.putExtra(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID, siteIds[position]);
-                    shortcutIntent.putExtra(EditPostActivityConstants.EXTRA_IS_QUICKPRESS, true);
 
                     String shortcutName = quickPressShortcutName.getText().toString();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -35,7 +35,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.main.BaseAppCompatActivity;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
 import org.wordpress.android.ui.posts.EditorLauncher;
 import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.util.SiteUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -23,6 +23,8 @@ import org.wordpress.android.ui.main.BaseAppCompatActivity;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
+import org.wordpress.android.ui.posts.EditorLauncher;
+import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.FluxCUtils;
@@ -175,7 +177,30 @@ public class ShareIntentReceiverActivity extends BaseAppCompatActivity implement
         mClickedSiteLocalId = selectedSiteLocalId;
 
         bumpAnalytics(shareAction, selectedSiteLocalId);
-        Intent intent = new Intent(this, shareAction.targetClass);
+
+        SiteModel selectedSite = mSiteStore.getSiteByLocalId(selectedSiteLocalId);
+        if (selectedSite == null) {
+            ToastUtils.showToast(this, R.string.cant_share_no_blog, ToastUtils.Duration.LONG);
+            finish();
+            return;
+        }
+
+        Intent intent;
+
+        switch (shareAction) {
+            case SHARE_TO_POST:
+                EditorLauncherParams params = new EditorLauncherParams.Builder(selectedSite)
+                        .build();
+                intent = EditorLauncher.getInstance().createEditorIntent(this, params);
+                break;
+            case SHARE_TO_MEDIA_LIBRARY:
+                intent = new Intent(this, MediaBrowserActivity.class);
+                intent.putExtra(WordPress.SITE, selectedSite);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown share action: " + shareAction);
+        }
+
         startActivityAndFinish(intent, selectedSiteLocalId);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -189,7 +189,7 @@ public class ShareIntentReceiverActivity extends BaseAppCompatActivity implement
 
         switch (shareAction) {
             case SHARE_TO_POST:
-                EditorLauncherParams params = new EditorLauncherParams.Builder(selectedSite)
+                EditorLauncherParams params = EditorLauncherParams.Builder.forSite(selectedSite)
                         .build();
                 intent = EditorLauncher.getInstance().createEditorIntent(this, params);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -21,8 +22,6 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.main.SitePickerAdapter;
 import org.wordpress.android.ui.main.SitePickerAdapter.ViewHolderHandler;
 import org.wordpress.android.ui.main.SiteRecord;
-import org.wordpress.android.ui.media.MediaBrowserActivity;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.image.ImageManager;
 
 import java.util.List;
@@ -211,15 +210,12 @@ public class ShareIntentReceiverFragment extends Fragment {
     }
 
     enum ShareAction {
-        SHARE_TO_POST("new_post", EditPostActivity.class),
-        SHARE_TO_MEDIA_LIBRARY("media_library", MediaBrowserActivity.class);
+        SHARE_TO_POST("new_post"),
+        SHARE_TO_MEDIA_LIBRARY("media_library");
 
-        public final Class targetClass;
-        public final String analyticsName;
+        @NonNull public final String analyticsName;
 
-
-        ShareAction(String analyticsName, Class targetClass) {
-            this.targetClass = targetClass;
+        ShareAction(@NonNull String analyticsName) {
             this.analyticsName = analyticsName;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -90,7 +90,10 @@ class EditorLauncher @Inject constructor(
     }
 
     private fun Intent.addBasicExtras(params: EditorLauncherParams) {
-        putExtra(WordPress.SITE, params.site)
+        when (params.siteParameter) {
+            is EditorLauncherSiteParameter.EditorLauncherSite -> putExtra(WordPress.SITE, params.siteParameter.siteModel)
+            is EditorLauncherSiteParameter.QuickPressBlogId -> putExtra(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID, params.siteParameter.quickPressBlogId)
+        }
         params.isPage?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, it) }
         params.isPromo?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, it) }
         putExtra(EXTRA_LAUNCHED_VIA_EDITOR_LAUNCHER, true)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -90,14 +90,14 @@ class EditorLauncher @Inject constructor(
     }
 
     private fun Intent.addBasicExtras(params: EditorLauncherParams) {
-        when (params.siteParameter) {
-            is EditorLauncherSiteParameter.EditorLauncherSite -> putExtra(
-                WordPress.SITE, params.siteParameter.siteModel
+        when (params.siteSource) {
+            is EditorLauncherSiteSource.DirectSite -> putExtra(
+                WordPress.SITE, params.siteSource.siteModel
             )
 
-            is EditorLauncherSiteParameter.QuickPressBlogId -> putExtra(
+            is EditorLauncherSiteSource.QuickPressSiteId -> putExtra(
                 EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID,
-                params.siteParameter.quickPressBlogId
+                params.siteSource.siteId
             )
         }
         params.isPage?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -91,8 +91,14 @@ class EditorLauncher @Inject constructor(
 
     private fun Intent.addBasicExtras(params: EditorLauncherParams) {
         when (params.siteParameter) {
-            is EditorLauncherSiteParameter.EditorLauncherSite -> putExtra(WordPress.SITE, params.siteParameter.siteModel)
-            is EditorLauncherSiteParameter.QuickPressBlogId -> putExtra(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID, params.siteParameter.quickPressBlogId)
+            is EditorLauncherSiteParameter.EditorLauncherSite -> putExtra(
+                WordPress.SITE, params.siteParameter.siteModel
+            )
+
+            is EditorLauncherSiteParameter.QuickPressBlogId -> putExtra(
+                EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID,
+                params.siteParameter.quickPressBlogId
+            )
         }
         params.isPage?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, it) }
         params.isPromo?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, it) }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
@@ -5,11 +5,11 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostUtils.EntryPoint
 
 /**
- * Site parameter for EditorLauncherParams - supports direct SiteModel or QuickPress blog ID.
+ * Site source for EditorLauncherParams - supports direct SiteModel or QuickPress blog ID.
  */
-sealed class EditorLauncherSiteParameter {
-    data class EditorLauncherSite(val siteModel: SiteModel) : EditorLauncherSiteParameter()
-    data class QuickPressBlogId(val quickPressBlogId: Int) : EditorLauncherSiteParameter()
+sealed class EditorLauncherSiteSource {
+    data class DirectSite(val siteModel: SiteModel) : EditorLauncherSiteSource()
+    data class QuickPressSiteId(val siteId: Int) : EditorLauncherSiteSource()
 }
 
 /**
@@ -22,7 +22,7 @@ sealed class EditorLauncherSiteParameter {
  * See EditorLauncherTest for field-to-method mapping documentation.
  */
 data class EditorLauncherParams(
-    val siteParameter: EditorLauncherSiteParameter,
+    val siteSource: EditorLauncherSiteSource,
     val isPage: Boolean? = null,
     val isPromo: Boolean? = null,
     val postLocalId: Int? = null,
@@ -48,20 +48,20 @@ data class EditorLauncherParams(
     /**
      * Java-friendly builder pattern for EditorLauncherParams.
      */
-    class Builder(private val siteParameter: EditorLauncherSiteParameter) {
+    class Builder(private val siteSource: EditorLauncherSiteSource) {
         companion object {
             /**
              * Create builder for SiteModel (most common case)
              */
             @JvmStatic
-            fun forSite(site: SiteModel): Builder = Builder(EditorLauncherSiteParameter.EditorLauncherSite(site))
+            fun forSite(site: SiteModel): Builder = Builder(EditorLauncherSiteSource.DirectSite(site))
 
             /**
              * Create builder for QuickPress blog ID (for shortcuts that resolve site at launch time)
              */
             @JvmStatic
             fun forQuickPressBlogId(blogId: Int): Builder =
-                Builder(EditorLauncherSiteParameter.QuickPressBlogId(blogId))
+                Builder(EditorLauncherSiteSource.QuickPressSiteId(blogId))
         }
         private var isPage: Boolean? = null
         private var isPromo: Boolean? = null
@@ -115,7 +115,7 @@ data class EditorLauncherParams(
 
         fun build(): EditorLauncherParams {
             return EditorLauncherParams(
-                siteParameter = siteParameter,
+                siteSource = siteSource,
                 isPage = isPage,
                 isPromo = isPromo,
                 postLocalId = postLocalId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
@@ -5,6 +5,14 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.PostUtils.EntryPoint
 
 /**
+ * Site parameter for EditorLauncherParams - supports direct SiteModel or QuickPress blog ID.
+ */
+sealed class EditorLauncherSiteParameter {
+    data class EditorLauncherSite(val siteModel: SiteModel) : EditorLauncherSiteParameter()
+    data class QuickPressBlogId(val quickPressBlogId: Int) : EditorLauncherSiteParameter()
+}
+
+/**
  * Type-safe parameters for launching editor activities.
  *
  * This data class replaces the Bundle-based approach with named parameters in Kotlin
@@ -14,7 +22,7 @@ import org.wordpress.android.ui.posts.PostUtils.EntryPoint
  * See EditorLauncherTest for field-to-method mapping documentation.
  */
 data class EditorLauncherParams(
-    val site: SiteModel,
+    val siteParameter: EditorLauncherSiteParameter,
     val isPage: Boolean? = null,
     val isPromo: Boolean? = null,
     val postLocalId: Int? = null,
@@ -40,7 +48,20 @@ data class EditorLauncherParams(
     /**
      * Java-friendly builder pattern for EditorLauncherParams.
      */
-    class Builder(private val site: SiteModel) {
+    class Builder(private val siteParameter: EditorLauncherSiteParameter) {
+        companion object {
+            /**
+             * Create builder for SiteModel (most common case)
+             */
+            @JvmStatic
+            fun forSite(site: SiteModel): Builder = Builder(EditorLauncherSiteParameter.EditorLauncherSite(site))
+
+            /**
+             * Create builder for QuickPress blog ID (for shortcuts that resolve site at launch time)
+             */
+            @JvmStatic
+            fun forQuickPressBlogId(blogId: Int): Builder = Builder(EditorLauncherSiteParameter.QuickPressBlogId(blogId))
+        }
         private var isPage: Boolean? = null
         private var isPromo: Boolean? = null
         private var postLocalId: Int? = null
@@ -93,7 +114,7 @@ data class EditorLauncherParams(
 
         fun build(): EditorLauncherParams {
             return EditorLauncherParams(
-                site = site,
+                siteParameter = siteParameter,
                 isPage = isPage,
                 isPromo = isPromo,
                 postLocalId = postLocalId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
@@ -60,7 +60,8 @@ data class EditorLauncherParams(
              * Create builder for QuickPress blog ID (for shortcuts that resolve site at launch time)
              */
             @JvmStatic
-            fun forQuickPressBlogId(blogId: Int): Builder = Builder(EditorLauncherSiteParameter.QuickPressBlogId(blogId))
+            fun forQuickPressBlogId(blogId: Int): Builder =
+                Builder(EditorLauncherSiteParameter.QuickPressBlogId(blogId))
         }
         private var isPage: Boolean? = null
         private var isPromo: Boolean? = null

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -27,7 +27,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.pages.PagesActivity;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
 import org.wordpress.android.ui.posts.EditorLauncher;
 import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.ui.posts.PostUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -27,8 +27,9 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.SystemNotificationsTracker;
 import org.wordpress.android.ui.pages.PagesActivity;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorLauncher;
+import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.posts.PostsListActivityKt;
@@ -441,12 +442,15 @@ class PostUploadNotifier {
         if (mediaList != null && !mediaList.isEmpty()) {
             ArrayList<MediaModel> mediaToIncludeInPost = new ArrayList<>(mediaList);
 
-            Intent writePostIntent = new Intent(mContext, EditPostActivity.class);
+            EditorLauncherParams params = EditorLauncherParams.Builder
+                    .forSite(site)
+                    .isPage(false)
+                    .insertMedia(mediaToIncludeInPost)
+                    .build();
+
+            Intent writePostIntent = EditorLauncher.getInstance().createEditorIntent(mContext, params);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
             writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            writePostIntent.putExtra(WordPress.SITE, site);
-            writePostIntent.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, false);
-            writePostIntent.putExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA, mediaToIncludeInPost);
             writePostIntent.setAction(String.valueOf(notificationId));
 
             PendingIntent actionPendingIntent =

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -14,7 +14,6 @@ import androidx.annotation.StringRes;
 import com.google.android.material.snackbar.Snackbar;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -29,8 +29,9 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.utils.MimeTypes;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorLauncher;
+import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.uploads.UploadActionUseCase.UploadAction;
@@ -610,13 +611,16 @@ public class UploadUtils {
                                 ArrayList<MediaModel> mediaListToInsertInPost = new ArrayList<>();
                                 mediaListToInsertInPost.addAll(mediaList);
 
-                                Intent writePostIntent = new Intent(activity, EditPostActivity.class);
+                                EditorLauncherParams params = EditorLauncherParams.Builder
+                                        .forSite(site)
+                                        .isPage(false)
+                                        .insertMedia(mediaListToInsertInPost)
+                                        .build();
+
+                                Intent writePostIntent =
+                                        EditorLauncher.getInstance().createEditorIntent(activity, params);
                                 writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
                                 writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                                writePostIntent.putExtra(WordPress.SITE, site);
-                                writePostIntent.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, false);
-                                writePostIntent.putExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA,
-                                        mediaListToInsertInPost);
                                 activity.startActivity(writePostIntent);
                             }
                         }, sequencer);

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
@@ -12,7 +12,7 @@ class EditorLauncherTest {
 
         val handledFields = setOf(
             // addBasicExtras()
-            "siteParameter",  // -> WordPress.SITE or EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID
+            "siteSource",     // -> WordPress.SITE or EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID
             "isPage",         // -> EditPostActivityConstants.EXTRA_IS_PAGE
             "isPromo",        // -> EditPostActivityConstants.EXTRA_IS_PROMO
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
@@ -12,7 +12,7 @@ class EditorLauncherTest {
 
         val handledFields = setOf(
             // addBasicExtras()
-            "site",           // -> WordPress.SITE
+            "siteParameter",  // -> WordPress.SITE or EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID
             "isPage",         // -> EditPostActivityConstants.EXTRA_IS_PAGE
             "isPromo",        // -> EditPostActivityConstants.EXTRA_IS_PROMO
 


### PR DESCRIPTION
Follow up to #22111 to migrate the remaining `EditPostActivity` launches to use the `EditorLauncher`.

## ShareIntentReceiverActivity Migration

**Commit**: 934ed82a3ff

Migrated share intents to use EditorLauncher and removed the reflection-like `targetClass` pattern from ShareAction enum.

**Changes:**
- Replace `shareAction.targetClass` with explicit switch statement
- Use `EditorLauncher.getInstance().createEditorIntent()` for `SHARE_TO_POST`
- Add null checking for `selectedSite`

**Testing:**
- Share text/media to WordPress → verify editor opens with content
- Share media to Media Library → verify `MediaBrowserActivity` opens
- Test single-site auto-share shortcut

---

## AddQuickPressShortcutActivity Migration

**Commit**: dfb51a068ce

Extended EditorLauncherParams to support QuickPress shortcuts while preserving the original site resolution behavior where shortcuts store site IDs and resolve them at launch time.

**Changes:**
- Add `EditorLauncherSiteSource` sealed class for compile-time type safety
- Add `Builder.forSite()` and `Builder.forQuickPressBlogId()` factory methods
- Update `EditorLauncher` to handle both site source types
- Migrate `AddQuickPressShortcutActivity` to use `Builder.forQuickPressBlogId()`

**Testing:**
- Create QuickPress home screen shortcuts → verify they launch editor correctly
- Test shortcuts with different sites → verify site resolution works at launch time

---

## UploadUtils Migration

**Commit**: ed06a15d5a4

Migrated the "Write Post" action that appears in snackbars after successful media uploads to use EditorLauncher.

**Changes:**
- Use `EditorLauncher.getInstance().createEditorIntent()` for write post action
- Pass `insertMedia` parameter with uploaded media files
- Preserve `isPage(false)` for new post creation

**Testing:**
- Upload media files (images/videos) → verify success snackbar shows "Write Post" action
- Tap "Write Post" → verify editor opens with uploaded media inserted
- Test with multiple media files → verify all media is included

---

## PostUploadNotifier Migration

**Commit**: 8e2fdd36038

Migrated the "Write Post" action in upload completion notifications to use EditorLauncher.

**Changes:**
- Use `EditorLauncher.getInstance().createEditorIntent()` for notification write post action
- Pass `insertMedia` parameter with uploaded media files
- Preserve `isPage(false)` for new post creation

**Testing:**
- Upload media files → verify upload completion notification appears
- Tap "Write Post" action in notification → verify editor opens with uploaded media inserted
- Test notification `PendingIntent` behavior → verify proper activity launch
