### PR TITLE
Improve editor selection logic and add detailed logging in EditorLauncher

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -116,40 +116,6 @@ class EditorLauncher @Inject constructor(
         }
     }
 
-    private fun logFeatureDisabledReason(isGutenbergDisabled: Boolean, isGutenbergEnabled: Boolean) {
-        val reason = when {
-            isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
-            !isGutenbergEnabled -> "neither the experimental block editor feature nor " +
-                    "GutenbergKit feature is enabled"
-
-            else -> "GutenbergKit feature checks failed"
-        }
-        val featureFlags = getFeatureFlagsString(includeDisableExperimentalBlockEditor = true)
-        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
-    }
-
-    private fun logNoSiteInfoReason() {
-        val featureFlags = getFeatureFlagsString(includeDisableExperimentalBlockEditor = false)
-        AppLog.d(
-            AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
-                    "is available, defaulting to GutenbergKit $featureFlags"
-        )
-    }
-
-    private fun getFeatureFlagsString(includeDisableExperimentalBlockEditor: Boolean): String {
-        val experimentalBlockEditor = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)
-        val gutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled()
-        val disableExperimentalBlockEditor = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        return if (includeDisableExperimentalBlockEditor) {
-            "(experimental_block_editor: $experimentalBlockEditor, " +
-            "gutenberg_kit_feature: $gutenbergKitFeatureEnabled, " +
-            "disable_experimental_block_editor: $disableExperimentalBlockEditor)"
-        } else {
-            "(experimental_block_editor: $experimentalBlockEditor, " +
-            "gutenberg_kit_feature: $gutenbergKitFeatureEnabled)"
-        }
-    }
-
     private fun determineEditorForSite(params: EditorLauncherParams, site: SiteModel): Boolean {
         val post = getPostFromParams(params)
         val isNewPost = post == null || post.isLocalDraft
@@ -158,6 +124,35 @@ class EditorLauncher @Inject constructor(
 
         logEditorDecision(shouldUseGutenberg, isNewPost, postContent, post, site)
         return shouldUseGutenberg
+    }
+
+    private fun logFeatureDisabledReason(isGutenbergDisabled: Boolean, isGutenbergEnabled: Boolean) {
+        val reason = when {
+            isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
+            !isGutenbergEnabled -> "neither the experimental block editor feature nor " +
+                    "GutenbergKit feature is enabled"
+
+            else -> "GutenbergKit feature checks failed"
+        }
+        val featureFlags = getFeatureFlagsString()
+        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
+    }
+
+    private fun logNoSiteInfoReason() {
+        val featureFlags = getFeatureFlagsString()
+        AppLog.d(
+            AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
+                    "is available, defaulting to GutenbergKit $featureFlags"
+        )
+    }
+
+    private fun getFeatureFlagsString(): String {
+        val experimentalBlockEditor = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)
+        val gutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled()
+        val disableExperimentalBlockEditor = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        return "(experimental_block_editor: $experimentalBlockEditor, " +
+                "gutenberg_kit_feature: $gutenbergKitFeatureEnabled, " +
+                "disable_experimental_block_editor: $disableExperimentalBlockEditor)"
     }
 
     private fun logEditorDecision(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -124,22 +124,30 @@ class EditorLauncher @Inject constructor(
 
             else -> "GutenbergKit feature checks failed"
         }
-        val featureFlags = "(experimental_block_editor: " +
-                "${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
-                "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()}, " +
-                "disable_experimental_block_editor: " +
-                "${experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)})"
+        val featureFlags = getFeatureFlagsString(includeDisableExperimentalBlockEditor = true)
         AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
     }
 
     private fun logNoSiteInfoReason() {
-        val featureFlags = "(experimental_block_editor: " +
-                "${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
-                "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()})"
+        val featureFlags = getFeatureFlagsString(includeDisableExperimentalBlockEditor = false)
         AppLog.d(
             AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
                     "is available, defaulting to GutenbergKit $featureFlags"
         )
+    }
+
+    private fun getFeatureFlagsString(includeDisableExperimentalBlockEditor: Boolean): String {
+        val experimentalBlockEditor = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)
+        val gutenbergKitFeatureEnabled = gutenbergKitFeature.isEnabled()
+        val disableExperimentalBlockEditor = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        return if (includeDisableExperimentalBlockEditor) {
+            "(experimental_block_editor: $experimentalBlockEditor, " +
+            "gutenberg_kit_feature: $gutenbergKitFeatureEnabled, " +
+            "disable_experimental_block_editor: $disableExperimentalBlockEditor)"
+        } else {
+            "(experimental_block_editor: $experimentalBlockEditor, " +
+            "gutenberg_kit_feature: $gutenbergKitFeatureEnabled)"
+        }
     }
 
     private fun determineEditorForSite(params: EditorLauncherParams, site: SiteModel): Boolean {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -98,19 +98,19 @@ class EditorLauncher @Inject constructor(
         val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
         val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
 
+        val site = params.siteSource.getSite(siteStore)
         return when {
             !isGutenbergFeatureEnabled -> {
                 logFeatureDisabledReason(isGutenbergDisabled, isGutenbergEnabled)
                 false
             }
 
-            params.siteSource.getSite(siteStore) == null -> {
+            site == null -> {
                 logNoSiteInfoReason()
                 true
             }
 
             else -> {
-                val site = params.siteSource.getSite(siteStore)!!
                 determineEditorForSite(params, site)
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -103,12 +103,12 @@ class EditorLauncher @Inject constructor(
                 logFeatureDisabledReason(isGutenbergDisabled, isGutenbergEnabled)
                 false
             }
-            
+
             params.siteSource.getSite(siteStore) == null -> {
                 logNoSiteInfoReason()
                 true
             }
-            
+
             else -> {
                 val site = params.siteSource.getSite(siteStore)!!
                 determineEditorForSite(params, site)
@@ -121,6 +121,7 @@ class EditorLauncher @Inject constructor(
             isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
             !isGutenbergEnabled -> "neither the experimental block editor feature nor " +
                     "GutenbergKit feature is enabled"
+
             else -> "GutenbergKit feature checks failed"
         }
         val featureFlags = "(experimental_block_editor: " +
@@ -135,8 +136,10 @@ class EditorLauncher @Inject constructor(
         val featureFlags = "(experimental_block_editor: " +
                 "${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
                 "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()})"
-        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
-                "is available, defaulting to GutenbergKit $featureFlags")
+        AppLog.d(
+            AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
+                    "is available, defaulting to GutenbergKit $featureFlags"
+        )
     }
 
     private fun determineEditorForSite(params: EditorLauncherParams, site: SiteModel): Boolean {
@@ -156,34 +159,37 @@ class EditorLauncher @Inject constructor(
         post: PostModel?,
         site: SiteModel
     ) {
+        val hasGutenbergBlocks = PostUtils.contentContainsGutenbergBlocks(postContent)
+        val isBlockEditorDefaultForNewPosts = SiteUtils.isBlockEditorDefaultForNewPost(site)
+
         val postInfo = if (post != null) {
             "post_id: ${post.id}, remote_id: ${post.remotePostId}, is_local_draft: ${post.isLocalDraft}, " +
-                    "content_length: ${postContent.length}, " +
-                    "has_blocks: ${PostUtils.contentContainsGutenbergBlocks(postContent)}"
+                    "content_length: ${postContent.length}, has_blocks: $hasGutenbergBlocks"
         } else {
             "new_post: true"
         }
 
         val siteInfo = "site_id: ${site.id}, site_url: ${site.url}, " +
-                "block_editor_default_for_new_posts: ${SiteUtils.isBlockEditorDefaultForNewPost(site)}"
+                "block_editor_default_for_new_posts: $isBlockEditorDefaultForNewPosts"
 
-        if (shouldUseGutenberg) {
-            val reason = when {
+        val reason = if (shouldUseGutenberg) {
+            when {
                 isNewPost -> "this is a new post and the site has block editor enabled as default for new posts"
-                PostUtils.contentContainsGutenbergBlocks(postContent) -> "the existing post contains Gutenberg blocks"
+                hasGutenbergBlocks -> "the existing post contains Gutenberg blocks"
                 else -> "PostUtils.shouldShowGutenbergEditor returned true"
             }
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because $reason ($postInfo, $siteInfo)")
         } else {
-            val reason = when {
-                !isNewPost && !PostUtils.contentContainsGutenbergBlocks(postContent) -> 
-                    "this is an existing post without Gutenberg blocks"
-                isNewPost && !SiteUtils.isBlockEditorDefaultForNewPost(site) -> 
+            when {
+                !isNewPost && !hasGutenbergBlocks -> "this is an existing post without Gutenberg blocks"
+                isNewPost && !isBlockEditorDefaultForNewPosts ->
                     "this is a new post but the site doesn't have block editor as default for new posts"
+
                 else -> "PostUtils.shouldShowGutenbergEditor returned false"
             }
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason ($postInfo, $siteInfo)")
         }
+
+        val action = if (shouldUseGutenberg) "is being used" else "is NOT being used"
+        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor $action because $reason ($postInfo, $siteInfo)")
     }
 
     private fun getPostFromParams(params: EditorLauncherParams): PostModel? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.posts
 import android.content.Context
 import android.content.Intent
 import org.wordpress.android.WordPress.Companion.getContext
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.SiteUtils
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.config.GutenbergKitFeature
@@ -97,15 +99,62 @@ class EditorLauncher @Inject constructor(
         val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
 
         if (!isGutenbergFeatureEnabled) {
+            val reason = when {
+                isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
+                !isGutenbergEnabled -> "neither the experimental block editor feature nor GutenbergKit feature is enabled"
+                else -> "GutenbergKit feature checks failed"
+            }
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason" +
+                    " (experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
+                    "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()}, " +
+                    "disable_experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)})")
             return false
         }
 
-        val site = params.siteSource.getSite(siteStore) ?: return true
+        val site = params.siteSource.getSite(siteStore)
+        if (site == null) {
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information is available, " +
+                    "defaulting to GutenbergKit (experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
+                    "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()})")
+            return true
+        }
+
         val post = getPostFromParams(params)
         val isNewPost = post == null || post.isLocalDraft
         val postContent = post?.content ?: ""
+        val shouldUseGutenberg = PostUtils.shouldShowGutenbergEditor(isNewPost, postContent, site)
 
-        return PostUtils.shouldShowGutenbergEditor(isNewPost, postContent, site)
+        val postInfo = if (post != null) {
+            "post_id: ${post.id}, local_id: ${post.localId}, is_local_draft: ${post.isLocalDraft}, " +
+                    "content_length: ${postContent.length}, has_blocks: ${PostUtils.contentContainsGutenbergBlocks(postContent)}"
+        } else {
+            "new_post: true"
+        }
+
+        val siteInfo = "site_id: ${site.id}, site_url: ${site.url}, " +
+                "block_editor_default_for_new_posts: ${SiteUtils.isBlockEditorDefaultForNewPost(site)}"
+
+        if (shouldUseGutenberg) {
+            val reason = when {
+                isNewPost -> "this is a new post and the site has block editor enabled as default for new posts"
+                PostUtils.contentContainsGutenbergBlocks(postContent) -> "the existing post contains Gutenberg blocks"
+                else -> "PostUtils.shouldShowGutenbergEditor returned true"
+            }
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because $reason " +
+                    "($postInfo, $siteInfo)")
+        } else {
+            val reason = when {
+                !isNewPost && !PostUtils.contentContainsGutenbergBlocks(postContent) -> 
+                    "this is an existing post without Gutenberg blocks"
+                isNewPost && !SiteUtils.isBlockEditorDefaultForNewPost(site) -> 
+                    "this is a new post but the site doesn't have block editor as default for new posts"
+                else -> "PostUtils.shouldShowGutenbergEditor returned false"
+            }
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason " +
+                    "($postInfo, $siteInfo)")
+        }
+
+        return shouldUseGutenberg
     }
 
     private fun getPostFromParams(params: EditorLauncherParams): PostModel? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -15,8 +15,8 @@ import org.wordpress.android.ui.posts.EditorConstants.RestartEditorOptions
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.fluxc.store.PostStore
-import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.model.PostModel
+import org.wordpress.android.fluxc.model.SiteModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -98,35 +98,68 @@ class EditorLauncher @Inject constructor(
         val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
         val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
 
-        if (!isGutenbergFeatureEnabled) {
-            val reason = when {
-                isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
-                !isGutenbergEnabled -> "neither the experimental block editor feature nor GutenbergKit feature is enabled"
-                else -> "GutenbergKit feature checks failed"
+        return when {
+            !isGutenbergFeatureEnabled -> {
+                logFeatureDisabledReason(isGutenbergDisabled, isGutenbergEnabled)
+                false
             }
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason" +
-                    " (experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
-                    "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()}, " +
-                    "disable_experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)})")
-            return false
+            
+            params.siteSource.getSite(siteStore) == null -> {
+                logNoSiteInfoReason()
+                true
+            }
+            
+            else -> {
+                val site = params.siteSource.getSite(siteStore)!!
+                determineEditorForSite(params, site)
+            }
         }
+    }
 
-        val site = params.siteSource.getSite(siteStore)
-        if (site == null) {
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information is available, " +
-                    "defaulting to GutenbergKit (experimental_block_editor: ${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
-                    "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()})")
-            return true
+    private fun logFeatureDisabledReason(isGutenbergDisabled: Boolean, isGutenbergEnabled: Boolean) {
+        val reason = when {
+            isGutenbergDisabled -> "the experimental block editor is explicitly disabled"
+            !isGutenbergEnabled -> "neither the experimental block editor feature nor " +
+                    "GutenbergKit feature is enabled"
+            else -> "GutenbergKit feature checks failed"
         }
+        val featureFlags = "(experimental_block_editor: " +
+                "${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
+                "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()}, " +
+                "disable_experimental_block_editor: " +
+                "${experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)})"
+        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason $featureFlags")
+    }
 
+    private fun logNoSiteInfoReason() {
+        val featureFlags = "(experimental_block_editor: " +
+                "${experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR)}, " +
+                "gutenberg_kit_feature: ${gutenbergKitFeature.isEnabled()})"
+        AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because no site information " +
+                "is available, defaulting to GutenbergKit $featureFlags")
+    }
+
+    private fun determineEditorForSite(params: EditorLauncherParams, site: SiteModel): Boolean {
         val post = getPostFromParams(params)
         val isNewPost = post == null || post.isLocalDraft
         val postContent = post?.content ?: ""
         val shouldUseGutenberg = PostUtils.shouldShowGutenbergEditor(isNewPost, postContent, site)
 
+        logEditorDecision(shouldUseGutenberg, isNewPost, postContent, post, site)
+        return shouldUseGutenberg
+    }
+
+    private fun logEditorDecision(
+        shouldUseGutenberg: Boolean,
+        isNewPost: Boolean,
+        postContent: String,
+        post: PostModel?,
+        site: SiteModel
+    ) {
         val postInfo = if (post != null) {
             "post_id: ${post.id}, local_id: ${post.localId}, is_local_draft: ${post.isLocalDraft}, " +
-                    "content_length: ${postContent.length}, has_blocks: ${PostUtils.contentContainsGutenbergBlocks(postContent)}"
+                    "content_length: ${postContent.length}, " +
+                    "has_blocks: ${PostUtils.contentContainsGutenbergBlocks(postContent)}"
         } else {
             "new_post: true"
         }
@@ -140,8 +173,7 @@ class EditorLauncher @Inject constructor(
                 PostUtils.contentContainsGutenbergBlocks(postContent) -> "the existing post contains Gutenberg blocks"
                 else -> "PostUtils.shouldShowGutenbergEditor returned true"
             }
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because $reason " +
-                    "($postInfo, $siteInfo)")
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is being used because $reason ($postInfo, $siteInfo)")
         } else {
             val reason = when {
                 !isNewPost && !PostUtils.contentContainsGutenbergBlocks(postContent) -> 
@@ -150,11 +182,8 @@ class EditorLauncher @Inject constructor(
                     "this is a new post but the site doesn't have block editor as default for new posts"
                 else -> "PostUtils.shouldShowGutenbergEditor returned false"
             }
-            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason " +
-                    "($postInfo, $siteInfo)")
+            AppLog.d(AppLog.T.EDITOR, "GutenbergKit editor is NOT being used because $reason ($postInfo, $siteInfo)")
         }
-
-        return shouldUseGutenberg
     }
 
     private fun getPostFromParams(params: EditorLauncherParams): PostModel? {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -157,7 +157,7 @@ class EditorLauncher @Inject constructor(
         site: SiteModel
     ) {
         val postInfo = if (post != null) {
-            "post_id: ${post.id}, local_id: ${post.localId}, is_local_draft: ${post.isLocalDraft}, " +
+            "post_id: ${post.id}, remote_id: ${post.remotePostId}, is_local_draft: ${post.isLocalDraft}, " +
                     "content_length: ${postContent.length}, " +
                     "has_blocks: ${PostUtils.contentContainsGutenbergBlocks(postContent)}"
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -11,6 +11,10 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.ui.posts.EditorConstants.RestartEditorOptions
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import org.wordpress.android.fluxc.store.SiteStore
+import org.wordpress.android.fluxc.store.PostStore
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.PostModel
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,7 +28,9 @@ import javax.inject.Singleton
 class EditorLauncher @Inject constructor(
     private val gutenbergKitFeature: GutenbergKitFeature,
     private val experimentalFeatures: ExperimentalFeatures,
-    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
+    private val siteStore: SiteStore,
+    private val postStore: PostStore
 ) {
     companion object {
         /**
@@ -32,6 +38,7 @@ class EditorLauncher @Inject constructor(
          * Used for analytics to distinguish between EditorLauncher and direct Intent creation.
          */
         const val EXTRA_LAUNCHED_VIA_EDITOR_LAUNCHER = "launched_via_editor_launcher"
+
         /**
          * Static accessor for use in static utility classes like ActivityLauncher.
          * Prefer constructor injection when possible.
@@ -62,7 +69,7 @@ class EditorLauncher @Inject constructor(
      * @return Intent configured for the appropriate editor activity
      */
     fun createEditorIntent(context: Context, params: EditorLauncherParams): Intent {
-        val shouldUseGutenbergKit = shouldUseGutenbergKitEditor()
+        val shouldUseGutenbergKit = shouldUseGutenbergKitEditor(params)
 
         val targetActivity = if (shouldUseGutenbergKit) {
             GutenbergKitActivity::class.java
@@ -81,13 +88,30 @@ class EditorLauncher @Inject constructor(
     }
 
     /**
-     * Determines if GutenbergKit editor should be used based on feature flags.
+     * Determines if GutenbergKit editor should be used based on feature flags and post content.
      */
-    private fun shouldUseGutenbergKitEditor(): Boolean {
+    private fun shouldUseGutenbergKitEditor(params: EditorLauncherParams): Boolean {
         val isGutenbergEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
                 gutenbergKitFeature.isEnabled()
         val isGutenbergDisabled = experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        return isGutenbergEnabled && !isGutenbergDisabled
+        val isGutenbergFeatureEnabled = isGutenbergEnabled && !isGutenbergDisabled
+
+        if (!isGutenbergFeatureEnabled) {
+            return false
+        }
+
+        val site = params.siteSource.getSite(siteStore) ?: return true
+        val post = getPostFromParams(params)
+        val isNewPost = post == null || post.isLocalDraft
+        val postContent = post?.content ?: ""
+
+        return PostUtils.shouldShowGutenbergEditor(isNewPost, postContent, site)
+    }
+
+    private fun getPostFromParams(params: EditorLauncherParams): PostModel? {
+        return params.postLocalId?.let { localId ->
+            postStore.getPostByLocalPostId(localId)
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncher.kt
@@ -177,17 +177,17 @@ class EditorLauncher @Inject constructor(
 
         val reason = if (shouldUseGutenberg) {
             when {
-                isNewPost -> "this is a new post and the site has block editor enabled as default for new posts"
-                hasGutenbergBlocks -> "the existing post contains Gutenberg blocks"
-                else -> "PostUtils.shouldShowGutenbergEditor returned true"
+                isNewPost -> "GutenbergKit feature is enabled and this is a new post with block editor as site default"
+                hasGutenbergBlocks -> "GutenbergKit feature is enabled and the existing post contains Gutenberg blocks"
+                else -> "GutenbergKit feature is enabled and PostUtils.shouldShowGutenbergEditor returned true"
             }
         } else {
             when {
-                !isNewPost && !hasGutenbergBlocks -> "this is an existing post without Gutenberg blocks"
-                isNewPost && !isBlockEditorDefaultForNewPosts ->
-                    "this is a new post but the site doesn't have block editor as default for new posts"
-
-                else -> "PostUtils.shouldShowGutenbergEditor returned false"
+                !isNewPost && !hasGutenbergBlocks -> 
+                    "GutenbergKit feature is enabled but this existing post has no Gutenberg blocks"
+                isNewPost && !isBlockEditorDefaultForNewPosts -> 
+                    "GutenbergKit feature is enabled but site doesn't default to block editor for new posts"
+                else -> "GutenbergKit feature is enabled but PostUtils.shouldShowGutenbergEditor returned false"
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditorLauncherParams.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts
 
 import org.wordpress.android.ui.PagePostCreationSourcesDetail
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.ui.posts.PostUtils.EntryPoint
 
 /**
@@ -10,6 +11,13 @@ import org.wordpress.android.ui.posts.PostUtils.EntryPoint
 sealed class EditorLauncherSiteSource {
     data class DirectSite(val siteModel: SiteModel) : EditorLauncherSiteSource()
     data class QuickPressSiteId(val siteId: Int) : EditorLauncherSiteSource()
+
+    fun getSite(siteStore: SiteStore): SiteModel? {
+        return when (this) {
+            is DirectSite -> siteModel
+            is QuickPressSiteId -> siteStore.getSiteByLocalId(siteId)
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enhanced editor selection logic in `EditorLauncher` to properly determine which editor to use
- Added comprehensive logging explaining editor selection decisions in spoken language

## Test plan
- Verify correct editor is selected based on post content and site settings
- Check log messages provide clear reasoning for editor selection decisions