### PR TITLE
Extract unit functions and repository logic from `EditPostActivity`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2551,11 +2551,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun shouldSavePost(): Boolean {
-        val hasChanges = editPostRepository.postWasChangedInCurrentSession()
-        val isPublishable = editPostRepository.isPostPublishable()
-        val existingPostWithChanges = editPostRepository.hasPostSnapshotWhenEditorOpened() && hasChanges
-        // if post was modified during this editing session, save it
-        return isPublishable && (existingPostWithChanges || isNewPost)
+        return editPostRepository.shouldSavePost(isNewPost)
     }
 
     private val isDiscardable: Boolean

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2216,9 +2216,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 val exceptionHandler: AztecExceptionHandler.ExceptionHandlerHelper =
                     object : AztecExceptionHandler.ExceptionHandlerHelper {
                         override fun shouldLog(ex: Throwable): Boolean {
-                            // Do not log private or password protected post
-                            return editPostRepository.hasPost() && editPostRepository.password.isEmpty()
-                                    && !editPostRepository.hasStatus(PostStatus.PRIVATE)
+                            return editPostRepository.shouldLog()
                         }
                     }
                 aztecEditorFragment.enableContentLogOnCrashes(exceptionHandler)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -2564,11 +2564,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
 
     private fun isFirstTimePublish(publishPost: Boolean): Boolean {
-        val originalStatus = editPostRepository.status
-        return (((originalStatus == PostStatus.DRAFT || originalStatus == PostStatus.UNKNOWN) && publishPost)
-                || (originalStatus == PostStatus.SCHEDULED && publishPost)
-                || (originalStatus == PostStatus.PUBLISHED && editPostRepository.isLocalDraft)
-                || (originalStatus == PostStatus.PUBLISHED && editPostRepository.remotePostId == 0L))
+        return editPostRepository.isFirstTimePublish(publishPost)
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -265,11 +265,9 @@ import org.wordpress.aztec.exceptions.DynamicLayoutGetBlockIndexOutOfBoundsExcep
 import org.wordpress.aztec.util.AztecLog
 import org.wordpress.gutenberg.GutenbergJsException
 import org.wordpress.gutenberg.GutenbergView
-import org.wordpress.gutenberg.MediaType
 import org.wordpress.gutenberg.WebViewGlobal
 import org.wordpress.gutenberg.WebViewGlobalValue
 import java.io.File
-import java.util.Locale
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -2839,16 +2837,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
 
     private var mediaCapturePath: String? = ""
-    private fun getUploadErrorHtml(mediaId: String, path: String): String {
-        return String.format(
-            Locale.US,
-            ("<span id=\"img_container_%s\" class=\"img_container failed\" data-failed=\"%s\">"
-                    + "<progress id=\"progress_%s\" value=\"0\" class=\"wp_media_indicator failed\" "
-                    + "contenteditable=\"false\"></progress>"
-                    + "<img data-wpid=\"%s\" src=\"%s\" alt=\"\" class=\"failed\"></span>"),
-            mediaId, getString(R.string.tap_to_try_again), mediaId, mediaId, path
-        )
-    }
 
     private fun migrateLegacyDraft(inputContent: String): String {
         var content = inputContent
@@ -2865,7 +2853,11 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                     editorMedia
                         .updateMediaUploadStateBlocking(stringUri.toUri(), MediaUploadState.FAILED)
                 )?.let { mediaFile ->
-                    val replacement = getUploadErrorHtml(mediaFile.id.toString(), mediaFile.filePath)
+                    val replacement = EditorUnitFunctions.getUploadErrorHtml(
+                        mediaFile.id.toString(),
+                        mediaFile.filePath,
+                        getString(R.string.tap_to_try_again)
+                    )
                     matcher.appendReplacement(stringBuffer, replacement)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -464,13 +464,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun newPostFromShareAction() {
-        if (isMediaTypeIntent(intent, null)) {
+        if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
             newPostSetup()
             setPostMediaFromShareAction()
         } else {
             val title = intent.getStringExtra(Intent.EXTRA_SUBJECT)
             val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-            val content = migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text?:""))
+            val content = EditorUnitFunctions.migrateToGutenbergEditor(AutolinkUtils.autoCreateLinks(text?:""))
             newPostSetup(title, content)
         }
     }
@@ -674,12 +674,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         return true
     }
 
-    private fun isActionSendOrNewMedia(action: String?): Boolean {
-        return action == Intent.ACTION_SEND
-                || action == Intent.ACTION_SEND_MULTIPLE
-                || action == EditorConstants.NEW_MEDIA_POST
-    }
-
     private fun refreshMobileEditorFromSiteSetting() {
         // Make sure to use the latest fresh info about the site we've in the DB set only the editor setting for now
         siteStore.getSiteByLocalId(siteModel.id)?.let {
@@ -694,7 +688,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             return null
         }
 
-        val isActionSendOrNewMedia = isActionSendOrNewMedia(intent.action)
+        val isActionSendOrNewMedia = EditorUnitFunctions.isActionSendOrNewMedia(intent.action)
         val hasQuickPressFlag = extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
         val hasQuickPressBlogId = extras.containsKey(EditorConstants.EXTRA_QUICKPRESS_BLOG_ID)
 
@@ -713,7 +707,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         val action = intent.action
 
         if (!extras.containsKey(EditorConstants.EXTRA_POST_LOCAL_ID) ||
-            isActionSendOrNewMedia(intent.action) ||
+            EditorUnitFunctions.isActionSendOrNewMedia(intent.action) ||
             extras.containsKey(EditorConstants.EXTRA_IS_QUICKPRESS)
         ) {
             isPage = extras.getBoolean(EditorConstants.EXTRA_IS_PAGE)
@@ -2153,7 +2147,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             editorFragment?.onOpenMediaLibrary(object: GutenbergView.OpenMediaLibraryListener {
                 override fun onOpenMediaLibrary(config: GutenbergView.OpenMediaLibraryConfig) {
                     editorPhotoPicker?.allowMultipleSelection = config.multiple
-                    val mediaType = mapAllowedTypesToMediaBrowserType(config.allowedTypes, config.multiple)
+                    val mediaType = EditorUnitFunctions.mapAllowedTypesToMediaBrowserType(
+                        config.allowedTypes,
+                        config.multiple
+                    )
                     val initialSelection = when (val value = config.value) {
                         is GutenbergView.Value.Single -> listOf(value.value)
                         is GutenbergView.Value.Multiple -> value.toList()
@@ -2316,7 +2313,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         ActivityLauncher.openImageEditor(this, inputData)
     }
 
-
     interface OnPostUpdatedFromUIListener {
         fun onPostUpdatedFromUI(updatePostResult: UpdatePostResult)
     }
@@ -2327,18 +2323,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         val postId = editPostRepository.remotePostId
         this.revision?.let {
             ActivityLauncher.viewHistoryDetailForResult(
-                this, it, getRevisionsIds(revisions), postId, siteModel.siteId
+                this, it, EditorUnitFunctions.getRevisionsIds(revisions), postId, siteModel.siteId
             )
         }
-    }
-
-    private fun getRevisionsIds(revisions: List<Revision>): LongArray {
-        val idsArray = LongArray(revisions.size)
-        for (i in revisions.indices) {
-            val current: Revision = revisions[i]
-            idsArray[i] = current.revisionId
-        }
-        return idsArray
     }
 
     private fun loadRevision() {
@@ -2409,7 +2396,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             showPrepublishingBottomSheetHandler?.postDelayed(it, delayMs)
         }
     }
-
 
     private fun uploadPost(publishPost: Boolean) {
         updateAndSavePostAsyncOnEditorExit(object : OnPostUpdatedFromUIListener {
@@ -2916,10 +2902,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         return content
     }
 
-    private fun migrateToGutenbergEditor(content: String): String {
-        return "<!-- wp:paragraph --><p>$content</p><!-- /wp:paragraph -->"
-    }
-
     private fun fillContentEditorFields() {
         // Needed blog settings needed by the editor
         editorFragment?.setFeaturedImageSupported(siteModel.isFeaturedImageSupported)
@@ -3007,7 +2989,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
                 // If editor is Gutenberg, add Gutenberg block around content
                 if (showGutenbergEditor) {
-                    updatedContent = migrateToGutenbergEditor(updatedContent)
+                    updatedContent = EditorUnitFunctions.migrateToGutenbergEditor(updatedContent)
                 }
 
                 // update PostModel
@@ -3036,13 +3018,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         if ((Intent.ACTION_SEND_MULTIPLE == action)) {
             val potentialUris: ArrayList<Uri>? = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
             potentialUris?.forEach { uri ->
-                if (isMediaTypeIntent(intent, uri)) {
+                if (EditorUnitFunctions.isMediaTypeIntent(intent, uri)) {
                     sharedUris.add(uri)
                 }
             }
         } else {
             // For a single media share, we only allow images and video types
-            if (isMediaTypeIntent(intent, null)) {
+            if (EditorUnitFunctions.isMediaTypeIntent(intent, null)) {
                 intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.let {
                     sharedUris.add(it)
                 }
@@ -3054,19 +3036,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             intent.removeExtra(Intent.EXTRA_STREAM)
             editorMedia.addNewMediaItemsToEditorAsync(sharedUris, false)
         }
-    }
-
-    private fun isMediaTypeIntent(intent: Intent, uri: Uri?): Boolean {
-        var type: String? = null
-        if (uri != null) {
-            val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
-            if (extension != null) {
-                type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-            }
-        } else {
-            type = intent.type
-        }
-        return type != null && (type.startsWith("image") || type.startsWith("video"))
     }
 
     private fun setFeaturedImageId(mediaId: Long, imagePicked: Boolean, isGutenbergEditor: Boolean) {
@@ -3272,21 +3241,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private fun handleFileOrAudioLibrary(data: Intent?) {
         if (data?.hasExtra(MediaPickerConstants.EXTRA_MEDIA_URIS) == true) {
             val uriResults: List<Uri> = data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
-                ?.let { convertStringArrayIntoUrisList(it) }
+                ?.let { EditorUnitFunctions.convertStringArrayIntoUrisList(it) }
                 ?: emptyList()
 
             uriResults.forEach { uri ->
                 uri.let { editorMedia.addNewMediaToEditorAsync(it, false) }
             }
         }
-    }
-
-    private fun convertStringArrayIntoUrisList(stringArray: Array<String>?): List<Uri> {
-        val uris: MutableList<Uri> = ArrayList(stringArray?.size ?: 0)
-        stringArray?.forEach { stringUri ->
-            uris.add(stringUri.toUri())
-        }
-        return uris
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -3317,7 +3278,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             val mediaId = data.getLongExtra(MediaPickerConstants.EXTRA_MEDIA_ID, 0L)
             setFeaturedImageId(mediaId, true, isGutenbergEditor = false)
         } else if (data?.hasExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED_URIS) == true) {
-            val uris: List<Uri> = convertStringArrayIntoUrisList(
+            val uris: List<Uri> = EditorUnitFunctions.convertStringArrayIntoUrisList(
                 data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_QUEUED_URIS)
             )
             val postId: Int = getImmutablePost().id
@@ -3346,7 +3307,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             }
             editPostSettingsFragment?.refreshViews()
         } else if (data?.hasExtra(MediaPickerConstants.EXTRA_MEDIA_URIS) == true) {
-            val uris: List<Uri> = convertStringArrayIntoUrisList(
+            val uris: List<Uri> = EditorUnitFunctions.convertStringArrayIntoUrisList(
                 data.getStringArrayExtra(MediaPickerConstants.EXTRA_MEDIA_URIS)
             )
             editorMedia.addNewMediaItemsToEditorAsync(uris, false)
@@ -3799,6 +3760,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         onEditorFinalTouchesBeforeShowingForGutenbergKitIfNeeded()
         onEditorFinalTouchesBeforeShowingForAztecIfNeeded()
     }
+
     private fun onEditorFinalTouchesBeforeShowingForGutenbergIfNeeded() {
         // probably here is best for Gutenberg to start interacting with
         if (!(showGutenbergEditor && editorFragment is GutenbergEditorFragment))
@@ -4291,21 +4253,11 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun getExceptionLogger(): Consumer<Exception> {
-        return Consumer { e: Exception? ->
-            AppLog.e(
-                AppLog.T.EDITOR,
-                e
-            )
-        }
+        return EditorUnitFunctions.getExceptionLogger()
     }
 
     override fun getBreadcrumbLogger(): Consumer<String> {
-        return Consumer { s: String? ->
-            AppLog.e(
-                AppLog.T.EDITOR,
-                s
-            )
-        }
+        return EditorUnitFunctions.getBreadcrumbLogger()
     }
 
     private fun updateAddingMediaToEditorProgressDialogState(uiState: ProgressDialogUiState) {
@@ -4336,21 +4288,5 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     override fun onLogJsException(exception: JsException, onSendJsException: JsExceptionCallback) {
         crashLogging.sendJavaScriptReport(exception, onSendJsException)
-    }
-}
-
-fun mapAllowedTypesToMediaBrowserType(allowedTypes: Array<MediaType>, multiple: Boolean): MediaBrowserType {
-    return when {
-        allowedTypes.contains(MediaType.IMAGE) && allowedTypes.contains(MediaType.VIDEO) -> {
-            if (multiple) MediaBrowserType.GUTENBERG_MEDIA_PICKER else MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER
-        }
-        allowedTypes.contains(MediaType.IMAGE) -> {
-            if (multiple) MediaBrowserType.GUTENBERG_IMAGE_PICKER else MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
-        }
-        allowedTypes.contains(MediaType.VIDEO) -> {
-            if (multiple) MediaBrowserType.GUTENBERG_VIDEO_PICKER else MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER
-        }
-        allowedTypes.contains(MediaType.AUDIO) -> MediaBrowserType.GUTENBERG_SINGLE_AUDIO_FILE_PICKER
-        else -> if (multiple) MediaBrowserType.GUTENBERG_MEDIA_PICKER else MediaBrowserType.GUTENBERG_SINGLE_FILE_PICKER
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -259,6 +259,14 @@ class EditPostRepository
                 || (originalStatus == PostStatus.PUBLISHED && remotePostId == 0L))
     }
 
+    fun shouldSavePost(isNewPost: Boolean): Boolean {
+        val hasChanges = postWasChangedInCurrentSession()
+        val isPublishable = isPostPublishable()
+        val existingPostWithChanges = hasPostSnapshotWhenEditorOpened() && hasChanges
+        // if post was modified during this editing session, save it
+        return isPublishable && (existingPostWithChanges || isNewPost)
+    }
+
     sealed class UpdatePostResult {
         object Updated : UpdatePostResult()
         object NoChanges : UpdatePostResult()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -251,6 +251,14 @@ class EditPostRepository
     // Do not log private or password protected post
     fun shouldLog(): Boolean = hasPost() && password.isEmpty() && !hasStatus(PostStatus.PRIVATE)
 
+    fun isFirstTimePublish(publishPost: Boolean): Boolean {
+        val originalStatus = status
+        return (((originalStatus == DRAFT || originalStatus == PostStatus.UNKNOWN) && publishPost)
+                || (originalStatus == PostStatus.SCHEDULED && publishPost)
+                || (originalStatus == PostStatus.PUBLISHED && isLocalDraft)
+                || (originalStatus == PostStatus.PUBLISHED && remotePostId == 0L))
+    }
+
     sealed class UpdatePostResult {
         object Updated : UpdatePostResult()
         object NoChanges : UpdatePostResult()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostRepository.kt
@@ -248,6 +248,9 @@ class EditPostRepository
         return parent?.title ?: EMPTY_STRING
     }
 
+    // Do not log private or password protected post
+    fun shouldLog(): Boolean = hasPost() && password.isEmpty() && !hasStatus(PostStatus.PRIVATE)
+
     sealed class UpdatePostResult {
         object Updated : UpdatePostResult()
         object NoChanges : UpdatePostResult()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
@@ -137,4 +137,18 @@ object EditorUnitFunctions {
             }
         }
     }
+
+    /**
+     * Generates HTML for displaying a failed media upload with retry functionality.
+     */
+    fun getUploadErrorHtml(mediaId: String, path: String, tapToTryAgainString: String): String {
+        return String.format(
+            java.util.Locale.US,
+            ("<span id=\"img_container_%s\" class=\"img_container failed\" data-failed=\"%s\">"
+                    + "<progress id=\"progress_%s\" value=\"0\" class=\"wp_media_indicator failed\" "
+                    + "contenteditable=\"false\"></progress>"
+                    + "<img data-wpid=\"%s\" src=\"%s\" alt=\"\" class=\"failed\"></span>"),
+            mediaId, tapToTryAgainString, mediaId, mediaId, path
+        )
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
@@ -13,6 +13,22 @@ import org.wordpress.android.util.AppLog
 /**
  * Pure utility functions extracted from EditPostActivity.
  * These functions take parameters, return values, and don't access class state.
+ * 
+ * Implementation note: This is an `object` (singleton) rather than a class to prevent
+ * accidental introduction of mutable state. Since these are pure functions with no 
+ * side effects, they don't typically need mocking at call sites - tests can use real
+ * data and verify actual behavior.
+ * 
+ * If mockability becomes necessary for complex test scenarios, consider refactoring to:
+ * ```
+ * interface EditorUnitFunctions {
+ *     fun isActionSendOrNewMedia(action: String?): Boolean = ...
+ *     // ... other functions with default implementations
+ *     companion object : EditorUnitFunctions
+ * }
+ * ```
+ * This would provide mockability while maintaining default implementations and 
+ * discouraging stateful modifications.
  */
 object EditorUnitFunctions {
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorUnitFunctions.kt
@@ -1,0 +1,124 @@
+package org.wordpress.android.ui.posts
+
+import android.content.Intent
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.core.net.toUri
+import androidx.core.util.Consumer
+import org.wordpress.android.ui.history.HistoryListItem.Revision
+import org.wordpress.gutenberg.MediaType
+import org.wordpress.android.ui.media.MediaBrowserType
+import org.wordpress.android.util.AppLog
+
+/**
+ * Pure utility functions extracted from EditPostActivity.
+ * These functions take parameters, return values, and don't access class state.
+ */
+object EditorUnitFunctions {
+    /**
+     * Checks if the given action is a send or new media action.
+     */
+    fun isActionSendOrNewMedia(action: String?): Boolean {
+        return action == Intent.ACTION_SEND
+                || action == Intent.ACTION_SEND_MULTIPLE
+                || action == EditorConstants.NEW_MEDIA_POST
+    }
+
+    /**
+     * Converts a list of revisions to an array of revision IDs.
+     */
+    fun getRevisionsIds(revisions: List<Revision>): LongArray {
+        val idsArray = LongArray(revisions.size)
+        for (i in revisions.indices) {
+            val current: Revision = revisions[i]
+            idsArray[i] = current.revisionId
+        }
+        return idsArray
+    }
+
+    /**
+     * Migrates content to Gutenberg editor format by wrapping it in a paragraph block.
+     */
+    fun migrateToGutenbergEditor(content: String): String {
+        return "<!-- wp:paragraph --><p>$content</p><!-- /wp:paragraph -->"
+    }
+
+    /**
+     * Checks if an intent contains media (image or video) content.
+     */
+    fun isMediaTypeIntent(intent: Intent, uri: Uri?): Boolean {
+        var type: String? = null
+        if (uri != null) {
+            val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+            if (extension != null) {
+                type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            }
+        } else {
+            type = intent.type
+        }
+        return type != null && (type.startsWith("image") || type.startsWith("video"))
+    }
+
+    /**
+     * Converts an array of string URIs to a list of Uri objects.
+     */
+    fun convertStringArrayIntoUrisList(stringArray: Array<String>?): List<Uri> {
+        val uris: MutableList<Uri> = ArrayList(stringArray?.size ?: 0)
+        stringArray?.forEach { stringUri ->
+            uris.add(stringUri.toUri())
+        }
+        return uris
+    }
+
+    /**
+     * Creates an exception logger consumer that logs exceptions to AppLog.
+     */
+    fun getExceptionLogger(): Consumer<Exception> {
+        return Consumer { e: Exception? ->
+            AppLog.e(
+                AppLog.T.EDITOR,
+                e
+            )
+        }
+    }
+
+    /**
+     * Creates a breadcrumb logger consumer that logs strings to AppLog.
+     */
+    fun getBreadcrumbLogger(): Consumer<String> {
+        return Consumer { s: String? ->
+            AppLog.e(
+                AppLog.T.EDITOR,
+                s
+            )
+        }
+    }
+
+    /**
+     * Maps allowed media types to the appropriate MediaBrowserType.
+     */
+    fun mapAllowedTypesToMediaBrowserType(allowedTypes: Array<MediaType>, multiple: Boolean): MediaBrowserType {
+        return when {
+            allowedTypes.contains(MediaType.IMAGE) && allowedTypes.contains(MediaType.VIDEO) -> {
+                if (multiple) MediaBrowserType.GUTENBERG_MEDIA_PICKER
+                else MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER
+            }
+
+            allowedTypes.contains(MediaType.IMAGE) -> {
+                if (multiple) MediaBrowserType.GUTENBERG_IMAGE_PICKER
+                else MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER
+            }
+
+            allowedTypes.contains(MediaType.VIDEO) -> {
+                if (multiple) MediaBrowserType.GUTENBERG_VIDEO_PICKER
+                else MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER
+            }
+
+            allowedTypes.contains(MediaType.AUDIO) -> MediaBrowserType.GUTENBERG_SINGLE_AUDIO_FILE_PICKER
+            else -> {
+                if (multiple) MediaBrowserType.GUTENBERG_MEDIA_PICKER
+                else MediaBrowserType.GUTENBERG_SINGLE_FILE_PICKER
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extract pure utility functions and repository-specific logic from `EditPostActivity` to improve code organization and prepare for `GutenbergKitActivity` duplication.

## Changes
- **9 unit functions** → `EditorUnitFunctions.kt` (8 pure functions + 1 HTML formatter)
- **3 repository functions** → `EditPostRepository.kt` (`shouldLog`, `isFirstTimePublish`, `shouldSavePost`)
- **134 lines removed** from `EditPostActivity.kt`

## Benefits
- Improved testability through function isolation
- Better separation of concerns
- Reduced coupling in preparation for activity duplication
- No functional changes (pure refactor)