### PR TITLE
Fix HTML Mode toggle for Gutenberg Mobile editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.kt
@@ -1740,6 +1740,8 @@ class EditPostActivity : BaseAppCompatActivity(), EditorFragmentActivity, Editor
                 // toggle HTML mode
                 if (editorFragment is AztecEditorFragment) {
                     (editorFragment as AztecEditorFragment).onToolbarHtmlButtonClicked()
+                } else if (editorFragment is GutenbergEditorFragment) {
+                    (editorFragment as GutenbergEditorFragment).onToggleHtmlMode()
                 }
             } else if (itemId == R.id.menu_switch_to_gutenberg) {
                 // The following boolean check should be always redundant but was added to manage


### PR DESCRIPTION
## Summary
Restores HTML Mode functionality that was erroneously removed in #22143.

## Changes
- Add back `GutenbergEditorFragment.onToggleHtmlMode()` call in HTML Mode menu handler

Addresses: https://github.com/wordpress-mobile/WordPress-Android/pull/22143#discussion_r2286075364