### PR TITLE
Rename `EditPostActivity` types for `GutenbergKitActivity` preparation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -87,7 +87,7 @@ import org.wordpress.android.ui.plans.PlansActivity;
 import org.wordpress.android.ui.plugins.PluginBrowserActivity;
 import org.wordpress.android.ui.plugins.PluginDetailActivity;
 import org.wordpress.android.ui.plugins.PluginUtils;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorConstants;
 import org.wordpress.android.ui.posts.EditorLauncher;
 import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.ui.posts.JetpackSecuritySettingsActivity;
@@ -467,7 +467,7 @@ public class ActivityLauncher {
                 .reblogPostQuote(post.getExcerpt())
                 .reblogPostImage(post.getFeaturedImage())
                 .reblogPostCitation(post.getUrl())
-                .reblogAction(EditPostActivityConstants.ACTION_REBLOG)
+                .reblogAction(EditorConstants.ACTION_REBLOG)
                 .build();
 
         Intent editorIntent = EditorLauncher.getInstance().createEditorIntent(activity, params);
@@ -1033,11 +1033,11 @@ public class ActivityLauncher {
         }
 
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, false);
-        intent.putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, isPromo);
+        intent.putExtra(EditorConstants.EXTRA_IS_PAGE, false);
+        intent.putExtra(EditorConstants.EXTRA_IS_PROMO, isPromo);
         intent.putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, source);
-        intent.putExtra(EditPostActivityConstants.EXTRA_PROMPT_ID, promptId);
-        intent.putExtra(EditPostActivityConstants.EXTRA_ENTRY_POINT, entryPoint);
+        intent.putExtra(EditorConstants.EXTRA_PROMPT_ID, promptId);
+        intent.putExtra(EditorConstants.EXTRA_ENTRY_POINT, entryPoint);
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
 
@@ -1086,8 +1086,8 @@ public class ActivityLauncher {
         // PostModel objects can be quite large, since content field is not size restricted,
         // in order to avoid issues like TransactionTooLargeException it's better to pass the id of the post.
         // However, we still want to keep passing the SiteModel to avoid confusion around local & remote ids.
-        intent.putExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, postLocalId);
-        intent.putExtra(EditPostActivityConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
+        intent.putExtra(EditorConstants.EXTRA_POST_LOCAL_ID, postLocalId);
+        intent.putExtra(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
 
         activity.startActivityForResult(intent, RequestCodes.EDIT_POST);
     }
@@ -1126,8 +1126,8 @@ public class ActivityLauncher {
     public static void editPageForResult(Intent intent, @NonNull Fragment fragment, @NonNull SiteModel site,
                                          int pageLocalId, boolean loadAutoSaveRevision, int requestCode) {
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, pageLocalId);
-        intent.putExtra(EditPostActivityConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
+        intent.putExtra(EditorConstants.EXTRA_POST_LOCAL_ID, pageLocalId);
+        intent.putExtra(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, loadAutoSaveRevision);
         fragment.startActivityForResult(intent, requestCode);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -120,7 +120,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerLauncher;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface;
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface;
 import org.wordpress.android.ui.posts.EditPostActivity;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorConstants;
 import org.wordpress.android.ui.posts.PostUtils.EntryPoint;
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment.QuickStartPromptClickInterface;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -1379,13 +1379,13 @@ public class WPMainActivity extends BaseAppCompatActivity implements
                 if (resultCode != Activity.RESULT_OK || data == null || isFinishing()) {
                     return;
                 }
-                int localId = data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0);
+                int localId = data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0);
                 final SiteModel site = (SiteModel) data.getSerializableExtra(WordPress.SITE);
                 final PostModel post = mPostStore.getPostByLocalPostId(localId);
 
                 if (EditPostActivity.checkToRestart(data)) {
                     ActivityLauncher.editPostOrPageForResult(data, WPMainActivity.this, site,
-                            data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0));
+                            data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0));
 
                     // a restart will happen so, no need to continue here
                     break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteFragment.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.BasicDialogViewModel
-import org.wordpress.android.ui.posts.EditPostActivityConstants
+import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.posts.PostListType
 import org.wordpress.android.ui.posts.PostUtils
 import org.wordpress.android.ui.posts.QuickStartPromptDialogFragment
@@ -296,7 +296,7 @@ class MySiteFragment : Fragment(R.layout.my_site_fragment),
                 viewModel.checkAndStartQuickStart(
                     data.getBooleanExtra(ChooseSiteActivity.KEY_SITE_TITLE_TASK_COMPLETED, false),
                     isNewSite = data.getBooleanExtra(
-                        EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE, false
+                        EditorConstants.EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE, false
                     )
                 )
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/pages/PagesFragment.kt
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.jetpackoverlay.JetpackFeatureRemovalPhaseHelper
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment
 import org.wordpress.android.ui.mlp.ModalLayoutPickerFragment.Companion.MODAL_LAYOUT_PICKER_TAG
 import org.wordpress.android.ui.posts.EditPostActivity
-import org.wordpress.android.ui.posts.EditPostActivityConstants
+import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.posts.PostListAction.PreviewPost
 import org.wordpress.android.ui.posts.PostResolutionOverlayActionEvent
 import org.wordpress.android.ui.posts.PostResolutionOverlayFragment
@@ -179,7 +179,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                     data,
                     this@PagesFragment,
                     viewModel.site,
-                    data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0),
+                    data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0),
                     false
                 )
 
@@ -187,7 +187,7 @@ class PagesFragment : Fragment(R.layout.pages_fragment), ScrollableViewInitializ
                 return
             }
             // we need to work with local ids, since local drafts don't have remote ids
-            val localPageId = data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, -1)
+            val localPageId = data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, -1)
             if (localPageId != -1) {
                 viewModel.onPageEditFinished(localPageId, data)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -157,7 +157,6 @@ import org.wordpress.android.ui.posts.EditPostCustomerSupportHelper.onGotoCustom
 import org.wordpress.android.ui.posts.EditPostPublishSettingsFragment.Companion.newInstance
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult.Updated
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.EditorBloggingPromptsViewModel.EditorLoadedPrompt
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenEditShareMessage
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenSocialConnectionsList
@@ -278,7 +277,7 @@ import kotlin.math.max
 class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, EditorImageSettingsListener,
     EditorImagePreviewListener, EditorEditMediaListener, EditorDragAndDropListener, EditorFragmentListener,
     ActivityCompat.OnRequestPermissionsResultCallback, PhotoPickerListener, EditorPhotoPickerListener,
-    EditorMediaListener, EditPostActivityHook, HistoryItemClickInterface,
+    EditorMediaListener, EditPostSettingsFragment.EditorDataProvider, HistoryItemClickInterface,
     PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger, SiteSettingsListener {
     // External Access to the Image Loader
     var aztecImageLoader: AztecImageLoader? = null
@@ -4224,7 +4223,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         (editorFragment as? GutenbergKitEditorFragment)?.startWithEditorSettings(editorSettings.toJsonString())
     }
 
-    // EditPostActivityHook methods
+    // EditorDataProvider methods
     override fun getEditPostRepository() = editPostRepository
     override fun getSite() = siteModel
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -475,10 +475,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun newReblogPostSetup() {
-        val title = intent.getStringExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_TITLE)
-        val quote = intent.getStringExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_QUOTE)
-        val citation = intent.getStringExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_CITATION)
-        val image = intent.getStringExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_IMAGE)
+        val title = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_TITLE)
+        val quote = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_QUOTE)
+        val citation = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_CITATION)
+        val image = intent.getStringExtra(EditorConstants.EXTRA_REBLOG_POST_IMAGE)
         val content = reblogUtils.reblogContent(image, quote ?: "", title, citation)
         newPostSetup(title, content)
     }
@@ -554,7 +554,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             return
         }
 
-        isLandingEditor = intent.extras?.getBoolean(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR) ?: false
+        isLandingEditor = intent.extras?.getBoolean(EditorConstants.EXTRA_IS_LANDING_EDITOR) ?: false
 
         refreshMobileEditorFromSiteSetting()
 
@@ -683,17 +683,17 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
     }
     private fun getSiteModelForExtraQuickPressBlogIdIfRequested(extras: Bundle?): SiteModel? {
-        if (extras == null || extras.containsKey(EditPostActivityConstants.EXTRA_POST_LOCAL_ID)) {
+        if (extras == null || extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID)) {
             return null
         }
 
         val isActionSendOrNewMedia = isActionSendOrNewMedia(intent.action)
-        val hasQuickPressFlag = extras.containsKey(EditPostActivityConstants.EXTRA_IS_QUICKPRESS)
-        val hasQuickPressBlogId = extras.containsKey(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID)
+        val hasQuickPressFlag = extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
+        val hasQuickPressBlogId = extras.containsKey(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID)
 
         // QuickPress might want to use a different blog than the current blog
         return if ((isActionSendOrNewMedia || hasQuickPressFlag) && hasQuickPressBlogId) {
-            val localSiteId = intent.getIntExtra(EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID, -1)
+            val localSiteId = intent.getIntExtra(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID, -1)
             siteStore.getSiteByLocalId(localSiteId)
         } else {
             null
@@ -705,28 +705,28 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         extras ?: return
         val action = intent.action
 
-        if (!extras.containsKey(EditPostActivityConstants.EXTRA_POST_LOCAL_ID) ||
+        if (!extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID) ||
             isActionSendOrNewMedia(intent.action) ||
-            extras.containsKey(EditPostActivityConstants.EXTRA_IS_QUICKPRESS)
+            extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
         ) {
-            isPage = extras.getBoolean(EditPostActivityConstants.EXTRA_IS_PAGE)
-            if (isPage && !TextUtils.isEmpty(extras.getString(EditPostActivityConstants.EXTRA_PAGE_TITLE))) {
+            isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
+            if (isPage && !TextUtils.isEmpty(extras.getString(EditorConstants.EXTRA_PAGE_TITLE))) {
                 newPageFromLayoutPickerSetup(
-                    extras.getString(EditPostActivityConstants.EXTRA_PAGE_TITLE),
-                    extras.getString(EditPostActivityConstants.EXTRA_PAGE_TEMPLATE)
+                    extras.getString(EditorConstants.EXTRA_PAGE_TITLE),
+                    extras.getString(EditorConstants.EXTRA_PAGE_TEMPLATE)
                 )
             } else if ((Intent.ACTION_SEND == action)) {
                 newPostFromShareAction()
-            } else if ((EditPostActivityConstants.ACTION_REBLOG == action)) {
+            } else if ((EditorConstants.ACTION_REBLOG == action)) {
                 newReblogPostSetup()
             } else {
                 newPostSetup()
             }
         } else {
-            editPostRepository.loadPostByLocalPostId(extras.getInt(EditPostActivityConstants.EXTRA_POST_LOCAL_ID))
+            editPostRepository.loadPostByLocalPostId(extras.getInt(EditorConstants.EXTRA_POST_LOCAL_ID))
             // Load post from extra's
             if (editPostRepository.hasPost()) {
-                if (extras.getBoolean(EditPostActivityConstants.EXTRA_LOAD_AUTO_SAVE_REVISION)) {
+                if (extras.getBoolean(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION)) {
                     editPostRepository.update { postModel: PostModel ->
                         val updateTitle = !TextUtils.isEmpty(postModel.autoSaveTitle)
                         if (updateTitle) {
@@ -750,61 +750,61 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             }
         }
 
-        if (isRestarting && extras.getBoolean(EditPostActivityConstants.EXTRA_IS_NEW_POST)) {
+        if (isRestarting && extras.getBoolean(EditorConstants.EXTRA_IS_NEW_POST)) {
             // editor was on a new post before the switch so, keep that signal.
             // Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2072
             isNewPost = true
         }
 
         // retrieve Editor session data if switched editors
-        if (isRestarting && extras.containsKey(EditPostActivityConstants.STATE_KEY_EDITOR_SESSION_DATA)) {
+        if (isRestarting && extras.containsKey(EditorConstants.STATE_KEY_EDITOR_SESSION_DATA)) {
             postEditorAnalyticsSession = PostEditorAnalyticsSession
-                .fromBundle(extras, EditPostActivityConstants.STATE_KEY_EDITOR_SESSION_DATA, analyticsTrackerWrapper)
+                .fromBundle(extras, EditorConstants.STATE_KEY_EDITOR_SESSION_DATA, analyticsTrackerWrapper)
         }
     }
 
     private fun retrieveSavedInstanceState(savedInstanceState: Bundle?) {
         savedInstanceState?.let { state ->
-            state.getParcelableArrayList<Uri>(EditPostActivityConstants.STATE_KEY_DROPPED_MEDIA_URIS)
+            state.getParcelableArrayList<Uri>(EditorConstants.STATE_KEY_DROPPED_MEDIA_URIS)
                 ?.let { parcelableArrayList ->
                     editorMedia.droppedMediaUris = parcelableArrayList
                 }
 
-            isNewPost = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, false)
-            isGutenbergKitEditor = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_GUTENBERG_KIT, false)
-            isVoiceContentSet = state.getBoolean(EditPostActivityConstants.STATE_KEY_IS_VOICE_CONTENT_SET, false)
+            isNewPost = state.getBoolean(EditorConstants.STATE_KEY_IS_NEW_POST, false)
+            isGutenbergKitEditor = state.getBoolean(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, false)
+            isVoiceContentSet = state.getBoolean(EditorConstants.STATE_KEY_IS_VOICE_CONTENT_SET, false)
             updatePostLoadingAndDialogState(
                 fromInt(
-                    state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOADING_STATE, 0)
+                    state.getInt(EditorConstants.STATE_KEY_POST_LOADING_STATE, 0)
                 )
             )
             dB?.let {
-                revision = it.getParcel(EditPostActivityConstants.STATE_KEY_REVISION, parcelableCreator())
+                revision = it.getParcel(EditorConstants.STATE_KEY_REVISION, parcelableCreator())
             }
             postEditorAnalyticsSession = PostEditorAnalyticsSession
                 .fromBundle(
                     state,
-                    EditPostActivityConstants.STATE_KEY_EDITOR_SESSION_DATA,
+                    EditorConstants.STATE_KEY_EDITOR_SESSION_DATA,
                     analyticsTrackerWrapper
                 )
 
             // if we have a remote id saved, let's first try that, as the local Id might have changed after FETCH_POSTS
-            if (state.containsKey(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID)) {
+            if (state.containsKey(EditorConstants.STATE_KEY_POST_REMOTE_ID)) {
                 editPostRepository.loadPostByRemotePostId(
-                    state.getLong(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID),
+                    state.getLong(EditorConstants.STATE_KEY_POST_REMOTE_ID),
                     siteModel
                 )
                 initializePostObject()
-            } else if (state.containsKey(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID)) {
+            } else if (state.containsKey(EditorConstants.STATE_KEY_POST_LOCAL_ID)) {
                 editPostRepository.loadPostByLocalPostId(
-                    state.getInt(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID)
+                    state.getInt(EditorConstants.STATE_KEY_POST_LOCAL_ID)
                 )
                 initializePostObject()
             }
 
             (supportFragmentManager.getFragment(
                 state,
-                EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT
+                EditorConstants.STATE_KEY_EDITOR_FRAGMENT
             ) as EditorFragmentAbstract?)?.let { frag ->
                 editorFragment = frag
                 if (frag is EditorMediaUploadListener) {
@@ -816,14 +816,14 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun setShowGutenbergEditor(savedInstanceState: Bundle?) {
         showGutenbergEditor = if (savedInstanceState == null) {
-            val restartEditorOptionName = intent.getStringExtra(EditPostActivityConstants.EXTRA_RESTART_EDITOR)
+            val restartEditorOptionName = intent.getStringExtra(EditorConstants.EXTRA_RESTART_EDITOR)
             val restartEditorOption =  if (restartEditorOptionName == null)
                 RestartEditorOptions.RESTART_DONT_SUPPRESS_GUTENBERG
             else RestartEditorOptions.valueOf(restartEditorOptionName)
             (PostUtils.shouldShowGutenbergEditor(isNewPost, editPostRepository.content, siteModel)
                     && restartEditorOption != RestartEditorOptions.RESTART_SUPPRESS_GUTENBERG)
         } else {
-            savedInstanceState.getBoolean(EditPostActivityConstants.STATE_KEY_GUTENBERG_IS_SHOWN)
+            savedInstanceState.getBoolean(EditorConstants.STATE_KEY_GUTENBERG_IS_SHOWN)
         }
     }
 
@@ -1335,49 +1335,49 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         super.onSaveInstanceState(outState)
         // Saves both post objects so we can restore them in onCreate()
         updateAndSavePostAsync()
-        outState.putInt(EditPostActivityConstants.STATE_KEY_POST_LOCAL_ID, editPostRepository.id)
+        outState.putInt(EditorConstants.STATE_KEY_POST_LOCAL_ID, editPostRepository.id)
         if (!editPostRepository.isLocalDraft) {
-            outState.putLong(EditPostActivityConstants.STATE_KEY_POST_REMOTE_ID, editPostRepository.remotePostId)
+            outState.putLong(EditorConstants.STATE_KEY_POST_REMOTE_ID, editPostRepository.remotePostId)
         }
-        outState.putInt(EditPostActivityConstants.STATE_KEY_POST_LOADING_STATE, postLoadingState.value)
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_IS_NEW_POST, isNewPost)
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_IS_VOICE_CONTENT_SET, isVoiceContentSet)
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
+        outState.putInt(EditorConstants.STATE_KEY_POST_LOADING_STATE, postLoadingState.value)
+        outState.putBoolean(EditorConstants.STATE_KEY_IS_NEW_POST, isNewPost)
+        outState.putBoolean(EditorConstants.STATE_KEY_IS_VOICE_CONTENT_SET, isVoiceContentSet)
+        outState.putBoolean(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
         outState.putBoolean(
-            EditPostActivityConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE,
+            EditorConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE,
             editorPhotoPicker?.isPhotoPickerShowing() ?: false
         )
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_HTML_MODE_ON, htmlModeMenuStateOn)
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_UNDO, menuHasUndo)
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_REDO, menuHasRedo)
+        outState.putBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON, htmlModeMenuStateOn)
+        outState.putBoolean(EditorConstants.STATE_KEY_UNDO, menuHasUndo)
+        outState.putBoolean(EditorConstants.STATE_KEY_REDO, menuHasRedo)
         outState.putSerializable(WordPress.SITE, siteModel)
-        dB?.addParcel(EditPostActivityConstants.STATE_KEY_REVISION, revision)
-        outState.putSerializable(EditPostActivityConstants.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
+        dB?.addParcel(EditorConstants.STATE_KEY_REVISION, revision)
+        outState.putSerializable(EditorConstants.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
         isConfigChange = true // don't call sessionData.end() in onDestroy() if this is an Android config change
-        outState.putBoolean(EditPostActivityConstants.STATE_KEY_GUTENBERG_IS_SHOWN, showGutenbergEditor)
+        outState.putBoolean(EditorConstants.STATE_KEY_GUTENBERG_IS_SHOWN, showGutenbergEditor)
         outState.putParcelableArrayList(
-            EditPostActivityConstants.STATE_KEY_DROPPED_MEDIA_URIS, editorMedia.droppedMediaUris
+            EditorConstants.STATE_KEY_DROPPED_MEDIA_URIS, editorMedia.droppedMediaUris
         )
 
         editorFragment?.let {
-            supportFragmentManager.putFragment(outState, EditPostActivityConstants.STATE_KEY_EDITOR_FRAGMENT, it)
+            supportFragmentManager.putFragment(outState, EditorConstants.STATE_KEY_EDITOR_FRAGMENT, it)
         }
         // We must save the media capture path when the activity is destroyed to handle orientation changes during
         // photo capture (see: https://github.com/wordpress-mobile/WordPress-Android/issues/11296)
-        outState.putString(EditPostActivityConstants.STATE_KEY_MEDIA_CAPTURE_PATH, mediaCapturePath)
+        outState.putString(EditorConstants.STATE_KEY_MEDIA_CAPTURE_PATH, mediaCapturePath)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        htmlModeMenuStateOn = savedInstanceState.getBoolean(EditPostActivityConstants.STATE_KEY_HTML_MODE_ON)
-        menuHasUndo = savedInstanceState.getBoolean(EditPostActivityConstants.STATE_KEY_UNDO)
-        menuHasRedo = savedInstanceState.getBoolean(EditPostActivityConstants.STATE_KEY_REDO)
-        if (savedInstanceState.getBoolean(EditPostActivityConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
+        htmlModeMenuStateOn = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_HTML_MODE_ON)
+        menuHasUndo = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_UNDO)
+        menuHasRedo = savedInstanceState.getBoolean(EditorConstants.STATE_KEY_REDO)
+        if (savedInstanceState.getBoolean(EditorConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE, false)) {
             editorPhotoPicker?.showPhotoPicker(siteModel)
         }
 
         // Restore media capture path for orientation changes during photo capture
-        mediaCapturePath = savedInstanceState.getString(EditPostActivityConstants.STATE_KEY_MEDIA_CAPTURE_PATH, "")
+        mediaCapturePath = savedInstanceState.getString(EditorConstants.STATE_KEY_MEDIA_CAPTURE_PATH, "")
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -2352,17 +2352,17 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun saveResult(saved: Boolean, uploadNotStarted: Boolean) {
         val i = intent
-        i.putExtra(EditPostActivityConstants.EXTRA_UPLOAD_NOT_STARTED, uploadNotStarted)
-        i.putExtra(EditPostActivityConstants.EXTRA_HAS_FAILED_MEDIA, hasFailedMedia())
-        i.putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, isPage)
-        i.putExtra(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR, isLandingEditor)
-        i.putExtra(EditPostActivityConstants.EXTRA_HAS_CHANGES, saved)
-        i.putExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, editPostRepository.id)
-        i.putExtra(EditPostActivityConstants.EXTRA_POST_REMOTE_ID, editPostRepository.remotePostId)
-        i.putExtra(EditPostActivityConstants.EXTRA_RESTART_EDITOR, restartEditorOption.name)
-        i.putExtra(EditPostActivityConstants.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
-        i.putExtra(EditPostActivityConstants.EXTRA_IS_NEW_POST, isNewPost)
-        i.putExtra(EditPostActivityConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
+        i.putExtra(EditorConstants.EXTRA_UPLOAD_NOT_STARTED, uploadNotStarted)
+        i.putExtra(EditorConstants.EXTRA_HAS_FAILED_MEDIA, hasFailedMedia())
+        i.putExtra(EditorConstants.EXTRA_IS_PAGE, isPage)
+        i.putExtra(EditorConstants.EXTRA_IS_LANDING_EDITOR, isLandingEditor)
+        i.putExtra(EditorConstants.EXTRA_HAS_CHANGES, saved)
+        i.putExtra(EditorConstants.EXTRA_POST_LOCAL_ID, editPostRepository.id)
+        i.putExtra(EditorConstants.EXTRA_POST_REMOTE_ID, editPostRepository.remotePostId)
+        i.putExtra(EditorConstants.EXTRA_RESTART_EDITOR, restartEditorOption.name)
+        i.putExtra(EditorConstants.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
+        i.putExtra(EditorConstants.EXTRA_IS_NEW_POST, isNewPost)
+        i.putExtra(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
         setResult(RESULT_OK, i)
     }
 
@@ -2939,7 +2939,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 editorFragment?.setTitle(editPostRepository.title)
             } else if (editorFragment is GutenbergEditorFragment) {
                 // don't avoid calling setTitle() for GutenbergEditorFragment so RN gets initialized
-                val title: String? = intent.getStringExtra(EditPostActivityConstants.EXTRA_PAGE_TITLE)
+                val title: String? = intent.getStringExtra(EditorConstants.EXTRA_PAGE_TITLE)
                 if (title != null) {
                     editorFragment?.setTitle(title)
                 } else {
@@ -3083,7 +3083,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
      */
     private fun setPageContent() {
         val intent: Intent = intent
-        val content: String? = intent.getStringExtra(EditPostActivityConstants.EXTRA_PAGE_CONTENT)
+        val content: String? = intent.getStringExtra(EditorConstants.EXTRA_PAGE_CONTENT)
         if (!content.isNullOrEmpty()) {
             hasSetPostContent = true
             editPostRepository.updateAsync({ postModel: PostModel ->
@@ -3752,10 +3752,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     override fun onEditorFragmentInitialized() {
         // now that we have the Post object initialized,
         // check whether we have media items to insert from the WRITE POST with media functionality
-        if (intent.hasExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA)) {
+        if (intent.hasExtra(EditorConstants.EXTRA_INSERT_MEDIA)) {
             // Bump analytics
             AnalyticsTracker.track(Stat.NOTIFICATION_UPLOAD_MEDIA_SUCCESS_WRITE_POST)
-            val serializableExtra = intent.getSerializableExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA)
+            val serializableExtra = intent.getSerializableExtra(EditorConstants.EXTRA_INSERT_MEDIA)
 
             val mediaList = if (serializableExtra is List<*> && serializableExtra.all { it is MediaModel } ) {
                 @Suppress("UNCHECKED_CAST")
@@ -3764,7 +3764,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 null
             }
             // removing this from the intent so it doesn't insert the media items again on each Activity re-creation
-            intent.removeExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA)
+            intent.removeExtra(EditorConstants.EXTRA_INSERT_MEDIA)
             if (!mediaList.isNullOrEmpty()) {
                 editorMedia.addExistingMediaToEditorAsync(mediaList, AddExistingMediaSource.WP_MEDIA_LIBRARY)
             }
@@ -3811,7 +3811,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private fun onEditorFinalTouchesBeforeShowingForAztecIfNeeded() {
         if (showAztecEditor && editorFragment is AztecEditorFragment) {
             val entryPoint =
-                intent.getSerializableExtra(EditPostActivityConstants.EXTRA_ENTRY_POINT) as PostUtils.EntryPoint?
+                intent.getSerializableExtra(EditorConstants.EXTRA_ENTRY_POINT) as PostUtils.EntryPoint?
             postEditorAnalyticsSession?.start(null, entryPoint)
         }
     }
@@ -3821,7 +3821,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         replaceBlockActionWaiting: Boolean
     ) {
         val entryPoint: PostUtils.EntryPoint? =
-            intent.getSerializableExtra(EditPostActivityConstants.EXTRA_ENTRY_POINT) as PostUtils.EntryPoint?
+            intent.getSerializableExtra(EditorConstants.EXTRA_ENTRY_POINT) as PostUtils.EntryPoint?
 
         // Note that this method is also used to track startup performance
         // It assumes this is being called when the editor has finished loading
@@ -3831,7 +3831,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         presentNewPageNoticeIfNeeded()
 
         // Start VM, load prompt and populate Editor with content after edit IS ready.
-        val promptId: Int = intent.getIntExtra(EditPostActivityConstants.EXTRA_PROMPT_ID, -1)
+        val promptId: Int = intent.getIntExtra(EditorConstants.EXTRA_PROMPT_ID, -1)
         editorBloggingPromptsViewModel.start(siteModel, promptId)
 
         updateVoiceContentIfNeeded()
@@ -3842,7 +3842,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             return
         }
         // Check if voice content exists and this is a new post for a Gutenberg editor fragment
-        val content = intent.getStringExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT)
+        val content = intent.getStringExtra(EditorConstants.EXTRA_VOICE_CONTENT)
         if (isNewPost && content != null && !isVoiceContentSet) {
             val gutenbergFragment = editorFragment as? GutenbergEditorFragment
             gutenbergFragment?.let {
@@ -3853,7 +3853,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun logTemplateSelection() {
-        val template = intent.getStringExtra(EditPostActivityConstants.EXTRA_PAGE_TEMPLATE) ?: return
+        val template = intent.getStringExtra(EditorConstants.EXTRA_PAGE_TEMPLATE) ?: return
         postEditorAnalyticsSession?.applyTemplate(template)
     }
 
@@ -4331,7 +4331,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         private const val SNACKBAR_DURATION = 4000
 
         @JvmStatic fun checkToRestart(data: Intent): Boolean {
-            val extraRestartEditor = data.getStringExtra(EditPostActivityConstants.EXTRA_RESTART_EDITOR)
+            val extraRestartEditor = data.getStringExtra(EditorConstants.EXTRA_RESTART_EDITOR)
             return extraRestartEditor != null &&
                     RestartEditorOptions.valueOf(extraRestartEditor) != RestartEditorOptions.NO_RESTART
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -665,7 +665,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         Intent categoriesIntent = new Intent(requireActivity(), SelectCategoriesActivity.class);
         categoriesIntent.putExtra(WordPress.SITE, getSite());
-        categoriesIntent.putExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, getEditPostRepository().getId());
+        categoriesIntent.putExtra(EditorConstants.EXTRA_POST_LOCAL_ID, getEditPostRepository().getId());
         startActivityForResult(categoriesIntent, ACTIVITY_REQUEST_CODE_SELECT_CATEGORIES);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -171,7 +171,7 @@ public class EditPostSettingsFragment extends Fragment {
             (buttonView, isChecked) -> onStickySwitchChanged(isChecked);
 
 
-    public interface EditPostActivityHook {
+    public interface EditorDataProvider {
         EditPostRepository getEditPostRepository();
 
         SiteModel getSite();
@@ -239,8 +239,8 @@ public class EditPostSettingsFragment extends Fragment {
 
                     @Override
                     public void onSettingsUpdated() {
-                        // mEditPostActivityHook will be null if the fragment is detached
-                        if (getEditPostActivityHook() != null) {
+                        // editorDataProvider will be null if the fragment is detached
+                        if (getEditorDataProvider() != null) {
                             updatePostFormat(
                                     mSiteSettings.getDefaultPostFormat());
                         }
@@ -823,31 +823,31 @@ public class EditPostSettingsFragment extends Fragment {
     // Helpers
 
     private EditPostRepository getEditPostRepository() {
-        if (getEditPostActivityHook() == null) {
+        if (getEditorDataProvider() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return getEditPostActivityHook().getEditPostRepository();
+        return getEditorDataProvider().getEditPostRepository();
     }
 
     private SiteModel getSite() {
-        if (getEditPostActivityHook() == null) {
+        if (getEditorDataProvider() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return getEditPostActivityHook().getSite();
+        return getEditorDataProvider().getSite();
     }
 
-    private EditPostActivityHook getEditPostActivityHook() {
+    private EditorDataProvider getEditorDataProvider() {
         Activity activity = getActivity();
         if (activity == null) {
             return null;
         }
 
-        if (activity instanceof EditPostActivityHook) {
-            return (EditPostActivityHook) activity;
+        if (activity instanceof EditorDataProvider) {
+            return (EditorDataProvider) activity;
         } else {
-            throw new RuntimeException(activity.toString() + " must implement EditPostActivityHook");
+            throw new RuntimeException(activity.toString() + " must implement EditorDataProvider");
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorConstants.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorConstants.kt
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.posts
 
-object EditPostActivityConstants{
+object EditorConstants{
     const val ACTION_REBLOG = "reblogAction"
     const val EXTRA_POST_LOCAL_ID = "postModelLocalId"
     const val EXTRA_LOAD_AUTO_SAVE_REVISION = "loadAutosaveRevision"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -96,45 +96,45 @@ class EditorLauncher @Inject constructor(
             )
 
             is EditorLauncherSiteSource.QuickPressSiteId -> putExtra(
-                EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID,
+                EditorConstants.EXTRA_QUICKPRESS_BLOG_ID,
                 params.siteSource.siteId
             )
         }
-        params.isPage?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PAGE, it) }
-        params.isPromo?.let { putExtra(EditPostActivityConstants.EXTRA_IS_PROMO, it) }
+        params.isPage?.let { putExtra(EditorConstants.EXTRA_IS_PAGE, it) }
+        params.isPromo?.let { putExtra(EditorConstants.EXTRA_IS_PROMO, it) }
         putExtra(EXTRA_LAUNCHED_VIA_EDITOR_LAUNCHER, true)
     }
 
     private fun Intent.addPostExtras(params: EditorLauncherParams) {
-        params.postLocalId?.let { putExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, it) }
-        params.postRemoteId?.let { putExtra(EditPostActivityConstants.EXTRA_POST_REMOTE_ID, it) }
-        params.loadAutoSaveRevision?.let { putExtra(EditPostActivityConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, it) }
-        params.isQuickPress?.let { putExtra(EditPostActivityConstants.EXTRA_IS_QUICKPRESS, it) }
-        params.isLandingEditor?.let { putExtra(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR, it) }
+        params.postLocalId?.let { putExtra(EditorConstants.EXTRA_POST_LOCAL_ID, it) }
+        params.postRemoteId?.let { putExtra(EditorConstants.EXTRA_POST_REMOTE_ID, it) }
+        params.loadAutoSaveRevision?.let { putExtra(EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION, it) }
+        params.isQuickPress?.let { putExtra(EditorConstants.EXTRA_IS_QUICKPRESS, it) }
+        params.isLandingEditor?.let { putExtra(EditorConstants.EXTRA_IS_LANDING_EDITOR, it) }
         params.isLandingEditorOpenedForNewSite?.let {
-            putExtra(EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE, it)
+            putExtra(EditorConstants.EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE, it)
         }
     }
 
     private fun Intent.addReblogExtras(params: EditorLauncherParams) {
-        params.reblogPostTitle?.let { putExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_TITLE, it) }
-        params.reblogPostQuote?.let { putExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_QUOTE, it) }
-        params.reblogPostImage?.let { putExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_IMAGE, it) }
-        params.reblogPostCitation?.let { putExtra(EditPostActivityConstants.EXTRA_REBLOG_POST_CITATION, it) }
+        params.reblogPostTitle?.let { putExtra(EditorConstants.EXTRA_REBLOG_POST_TITLE, it) }
+        params.reblogPostQuote?.let { putExtra(EditorConstants.EXTRA_REBLOG_POST_QUOTE, it) }
+        params.reblogPostImage?.let { putExtra(EditorConstants.EXTRA_REBLOG_POST_IMAGE, it) }
+        params.reblogPostCitation?.let { putExtra(EditorConstants.EXTRA_REBLOG_POST_CITATION, it) }
         params.reblogAction?.let { action = it }
     }
 
     private fun Intent.addPageExtras(params: EditorLauncherParams) {
-        params.pageTitle?.let { putExtra(EditPostActivityConstants.EXTRA_PAGE_TITLE, it) }
-        params.pageContent?.let { putExtra(EditPostActivityConstants.EXTRA_PAGE_CONTENT, it) }
-        params.pageTemplate?.let { putExtra(EditPostActivityConstants.EXTRA_PAGE_TEMPLATE, it) }
+        params.pageTitle?.let { putExtra(EditorConstants.EXTRA_PAGE_TITLE, it) }
+        params.pageContent?.let { putExtra(EditorConstants.EXTRA_PAGE_CONTENT, it) }
+        params.pageTemplate?.let { putExtra(EditorConstants.EXTRA_PAGE_TEMPLATE, it) }
     }
 
     private fun Intent.addMiscExtras(params: EditorLauncherParams) {
-        params.voiceContent?.let { putExtra(EditPostActivityConstants.EXTRA_VOICE_CONTENT, it) }
-        params.insertMedia?.let { putExtra(EditPostActivityConstants.EXTRA_INSERT_MEDIA, it) }
+        params.voiceContent?.let { putExtra(EditorConstants.EXTRA_VOICE_CONTENT, it) }
+        params.insertMedia?.let { putExtra(EditorConstants.EXTRA_INSERT_MEDIA, it) }
         params.source?.let { putExtra(AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL, it) }
-        params.promptId?.let { putExtra(EditPostActivityConstants.EXTRA_PROMPT_ID, it) }
-        params.entryPoint?.let { putExtra(EditPostActivityConstants.EXTRA_ENTRY_POINT, it) }
+        params.promptId?.let { putExtra(EditorConstants.EXTRA_PROMPT_ID, it) }
+        params.entryPoint?.let { putExtra(EditorConstants.EXTRA_ENTRY_POINT, it) }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostActionHandler.kt
@@ -157,7 +157,7 @@ class PostActionHandler(
     }
 
     fun handleEditPostResult(data: Intent?) {
-        val localPostId = data?.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+        val localPostId = data?.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
         if (localPostId == null || localPostId == 0) {
             return
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostListMainViewModel.kt
@@ -421,8 +421,8 @@ class PostListMainViewModel @Inject constructor(
     }
 
     private fun switchToDraftTabIfNeeded(data: Intent?) {
-        if (data != null && data.getBooleanExtra(EditPostActivityConstants.EXTRA_IS_NEW_POST, false) &&
-            data.getBooleanExtra(EditPostActivityConstants.EXTRA_HAS_CHANGES, false)
+        if (data != null && data.getBooleanExtra(EditorConstants.EXTRA_IS_NEW_POST, false) &&
+            data.getBooleanExtra(EditorConstants.EXTRA_HAS_CHANGES, false)
         ) {
             _selectTab.value = POST_LIST_PAGES.indexOf(DRAFTS)
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -439,7 +439,7 @@ class PostsListActivity : BaseAppCompatActivity(),
                 if (data != null && EditPostActivity.checkToRestart(data)) {
                     ActivityLauncher.editPostOrPageForResult(
                         data, this, site,
-                        data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+                        data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
                     )
                     // a restart will happen so, no need to continue here
                     return

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.kt
@@ -44,7 +44,7 @@ import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogNegativeClickInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogOnDismissByOutsideTouchInterface
 import org.wordpress.android.ui.posts.BasicFragmentDialog.BasicDialogPositiveClickInterface
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditorDataProvider
 import org.wordpress.android.ui.posts.PostListType.SEARCH
 import org.wordpress.android.ui.posts.adapters.AuthorSelectionAdapter
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingBottomSheetFragment
@@ -71,7 +71,7 @@ const val STATE_KEY_PREVIEW_STATE = "stateKeyPreviewState"
 const val STATE_KEY_BOTTOMSHEET_POST_ID = "stateKeyBottomSheetPostId"
 
 class PostsListActivity : BaseAppCompatActivity(),
-    EditPostActivityHook,
+    EditorDataProvider,
     PrepublishingBottomSheetListener,
     BasicDialogPositiveClickInterface,
     BasicDialogNegativeClickInterface,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PublishSettingsFragment.kt
@@ -23,7 +23,6 @@ import kotlinx.parcelize.Parcelize
 import org.wordpress.android.R
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.fluxc.store.PostSchedulingNotificationStore.SchedulingReminderModel
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
 import org.wordpress.android.ui.posts.PublishSettingsFragmentType.EDIT_POST
 import org.wordpress.android.util.AccessibilityUtils
 import org.wordpress.android.util.ToastUtils
@@ -245,16 +244,16 @@ abstract class PublishSettingsFragment : Fragment() {
     }
 
     private fun getPostRepository(): EditPostRepository? {
-        return getEditPostActivityHook()?.editPostRepository
+        return getEditorDataProvider()?.editPostRepository
     }
 
-    private fun getEditPostActivityHook(): EditPostActivityHook? {
+    private fun getEditorDataProvider(): EditPostSettingsFragment.EditorDataProvider? {
         val activity = activity ?: return null
 
-        return if (activity is EditPostActivityHook) {
+        return if (activity is EditPostSettingsFragment.EditorDataProvider) {
             activity
         } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
+            throw RuntimeException("$activity must implement EditorDataProvider")
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -49,7 +49,7 @@ import java.util.HashSet;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.posts.EditPostActivityConstants.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.EditorConstants.EXTRA_POST_LOCAL_ID;
 import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class SelectCategoriesActivity extends BaseAppCompatActivity {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/PrepublishingBottomSheetFragment.kt
@@ -24,7 +24,8 @@ import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.ActivityLauncher
 import org.wordpress.android.ui.WPBottomSheetDialogFragment
 import org.wordpress.android.ui.WPWebViewActivity
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.EditPostSettingsFragment
+import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditorDataProvider
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenEditShareMessage
 import org.wordpress.android.ui.posts.EditorJetpackSocialViewModel.ActionEvent.OpenSocialConnectionsList
@@ -325,12 +326,12 @@ class PrepublishingBottomSheetFragment : WPBottomSheetDialogFragment(),
     }
 
     @Suppress("TooGenericExceptionThrown")
-    private fun getEditorHook(): EditPostActivityHook {
+    private fun getEditorHook(): EditorDataProvider {
         val activity = activity
-        return if (activity is EditPostActivityHook) {
+        return if (activity is EditPostSettingsFragment.EditorDataProvider) {
             activity
         } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
+            throw RuntimeException("$activity must implement EditorDataProvider")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/categories/PrepublishingCategoriesFragment.kt
@@ -20,7 +20,7 @@ import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTermUploaded
 import org.wordpress.android.ui.pages.SnackbarMessageHolder
 import org.wordpress.android.ui.posts.EditPostRepository
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditorDataProvider
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingAddCategoryRequest
 import org.wordpress.android.ui.posts.prepublishing.PrepublishingViewModel
 import org.wordpress.android.ui.posts.prepublishing.home.PrepublishingHomeItemUiState.ActionType.PrepublishingScreenNavigation
@@ -164,20 +164,20 @@ class PrepublishingCategoriesFragment : Fragment(R.layout.prepublishing_categori
     }
 
     private fun getEditPostRepository(): EditPostRepository {
-        val editPostActivityHook = requireNotNull(getEditPostActivityHook()) {
+        val editorDataProvider = requireNotNull(getEditorDataProvider()) {
             "This is possibly null because it's " +
                     "called during config changes."
         }
 
-        return editPostActivityHook.editPostRepository
+        return editorDataProvider.editPostRepository
     }
 
-    private fun getEditPostActivityHook(): EditPostActivityHook? {
+    private fun getEditorDataProvider(): EditorDataProvider? {
         val activity = activity ?: return null
-        return if (activity is EditPostActivityHook) {
+        return if (activity is EditorDataProvider) {
             activity
         } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
+            throw RuntimeException("$activity must implement EditorDataProvider")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/home/PrepublishingHomeFragment.kt
@@ -122,28 +122,28 @@ class PrepublishingHomeFragment : Fragment(R.layout.post_prepublishing_home_frag
     }
 
     private fun getSite(): SiteModel {
-        val editPostActivityHook = requireNotNull(getEditPostActivityHook()) {
-            "EditPostActivityHook shouldn't be null."
+        val editorDataProvider = requireNotNull(getEditorDataProvider()) {
+            "EditorDataProvider shouldn't be null."
         }
 
-        return editPostActivityHook.site
+        return editorDataProvider.site
     }
 
     private fun getEditPostRepository(): EditPostRepository {
-        val editPostActivityHook = requireNotNull(getEditPostActivityHook()) {
+        val editorDataProvider = requireNotNull(getEditorDataProvider()) {
             "This is possibly null because it's " +
                     "called during config changes."
         }
 
-        return editPostActivityHook.editPostRepository
+        return editorDataProvider.editPostRepository
     }
 
-    private fun getEditPostActivityHook(): EditPostSettingsFragment.EditPostActivityHook? {
+    private fun getEditorDataProvider(): EditPostSettingsFragment.EditorDataProvider? {
         val activity = activity ?: return null
-        return if (activity is EditPostSettingsFragment.EditPostActivityHook) {
+        return if (activity is EditPostSettingsFragment.EditorDataProvider) {
             activity
         } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
+            throw RuntimeException("$activity must implement EditorDataProvider")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/tags/PrepublishingTagsFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/prepublishing/tags/PrepublishingTagsFragment.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.databinding.PrepublishingTagsFragmentBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.posts.EditPostRepository
-import org.wordpress.android.ui.posts.EditPostSettingsFragment.EditPostActivityHook
+import org.wordpress.android.ui.posts.EditPostSettingsFragment
 import org.wordpress.android.ui.posts.TagsFragment
 import org.wordpress.android.ui.posts.TagsSelectedListener
 import org.wordpress.android.ui.posts.prepublishing.listeners.PrepublishingScreenClosedListener
@@ -104,20 +104,20 @@ class PrepublishingTagsFragment : TagsFragment(), TagsSelectedListener {
     }
 
     private fun getEditPostRepository(): EditPostRepository {
-        val editPostActivityHook = requireNotNull(getEditPostActivityHook()) {
+        val editorDataProvider = requireNotNull(getEditorDataProvider()) {
             "This is possibly null because it's " +
                     "called during config changes."
         }
 
-        return editPostActivityHook.editPostRepository
+        return editorDataProvider.editPostRepository
     }
 
-    private fun getEditPostActivityHook(): EditPostActivityHook? {
+    private fun getEditorDataProvider(): EditPostSettingsFragment.EditorDataProvider? {
         val activity = activity ?: return null
-        return if (activity is EditPostActivityHook) {
+        return if (activity is EditPostSettingsFragment.EditorDataProvider) {
             activity
         } else {
-            throw RuntimeException("$activity must implement EditPostActivityHook")
+            throw RuntimeException("$activity must implement EditorDataProvider")
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.kt
@@ -30,7 +30,7 @@ import org.wordpress.android.ui.RequestCodes
 import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.posts.EditPostActivity.Companion.checkToRestart
-import org.wordpress.android.ui.posts.EditPostActivityConstants
+import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType
 import org.wordpress.android.ui.reader.tracker.ReaderTracker
 import org.wordpress.android.ui.uploads.UploadActionUseCase
@@ -345,7 +345,7 @@ class ReaderPostListActivity : BaseAppCompatActivity() {
             }
 
             RequestCodes.EDIT_POST -> if (resultCode == RESULT_OK && data != null && !isFinishing) {
-                val localId = data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+                val localId = data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
                 val site = BundleCompat.getSerializable(
                     data.extras!!,
                     WordPress.SITE,
@@ -357,7 +357,7 @@ class ReaderPostListActivity : BaseAppCompatActivity() {
                     ActivityLauncher.editPostOrPageForResult(
                         data,
                         this@ReaderPostListActivity, site,
-                        data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+                        data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
                     )
                     // a restart will happen so no need to continue here
                     return

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.kt
@@ -51,7 +51,7 @@ import org.wordpress.android.ui.main.BaseAppCompatActivity
 import org.wordpress.android.ui.main.WPMainActivity
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.ui.posts.EditPostActivity.Companion.checkToRestart
-import org.wordpress.android.ui.posts.EditPostActivityConstants
+import org.wordpress.android.ui.posts.EditorConstants
 import org.wordpress.android.ui.prefs.AppPrefs
 import org.wordpress.android.ui.reader.ReaderEvents.DoSignIn
 import org.wordpress.android.ui.reader.ReaderEvents.PostSlugsRequestCompleted
@@ -988,7 +988,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                 if (resultCode != RESULT_OK || data == null || isFinishing) {
                     return
                 }
-                val localId = data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+                val localId = data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
                 val site = data.extras?.let {
                     BundleCompat.getSerializable(
                         it,
@@ -1002,7 +1002,7 @@ class ReaderPostPagerActivity : BaseAppCompatActivity() {
                     ActivityLauncher.editPostOrPageForResult(
                         data,
                         this@ReaderPostPagerActivity, site,
-                        data.getIntExtra(EditPostActivityConstants.EXTRA_POST_LOCAL_ID, 0)
+                        data.getIntExtra(EditorConstants.EXTRA_POST_LOCAL_ID, 0)
                     )
 
                     // a restart will happen so, no need to continue here

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -28,7 +28,7 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 import org.wordpress.android.fluxc.utils.MimeTypes;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorConstants;
 import org.wordpress.android.ui.posts.EditorLauncher;
 import org.wordpress.android.ui.posts.EditorLauncherParams;
 import org.wordpress.android.ui.posts.PostUtils;
@@ -198,13 +198,13 @@ public class UploadUtils {
                                                           SnackbarSequencer sequencer,
                                                           View.OnClickListener publishPostListener,
                                                           @Nullable OnPublishingCallback onPublishingCallback) {
-        boolean hasChanges = data.getBooleanExtra(EditPostActivityConstants.EXTRA_HAS_CHANGES, false);
+        boolean hasChanges = data.getBooleanExtra(EditorConstants.EXTRA_HAS_CHANGES, false);
         if (!hasChanges) {
             // if there are no changes, we don't need to do anything
             return;
         }
 
-        boolean uploadNotStarted = data.getBooleanExtra(EditPostActivityConstants.EXTRA_UPLOAD_NOT_STARTED, false);
+        boolean uploadNotStarted = data.getBooleanExtra(EditorConstants.EXTRA_UPLOAD_NOT_STARTED, false);
         if (uploadNotStarted && !NetworkUtils.isNetworkAvailable(activity)) {
             // The network is not available, we can enqueue a request to upload local changes later
             UploadWorkerKt.enqueueUploadWorkRequestForSite(site);
@@ -218,7 +218,7 @@ public class UploadUtils {
             return;
         }
 
-        boolean hasFailedMedia = data.getBooleanExtra(EditPostActivityConstants.EXTRA_HAS_FAILED_MEDIA, false);
+        boolean hasFailedMedia = data.getBooleanExtra(EditorConstants.EXTRA_HAS_FAILED_MEDIA, false);
         if (hasFailedMedia) {
             showSnackbar(snackbarAttachView, post.isPage() ? R.string.editor_page_saved_locally_failed_media
                             : R.string.editor_post_saved_locally_failed_media, R.string.button_edit,

--- a/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/analytics/AnalyticsUtils.java
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.PagePostCreationSourcesDetail;
 import org.wordpress.android.ui.posts.EditPostActivity;
-import org.wordpress.android.ui.posts.EditPostActivityConstants;
+import org.wordpress.android.ui.posts.EditorConstants;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.FluxCUtils;
@@ -108,7 +108,7 @@ public class AnalyticsUtils {
             // Post created from the media library
             normalizedSourceName = "media-library";
         }
-        if (intent != null && intent.hasExtra(EditPostActivityConstants.EXTRA_IS_QUICKPRESS)) {
+        if (intent != null && intent.hasExtra(EditorConstants.EXTRA_IS_QUICKPRESS)) {
             // Quick press
             normalizedSourceName = "quick-press";
         }

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/EditorLauncherTest.kt
@@ -12,37 +12,37 @@ class EditorLauncherTest {
 
         val handledFields = setOf(
             // addBasicExtras()
-            "siteSource",     // -> WordPress.SITE or EditPostActivityConstants.EXTRA_QUICKPRESS_BLOG_ID
-            "isPage",         // -> EditPostActivityConstants.EXTRA_IS_PAGE
-            "isPromo",        // -> EditPostActivityConstants.EXTRA_IS_PROMO
+            "siteSource",     // -> WordPress.SITE or EditorConstants.EXTRA_QUICKPRESS_BLOG_ID
+            "isPage",         // -> EditorConstants.EXTRA_IS_PAGE
+            "isPromo",        // -> EditorConstants.EXTRA_IS_PROMO
 
             // addPostExtras()
-            "postLocalId",    // -> EditPostActivityConstants.EXTRA_POST_LOCAL_ID
-            "postRemoteId",   // -> EditPostActivityConstants.EXTRA_POST_REMOTE_ID
-            "loadAutoSaveRevision", // -> EditPostActivityConstants.EXTRA_LOAD_AUTO_SAVE_REVISION
-            "isQuickPress",   // -> EditPostActivityConstants.EXTRA_IS_QUICKPRESS
-            "isLandingEditor", // -> EditPostActivityConstants.EXTRA_IS_LANDING_EDITOR
-            "isLandingEditorOpenedForNewSite", // -> EditPostActivityConstants
+            "postLocalId",    // -> EditorConstants.EXTRA_POST_LOCAL_ID
+            "postRemoteId",   // -> EditorConstants.EXTRA_POST_REMOTE_ID
+            "loadAutoSaveRevision", // -> EditorConstants.EXTRA_LOAD_AUTO_SAVE_REVISION
+            "isQuickPress",   // -> EditorConstants.EXTRA_IS_QUICKPRESS
+            "isLandingEditor", // -> EditorConstants.EXTRA_IS_LANDING_EDITOR
+            "isLandingEditorOpenedForNewSite", // -> EditorConstants
                                                //    .EXTRA_IS_LANDING_EDITOR_OPENED_FOR_NEW_SITE
 
             // addReblogExtras()
-            "reblogPostTitle", // -> EditPostActivityConstants.EXTRA_REBLOG_POST_TITLE
-            "reblogPostQuote", // -> EditPostActivityConstants.EXTRA_REBLOG_POST_QUOTE
-            "reblogPostImage", // -> EditPostActivityConstants.EXTRA_REBLOG_POST_IMAGE
-            "reblogPostCitation", // -> EditPostActivityConstants.EXTRA_REBLOG_POST_CITATION
+            "reblogPostTitle", // -> EditorConstants.EXTRA_REBLOG_POST_TITLE
+            "reblogPostQuote", // -> EditorConstants.EXTRA_REBLOG_POST_QUOTE
+            "reblogPostImage", // -> EditorConstants.EXTRA_REBLOG_POST_IMAGE
+            "reblogPostCitation", // -> EditorConstants.EXTRA_REBLOG_POST_CITATION
             "reblogAction",   // -> Intent.setAction()
 
             // addPageExtras()
-            "pageTitle",      // -> EditPostActivityConstants.EXTRA_PAGE_TITLE
-            "pageContent",    // -> EditPostActivityConstants.EXTRA_PAGE_CONTENT
-            "pageTemplate",   // -> EditPostActivityConstants.EXTRA_PAGE_TEMPLATE
+            "pageTitle",      // -> EditorConstants.EXTRA_PAGE_TITLE
+            "pageContent",    // -> EditorConstants.EXTRA_PAGE_CONTENT
+            "pageTemplate",   // -> EditorConstants.EXTRA_PAGE_TEMPLATE
 
             // addMiscExtras()
-            "voiceContent",   // -> EditPostActivityConstants.EXTRA_VOICE_CONTENT
-            "insertMedia",    // -> EditPostActivityConstants.EXTRA_INSERT_MEDIA
+            "voiceContent",   // -> EditorConstants.EXTRA_VOICE_CONTENT
+            "insertMedia",    // -> EditorConstants.EXTRA_INSERT_MEDIA
             "source",         // -> AnalyticsUtils.EXTRA_CREATION_SOURCE_DETAIL
-            "promptId",       // -> EditPostActivityConstants.EXTRA_PROMPT_ID
-            "entryPoint"      // -> EditPostActivityConstants.EXTRA_ENTRY_POINT
+            "promptId",       // -> EditorConstants.EXTRA_PROMPT_ID
+            "entryPoint"      // -> EditorConstants.EXTRA_ENTRY_POINT
         )
 
         val actualFields = EditorLauncherParams::class.java.declaredFields

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -202,10 +202,10 @@
     <ID>TooGenericExceptionThrown:PageSearchAdapter.kt$PageSearchAdapter$throw Throwable("Unexpected view type")</ID>
     <ID>TooGenericExceptionThrown:PostSettingsTagsFragment.kt$PostSettingsTagsFragment$throw RuntimeException("$context must implement TagsSelectedListener")</ID>
     <ID>TooGenericExceptionThrown:PrepublishingBottomSheetFragment.kt$PrepublishingBottomSheetFragment$throw RuntimeException("$context must implement PrepublishingBottomSheetListener")</ID>
-    <ID>TooGenericExceptionThrown:PrepublishingCategoriesFragment.kt$PrepublishingCategoriesFragment$throw RuntimeException("$activity must implement EditPostActivityHook")</ID>
-    <ID>TooGenericExceptionThrown:PrepublishingHomeFragment.kt$PrepublishingHomeFragment$throw RuntimeException("$activity must implement EditPostActivityHook")</ID>
-    <ID>TooGenericExceptionThrown:PrepublishingTagsFragment.kt$PrepublishingTagsFragment$throw RuntimeException("$activity must implement EditPostActivityHook")</ID>
-    <ID>TooGenericExceptionThrown:PublishSettingsFragment.kt$PublishSettingsFragment$throw RuntimeException("$activity must implement EditPostActivityHook")</ID>
+    <ID>TooGenericExceptionThrown:PrepublishingCategoriesFragment.kt$PrepublishingCategoriesFragment$throw RuntimeException("$activity must implement EditorDataProvider")</ID>
+    <ID>TooGenericExceptionThrown:PrepublishingHomeFragment.kt$PrepublishingHomeFragment$throw RuntimeException("$activity must implement EditorDataProvider")</ID>
+    <ID>TooGenericExceptionThrown:PrepublishingTagsFragment.kt$PrepublishingTagsFragment$throw RuntimeException("$activity must implement EditorDataProvider")</ID>
+    <ID>TooGenericExceptionThrown:PublishSettingsFragment.kt$PublishSettingsFragment$throw RuntimeException("$activity must implement EditorDataProvider")</ID>
     <ID>TooGenericExceptionThrown:ReaderTracker.kt$ReaderTab.Companion$throw RuntimeException("Unexpected ReaderTab id")</ID>
     <ID>TooGenericExceptionThrown:RestoreFragment.kt$RestoreFragment$throw Throwable("Couldn't initialize ${this.javaClass.simpleName} view model")</ID>
     <ID>TooGenericExceptionThrown:RestoreViewModel.kt$RestoreViewModel$throw Throwable("Unexpected restoreRequestResult ${this.javaClass.simpleName}")</ID>


### PR DESCRIPTION
## Motivation

Prepare for `GutenbergKitActivity` duplication by making `EditPostActivity`-specific types shareable between editor activities. These renames eliminate activity-specific naming from components that will be used by both `EditPostActivity` and the future `GutenbergKitActivity`.

## Changes

- `EditPostActivityConstants` → `EditorConstants`
- `EditPostActivityHook` → `EditorDataProvider`

## No Functional Changes

This PR contains only renaming for better code organization. No business logic, behavior, or functionality has been modified.