### PR TITLE
Fix `GutenbergKit` editor issues during dark mode toggle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -41,6 +41,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.distinctUntilChanged
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback
@@ -617,8 +618,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 )
             }
             siteModel.isWPCom && !siteModel.isWPComAtomic && siteModel.isPrivate -> {
-                showIfNecessary(fragmentManager)
-                editPostAuthViewModel.fetchWpComCookies()
+                val currentAuthState = editPostAuthViewModel.wpComCookieAuthState.value
+                if (currentAuthState !is EditPostAuthViewModel.WpComCookieAuthState.Success) {
+                    showIfNecessary(fragmentManager)
+                    editPostAuthViewModel.fetchWpComCookies()
+                } else {
+                    handleSuccessfulWpComCookieAuthState()
+                }
             }
             else -> {
                 setupViewPager()
@@ -991,18 +997,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
             updateUIForDestination(destination)
         }
 
-        editPostAuthViewModel.wpComCookieAuthState.observe(this) { authState ->
+        editPostAuthViewModel.wpComCookieAuthState.distinctUntilChanged().observe(this) { authState ->
             when (authState) {
                 is EditPostAuthViewModel.WpComCookieAuthState.Loading -> {
                     showIfNecessary(supportFragmentManager)
                 }
                 is EditPostAuthViewModel.WpComCookieAuthState.Success -> {
-                    if (isShowing(supportFragmentManager)) {
-                        setupViewPager()
-                        dismissIfNecessary(supportFragmentManager)
-                    } else {
-                        setupViewPager()
-                    }
+                    handleSuccessfulWpComCookieAuthState()
                 }
                 is EditPostAuthViewModel.WpComCookieAuthState.Error -> {
                     if (isShowing(supportFragmentManager)) {
@@ -1078,7 +1079,26 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         invalidateOptionsMenu()
     }
 
+    private fun handleSuccessfulWpComCookieAuthState() {
+        if (isShowing(supportFragmentManager)) {
+            setupViewPager()
+            dismissIfNecessary(supportFragmentManager)
+        } else {
+            setupViewPager()
+        }
+    }
+
     private fun setupViewPager() {
+        // Check if ViewPager is already configured
+        if (viewPager?.adapter != null) {
+            AppLog.e(
+                AppLog.T.EDITOR,
+                "EditPostActivity: setupViewPager() called but ViewPager already has adapter" +
+                        " - possible duplicate setup"
+            )
+            return
+        }
+
         // Set up the ViewPager with the sections adapter.
         viewPager = findViewById(R.id.pager)
         viewPager?.adapter = sectionsPagerAdapter

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -66,7 +66,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     private var openMediaLibraryListener: OpenMediaLibraryListener? = null
     private var onLogJsExceptionListener: LogJsExceptionListener? = null
 
-    private var isEditorStarted = false
     private var isEditorDidMount = false
     private var rootView: View? = null
 
@@ -78,7 +77,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
         if (savedInstanceState != null) {
             isHtmlModeEnabled = savedInstanceState.getBoolean(KEY_HTML_MODE_ENABLED)
-            isEditorStarted = savedInstanceState.getBoolean(KEY_EDITOR_STARTED)
             isEditorDidMount = savedInstanceState.getBoolean(KEY_EDITOR_DID_MOUNT)
             mFeaturedImageId = savedInstanceState.getLong(ARG_FEATURED_IMAGE_ID)
         }
@@ -235,7 +233,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putBoolean(KEY_HTML_MODE_ENABLED, isHtmlModeEnabled)
-        outState.putBoolean(KEY_EDITOR_STARTED, isEditorStarted)
         outState.putBoolean(KEY_EDITOR_DID_MOUNT, isEditorDidMount)
         outState.putLong(ARG_FEATURED_IMAGE_ID, mFeaturedImageId)
     }
@@ -464,7 +461,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
             historyChangeListener = null
             featuredImageChangeListener = null
         }
-        isEditorStarted = false
         super.onDestroy()
     }
 
@@ -507,12 +503,11 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     }
 
     fun startWithEditorSettings(editorSettings: String) {
-        if (gutenbergView == null || isEditorStarted) {
+        if (gutenbergView == null) {
             return
         }
 
         val config = buildEditorConfiguration(editorSettings)
-        isEditorStarted = true
         gutenbergView?.start(config)
     }
 
@@ -583,7 +578,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     companion object {
         private const val GUTENBERG_EDITOR_NAME = "gutenberg"
         private const val KEY_HTML_MODE_ENABLED = "KEY_HTML_MODE_ENABLED"
-        private const val KEY_EDITOR_STARTED = "KEY_EDITOR_STARTED"
         private const val KEY_EDITOR_DID_MOUNT = "KEY_EDITOR_DID_MOUNT"
         private const val ARG_IS_NEW_POST = "param_is_new_post"
         private const val ARG_GUTENBERG_WEB_VIEW_AUTH_DATA = "param_gutenberg_web_view_auth_data"


### PR DESCRIPTION
## Summary
Fixes content loss and WebView loading issues when toggling dark mode while using the GutenbergKit editor.

## Problem
- **Content loss**: Editor content disappeared when toggling dark mode
- **WebView loading issues**: Blank WebView after dark mode toggle on private sites
- **Root cause**: Double editor initialization due to duplicate auth state handling and `isEditorStarted` flag preventing proper reinitialization

## Solution
- Prevent duplicate `fetchWpComCookies()` calls by checking existing auth state
- Add ViewPager duplicate setup protection with error logging
- Use `distinctUntilChanged()` to prevent duplicate LiveData emissions
- Remove `isEditorStarted` flag that was preventing proper editor reinitialization
- Consolidate auth success handling logic

## Demo

[dark_mode_toggle_fixed.webm](https://github.com/user-attachments/assets/62743e78-69a6-4b8b-b10c-f6153f22f356)

## Testing Instructions

### Prerequisites
- Test with both **private WordPress.com sites** and **simple sites**
- Ensure GutenbergKit editor is enabled

### Test Cases

1. **Dark Mode Toggle Test**
   - Open a post in GutenbergKit editor
   - Add some content to the editor
   - Toggle device dark mode
   - Verify: Content is preserved and editor loads correctly
   - Toggle device dark mode again
   - Verify: Content is preserved and editor loads correctly

2. **Device Rotation Test (Regression Test)**
   - Open a post in GutenbergKit editor
   - Add some content to the editor
   - Rotate device (portrait ↔ landscape)
   - Verify: Content is preserved and editor loads correctly (ensure no regressions)

### Expected Results
- ✅ Editor content is preserved during dark mode toggle
- ✅ WebView loads correctly (no blank screen)
- ✅ No duplicate editor initialization warnings in logs
- ✅ Smooth transitions without content loss