### PR TITLE
Renamed variable to make it clear it's the site url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -458,7 +458,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
      * Called when auth fails in the WpApiClient created in JetpackConnectionHelper.initWpApiClient, reset the
      * access token and restart the connection flow so the user sees the login page
      */
-    override fun onRequestedWithInvalidAuthentication(authenticationUrl: String) {
+    override fun onRequestedWithInvalidAuthentication(siteUrl: String) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Invalid authentication, restarting")
         wpAppNotifierHandler.removeListener(this)
         accountStore.resetAccessToken()

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1984,8 +1984,8 @@ public class WPMainActivity extends BaseAppCompatActivity implements
         }
     }
 
-    @Override public void onRequestedWithInvalidAuthentication(@NonNull String authenticationUrl) {
-        showApplicationPasswordOffReauthenticateDialog(authenticationUrl);
+    @Override public void onRequestedWithInvalidAuthentication(@NonNull String siteUrl) {
+        showApplicationPasswordOffReauthenticateDialog(siteUrl);
     }
 
     private void showApplicationPasswordOffReauthenticateDialog(@NonNull String authenticationUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -306,8 +306,8 @@ public class MediaBrowserActivity extends BaseAppCompatActivity implements Media
         }
     }
 
-    @Override public void onRequestedWithInvalidAuthentication(@NonNull String authenticationUrl) {
-        showApplicationPasswordReauthenticateDialog(authenticationUrl);
+    @Override public void onRequestedWithInvalidAuthentication(@NonNull String siteUrl) {
+        showApplicationPasswordReauthenticateDialog(siteUrl);
     }
 
     private void showApplicationPasswordReauthenticateDialog(@NonNull String authenticationUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -310,8 +310,8 @@ public class MediaBrowserActivity extends BaseAppCompatActivity implements Media
         showApplicationPasswordReauthenticateDialog(siteUrl);
     }
 
-    private void showApplicationPasswordReauthenticateDialog(@NonNull String authenticationUrl) {
-        mActivityNavigator.navigateToApplicationPasswordReauthentication(this, authenticationUrl);
+    private void showApplicationPasswordReauthenticateDialog(@NonNull String siteUrl) {
+        mActivityNavigator.navigateToApplicationPasswordReauthentication(this, siteUrl);
     }
 
     public MediaDeleteService getMediaDeleteService() {

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WpAppNotifierHandler.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/applicationpasswords/WpAppNotifierHandler.kt
@@ -37,6 +37,6 @@ class WpAppNotifierHandler @Inject constructor() {
     }
 
     interface NotifierListener {
-        fun onRequestedWithInvalidAuthentication(authenticationUrl: String)
+        fun onRequestedWithInvalidAuthentication(siteUrl: String)
     }
 }


### PR DESCRIPTION
As discussed on Slack, the `WpAppNotifierHandler.notifierListener` had a parameter named `authenticationUrl` which is actually just the site url. This PR renames that parameter for clarity.