### PR TITLE
Remove redundant EditorFragmentListener assignment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -218,7 +218,6 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
         super.onAttach(context)
         val activity = context as Activity
 
-        mEditorFragmentListener = requireActivityImplements<EditorFragmentListener>(activity)!!
         mEditorImagePreviewListener = requireActivityImplements<EditorImagePreviewListener>(activity)
         mEditorEditMediaListener = requireActivityImplements<EditorEditMediaListener>(activity)
     }


### PR DESCRIPTION
Removes unnecessary `EditorFragmentListener` assignment since base class already handles it.

Addresses: https://github.com/wordpress-mobile/WordPress-Android/pull/22144#discussion_r2286089883