### PR TITLE
Create standalone `GutenbergKit` editor base class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -45,11 +45,9 @@ import androidx.lifecycle.distinctUntilChanged
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback
-import com.automattic.android.tracks.crashlogging.JsExceptionStackTraceElement
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import com.google.gson.JsonObject
 import kotlinx.parcelize.parcelableCreator
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
@@ -76,7 +74,6 @@ import org.wordpress.android.editor.EditorThemeUpdateListener
 import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.editor.gutenberg.GutenbergEditorFragment
-import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
 import org.wordpress.android.editor.gutenberg.GutenbergNetworkConnectionListener
 import org.wordpress.android.editor.gutenberg.GutenbergPropsBuilder
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
@@ -85,13 +82,11 @@ import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companio
 import org.wordpress.android.fluxc.Dispatcher
 import org.wordpress.android.fluxc.action.AccountAction
 import org.wordpress.android.fluxc.generated.AccountActionBuilder
-import org.wordpress.android.fluxc.generated.EditorSettingsActionBuilder
 import org.wordpress.android.fluxc.generated.EditorThemeActionBuilder
 import org.wordpress.android.fluxc.generated.PostActionBuilder
 import org.wordpress.android.fluxc.generated.SiteActionBuilder
 import org.wordpress.android.fluxc.model.AccountModel
 import org.wordpress.android.fluxc.model.CauseOfOnPostChanged
-import org.wordpress.android.fluxc.model.EditorSettings
 import org.wordpress.android.fluxc.model.EditorTheme
 import org.wordpress.android.fluxc.model.EditorThemeSupport
 import org.wordpress.android.fluxc.model.MediaModel
@@ -104,8 +99,6 @@ import org.wordpress.android.fluxc.network.UserAgent
 import org.wordpress.android.fluxc.network.rest.wpcom.site.PrivateAtomicCookie
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged
-import org.wordpress.android.fluxc.store.EditorSettingsStore.FetchEditorSettingsPayload
-import org.wordpress.android.fluxc.store.EditorSettingsStore.OnEditorSettingsChanged
 import org.wordpress.android.fluxc.store.EditorThemeStore
 import org.wordpress.android.fluxc.store.EditorThemeStore.FetchEditorThemePayload
 import org.wordpress.android.fluxc.store.EditorThemeStore.OnEditorThemeChanged
@@ -125,8 +118,6 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPrivateAtomicCookieFetched
 import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
-import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
-import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.InputData
 import org.wordpress.android.networking.ConnectionChangeReceiver.ConnectionChangeEvent
@@ -199,7 +190,6 @@ import org.wordpress.android.ui.posts.services.AztecVideoLoader
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity
 import org.wordpress.android.ui.posts.sharemessage.EditJetpackSocialShareMessageActivity.Companion.createIntent
 import org.wordpress.android.ui.prefs.AppPrefs
-import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.ui.prefs.SiteSettingsInterface
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
@@ -242,8 +232,6 @@ import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.util.analytics.AnalyticsUtils
 import org.wordpress.android.util.analytics.AnalyticsUtils.BlockEditorEnabledSource
 import org.wordpress.android.util.config.ContactSupportFeatureConfig
-import org.wordpress.android.util.config.GutenbergKitFeature
-import org.wordpress.android.util.config.GutenbergKitPluginsFeature
 import org.wordpress.android.util.config.PostConflictResolutionFeatureConfig
 import org.wordpress.android.util.extensions.setLiftOnScrollTargetViewIdAndRequestLayout
 import org.wordpress.android.util.helpers.MediaFile
@@ -263,10 +251,6 @@ import org.wordpress.android.widgets.WPViewPager
 import org.wordpress.aztec.AztecExceptionHandler
 import org.wordpress.aztec.exceptions.DynamicLayoutGetBlockIndexOutOfBoundsException
 import org.wordpress.aztec.util.AztecLog
-import org.wordpress.gutenberg.GutenbergJsException
-import org.wordpress.gutenberg.GutenbergView
-import org.wordpress.gutenberg.WebViewGlobal
-import org.wordpress.gutenberg.WebViewGlobalValue
 import java.io.File
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -325,7 +309,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     private var isXPostsCapable: Boolean? = null
     private var onGetSuggestionResult: Consumer<String?>? = null
     private var isVoiceContentSet = false
-    private var isGutenbergKitEditor = false
 
     // For opening the context menu after permissions have been granted
     private var menuView: View? = null
@@ -420,8 +403,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     @Inject lateinit var postConflictResolutionFeatureConfig: PostConflictResolutionFeatureConfig
 
-    @Inject lateinit var gutenbergKitFeature: GutenbergKitFeature
-    @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
     @Inject lateinit var experimentalFeatures: ExperimentalFeatures
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -493,7 +474,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     ) {
         if (postEditorAnalyticsSession == null) {
             val editor = when {
-                showGutenbergEditor && isGutenbergKitEditor -> PostEditorAnalyticsSession.Editor.GUTENBERG_KIT
                 showGutenbergEditor -> PostEditorAnalyticsSession.Editor.GUTENBERG
                 else -> PostEditorAnalyticsSession.Editor.CLASSIC
             }
@@ -540,10 +520,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         onBackPressedDispatcher.addCallback(this, callback)
         dispatcher.register(this)
-        val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-                gutenbergKitFeature.isEnabled()
-        val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        isGutenbergKitEditor = isGutenbergEnabled && !isGutenbergDisabled
 
         createEditShareMessageActivityResultLauncher()
 
@@ -770,7 +746,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 }
 
             isNewPost = state.getBoolean(EditorConstants.STATE_KEY_IS_NEW_POST, false)
-            isGutenbergKitEditor = state.getBoolean(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, false)
             isVoiceContentSet = state.getBoolean(EditorConstants.STATE_KEY_IS_VOICE_CONTENT_SET, false)
             updatePostLoadingAndDialogState(
                 fromInt(
@@ -1355,7 +1330,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         outState.putInt(EditorConstants.STATE_KEY_POST_LOADING_STATE, postLoadingState.value)
         outState.putBoolean(EditorConstants.STATE_KEY_IS_NEW_POST, isNewPost)
         outState.putBoolean(EditorConstants.STATE_KEY_IS_VOICE_CONTENT_SET, isVoiceContentSet)
-        outState.putBoolean(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
         outState.putBoolean(
             EditorConstants.STATE_KEY_IS_PHOTO_PICKER_VISIBLE,
             editorPhotoPicker?.isPhotoPickerShowing() ?: false
@@ -1611,20 +1585,16 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
         val contentInfo = menu.findItem(R.id.menu_content_info)
         (editorFragment as? GutenbergEditorFragment)?.let { gutenbergEditorFragment ->
-            if (isGutenbergKitEditor) {
-                contentInfo.isVisible = false
-            } else {
-                contentInfo.setOnMenuItemClickListener { _: MenuItem? ->
-                    try {
-                        gutenbergEditorFragment.showContentInfo()
-                    } catch (e: EditorFragmentNotAddedException) {
-                        ToastUtils.showToast(
-                            getContext(),
-                            R.string.toast_content_info_failed
-                        )
-                    }
-                    true
+            contentInfo.setOnMenuItemClickListener { _: MenuItem? ->
+                try {
+                    gutenbergEditorFragment.showContentInfo()
+                } catch (e: EditorFragmentNotAddedException) {
+                    ToastUtils.showToast(
+                        getContext(),
+                        R.string.toast_content_info_failed
+                    )
                 }
+                true
             }
         } ?: run {
             contentInfo.isVisible = false // only show the menu item for Gutenberg
@@ -1644,7 +1614,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
 
         if (sendFeedbackItem != null) {
-            sendFeedbackItem.isVisible = editorFragment is GutenbergKitEditorFragment
+            // Only available for GutenbergKit which is now moved to GutenbergKitActivity
+            sendFeedbackItem.isVisible = false
         }
 
         return super.onPrepareOptionsMenu(menu)
@@ -1769,10 +1740,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 // toggle HTML mode
                 if (editorFragment is AztecEditorFragment) {
                     (editorFragment as AztecEditorFragment).onToolbarHtmlButtonClicked()
-                } else if (editorFragment is GutenbergEditorFragment) {
-                    (editorFragment as GutenbergEditorFragment).onToggleHtmlMode()
-                } else if (editorFragment is GutenbergKitEditorFragment) {
-                    (editorFragment as GutenbergKitEditorFragment).onToggleHtmlMode()
                 }
             } else if (itemId == R.id.menu_switch_to_gutenberg) {
                 // The following boolean check should be always redundant but was added to manage
@@ -1799,15 +1766,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 if (editorFragment is GutenbergEditorFragment) {
                     (editorFragment as GutenbergEditorFragment).onUndoPressed()
                 }
-                if (editorFragment is GutenbergKitEditorFragment) {
-                    (editorFragment as GutenbergKitEditorFragment).onUndoPressed()
-                }
             } else if (itemId == R.id.menu_redo_action) {
                 if (editorFragment is GutenbergEditorFragment) {
                     (editorFragment as GutenbergEditorFragment).onRedoPressed()
-                }
-                if (editorFragment is GutenbergKitEditorFragment) {
-                    (editorFragment as GutenbergKitEditorFragment).onRedoPressed()
                 }
             }
         }
@@ -1960,12 +1921,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
 
     private fun trackPostSessionEditorModeSwitch() {
         val isGutenberg: Boolean = editorFragment is GutenbergEditorFragment
-        val isGutenbergKit: Boolean = editorFragment is GutenbergKitEditorFragment
         postEditorAnalyticsSession?.switchEditor(
             when {
                 htmlModeMenuStateOn -> PostEditorAnalyticsSession.Editor.HTML
                 isGutenberg -> PostEditorAnalyticsSession.Editor.GUTENBERG
-                isGutenbergKit -> PostEditorAnalyticsSession.Editor.GUTENBERG_KIT
                 else -> PostEditorAnalyticsSession.Editor.CLASSIC
             }
         )
@@ -2080,13 +2039,13 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         )
     }
 
-    private fun updateAndSavePostAsync(listener: OnPostUpdatedFromUIListener?, isFinishing: Boolean = false) {
+    private fun updateAndSavePostAsync(listener: OnPostUpdatedFromUIListener?) {
         if (editorFragment == null) {
             AppLog.e(AppLog.T.POSTS, "Fragment not initialized")
             return
         }
         storePostViewModel.updatePostObjectWithUIAsync(
-            (editPostRepository), { oldContent: String -> updateFromEditor(oldContent, isFinishing) }
+            (editPostRepository), { oldContent: String -> updateFromEditor(oldContent) }
         ) { _: PostImmutableModel?, result: UpdatePostResult ->
             storePostViewModel.isSavingPostOnEditorExit = false
             // Ignore the result as we want to invoke the listener even when the PostModel was up-to-date
@@ -2100,25 +2059,20 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
      * 2. Saves the post via [EditPostActivity.updateAndSavePostAsync];
      * 3. Invokes the listener method parameter
      */
-    private fun updateAndSavePostAsyncOnEditorExit(listener: OnPostUpdatedFromUIListener?,
-                                                   isFinishing: Boolean = false) {
+    private fun updateAndSavePostAsyncOnEditorExit(listener: OnPostUpdatedFromUIListener?) {
         if (editorFragment == null) {
             return
         }
         storePostViewModel.isSavingPostOnEditorExit = true
         storePostViewModel.showSavingProgressDialog()
-        updateAndSavePostAsync(listener, isFinishing)
+        updateAndSavePostAsync(listener)
     }
 
-    private fun updateFromEditor(oldContent: String, isFinishing: Boolean = false): UpdateFromEditor {
+    private fun updateFromEditor(oldContent: String): UpdateFromEditor {
         editorFragment?.let {
             return try {
                 // To reduce redundant bridge events emitted to the Gutenberg editor, we get title and content at once
-                val titleAndContent: Pair<CharSequence, CharSequence> = if (it is GutenbergKitEditorFragment) {
-                    it.getTitleAndContent(oldContent, isFinishing)
-                } else {
-                    it.getTitleAndContent(oldContent)
-                }
+                val titleAndContent: Pair<CharSequence, CharSequence> = it.getTitleAndContent(oldContent)
                 val title = titleAndContent.first as String
                 val content = titleAndContent.second as String
                 PostFields(title, content)
@@ -2130,64 +2084,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     override fun initializeEditorFragment() {
-        if (editorFragment is GutenbergKitEditorFragment) {
-            editorFragment?.onEditorHistoryChanged(object : GutenbergView.HistoryChangeListener {
-                override fun onHistoryChanged(hasUndo: Boolean, hasRedo: Boolean) {
-                    onToggleUndo(!hasUndo)
-                    onToggleRedo(!hasRedo)
-                }
-            })
-            editorFragment?.onFeaturedImageChanged(object : GutenbergView.FeaturedImageChangeListener {
-                override fun onFeaturedImageChanged(mediaID: Long) {
-                    setFeaturedImageId(mediaID, false, true)
-                }
-            })
-            editorFragment?.onOpenMediaLibrary(object: GutenbergView.OpenMediaLibraryListener {
-                override fun onOpenMediaLibrary(config: GutenbergView.OpenMediaLibraryConfig) {
-                    editorPhotoPicker?.allowMultipleSelection = config.multiple
-                    val mediaType = EditorUnitFunctions.mapAllowedTypesToMediaBrowserType(
-                        config.allowedTypes,
-                        config.multiple
-                    )
-                    val initialSelection = when (val value = config.value) {
-                        is GutenbergView.Value.Single -> listOf(value.value)
-                        is GutenbergView.Value.Multiple -> value.toList()
-                        else -> emptyList()
-                    }
-                    openMediaLibrary(mediaType, initialSelection)
-                }
-            })
-            editorFragment?.onLogJsException(object : GutenbergView.LogJsExceptionListener {
-                override fun onLogJsException(exception: GutenbergJsException) {
-                    val stackTraceElements = exception.stackTrace.map { stackTrace ->
-                        JsExceptionStackTraceElement(
-                            stackTrace.fileName,
-                            stackTrace.lineNumber,
-                            stackTrace.colNumber,
-                            stackTrace.function
-                        )
-                    }
-
-                    val jsException = JsException(
-                        exception.type,
-                        exception.message,
-                        stackTraceElements,
-                        exception.context,
-                        exception.tags,
-                        exception.isHandled,
-                        exception.handledBy
-                    )
-
-                    val callback = object : JsExceptionCallback {
-                        override fun onReportSent(sent: Boolean) {
-                            // Do nothing
-                        }
-                    }
-
-                    onLogJsException(jsException, callback)
-                }
-            })
-        } else if (editorFragment is AztecEditorFragment) {
+        if (editorFragment is AztecEditorFragment) {
             val aztecEditorFragment = editorFragment as AztecEditorFragment
             aztecEditorFragment.setEditorImageSettingsListener(this@EditPostActivity)
             aztecEditorFragment.setMediaToolbarButtonClickListener(editorPhotoPicker)
@@ -2366,7 +2263,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         i.putExtra(EditorConstants.EXTRA_RESTART_EDITOR, restartEditorOption.name)
         i.putExtra(EditorConstants.STATE_KEY_EDITOR_SESSION_DATA, postEditorAnalyticsSession)
         i.putExtra(EditorConstants.EXTRA_IS_NEW_POST, isNewPost)
-        i.putExtra(EditorConstants.STATE_KEY_IS_GUTENBERG_KIT, isGutenbergKitEditor)
         setResult(RESULT_OK, i)
     }
 
@@ -2536,7 +2432,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         }
 
         // Convert the lambda to OnPostUpdatedFromUIListener and pass it to the method
-        updateAndSavePostAsyncOnEditorExit(lambdaToListener(lambda), doFinish)
+        updateAndSavePostAsyncOnEditorExit(lambdaToListener(lambda))
     }
 
     // Helper function to convert a lambda to OnPostUpdatedFromUIListener
@@ -2581,9 +2477,7 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         override fun getItem(position: Int): Fragment {
             return when (position) {
                 VIEW_PAGER_PAGE_CONTENT -> {
-                    if (isGutenbergKitEditor && showGutenbergEditor) {
-                        createGutenbergKitEditorFragment()
-                    } else if (showGutenbergEditor) {
+                    if (showGutenbergEditor) {
                         createGutenbergEditorFragment()
                     } else {
                         // If gutenberg editor is not selected, default to Aztec.
@@ -2595,86 +2489,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 VIEW_PAGER_PAGE_HISTORY -> newInstance(editPostRepository.id, siteModel)
                 else -> throw IllegalArgumentException("Unexpected page type")
             }
-        }
-
-        private fun createGutenbergKitEditorFragment(): GutenbergKitEditorFragment {
-            // Enable gutenberg on the site & show the informative popup upon opening
-            // the GB editor the first time when the remote setting value is still null
-            setGutenbergEnabledIfNeeded()
-            xPostsCapabilityChecker.retrieveCapability(siteModel) { isXpostsCapable ->
-                onXpostsSettingsCapability(isXpostsCapable)
-            }
-
-            val isWpCom = site.isWPCom || siteModel.isWPComAtomic
-            val gutenbergWebViewAuthorizationData = createGutenbergWebViewAuthorizationData(isWpCom)
-            val settings = createGutenbergKitSettings(isWpCom)
-
-            return GutenbergKitEditorFragment.newInstance(
-                getContext(),
-                isNewPost,
-                gutenbergWebViewAuthorizationData,
-                jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
-                settings
-            )
-        }
-
-        private fun createGutenbergWebViewAuthorizationData(isWpCom: Boolean): GutenbergWebViewAuthorizationData {
-            return GutenbergWebViewAuthorizationData(
-                siteModel.url,
-                isWpCom,
-                accountStore.account.userId,
-                accountStore.account.userName,
-                accountStore.accessToken,
-                siteModel.selfHostedSiteId,
-                siteModel.getUserNameProcessed(),
-                siteModel.getPasswordProcessed(),
-                siteModel.isUsingWpComRestApi,
-                siteModel.webEditor,
-                userAgent.toString(),
-                isJetpackSsoEnabled
-            )
-        }
-
-        private fun createGutenbergKitSettings(isWpCom: Boolean): MutableMap<String, Any?> {
-            val postType = if (editPostRepository.isPage) "page" else "post"
-            val siteURL = siteModel.url
-            val siteApiRoot = if (isWpCom) "https://public-api.wordpress.com/"
-                else siteModel.wpApiRestUrl ?: "$siteURL/wp-json/"
-            // Use the application password for self-hosted sites when available
-            val authHeader = if (isWpCom) "Bearer ${accountStore.accessToken}" else "Basic "
-            val siteApiNamespace = if (isWpCom)
-                arrayOf("sites/${site.siteId}/", "sites/${UrlUtils.removeScheme(siteURL)}/")
-                else arrayOf()
-
-            val languageString = perAppLocaleManager.getCurrentLocaleLanguageCode()
-            val wpcomLocaleSlug = languageString.replace("_", "-").lowercase()
-
-            return mutableMapOf(
-                "postId" to editPostRepository.getPost()?.remotePostId?.toInt(),
-                "postType" to postType,
-                "postTitle" to editPostRepository.getPost()?.title,
-                "postContent" to editPostRepository.getPost()?.content,
-                "siteURL" to siteURL,
-                "siteApiRoot" to siteApiRoot,
-                "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
-                "authHeader" to authHeader,
-                "siteApiNamespace" to siteApiNamespace,
-                "themeStyles" to experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES),
-                // Limited to Simple sites until application passwords are supported
-                "plugins" to (gutenbergKitPluginsFeature.isEnabled() && site.isWPCom),
-                "locale" to wpcomLocaleSlug,
-                "cookies" to editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
-                "webViewGlobals" to listOf(
-                    WebViewGlobal(
-                        "_currentSiteType",
-                        when {
-                            siteModel.isWPComAtomic -> WebViewGlobalValue.StringValue("atomic")
-                            siteModel.isWPCom -> WebViewGlobalValue.StringValue("simple")
-                            else -> WebViewGlobalValue.NullValue
-                        }
-                    )
-                )
-            )
         }
 
         private fun createGutenbergEditorFragment(): GutenbergEditorFragment {
@@ -2740,23 +2554,10 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         private val numPagesInEditor: Int = 4
     }
 
-    private fun openMediaLibrary(mediaType: MediaBrowserType, initialSelection: List<Int>) {
-        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
-            activity = this,
-            site = siteModel,
-            browserType = mediaType,
-            initialSelection = initialSelection
-        )
-    }
-
     private fun onXpostsSettingsCapability(isXpostsCapable: Boolean) {
         isXPostsCapable = isXpostsCapable
         if (editorFragment is GutenbergEditorFragment) {
             (editorFragment as GutenbergEditorFragment).updateCapabilities(gutenbergPropsBuilder)
-        }
-        if (editorFragment is GutenbergKitEditorFragment) {
-            val enableXPosts = siteModel.isUsingWpComRestApi && (isXPostsCapable == null || isXPostsCapable == true)
-            (editorFragment as GutenbergKitEditorFragment).setXPostsEnabled(enableXPosts)
         }
     }
 
@@ -3734,12 +3535,9 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun onEditorFinalTouchesBeforeShowing() {
-        if (editorFragment !is GutenbergKitEditorFragment) {
-            refreshEditorContent()
-        }
+        refreshEditorContent()
 
         onEditorFinalTouchesBeforeShowingForGutenbergIfNeeded()
-        onEditorFinalTouchesBeforeShowingForGutenbergKitIfNeeded()
         onEditorFinalTouchesBeforeShowingForAztecIfNeeded()
     }
 
@@ -3761,12 +3559,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 }
             }
             (editorFragment as GutenbergEditorFragment).resetUploadingMediaToFailed(mediaIds)
-        }
-    }
-
-    private fun onEditorFinalTouchesBeforeShowingForGutenbergKitIfNeeded() {
-        if (showGutenbergEditor && editorFragment is GutenbergKitEditorFragment) {
-            refreshEditorSettings()
         }
     }
 
@@ -3800,9 +3592,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
     }
 
     private fun updateVoiceContentIfNeeded() {
-        if (isGutenbergKitEditor) {
-            return
-        }
         // Check if voice content exists and this is a new post for a Gutenberg editor fragment
         val content = intent.getStringExtra(EditorConstants.EXTRA_VOICE_CONTENT)
         if (isNewPost && content != null && !isVoiceContentSet) {
@@ -4172,18 +3961,6 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
         (editorFragment as EditorThemeUpdateListener)
             .onEditorThemeUpdated(editorThemeSupport.toBundle(siteModel))
         postEditorAnalyticsSession?.editorSettingsFetched(editorThemeSupport.isBlockBasedTheme, event.endpoint.value)
-    }
-
-    private fun refreshEditorSettings() {
-        val payload = FetchEditorSettingsPayload(siteModel)
-        dispatcher.dispatch(EditorSettingsActionBuilder.newFetchEditorSettingsAction(payload))
-    }
-
-    @Suppress("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
-    fun onEditorSettingsChanged(event: OnEditorSettingsChanged) {
-        val editorSettings = event.editorSettings ?: EditorSettings(JsonObject())
-        (editorFragment as? GutenbergKitEditorFragment)?.startWithEditorSettings(editorSettings.toJsonString())
     }
 
     // EditorDataProvider methods

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -60,9 +60,9 @@ import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.editor.EditorEditMediaListener
 import org.wordpress.android.editor.EditorFragmentAbstract
-import org.wordpress.android.editor.EditorFragmentAbstract.EditorDragAndDropListener
-import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener
-import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentNotAddedException
+import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase
+import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase.EditorDragAndDropListener
+import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase.EditorFragmentListener
 import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImageMetaData
 import org.wordpress.android.editor.EditorImagePreviewListener
@@ -1297,7 +1297,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
 
     @Suppress("SwallowedException")
     private fun shouldSwitchToGutenbergBeVisible(
-        editorFragment: EditorFragmentAbstract?,
+        editorFragment: GutenbergKitEditorFragmentBase?,
         site: SiteModel
     ): Boolean {
         // Some guard conditions
@@ -1319,7 +1319,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             val content = editorFragment?.getContent(editPostRepository.content) as String
             hasBlocks = PostUtils.contentContainsGutenbergBlocks(content)
             isEmpty = TextUtils.isEmpty(content)
-        } catch (e: EditorFragmentNotAddedException) {
+        } catch (e: EditorFragmentAbstract.EditorFragmentNotAddedException) {
             // legacy exception; just ignore.
         }
 
@@ -1925,7 +1925,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 val title = titleAndContent.first as String
                 val content = titleAndContent.second as String
                 PostFields(title, content)
-            } catch (e: EditorFragmentNotAddedException) {
+            } catch (e: EditorFragmentAbstract.EditorFragmentNotAddedException) {
                 AppLog.e(AppLog.T.EDITOR, "Impossible to save the post, we weren't able to update it.")
                 UpdateFromEditor.Failed(e)
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -48,7 +48,7 @@ import org.wordpress.gutenberg.WebViewGlobal
 import java.io.Serializable
 import java.util.concurrent.CountDownLatch
 
-class GutenbergKitEditorFragment : EditorFragmentAbstract() {
+class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
     private var gutenbergView: GutenbergView? = null
     private var isHtmlModeEnabled = false
 
@@ -303,7 +303,7 @@ class GutenbergKitEditorFragment : EditorFragmentAbstract() {
 
     private fun toggleHtmlMode() {
         isHtmlModeEnabled = !isHtmlModeEnabled
-        mEditorFragmentListener.onTrackableEvent(TrackableEvent.HTML_BUTTON_TAPPED)
+        mEditorFragmentListener.onTrackableEvent(EditorFragmentAbstract.TrackableEvent.HTML_BUTTON_TAPPED)
         mEditorFragmentListener.onHtmlModeToggledInToolbar()
         gutenbergView?.textEditorEnabled = isHtmlModeEnabled
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
@@ -1,0 +1,293 @@
+package org.wordpress.android.editor;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Bundle;
+import android.text.Editable;
+import android.view.DragEvent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
+import androidx.core.util.Pair;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LiveData;
+
+import com.android.volley.toolbox.ImageLoader;
+import com.automattic.android.tracks.crashlogging.JsException;
+import com.automattic.android.tracks.crashlogging.JsExceptionCallback;
+
+import org.wordpress.android.editor.gutenberg.DialogVisibilityProvider;
+import org.wordpress.android.util.helpers.MediaFile;
+import org.wordpress.android.util.helpers.MediaGallery;
+import org.wordpress.gutenberg.GutenbergView.FeaturedImageChangeListener;
+import org.wordpress.gutenberg.GutenbergView.HistoryChangeListener;
+import org.wordpress.gutenberg.GutenbergView.LogJsExceptionListener;
+import org.wordpress.gutenberg.GutenbergView.OpenMediaLibraryListener;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class EditorFragmentAbstract extends Fragment {
+    public class EditorFragmentNotAddedException extends Exception {
+    }
+
+    public abstract @NonNull String getEditorName();
+    public abstract void setTitle(CharSequence text);
+    public abstract void setContent(CharSequence text);
+    public abstract void showNotice(String message);
+    public abstract CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException;
+    public abstract void showContentInfo() throws EditorFragmentNotAddedException;
+    public abstract Pair<CharSequence, CharSequence> getTitleAndContent(CharSequence originalContent) throws
+            EditorFragmentNotAddedException;
+    public abstract void onEditorHistoryChanged(HistoryChangeListener listener);
+    public abstract void onFeaturedImageChanged(FeaturedImageChangeListener listener);
+    public abstract void onOpenMediaLibrary(OpenMediaLibraryListener listener);
+    public abstract void onLogJsException(LogJsExceptionListener listener);
+    public abstract LiveData<Editable> getTitleOrContentChanged();
+    public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
+    public abstract void appendMediaFiles(Map<String, MediaFile> mediaList);
+    public abstract void appendGallery(MediaGallery mediaGallery);
+    public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
+    public abstract boolean isUploadingMedia();
+    public abstract boolean isActionInProgress();
+    public abstract boolean hasFailedMediaUploads();
+    // Check whether we need to reload the content of the post from the editor or not.
+    // This was required since Aztec Visual->HTML can slightly change the content of the HTML. See #692 for details.
+    public abstract void removeAllFailedMediaUploads();
+    public abstract void removeMedia(String mediaId);
+    // Called from EditPostActivity to let the block editor know when a media selection is cancelled
+    public abstract void mediaSelectionCancelled();
+    public abstract void showEditorHelp();
+
+    public abstract void onUndoPressed();
+
+    public abstract void onRedoPressed();
+    public abstract void updateContent(CharSequence text);
+
+
+    public enum MediaType {
+        IMAGE, VIDEO;
+
+        public static MediaType fromString(String value) {
+            if (value != null) {
+                for (MediaType mediaType : MediaType.values()) {
+                    if (value.equalsIgnoreCase(mediaType.toString())) {
+                        return mediaType;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    protected static final String ARG_PARAM_TITLE = "param_title";
+    protected static final String ARG_PARAM_CONTENT = "param_content";
+    protected static final String ATTR_ALIGN = "align";
+    protected static final String ATTR_ALT = "alt";
+    protected static final String ATTR_CAPTION = "caption";
+    protected static final String ATTR_DIMEN_HEIGHT = "height";
+    protected static final String ATTR_DIMEN_WIDTH = "width";
+    protected static final String ATTR_ID = "id";
+    protected static final String ATTR_ID_ATTACHMENT = "attachment_id";
+    protected static final String ATTR_ID_IMAGE_REMOTE = "imageRemoteId";
+    protected static final String ATTR_SRC = "src";
+    protected static final String ATTR_STATUS_FAILED = "failed";
+    protected static final String ATTR_STATUS_UPLOADING = "uploading";
+    protected static final String ATTR_TITLE = "title";
+    protected static final String ATTR_URL_LINK = "linkUrl";
+    protected static final String EXTRA_ENABLED_AZTEC = "isAztecEnabled";
+    protected static final String EXTRA_FEATURED = "isFeatured";
+    protected static final String EXTRA_IMAGE_FEATURED = "featuredImageSupported";
+    protected static final String EXTRA_IMAGE_META = "imageMeta";
+    protected static final String EXTRA_MAX_WIDTH = "maxWidth";
+
+    private static final String FEATURED_IMAGE_SUPPORT_KEY = "featured-image-supported";
+    private static final String FEATURED_IMAGE_WIDTH_KEY = "featured-image-width";
+
+    protected EditorFragmentListener mEditorFragmentListener;
+    protected EditorDragAndDropListener mEditorDragAndDropListener;
+    protected EditorImagePreviewListener mEditorImagePreviewListener;
+    protected EditorEditMediaListener mEditorEditMediaListener;
+    protected boolean mFeaturedImageSupported;
+    protected long mFeaturedImageId;
+    protected String mBlogSettingMaxImageWidth;
+    protected ImageLoader mImageLoader;
+    protected boolean mDebugModeEnabled;
+
+    protected HashMap<String, String> mCustomHttpHeaders;
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        try {
+            mEditorFragmentListener = (EditorFragmentListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement EditorFragmentListener");
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(FEATURED_IMAGE_SUPPORT_KEY, mFeaturedImageSupported);
+        outState.putString(FEATURED_IMAGE_WIDTH_KEY, mBlogSettingMaxImageWidth);
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey(FEATURED_IMAGE_SUPPORT_KEY)) {
+                mFeaturedImageSupported = savedInstanceState.getBoolean(FEATURED_IMAGE_SUPPORT_KEY);
+            }
+            if (savedInstanceState.containsKey(FEATURED_IMAGE_WIDTH_KEY)) {
+                mBlogSettingMaxImageWidth = savedInstanceState.getString(FEATURED_IMAGE_WIDTH_KEY);
+            }
+        }
+    }
+
+    public void setImageLoader(ImageLoader imageLoader) {
+        mImageLoader = imageLoader;
+    }
+
+    public void setFeaturedImageSupported(boolean featuredImageSupported) {
+        mFeaturedImageSupported = featuredImageSupported;
+    }
+
+    public void setFeaturedImageId(long featuredImageId) {
+        mFeaturedImageId = featuredImageId;
+    }
+
+    public void setCustomHttpHeader(String name, String value) {
+        if (mCustomHttpHeaders == null) {
+            mCustomHttpHeaders = new HashMap<>();
+        }
+
+        mCustomHttpHeaders.put(name, value);
+    }
+
+    public void setDebugModeEnabled(boolean debugModeEnabled) {
+        mDebugModeEnabled = debugModeEnabled;
+    }
+
+    /**
+     * Called by the activity when back button is pressed.
+     */
+    public boolean onBackPressed() {
+        return false;
+    }
+
+    public static MediaType getEditorMimeType(MediaFile mediaFile) {
+        if (mediaFile == null) {
+            // default to image
+            return MediaType.IMAGE;
+        }
+        return mediaFile.isVideo() ? MediaType.VIDEO
+                : MediaType.IMAGE;
+    }
+
+    /**
+     * Callbacks used to communicate with the parent Activity
+     */
+    public interface EditorFragmentListener extends DialogVisibilityProvider {
+        void onEditorFragmentInitialized();
+        void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocks, boolean replaceBlockActionWaiting);
+        void updateFeaturedImage(long mediaId, boolean imagePicked);
+        void onAddMediaClicked();
+        void onAddMediaImageClicked(boolean allowMultipleSelection);
+        void onAddMediaVideoClicked(boolean allowMultipleSelection);
+        void onAddLibraryMediaClicked(boolean allowMultipleSelection);
+        void onAddLibraryFileClicked(boolean allowMultipleSelection);
+        void onAddLibraryAudioFileClicked(boolean allowMultipleSelection);
+        void onAddPhotoClicked(boolean allowMultipleSelection);
+        void onCapturePhotoClicked();
+        void onAddVideoClicked(boolean allowMultipleSelection);
+        void onAddDeviceMediaClicked(boolean allowMultipleSelection);
+        void onCaptureVideoClicked();
+        boolean onMediaRetryClicked(String mediaId);
+        void onMediaRetryAll(Set<String> mediaIdSet);
+        void onMediaUploadCancelClicked(String mediaId);
+        void onMediaDeleted(String mediaId);
+        void onUndoMediaCheck(String undoedContent);
+        void onVideoPressInfoRequested(String videoId);
+        Map<String, String> onAuthHeaderRequested(String url);
+        void onTrackableEvent(TrackableEvent event);
+        void onTrackableEvent(TrackableEvent event, Map<String, String> properties);
+        void onHtmlModeToggledInToolbar();
+        void onAddStockMediaClicked(boolean allowMultipleSelection);
+        void onAddGifClicked(boolean allowMultipleSelection);
+        void onAddFileClicked(boolean allowMultipleSelection);
+        void onAddAudioFileClicked(boolean allowMultipleSelection);
+        void onPerformFetch(String path, boolean enableCaching, Consumer<String> onResult, Consumer<Bundle> onError);
+        void onPerformPost(String path, Map<String, Object> body, Consumer<String> onResult, Consumer<Bundle> onError);
+        void showUserSuggestions(Consumer<String> onResult);
+        void showXpostSuggestions(Consumer<String> onResult);
+        void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown);
+        boolean onGutenbergEditorRequestFocalPointPickerTooltipShown();
+        String getErrorMessageFromMedia(int mediaId);
+        void showJetpackSettings();
+        boolean showPreview();
+        Map<String, Double> onRequestBlockTypeImpressions();
+        void onSetBlockTypeImpressions(Map<String, Double> impressions);
+        void onContactCustomerSupport();
+        void onGotoCustomerSupportOptions();
+        void onSendEventToHost(String eventName, Map<String, Object> properties);
+
+        void onToggleUndo(boolean isDisabled);
+
+        void onToggleRedo(boolean isDisabled);
+
+        void onBackHandlerButton();
+
+        void onLogJsException(JsException jsException, JsExceptionCallback onSendJsException);
+    }
+
+    /**
+     * Callbacks for drag and drop support
+     */
+    public interface EditorDragAndDropListener {
+        void onMediaDropped(ArrayList<Uri> mediaUri);
+        void onRequestDragAndDropPermissions(DragEvent dragEvent);
+    }
+
+    public enum TrackableEvent {
+        BLOCKQUOTE_BUTTON_TAPPED,
+        BOLD_BUTTON_TAPPED,
+        ELLIPSIS_COLLAPSE_BUTTON_TAPPED,
+        ELLIPSIS_EXPAND_BUTTON_TAPPED,
+        HEADING_BUTTON_TAPPED,
+        HEADING_1_BUTTON_TAPPED,
+        HEADING_2_BUTTON_TAPPED,
+        HEADING_3_BUTTON_TAPPED,
+        HEADING_4_BUTTON_TAPPED,
+        HEADING_5_BUTTON_TAPPED,
+        HEADING_6_BUTTON_TAPPED,
+        HORIZONTAL_RULE_BUTTON_TAPPED,
+        FORMAT_ALIGN_LEFT_BUTTON_TAPPED,
+        FORMAT_ALIGN_CENTER_BUTTON_TAPPED,
+        FORMAT_ALIGN_RIGHT_BUTTON_TAPPED,
+        HTML_BUTTON_TAPPED,
+        IMAGE_EDITED,
+        ITALIC_BUTTON_TAPPED,
+        LINK_ADDED_BUTTON_TAPPED,
+        LIST_BUTTON_TAPPED,
+        LIST_ORDERED_BUTTON_TAPPED,
+        LIST_UNORDERED_BUTTON_TAPPED,
+        MEDIA_BUTTON_TAPPED,
+        NEXT_PAGE_BUTTON_TAPPED,
+        PARAGRAPH_BUTTON_TAPPED,
+        PREFORMAT_BUTTON_TAPPED,
+        READ_MORE_BUTTON_TAPPED,
+        STRIKETHROUGH_BUTTON_TAPPED,
+        UNDERLINE_BUTTON_TAPPED,
+        REDO_TAPPED,
+        UNDO_TAPPED,
+        EDITOR_GUTENBERG_UNSUPPORTED_BLOCK_WEBVIEW_SHOWN,
+        EDITOR_GUTENBERG_UNSUPPORTED_BLOCK_WEBVIEW_CLOSED,
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.editor;
+package org.wordpress.android.ui.posts.editor;
 
 import android.app.Activity;
 import android.net.Uri;
@@ -17,6 +17,9 @@ import com.android.volley.toolbox.ImageLoader;
 import com.automattic.android.tracks.crashlogging.JsException;
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback;
 
+import org.wordpress.android.editor.EditorEditMediaListener;
+import org.wordpress.android.editor.EditorFragmentAbstract;
+import org.wordpress.android.editor.EditorImagePreviewListener;
 import org.wordpress.android.editor.gutenberg.DialogVisibilityProvider;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -30,18 +33,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class EditorFragmentAbstract extends Fragment {
-    public class EditorFragmentNotAddedException extends Exception {
-    }
-
+public abstract class GutenbergKitEditorFragmentBase extends Fragment {
     public abstract @NonNull String getEditorName();
     public abstract void setTitle(CharSequence text);
     public abstract void setContent(CharSequence text);
     public abstract void showNotice(String message);
-    public abstract CharSequence getContent(CharSequence originalContent) throws EditorFragmentNotAddedException;
-    public abstract void showContentInfo() throws EditorFragmentNotAddedException;
+    public abstract CharSequence getContent(CharSequence originalContent)
+            throws EditorFragmentAbstract.EditorFragmentNotAddedException;
+    public abstract void showContentInfo() throws EditorFragmentAbstract.EditorFragmentNotAddedException;
     public abstract Pair<CharSequence, CharSequence> getTitleAndContent(CharSequence originalContent) throws
-            EditorFragmentNotAddedException;
+            EditorFragmentAbstract.EditorFragmentNotAddedException;
     public abstract void onEditorHistoryChanged(HistoryChangeListener listener);
     public abstract void onFeaturedImageChanged(FeaturedImageChangeListener listener);
     public abstract void onOpenMediaLibrary(OpenMediaLibraryListener listener);
@@ -216,8 +217,9 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onUndoMediaCheck(String undoedContent);
         void onVideoPressInfoRequested(String videoId);
         Map<String, String> onAuthHeaderRequested(String url);
-        void onTrackableEvent(TrackableEvent event);
-        void onTrackableEvent(TrackableEvent event, Map<String, String> properties);
+        void onTrackableEvent(org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent event);
+        void onTrackableEvent(org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent event,
+                              Map<String, String> properties);
         void onHtmlModeToggledInToolbar();
         void onAddStockMediaClicked(boolean allowMultipleSelection);
         void onAddGifClicked(boolean allowMultipleSelection);
@@ -253,41 +255,5 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public interface EditorDragAndDropListener {
         void onMediaDropped(ArrayList<Uri> mediaUri);
         void onRequestDragAndDropPermissions(DragEvent dragEvent);
-    }
-
-    public enum TrackableEvent {
-        BLOCKQUOTE_BUTTON_TAPPED,
-        BOLD_BUTTON_TAPPED,
-        ELLIPSIS_COLLAPSE_BUTTON_TAPPED,
-        ELLIPSIS_EXPAND_BUTTON_TAPPED,
-        HEADING_BUTTON_TAPPED,
-        HEADING_1_BUTTON_TAPPED,
-        HEADING_2_BUTTON_TAPPED,
-        HEADING_3_BUTTON_TAPPED,
-        HEADING_4_BUTTON_TAPPED,
-        HEADING_5_BUTTON_TAPPED,
-        HEADING_6_BUTTON_TAPPED,
-        HORIZONTAL_RULE_BUTTON_TAPPED,
-        FORMAT_ALIGN_LEFT_BUTTON_TAPPED,
-        FORMAT_ALIGN_CENTER_BUTTON_TAPPED,
-        FORMAT_ALIGN_RIGHT_BUTTON_TAPPED,
-        HTML_BUTTON_TAPPED,
-        IMAGE_EDITED,
-        ITALIC_BUTTON_TAPPED,
-        LINK_ADDED_BUTTON_TAPPED,
-        LIST_BUTTON_TAPPED,
-        LIST_ORDERED_BUTTON_TAPPED,
-        LIST_UNORDERED_BUTTON_TAPPED,
-        MEDIA_BUTTON_TAPPED,
-        NEXT_PAGE_BUTTON_TAPPED,
-        PARAGRAPH_BUTTON_TAPPED,
-        PREFORMAT_BUTTON_TAPPED,
-        READ_MORE_BUTTON_TAPPED,
-        STRIKETHROUGH_BUTTON_TAPPED,
-        UNDERLINE_BUTTON_TAPPED,
-        REDO_TAPPED,
-        UNDO_TAPPED,
-        EDITOR_GUTENBERG_UNSUPPORTED_BLOCK_WEBVIEW_SHOWN,
-        EDITOR_GUTENBERG_UNSUPPORTED_BLOCK_WEBVIEW_CLOSED,
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
@@ -34,6 +34,9 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class GutenbergKitEditorFragmentBase extends Fragment {
+    public class EditorFragmentNotAddedException extends Exception {
+    }
+
     public abstract @NonNull String getEditorName();
     public abstract void setTitle(CharSequence text);
     public abstract void setContent(CharSequence text);


### PR DESCRIPTION
## Summary
Isolates `GutenbergKit` editor from shared `EditorFragmentAbstract` to enable independent interface cleanup. Removes all `GutenbergKit` dependencies from `EditPostActivity`.

## Changes
- Create `GutenbergKitEditorFragmentBase` as standalone copy of `EditorFragmentAbstract`
- Switch `GutenbergKitEditorFragment` to extend standalone base class
- Remove all `GutenbergKit` references from `EditPostActivity` (220+ lines removed)
- Clean separation: `EditPostActivity` handles Aztec + Gutenberg, `GutenbergKitActivity` handles `GutenbergKit`

## Impact
- **Zero functional changes** - pure architectural isolation
- **Enables aggressive cleanup** of unused `EditorFragmentListener` methods in follow-up PRs
- **Clean architecture** with no coupling between editor types