### PR TITLE
Clean up unused `GutenbergKit` interfaces and code

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2,7 +2,6 @@
 package org.wordpress.android.ui.posts
 
 import android.app.ProgressDialog
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.drawable.Drawable
@@ -14,7 +13,6 @@ import android.os.Looper
 import android.preference.PreferenceManager
 import android.text.Editable
 import android.text.TextUtils
-import android.view.DragEvent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -61,7 +59,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat
 import org.wordpress.android.editor.EditorEditMediaListener
 import org.wordpress.android.editor.EditorFragmentAbstract
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase
-import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase.EditorDragAndDropListener
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragmentBase.EditorFragmentListener
 import org.wordpress.android.editor.EditorFragmentActivity
 import org.wordpress.android.editor.EditorImageMetaData
@@ -137,8 +134,6 @@ import org.wordpress.android.ui.photopicker.MediaPickerConstants
 import org.wordpress.android.ui.photopicker.MediaPickerLauncher
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerListener
-import org.wordpress.android.ui.posts.EditPostCustomerSupportHelper.onContactCustomerSupport
-import org.wordpress.android.ui.posts.EditPostCustomerSupportHelper.onGotoCustomerSupportOptions
 import org.wordpress.android.ui.posts.EditPostPublishSettingsFragment.Companion.newInstance
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult
 import org.wordpress.android.ui.posts.EditPostRepository.UpdatePostResult.Updated
@@ -186,7 +181,6 @@ import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.reader.utils.ReaderUtilsWrapper
 import org.wordpress.android.ui.suggestion.SuggestionActivity
 import org.wordpress.android.ui.suggestion.SuggestionType
-import org.wordpress.android.ui.uploads.PostEvents.PostMediaCanceled
 import org.wordpress.android.ui.uploads.PostEvents.PostOpenedInEditor
 import org.wordpress.android.ui.uploads.PostEvents.PostPreviewingInEditor
 import org.wordpress.android.ui.uploads.UploadService
@@ -205,7 +199,6 @@ import org.wordpress.android.util.FluxCUtils
 import org.wordpress.android.util.MediaUtils
 import org.wordpress.android.util.NetworkUtils
 import org.wordpress.android.util.PerAppLocaleManager
-import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ReblogUtils
 import org.wordpress.android.util.ShortcutUtils
 import org.wordpress.android.util.SiteUtils
@@ -258,12 +251,11 @@ private const val MEDIA_ID_NO_FEATURED_IMAGE_SET = 0
 
 @Suppress("LargeClass")
 class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, EditorImageSettingsListener,
-    EditorImagePreviewListener, EditorEditMediaListener, EditorDragAndDropListener, EditorFragmentListener,
+    EditorImagePreviewListener, EditorEditMediaListener, EditorFragmentListener,
     ActivityCompat.OnRequestPermissionsResultCallback, PhotoPickerListener, EditorPhotoPickerListener,
     EditorMediaListener, EditPostSettingsFragment.EditorDataProvider, HistoryItemClickInterface,
     PrivateAtCookieProgressDialogOnDismissListener, ExceptionLogger, SiteSettingsListener {
     private var restartEditorOption: RestartEditorOptions = RestartEditorOptions.NO_RESTART
-    private var pendingVideoPressInfoRequests: MutableList<String>? = null
     private var postEditorAnalyticsSession: PostEditorAnalyticsSession? = null
     private var isConfigChange: Boolean = false
 
@@ -849,17 +841,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 resources.getDimensionPixelSize(R.dimen.edit_post_header_image_corner_radius)
             )
         }
-    }
-
-    private fun presentNewPageNoticeIfNeeded() {
-        if (!isPage || !isNewPost) {
-            return
-        }
-        val message: String =
-            if (editPostRepository.content.isEmpty()) getString(R.string.mlp_notice_blank_page_created) else getString(
-                R.string.mlp_notice_page_created
-            )
-        editorFragment?.showNotice(message)
     }
 
     private fun fetchSiteSettings() {
@@ -1766,16 +1747,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         htmlModeMenuStateOn = !htmlModeMenuStateOn
         trackPostSessionEditorModeSwitch()
         invalidateOptionsMenu()
-        showEditorModeSwitchedNotice()
-    }
-
-    private fun showEditorModeSwitchedNotice() {
-        val message: String = getString(
-            if (htmlModeMenuStateOn)
-                R.string.menu_html_mode_switched_notice
-            else R.string.menu_visual_mode_switched_notice
-        )
-        editorFragment?.showNotice(message)
     }
 
     private fun trackPostSessionEditorModeSwitch() {
@@ -2077,7 +2048,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     private fun saveResult(saved: Boolean, uploadNotStarted: Boolean) {
         val i = intent
         i.putExtra(EditorConstants.EXTRA_UPLOAD_NOT_STARTED, uploadNotStarted)
-        i.putExtra(EditorConstants.EXTRA_HAS_FAILED_MEDIA, hasFailedMedia())
         i.putExtra(EditorConstants.EXTRA_IS_PAGE, isPage)
         i.putExtra(EditorConstants.EXTRA_IS_LANDING_EDITOR, isLandingEditor)
         i.putExtra(EditorConstants.EXTRA_HAS_CHANGES, saved)
@@ -2278,10 +2248,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
 
     private fun isFirstTimePublish(publishPost: Boolean): Boolean {
         return editPostRepository.isFirstTimePublish(publishPost)
-    }
-
-    private fun hasFailedMedia(): Boolean {
-        return editorFragment?.hasFailedMediaUploads() == true
     }
 
     /**
@@ -2676,11 +2642,13 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             RequestCodes.TAKE_VIDEO,
             RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT,
             RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK -> {
-                editorFragment?.mediaSelectionCancelled()
+                // noop
                 return
             }
-            else ->                     // noop
+            else ->  {
+                // noop
                 return
+            }
         }
     }
     private fun handleRequest(requestCode: Int, data: Intent?) {
@@ -2927,88 +2895,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             if (!TextUtils.isEmpty(errorMessage)) {
                 ToastUtils.showToast(this@GutenbergKitActivity, errorMessage, ToastUtils.Duration.SHORT)
             }
-        } else {
-            if (pendingVideoPressInfoRequests?.isNotEmpty() == true) {
-                // If there are pending requests for video URLs from VideoPress ids, query the DB for
-                // them again and notify the editor
-                pendingVideoPressInfoRequests?.forEach { videoId ->
-                    val videoUrl = mediaStore.getUrlForSiteVideoWithVideoPressGuid(
-                        siteModel,
-                        videoId
-                    )
-                    val posterUrl = WPMediaUtils.getVideoPressVideoPosterFromURL(videoUrl)
-                    editorFragment?.setUrlForVideoPressId(videoId, videoUrl, posterUrl)
-                }
-                pendingVideoPressInfoRequests?.clear()
-            }
-        }
-    }
-
-    override fun updateFeaturedImage(mediaId: Long, imagePicked: Boolean) {
-        setFeaturedImageId(mediaId, imagePicked, true)
-    }
-
-    override fun onAddMediaClicked() {
-        if (editorPhotoPicker?.isPhotoPickerShowing() == true) {
-            editorPhotoPicker?.hidePhotoPicker()
-        } else if (WPMediaUtils.currentUserCanUploadMedia(siteModel)) {
-            editorPhotoPicker?.showPhotoPicker(siteModel)
-        } else {
-            // show the WP media library instead of the photo picker if the user doesn't have upload permission
-            mediaPickerLauncher.viewWPMediaLibraryPickerForResult(this, siteModel, MediaBrowserType.EDITOR_PICKER)
-        }
-    }
-
-    override fun onAddMediaImageClicked(allowMultipleSelection: Boolean) {
-        editorPhotoPicker?.allowMultipleSelection = allowMultipleSelection
-        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
-            this,
-            siteModel,
-            MediaBrowserType.GUTENBERG_IMAGE_PICKER
-        )
-    }
-
-    override fun onAddMediaVideoClicked(allowMultipleSelection: Boolean) {
-        editorPhotoPicker?.allowMultipleSelection = allowMultipleSelection
-        mediaPickerLauncher.viewWPMediaLibraryPickerForResult(
-            this,
-            siteModel,
-            MediaBrowserType.GUTENBERG_VIDEO_PICKER
-        )
-    }
-
-    override fun onAddLibraryMediaClicked(allowMultipleSelection: Boolean) {
-        editorPhotoPicker?.allowMultipleSelection = allowMultipleSelection
-        if (allowMultipleSelection) {
-            mediaPickerLauncher.viewWPMediaLibraryPickerForResult(this, siteModel, MediaBrowserType.EDITOR_PICKER)
-        } else {
-            mediaPickerLauncher
-                .viewWPMediaLibraryPickerForResult(this, siteModel, MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER)
-        }
-    }
-
-    override fun onAddLibraryFileClicked(allowMultipleSelection: Boolean) {
-        editorPhotoPicker?.allowMultipleSelection = allowMultipleSelection
-        mediaPickerLauncher
-            .viewWPMediaLibraryPickerForResult(this, siteModel, MediaBrowserType.GUTENBERG_SINGLE_FILE_PICKER)
-    }
-
-    override fun onAddLibraryAudioFileClicked(allowMultipleSelection: Boolean) {
-        mediaPickerLauncher
-            .viewWPMediaLibraryPickerForResult(this, siteModel, MediaBrowserType.GUTENBERG_SINGLE_AUDIO_FILE_PICKER)
-    }
-
-    override fun onAddPhotoClicked(allowMultipleSelection: Boolean) {
-        if (allowMultipleSelection) {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_IMAGE_PICKER, siteModel,
-                editPostRepository.id
-            )
-        } else {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_SINGLE_IMAGE_PICKER, siteModel,
-                editPostRepository.id
-            )
         }
     }
 
@@ -3016,176 +2902,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_PHOTO, false)
     }
 
-    override fun onAddVideoClicked(allowMultipleSelection: Boolean) {
-        if (allowMultipleSelection) {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_VIDEO_PICKER, siteModel,
-                editPostRepository.id
-            )
-        } else {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_SINGLE_VIDEO_PICKER, siteModel,
-                editPostRepository.id
-            )
-        }
-    }
-
-    override fun onAddDeviceMediaClicked(allowMultipleSelection: Boolean) {
-        if (allowMultipleSelection) {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_MEDIA_PICKER, siteModel,
-                editPostRepository.id
-            )
-        } else {
-            mediaPickerLauncher.showPhotoPickerForResult(
-                this, MediaBrowserType.GUTENBERG_SINGLE_MEDIA_PICKER, siteModel,
-                editPostRepository.id
-            )
-        }
-    }
-
-    override fun onAddStockMediaClicked(allowMultipleSelection: Boolean) {
-        onPhotoPickerIconClicked(PhotoPickerIcon.STOCK_MEDIA, allowMultipleSelection)
-    }
-
-    override fun onAddGifClicked(allowMultipleSelection: Boolean) {
-        onPhotoPickerIconClicked(PhotoPickerIcon.GIF, allowMultipleSelection)
-    }
-
-    override fun onAddFileClicked(allowMultipleSelection: Boolean) {
-        mediaPickerLauncher.showFilePicker(this, allowMultipleSelection, site)
-    }
-
-    override fun onAddAudioFileClicked(allowMultipleSelection: Boolean) {
-        mediaPickerLauncher.showAudioFilePicker(this, allowMultipleSelection, site)
-    }
-
-    override fun onPerformFetch(
-        path: String,
-        enableCaching: Boolean,
-        onResult: Consumer<String>,
-        onError: Consumer<Bundle>
-    ) {
-       reactNativeRequestHandler.performGetRequest(path, siteModel, enableCaching, onResult, onError)
-    }
-
-    override fun onPerformPost(
-        path: String,
-        body: Map<String, Any>,
-        onResult: Consumer<String>,
-        onError: Consumer<Bundle>
-    ) {
-       reactNativeRequestHandler.performPostRequest(path, body, siteModel, onResult, onError)
-    }
-
     override fun onCaptureVideoClicked() {
         onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CAPTURE_VIDEO, false)
-    }
-
-    override fun onMediaDropped(mediaUris: ArrayList<Uri>) {
-        editorMedia.droppedMediaUris = mediaUris
-        val media: ArrayList<Uri> = ArrayList(mediaUris)
-        editorMedia.addNewMediaItemsToEditorAsync(media, false)
-        editorMedia.droppedMediaUris.clear()
-    }
-
-    override fun onRequestDragAndDropPermissions(dragEvent: DragEvent) {
-        requestDragAndDropPermissions(dragEvent)
-    }
-
-    override fun onMediaRetryAll(failedMediaIds: Set<String>) {
-        UploadService.cancelFinalNotification(this, editPostRepository.getPost())
-        UploadService.cancelFinalNotificationForMedia(this, siteModel)
-        val localMediaIds: ArrayList<Int> = ArrayList()
-        for (idString: String? in failedMediaIds) {
-            idString?.toIntOrNull()?.let {
-                localMediaIds.add(it)
-            }
-        }
-        editorMedia.retryFailedMediaAsync(localMediaIds)
-    }
-
-    @Suppress("ReturnCount")
-    override fun onMediaRetryClicked(mediaId: String): Boolean {
-        if (TextUtils.isEmpty(mediaId)) {
-            AppLog.e(AppLog.T.MEDIA, "Invalid media id passed to onMediaRetryClicked")
-            return false
-        }
-        val media: MediaModel? = mediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId))
-        if (media == null) {
-            AppLog.e(
-                AppLog.T.MEDIA,
-                "Can't find media with local id: $mediaId"
-            )
-            val builder: AlertDialog.Builder = MaterialAlertDialogBuilder(this)
-            builder.setTitle(getString(R.string.cannot_retry_deleted_media_item))
-            builder.setPositiveButton(R.string.yes) { dialog, _ ->
-                runOnUiThread { editorFragment?.removeMedia(mediaId) }
-                dialog.dismiss()
-            }
-            builder.setNegativeButton(getString(R.string.no)
-            ) { dialog: DialogInterface, _: Int -> dialog.dismiss() }
-            val dialog: AlertDialog = builder.create()
-            dialog.show()
-            return false
-        }
-        if (!TextUtils.isEmpty(media.url) && (media.uploadState == MediaUploadState.UPLOADED.toString())) {
-            // Note: media upload success handling removed as GutenbergKit editor
-            // does not use EditorMediaUploadListener interface
-        } else {
-            UploadService.cancelFinalNotification(this, editPostRepository.getPost())
-            UploadService.cancelFinalNotificationForMedia(this, siteModel)
-            editorMedia.retryFailedMediaAsync(listOf(media.id))
-        }
-        AnalyticsUtils.trackWithSiteDetails(Stat.EDITOR_UPLOAD_MEDIA_RETRIED, siteModel)
-        return true
-    }
-
-    override fun onMediaUploadCancelClicked(localMediaId: String) {
-        if (!TextUtils.isEmpty(localMediaId)) {
-            editorMedia.cancelMediaUploadAsync(StringUtils.stringToInt(localMediaId), true)
-        } else {
-            // Passed mediaId is incorrect: cancel all uploads for this post
-            ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled))
-            EventBus.getDefault().post(PostMediaCanceled(editPostRepository.getEditablePost()))
-        }
-    }
-
-    override fun onMediaDeleted(localMediaId: String) {
-        if (!TextUtils.isEmpty(localMediaId)) {
-            editorMedia.onMediaDeleted(showAztecEditor = false, showGutenbergEditor = true, localMediaId)
-        }
-    }
-
-    override fun onUndoMediaCheck(undoedContent: String) {
-        // No-op because it was Aztec only
-    }
-
-    override fun onVideoPressInfoRequested(videoId: String) {
-        val videoUrl = mediaStore.getUrlForSiteVideoWithVideoPressGuid((siteModel), videoId)
-        if (videoUrl == null) {
-            AppLog.w(
-                AppLog.T.EDITOR, ("The editor wants more info about the following VideoPress code: " + videoId
-                        + " but it's not available in the current site " + siteModel.url
-                        + " Maybe it's from another site?")
-            )
-            return
-        }
-        if (videoUrl.isEmpty()) {
-            if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(
-                    this, WPPermissionUtils.EDITOR_MEDIA_PERMISSION_REQUEST_CODE
-                )
-            ) {
-                runOnUiThread {
-                    pendingVideoPressInfoRequests?.add(videoId) ?: run {
-                        pendingVideoPressInfoRequests = mutableListOf(videoId)
-                    }
-                    editorMedia.refreshBlogMedia()
-                }
-            }
-        }
-        val posterUrl: String = WPMediaUtils.getVideoPressVideoPosterFromURL(videoUrl)
-        editorFragment?.setUrlForVideoPressId(videoId, videoUrl, posterUrl)
     }
 
     override fun onAuthHeaderRequested(url: String): Map<String, String> {
@@ -3248,7 +2966,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         // If you need to refactor this, please ensure that the startup_time_ms property
         // is still reflecting the actual startup time of the editor
         postEditorAnalyticsSession?.start(unsupportedBlocksList, entryPoint)
-        presentNewPageNoticeIfNeeded()
 
         // Start VM, load prompt and populate Editor with content after edit IS ready.
         val promptId: Int = intent.getIntExtra(EditorConstants.EXTRA_PROMPT_ID, -1)
@@ -3271,14 +2988,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     private fun showSuggestions(type: SuggestionType, onResult: Consumer<String?>?) {
         onGetSuggestionResult = onResult
         ActivityLauncher.viewSuggestionsForResult(this, siteModel, type)
-    }
-
-    override fun onGutenbergEditorSetFocalPointPickerTooltipShown(tooltipShown: Boolean) {
-        AppPrefs.setGutenbergFocalPointPickerTooltipShown(tooltipShown)
-    }
-
-    override fun onGutenbergEditorRequestFocalPointPickerTooltipShown(): Boolean {
-        return AppPrefs.getGutenbergFocalPointPickerTooltipShown()
     }
 
     override fun onHtmlModeToggledInToolbar() {
@@ -3306,12 +3015,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         }
     }
 
-    override fun onTrackableEvent(event: EditorFragmentAbstract.TrackableEvent, properties: Map<String, String>) {
-        editorFragment?.let {
-            editorTracker.trackEditorEvent(event, it.editorName, properties)
-        }
-    }
-
     override fun showPreview(): Boolean {
         val post = editPostRepository.getPost() ?: return false
 
@@ -3336,31 +3039,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         }
     }
 
-    override fun onRequestBlockTypeImpressions(): Map<String, Double> {
-        return AppPrefs.getGutenbergBlockTypeImpressions()
-    }
-
-    override fun onSetBlockTypeImpressions(impressions: Map<String, Double>) {
-        AppPrefs.setGutenbergBlockTypeImpressions(impressions)
-    }
-
-    override fun onContactCustomerSupport() {
-        onContactCustomerSupport(
-            (zendeskHelper),
-            this,
-            site,
-            contactSupportFeatureConfig.isEnabled()
-        )
-    }
-
-    override fun onGotoCustomerSupportOptions() {
-        onGotoCustomerSupportOptions(this, site)
-    }
-
-    override fun onSendEventToHost(eventName: String, properties: Map<String, Any>) {
-        AnalyticsUtils.trackBlockEditorEvent(eventName, siteModel, properties)
-    }
-
     override fun onToggleUndo(isDisabled: Boolean) {
         if (menuHasUndo == !isDisabled) return
         menuHasUndo = !isDisabled
@@ -3371,10 +3049,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         if (menuHasRedo == !isDisabled) return
         menuHasRedo = !isDisabled
         Handler(Looper.getMainLooper()).post { invalidateOptionsMenu() }
-    }
-
-    override fun onBackHandlerButton() {
-        handleBackPressed()
     }
 
     // FluxC events
@@ -3614,18 +3288,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
     private fun updateAddingMediaToEditorProgressDialogState(uiState: ProgressDialogUiState) {
         addingMediaToEditorProgressDialog = progressDialogHelper
             .updateProgressDialogState(this, addingMediaToEditorProgressDialog, uiState, (uiHelpers))
-    }
-
-    override fun getErrorMessageFromMedia(mediaId: Int): String {
-        val media: MediaModel? = mediaStore.getMediaWithLocalId(mediaId)
-        if (media != null) {
-            return UploadUtils.getErrorMessageFromMedia(this, media)
-        }
-        return ""
-    }
-
-    override fun showJetpackSettings() {
-        ActivityLauncher.viewJetpackSecuritySettingsForResult(this, siteModel)
     }
 
     override val savingInProgressDialogVisibility: LiveData<DialogVisibility>

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2612,10 +2612,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             return
         }
 
-        if (resultCode != RESULT_OK) {
-            return handleNotOKRequest(resultCode)
-        }
-
         val shouldHandleRequest = (requestCode == RequestCodes.TAKE_PHOTO) ||
                 (requestCode == RequestCodes.TAKE_VIDEO) ||
                 (requestCode == RequestCodes.PHOTO_PICKER)
@@ -2628,29 +2624,6 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         }
     }
 
-    private fun handleNotOKRequest(requestCode: Int) {
-        // for all media related intents, let editor fragment know about cancellation
-        when (requestCode) {
-            RequestCodes.MULTI_SELECT_MEDIA_PICKER,
-            RequestCodes.SINGLE_SELECT_MEDIA_PICKER,
-            RequestCodes.PHOTO_PICKER,
-            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT,
-            RequestCodes.MEDIA_LIBRARY,
-            RequestCodes.PICTURE_LIBRARY,
-            RequestCodes.TAKE_PHOTO,
-            RequestCodes.VIDEO_LIBRARY,
-            RequestCodes.TAKE_VIDEO,
-            RequestCodes.STOCK_MEDIA_PICKER_MULTI_SELECT,
-            RequestCodes.STOCK_MEDIA_PICKER_SINGLE_SELECT_FOR_GUTENBERG_BLOCK -> {
-                // noop
-                return
-            }
-            else ->  {
-                // noop
-                return
-            }
-        }
-    }
     private fun handleRequest(requestCode: Int, data: Intent?) {
         when (requestCode) {
             RequestCodes.MULTI_SELECT_MEDIA_PICKER,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -16,7 +16,6 @@ import android.view.ViewGroup
 import android.webkit.URLUtil
 import androidx.core.util.Pair
 import androidx.lifecycle.LiveData
-import com.android.volley.toolbox.ImageLoader
 import com.google.gson.Gson
 import org.wordpress.android.R
 import org.wordpress.android.editor.BuildConfig
@@ -32,7 +31,6 @@ import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ProfilingUtils
 import org.wordpress.android.util.UrlUtils
 import org.wordpress.android.util.helpers.MediaFile
-import org.wordpress.android.util.helpers.MediaGallery
 import org.wordpress.gutenberg.EditorConfiguration
 import org.wordpress.gutenberg.GutenbergView
 import org.wordpress.gutenberg.GutenbergView.ContentChangeListener
@@ -220,7 +218,7 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         super.onAttach(context)
         val activity = context as Activity
 
-        mEditorDragAndDropListener = requireActivityImplements<EditorDragAndDropListener>(activity)
+        mEditorFragmentListener = requireActivityImplements<EditorFragmentListener>(activity)!!
         mEditorImagePreviewListener = requireActivityImplements<EditorImagePreviewListener>(activity)
         mEditorEditMediaListener = requireActivityImplements<EditorEditMediaListener>(activity)
     }
@@ -289,10 +287,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         gutenbergView?.setContent(text as String)
     }
 
-    override fun updateContent(text: CharSequence?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
     fun onToggleHtmlMode() {
         if (!isAdded) {
             return
@@ -347,10 +341,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         return GUTENBERG_EDITOR_NAME
     }
 
-    override fun isActionInProgress(): Boolean {
-        return false
-    }
-
     /**
      * Returns the contents of the content field from the JavaScript editor. Should be called from a background thread
      * where possible.
@@ -362,13 +352,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         }
 
         return ""
-    }
-
-    @Throws(EditorFragmentNotAddedException::class)
-    override fun showContentInfo() {
-        if (!isAdded) {
-            throw EditorFragmentNotAddedException()
-        }
     }
 
     override fun onEditorHistoryChanged(listener: HistoryChangeListener) {
@@ -389,12 +372,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
 
     override fun getTitleOrContentChanged(): LiveData<Editable> {
         return textWatcher.afterTextChanged
-    }
-
-    override fun appendMediaFile(
-        mediaFile: MediaFile?, mediaUrl: String?, imageLoader: ImageLoader?
-    ) {
-        // noop implementation for shared interface with Aztec
     }
 
     override fun appendMediaFiles(mediaList: MutableMap<String?, MediaFile?>) {
@@ -431,32 +408,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         gutenbergView?.setMediaUploadAttachment(mediaString)
     }
 
-    override fun appendGallery(mediaGallery: MediaGallery?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun setUrlForVideoPressId(videoId: String?, videoUrl: String?, posterUrl: String?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun isUploadingMedia(): Boolean {
-        // Unused, no-op retained for the shared interface with Gutenberg
-        return false
-    }
-
-    override fun hasFailedMediaUploads(): Boolean {
-        // Unused, no-op retained for the shared interface with Gutenberg
-        return false
-    }
-
-    override fun removeAllFailedMediaUploads() {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun removeMedia(mediaId: String?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
     override fun onDestroy() {
         gutenbergView?.let { gutenbergView ->
             recycleWebView(gutenbergView)
@@ -464,10 +415,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
             featuredImageChangeListener = null
         }
         super.onDestroy()
-    }
-
-    override fun mediaSelectionCancelled() {
-        // Unused, no-op retained for the shared interface with Gutenberg
     }
 
     fun startWithEditorSettings(editorSettings: String) {
@@ -517,14 +464,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
                 .setCookies(cookies)
                 .build()
         }
-    }
-
-    override fun showNotice(message: String?) {
-        // Unused, no-op retained for the shared interface with Gutenberg
-    }
-
-    override fun showEditorHelp() {
-        // Unused, no-op retained for the shared interface with Gutenberg
     }
 
     override fun onUndoPressed() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragmentBase.java
@@ -1,10 +1,8 @@
 package org.wordpress.android.ui.posts.editor;
 
 import android.app.Activity;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
-import android.view.DragEvent;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,7 +20,6 @@ import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorImagePreviewListener;
 import org.wordpress.android.editor.gutenberg.DialogVisibilityProvider;
 import org.wordpress.android.util.helpers.MediaFile;
-import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.gutenberg.GutenbergView.FeaturedImageChangeListener;
 import org.wordpress.gutenberg.GutenbergView.HistoryChangeListener;
 import org.wordpress.gutenberg.GutenbergView.LogJsExceptionListener;
@@ -31,7 +28,6 @@ import org.wordpress.gutenberg.GutenbergView.OpenMediaLibraryListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public abstract class GutenbergKitEditorFragmentBase extends Fragment {
     public class EditorFragmentNotAddedException extends Exception {
@@ -40,10 +36,8 @@ public abstract class GutenbergKitEditorFragmentBase extends Fragment {
     public abstract @NonNull String getEditorName();
     public abstract void setTitle(CharSequence text);
     public abstract void setContent(CharSequence text);
-    public abstract void showNotice(String message);
     public abstract CharSequence getContent(CharSequence originalContent)
             throws EditorFragmentAbstract.EditorFragmentNotAddedException;
-    public abstract void showContentInfo() throws EditorFragmentAbstract.EditorFragmentNotAddedException;
     public abstract Pair<CharSequence, CharSequence> getTitleAndContent(CharSequence originalContent) throws
             EditorFragmentAbstract.EditorFragmentNotAddedException;
     public abstract void onEditorHistoryChanged(HistoryChangeListener listener);
@@ -51,26 +45,11 @@ public abstract class GutenbergKitEditorFragmentBase extends Fragment {
     public abstract void onOpenMediaLibrary(OpenMediaLibraryListener listener);
     public abstract void onLogJsException(LogJsExceptionListener listener);
     public abstract LiveData<Editable> getTitleOrContentChanged();
-    public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendMediaFiles(Map<String, MediaFile> mediaList);
-    public abstract void appendGallery(MediaGallery mediaGallery);
-    public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
-    public abstract boolean isUploadingMedia();
-    public abstract boolean isActionInProgress();
-    public abstract boolean hasFailedMediaUploads();
-    // Check whether we need to reload the content of the post from the editor or not.
-    // This was required since Aztec Visual->HTML can slightly change the content of the HTML. See #692 for details.
-    public abstract void removeAllFailedMediaUploads();
-    public abstract void removeMedia(String mediaId);
-    // Called from EditPostActivity to let the block editor know when a media selection is cancelled
-    public abstract void mediaSelectionCancelled();
-    public abstract void showEditorHelp();
 
     public abstract void onUndoPressed();
 
     public abstract void onRedoPressed();
-    public abstract void updateContent(CharSequence text);
-
 
     public enum MediaType {
         IMAGE, VIDEO;
@@ -87,39 +66,16 @@ public abstract class GutenbergKitEditorFragmentBase extends Fragment {
         }
     }
 
-    protected static final String ARG_PARAM_TITLE = "param_title";
-    protected static final String ARG_PARAM_CONTENT = "param_content";
-    protected static final String ATTR_ALIGN = "align";
-    protected static final String ATTR_ALT = "alt";
-    protected static final String ATTR_CAPTION = "caption";
-    protected static final String ATTR_DIMEN_HEIGHT = "height";
-    protected static final String ATTR_DIMEN_WIDTH = "width";
-    protected static final String ATTR_ID = "id";
-    protected static final String ATTR_ID_ATTACHMENT = "attachment_id";
-    protected static final String ATTR_ID_IMAGE_REMOTE = "imageRemoteId";
-    protected static final String ATTR_SRC = "src";
-    protected static final String ATTR_STATUS_FAILED = "failed";
-    protected static final String ATTR_STATUS_UPLOADING = "uploading";
-    protected static final String ATTR_TITLE = "title";
-    protected static final String ATTR_URL_LINK = "linkUrl";
-    protected static final String EXTRA_ENABLED_AZTEC = "isAztecEnabled";
-    protected static final String EXTRA_FEATURED = "isFeatured";
-    protected static final String EXTRA_IMAGE_FEATURED = "featuredImageSupported";
-    protected static final String EXTRA_IMAGE_META = "imageMeta";
-    protected static final String EXTRA_MAX_WIDTH = "maxWidth";
-
     private static final String FEATURED_IMAGE_SUPPORT_KEY = "featured-image-supported";
     private static final String FEATURED_IMAGE_WIDTH_KEY = "featured-image-width";
 
     protected EditorFragmentListener mEditorFragmentListener;
-    protected EditorDragAndDropListener mEditorDragAndDropListener;
     protected EditorImagePreviewListener mEditorImagePreviewListener;
     protected EditorEditMediaListener mEditorEditMediaListener;
     protected boolean mFeaturedImageSupported;
     protected long mFeaturedImageId;
     protected String mBlogSettingMaxImageWidth;
     protected ImageLoader mImageLoader;
-    protected boolean mDebugModeEnabled;
 
     protected HashMap<String, String> mCustomHttpHeaders;
 
@@ -175,24 +131,11 @@ public abstract class GutenbergKitEditorFragmentBase extends Fragment {
         mCustomHttpHeaders.put(name, value);
     }
 
-    public void setDebugModeEnabled(boolean debugModeEnabled) {
-        mDebugModeEnabled = debugModeEnabled;
-    }
-
     /**
      * Called by the activity when back button is pressed.
      */
     public boolean onBackPressed() {
         return false;
-    }
-
-    public static MediaType getEditorMimeType(MediaFile mediaFile) {
-        if (mediaFile == null) {
-            // default to image
-            return MediaType.IMAGE;
-        }
-        return mediaFile.isVideo() ? MediaType.VIDEO
-                : MediaType.IMAGE;
     }
 
     /**
@@ -201,62 +144,16 @@ public abstract class GutenbergKitEditorFragmentBase extends Fragment {
     public interface EditorFragmentListener extends DialogVisibilityProvider {
         void onEditorFragmentInitialized();
         void onEditorFragmentContentReady(ArrayList<Object> unsupportedBlocks, boolean replaceBlockActionWaiting);
-        void updateFeaturedImage(long mediaId, boolean imagePicked);
-        void onAddMediaClicked();
-        void onAddMediaImageClicked(boolean allowMultipleSelection);
-        void onAddMediaVideoClicked(boolean allowMultipleSelection);
-        void onAddLibraryMediaClicked(boolean allowMultipleSelection);
-        void onAddLibraryFileClicked(boolean allowMultipleSelection);
-        void onAddLibraryAudioFileClicked(boolean allowMultipleSelection);
-        void onAddPhotoClicked(boolean allowMultipleSelection);
         void onCapturePhotoClicked();
-        void onAddVideoClicked(boolean allowMultipleSelection);
-        void onAddDeviceMediaClicked(boolean allowMultipleSelection);
         void onCaptureVideoClicked();
-        boolean onMediaRetryClicked(String mediaId);
-        void onMediaRetryAll(Set<String> mediaIdSet);
-        void onMediaUploadCancelClicked(String mediaId);
-        void onMediaDeleted(String mediaId);
-        void onUndoMediaCheck(String undoedContent);
-        void onVideoPressInfoRequested(String videoId);
         Map<String, String> onAuthHeaderRequested(String url);
         void onTrackableEvent(org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent event);
-        void onTrackableEvent(org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent event,
-                              Map<String, String> properties);
         void onHtmlModeToggledInToolbar();
-        void onAddStockMediaClicked(boolean allowMultipleSelection);
-        void onAddGifClicked(boolean allowMultipleSelection);
-        void onAddFileClicked(boolean allowMultipleSelection);
-        void onAddAudioFileClicked(boolean allowMultipleSelection);
-        void onPerformFetch(String path, boolean enableCaching, Consumer<String> onResult, Consumer<Bundle> onError);
-        void onPerformPost(String path, Map<String, Object> body, Consumer<String> onResult, Consumer<Bundle> onError);
         void showUserSuggestions(Consumer<String> onResult);
         void showXpostSuggestions(Consumer<String> onResult);
-        void onGutenbergEditorSetFocalPointPickerTooltipShown(boolean tooltipShown);
-        boolean onGutenbergEditorRequestFocalPointPickerTooltipShown();
-        String getErrorMessageFromMedia(int mediaId);
-        void showJetpackSettings();
         boolean showPreview();
-        Map<String, Double> onRequestBlockTypeImpressions();
-        void onSetBlockTypeImpressions(Map<String, Double> impressions);
-        void onContactCustomerSupport();
-        void onGotoCustomerSupportOptions();
-        void onSendEventToHost(String eventName, Map<String, Object> properties);
-
         void onToggleUndo(boolean isDisabled);
-
         void onToggleRedo(boolean isDisabled);
-
-        void onBackHandlerButton();
-
         void onLogJsException(JsException jsException, JsExceptionCallback onSendJsException);
-    }
-
-    /**
-     * Callbacks for drag and drop support
-     */
-    public interface EditorDragAndDropListener {
-        void onMediaDropped(ArrayList<Uri> mediaUri);
-        void onRequestDragAndDropPermissions(DragEvent dragEvent);
     }
 }


### PR DESCRIPTION
## Summary
- Removes 500+ lines of unused code from GutenbergKit components following the standalone refactoring
- Cleans up unused imports, methods, and interface implementations
- Maintains all functional behavior while removing dead code

## Changes
- **`GutenbergKitActivity`**: Remove unused interface implementations (`EditorDragAndDropListener`), dead methods like `presentNewPageNoticeIfNeeded()` and `hasFailedMedia()`, and unused media handling callbacks
- **`GutenbergKitEditorFragment`**: Remove no-op method implementations and unused imports like `ImageLoader` and `MediaGallery`
- **`GutenbergKitEditorFragmentBase`**: Clean up unused interface methods and imports

## Test Plan
- [ ] GutenbergKit editor functionality remains intact
- [ ] No behavioral changes to editor features
