### PR TITLE
Remove unused listener interfaces from `GutenbergKitActivity`

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -68,7 +68,6 @@ import org.wordpress.android.editor.EditorImageMetaData
 import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.EditorImageSettingsListener
 import org.wordpress.android.editor.EditorMediaUploadListener
-import org.wordpress.android.editor.EditorThemeUpdateListener
 import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
@@ -85,8 +84,6 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
 import org.wordpress.android.fluxc.model.EditorSettings
-import org.wordpress.android.fluxc.model.EditorTheme
-import org.wordpress.android.fluxc.model.EditorThemeSupport
 import org.wordpress.android.fluxc.model.MediaModel
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState
 import org.wordpress.android.fluxc.model.PostImmutableModel
@@ -100,7 +97,6 @@ import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
 import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettingsPayload
 import org.wordpress.android.fluxc.store.EditorSettingsStore.OnEditorSettingsChanged
 import org.wordpress.android.fluxc.store.EditorThemeStore
-import org.wordpress.android.fluxc.store.EditorThemeStore.OnEditorThemeChanged
 import org.wordpress.android.fluxc.store.MediaStore
 import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
@@ -3623,17 +3619,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onEventMainThread(event: ConnectionChangeEvent) {
         (editorFragment as? GutenbergNetworkConnectionListener)?.onConnectionStatusChange(event.isConnected)
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
-    fun onEditorThemeChanged(event: OnEditorThemeChanged) {
-        if (editorFragment !is EditorThemeUpdateListener || (siteModel.id != event.siteId)) return
-        val editorTheme: EditorTheme = event.editorTheme ?: return
-        val editorThemeSupport: EditorThemeSupport = editorTheme.themeSupport
-        (editorFragment as EditorThemeUpdateListener)
-            .onEditorThemeUpdated(editorThemeSupport.toBundle(siteModel))
-        postEditorAnalyticsSession?.editorSettingsFetched(editorThemeSupport.isBlockBasedTheme, event.endpoint.value)
     }
 
     private fun refreshEditorSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -71,7 +71,6 @@ import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
-import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
@@ -117,7 +116,6 @@ import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
 import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.InputData
-import org.wordpress.android.networking.ConnectionChangeReceiver.ConnectionChangeEvent
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.ActivityLauncher
@@ -3614,11 +3612,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 editorMediaUploadListener?.onMediaUploadRetry(localMediaId, mediaType)
             }
         }
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: ConnectionChangeEvent) {
-        (editorFragment as? GutenbergNetworkConnectionListener)?.onConnectionStatusChange(event.isConnected)
     }
 
     private fun refreshEditorSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -67,7 +67,6 @@ import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImageMetaData
 import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.EditorImageSettingsListener
-import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
@@ -97,7 +96,6 @@ import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettings
 import org.wordpress.android.fluxc.store.EditorSettingsStore.OnEditorSettingsChanged
 import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.fluxc.store.MediaStore
-import org.wordpress.android.fluxc.store.MediaStore.MediaError
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched
@@ -191,9 +189,7 @@ import org.wordpress.android.ui.suggestion.SuggestionType
 import org.wordpress.android.ui.uploads.PostEvents.PostMediaCanceled
 import org.wordpress.android.ui.uploads.PostEvents.PostOpenedInEditor
 import org.wordpress.android.ui.uploads.PostEvents.PostPreviewingInEditor
-import org.wordpress.android.ui.uploads.ProgressEvent
 import org.wordpress.android.ui.uploads.UploadService
-import org.wordpress.android.ui.uploads.UploadService.UploadMediaRetryEvent
 import org.wordpress.android.ui.uploads.UploadUtils
 import org.wordpress.android.ui.uploads.UploadUtilsWrapper
 import org.wordpress.android.ui.utils.AuthenticationUtils
@@ -288,7 +284,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     private var revision: Revision? = null
     private var editorFragment: GutenbergKitEditorFragment? = null
     private var editPostSettingsFragment: EditPostSettingsFragment? = null
-    private var editorMediaUploadListener: EditorMediaUploadListener? = null
     private var editorPhotoPicker: EditorPhotoPicker? = null
     private var progressDialog: ProgressDialog? = null
     private var addingMediaToEditorProgressDialog: ProgressDialog? = null
@@ -769,7 +764,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 EditorConstants.STATE_KEY_EDITOR_FRAGMENT
             ) as GutenbergKitEditorFragment?)?.let { frag ->
                 editorFragment = frag
-                editorMediaUploadListener = frag
             }
         }
     }
@@ -1852,20 +1846,13 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     private fun onUploadSuccess(media: MediaModel?) {
         if (media != null) {
             // TODO Should this statement check media.getLocalPostId() == mEditPostRepository.getId()?
-            if (!media.markedLocallyAsFeatured && editorMediaUploadListener != null) {
-                editorMediaUploadListener?.onMediaUploadSucceeded(
-                    media.id.toString(),
-                    FluxCUtils.mediaFileFromMediaModel(media)
-                )
+            if (!media.markedLocallyAsFeatured) {
+                // Note: media upload success handling removed as GutenbergKit editor
+                // does not use EditorMediaUploadListener interface
             } else if (media.markedLocallyAsFeatured && media.localPostId == editPostRepository.id) {
                 setFeaturedImageId(media.mediaId, imagePicked = false, isGutenbergEditor = false)
             }
         }
-    }
-
-    private fun onUploadProgress(media: MediaModel?, progress: Float) {
-        val localMediaId = media?.id.toString()
-        editorMediaUploadListener?.onMediaUploadProgress(localMediaId, progress)
     }
 
     private fun launchPictureLibrary() {
@@ -2403,12 +2390,9 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                     editorFragment?.titleOrContentChanged?.observe(this@GutenbergKitActivity) { _: Editable? ->
                         storePostViewModel.savePostWithDelay()
                     }
-                    if (editorFragment is EditorMediaUploadListener) {
-                        editorMediaUploadListener = editorFragment as EditorMediaUploadListener?
 
-                        // Set up custom headers for the visual editor's internal WebView
-                        editorFragment?.setCustomHttpHeader("User-Agent", userAgent.toString())
-                    }
+                    // Set up custom headers for the visual editor's internal WebView
+                    editorFragment?.setCustomHttpHeader("User-Agent", userAgent.toString())
                 }
                 VIEW_PAGER_PAGE_SETTINGS -> editPostSettingsFragment = fragment as EditPostSettingsFragment
             }
@@ -3146,12 +3130,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             return false
         }
         if (!TextUtils.isEmpty(media.url) && (media.uploadState == MediaUploadState.UPLOADED.toString())) {
-            // Note: we should actually do this when the editor fragment starts instead of waiting for user input.
-            // Notify the editor fragment upload was successful and it should replace the local url by the remote url.
-                editorMediaUploadListener?.onMediaUploadSucceeded(
-                    media.id.toString(),
-                    FluxCUtils.mediaFileFromMediaModel(media)
-                )
+            // Note: media upload success handling removed as GutenbergKit editor
+            // does not use EditorMediaUploadListener interface
         } else {
             UploadService.cancelFinalNotification(this, editPostRepository.getPost())
             UploadService.cancelFinalNotificationForMedia(this, siteModel)
@@ -3406,11 +3386,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         }
 
         if (event.isError && !NetworkUtils.isNetworkAvailable(this)) {
-            editorMediaUploadListener?.let { listener ->
-                event.media?.let { media ->
-                    editorMedia.onMediaUploadPaused(listener, media, event.error)
-                }
-            }
+            // Note: media upload pause handling removed as GutenbergKit editor
+            // does not use EditorMediaUploadListener interface
             return
         }
 
@@ -3419,8 +3396,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 handleOnMediaUploadedError(event)
             } else if (event.completed) {
                 handleOnMediaUploadedCompleted(event)
-            } else {
-                onUploadProgress(event.media, event.progress)
             }
         } ?: run {
             // event for unknown media, ignoring
@@ -3438,28 +3413,14 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 )
             )
         }
-        editorMediaUploadListener?.let { listener ->
-            event.media?.let { media ->
-                editorMedia.onMediaUploadError(listener, media, event.error)
-            }
-        }
     }
 
     private fun handleOnMediaUploadedCompleted(event: OnMediaUploaded){
         // if the remote url on completed is null, we consider this upload wasn't successful
         val media = event.media ?: return
 
-        editorMediaUploadListener?.let { listener ->
-            if (TextUtils.isEmpty(media.url)) {
-                val error = MediaError(MediaErrorType.GENERIC_ERROR)
-                if (!NetworkUtils.isNetworkAvailable(this)) {
-                    editorMedia.onMediaUploadPaused(listener, media, error)
-                } else {
-                    editorMedia.onMediaUploadError(listener, media, error)
-                }
-            } else {
-                onUploadSuccess(media)
-            }
+        if (!TextUtils.isEmpty(media.url)) {
+            onUploadSuccess(media)
         }
     }
 
@@ -3582,34 +3543,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             } else {
                 editPostRepository.set { post }
                 handleRemotePreviewUploadResult(event.isError, RemotePreviewType.REMOTE_PREVIEW)
-            }
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: ProgressEvent) {
-        if (!isFinishing) {
-            // use upload progress rather than optimizer progress since the former includes upload+optimization
-            val progress: Float = UploadService.getUploadProgressForMedia(event.media)
-            onUploadProgress(event.media, progress)
-        }
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onEventMainThread(event: UploadMediaRetryEvent) {
-        if ((!isFinishing
-                    && (event.mediaModelList != null
-                    ) && (editorMediaUploadListener != null))
-        ) {
-            for (media: MediaModel in event.mediaModelList) {
-                val localMediaId = media.id.toString()
-                val mediaType: EditorFragmentAbstract.MediaType =
-                    if (media.isVideo)
-                        EditorFragmentAbstract.MediaType.VIDEO
-                    else EditorFragmentAbstract.MediaType.IMAGE
-                editorMediaUploadListener?.onMediaUploadRetry(localMediaId, mediaType)
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -25,7 +25,6 @@ import org.wordpress.android.editor.EditorFragmentAbstract
 import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.EditorMediaUploadListener
-import org.wordpress.android.editor.EditorThemeUpdateListener
 import org.wordpress.android.editor.LiveTextWatcher
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
@@ -52,7 +51,7 @@ import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
 class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener,
-    EditorThemeUpdateListener, GutenbergNetworkConnectionListener {
+    GutenbergNetworkConnectionListener {
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -501,10 +500,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     override fun onGalleryMediaUploadSucceeded(
         galleryId: Long, remoteMediaId: Long, remaining: Int
     ) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onEditorThemeUpdated(editorTheme: Bundle?) {
         // Unused, no-op retained for the shared interface with Gutenberg
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -26,7 +26,6 @@ import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.editor.LiveTextWatcher
-import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
 import org.wordpress.android.util.AppLog
@@ -50,8 +49,7 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
-class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener,
-    GutenbergNetworkConnectionListener {
+class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener {
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -566,10 +564,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
     override fun onRedoPressed() {
         gutenbergView?.redo()
-    }
-
-    override fun onConnectionStatusChange(isConnected: Boolean) {
-        // Unused, no-op retained for the shared interface with Gutenberg
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -27,8 +27,6 @@ import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.editor.EditorThemeUpdateListener
 import org.wordpress.android.editor.LiveTextWatcher
-import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogNegativeClickInterface
-import org.wordpress.android.editor.gutenberg.GutenbergDialogFragment.GutenbergDialogPositiveClickInterface
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
@@ -38,7 +36,6 @@ import org.wordpress.android.util.ProfilingUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.helpers.MediaFile
 import org.wordpress.android.util.helpers.MediaGallery
-import org.wordpress.aztec.IHistoryListener
 import org.wordpress.gutenberg.EditorConfiguration
 import org.wordpress.gutenberg.GutenbergView
 import org.wordpress.gutenberg.GutenbergView.ContentChangeListener
@@ -54,9 +51,8 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
-class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener, IHistoryListener,
-    EditorThemeUpdateListener, GutenbergDialogPositiveClickInterface, GutenbergDialogNegativeClickInterface,
-    GutenbergNetworkConnectionListener {
+class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener,
+    EditorThemeUpdateListener, GutenbergNetworkConnectionListener {
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -282,22 +278,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     @Suppress("DEPRECATION")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return false
-    }
-
-    override fun onRedoEnabled() {
-        // Currently unsupported
-    }
-
-    override fun onUndoEnabled() {
-        // Currently unsupported
-    }
-
-    override fun onUndo() {
-        // Analytics tracking is not available in GB mobile
-    }
-
-    override fun onRedo() {
-        // Analytics tracking is not available in GB mobile
     }
 
     override fun setTitle(title: CharSequence?) {
@@ -591,14 +571,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
 
     override fun onRedoPressed() {
         gutenbergView?.redo()
-    }
-
-    override fun onGutenbergDialogPositiveClicked(instanceTag: String, id: Int) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onGutenbergDialogNegativeClicked(instanceTag: String) {
-        // Unused, no-op retained for the shared interface with Gutenberg
     }
 
     override fun onConnectionStatusChange(isConnected: Boolean) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -24,7 +24,6 @@ import org.wordpress.android.editor.EditorEditMediaListener
 import org.wordpress.android.editor.EditorFragmentAbstract
 import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImagePreviewListener
-import org.wordpress.android.editor.EditorMediaUploadListener
 import org.wordpress.android.editor.LiveTextWatcher
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
@@ -49,7 +48,7 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
-class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadListener {
+class GutenbergKitEditorFragment : EditorFragmentAbstract() {
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -468,36 +467,6 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract(), EditorMediaUploadLi
     }
 
     override fun mediaSelectionCancelled() {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadReattached(localMediaId: String?, currentProgress: Float) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadRetry(localMediaId: String?, mediaType: MediaType?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadSucceeded(localMediaId: String?, mediaFile: MediaFile?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadProgress(localMediaId: String?, progress: Float) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadFailed(localMediaId: String?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onMediaUploadPaused(localMediaId: String?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun onGalleryMediaUploadSucceeded(
-        galleryId: Long, remoteMediaId: Long, remaining: Int
-    ) {
         // Unused, no-op retained for the shared interface with Gutenberg
     }
 


### PR DESCRIPTION
## Summary
Systematic cleanup of dead listener code in `GutenbergKitActivity` and `GutenbergKitEditorFragment`. All removed listeners contained only no-op implementations that served no functional purpose.

## Changes
- Remove `IHistoryListener`, `GutenbergDialogPositiveClickInterface`, `GutenbergDialogNegativeClickInterface` - all no-op methods
- Remove `EditorThemeUpdateListener` - theme change events unused by GutenbergKit editor  
- Remove `GutenbergNetworkConnectionListener` - network status handling unused
- Remove `EditorMediaUploadListener` - all 8 methods were no-ops, media upload progress/events unused
