### PR TITLE
fix: Persist GutenbergKit content during appearance change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -66,7 +66,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     private var openMediaLibraryListener: OpenMediaLibraryListener? = null
     private var onLogJsExceptionListener: LogJsExceptionListener? = null
 
-    private var isEditorStarted = false
     private var isEditorDidMount = false
     private var rootView: View? = null
 
@@ -78,7 +77,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
         if (savedInstanceState != null) {
             isHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED)
-            isEditorStarted = savedInstanceState.getBoolean(KEY_EDITOR_STARTED)
             isEditorDidMount = savedInstanceState.getBoolean(KEY_EDITOR_DID_MOUNT)
             mFeaturedImageId = savedInstanceState.getLong(ARG_FEATURED_IMAGE_ID)
         }
@@ -235,7 +233,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(KEY_HTML_MODE_ENABLED, isHtmlModeEnabled)
-        outState.putBoolean(KEY_EDITOR_STARTED, isEditorStarted)
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, isEditorDidMount)
         outState.putLong(ARG_FEATURED_IMAGE_ID, mFeaturedImageId)
     }
@@ -464,7 +461,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
             historyChangeListener = null
             featuredImageChangeListener = null
         }
-        isEditorStarted = false
         super.onDestroy()
     }
 
@@ -507,12 +503,11 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     }
 
     fun startWithEditorSettings(editorSettings: String) {
-        if (gutenbergView == null || isEditorStarted) {
+        if (gutenbergView == null) {
             return
         }
 
         val config = buildEditorConfiguration(editorSettings)
-        isEditorStarted = true
         gutenbergView?.start(config)
     }
 


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
When toggling the OS appearance, the activity is recreated. To ensure
the WebView is populated with the correct editor content, we must
restart the editor.

The `isEditorStarted` guard was added to prevent multiple starts
occurring when FluxC subscriptions update. We should investigate how we
might reinstate a protection against this.


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the experimental GutenbergKit editor for a post with content.
1. Toggle the OS appearance (dark mode).
1. Verify the editor content is not empty, that it contains the original post
   content.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
