### PR TITLE
Jetpack REST connection analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -68,7 +68,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         _buttonType.value = null
         _uiEvent.value = null
 
-        trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
+        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         wpAppNotifierHandler.addListener(this)
 
         startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -78,7 +78,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         if (wasSuccessful) {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
-            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
+            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
         } else {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
@@ -115,7 +115,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
-        trackStep(step)
+        trackStepStarted(step)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -124,21 +124,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
                 executeStepWithErrorHandling(step)
             }
         }
-    }
-
-    private fun trackStep(step: ConnectionStep) {
-        val event = when (step) {
-            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
-            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
-            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
-            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
-            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
-        }
-        trackEvent(event)
-    }
-
-    private fun trackEvent(event: AnalyticsTracker.Stat) {
-        analyticsTrackerWrapper.track(event)
     }
 
     /**
@@ -156,10 +141,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
+                trackStepFailed(step)
                 onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
+                trackStepCompleted(step)
                 if (step == ConnectionStep.Finalize) {
                     onFlowCompleted(true)
                 } else {
@@ -230,7 +217,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
+            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found
@@ -478,6 +465,37 @@ class JetpackRestConnectionViewModel @Inject constructor(
         accountStore.resetAccessToken()
         clearValues()
         startConnectionFlow()
+    }
+
+    private fun trackStepStarted(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "started")
+        )
+    }
+
+    private fun trackStepCompleted(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "completed")
+        )
+    }
+
+    private fun trackStepFailed(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "failed")
+        )
+    }
+
+    private fun getStatForStep(step: ConnectionStep): AnalyticsTracker.Stat {
+        return when (step) {
+            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
+            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
+            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
+            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
+            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
+        }
     }
 
     sealed class ConnectionStep {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpackrestconnection
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,7 +45,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val _stepStates = MutableStateFlow(initialStepStates)
     val stepStates = _stepStates
 
-    private var job: Job? = null
     private var isWaitingForWPComLogin = false
 
     private var connectionSource: ConnectionSource = DEFAULT_CONNECTION_SOURCE
@@ -60,34 +58,29 @@ class JetpackRestConnectionViewModel @Inject constructor(
         appLogWrapper.d(AppLog.T.API, "$TAG: Connection source set to: $source")
     }
 
-    private fun startConnectionJob(fromStep: ConnectionStep? = null) {
+    private fun startConnectionFlow(fromStep: ConnectionStep? = null) {
         val stepInfo = fromStep?.let { " from step: $it" } ?: ""
-        appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection job$stepInfo")
+        appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection flow $stepInfo")
 
         _buttonType.value = null
         _uiEvent.value = null
 
         wpAppNotifierHandler.addListener(this)
 
-        job?.cancel()
-        job = launch {
-            startStep(fromStep ?: ConnectionStep.LoginWpCom)
-        }
+        startStep(fromStep ?: ConnectionStep.LoginWpCom)
     }
 
-    private fun onJobCompleted(wasSuccessful: Boolean) {
+    private fun onFlowCompleted(wasSuccessful: Boolean) {
         if (wasSuccessful) {
-            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection job completed successfully")
+            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
         } else {
-            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection job failed")
+            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
         }
 
         wpAppNotifierHandler.removeListener(this)
-
         _currentStep.value = null
-        job?.cancel()
     }
 
     private fun getNextStep(): ConnectionStep? = when (currentStep.value) {
@@ -142,12 +135,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
-                onJobCompleted(false)
+                onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
                 if (step == ConnectionStep.Finalize) {
-                    onJobCompleted(true)
+                    onFlowCompleted(true)
                 } else {
                     startNextStep()
                 }
@@ -162,7 +155,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
      */
     fun onStartClick() {
         appLogWrapper.d(AppLog.T.API, "$TAG: Start clicked")
-        startConnectionJob()
+        startConnectionFlow()
     }
 
     /**
@@ -191,7 +184,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
      */
     fun onCancelConfirmed() {
         appLogWrapper.d(AppLog.T.API, "$TAG: Cancel confirmed")
-        job?.cancel()
         setUiEvent(UiEvent.Close)
     }
 
@@ -217,11 +209,11 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            startConnectionJob(fromStep = step)
+            startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found
             clearValues()
-            startConnectionJob()
+            startConnectionFlow()
         }
     }
 
@@ -233,9 +225,9 @@ class JetpackRestConnectionViewModel @Inject constructor(
     }
 
     /**
-     * Returns true if the connection job is active
+     * Returns true if the connection flow is active
      */
-    private fun isActive(): Boolean = job?.isActive == true || run {
+    private fun isActive(): Boolean = run {
         val step = currentStep.value
         step != null && _stepStates.value[step]?.status != ConnectionStatus.Failed
     }
@@ -463,7 +455,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         wpAppNotifierHandler.removeListener(this)
         accountStore.resetAccessToken()
         clearValues()
-        startConnectionJob()
+        startConnectionFlow()
     }
 
     sealed class ConnectionStep {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -16,6 +17,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.VersionUtils.checkMinimalVersion
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import uniffi.wp_api.PluginStatus
 import javax.inject.Inject
@@ -31,6 +33,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val jetpackConnector: JetpackConnector,
     private val jetpackModuleHelper: JetpackStatsModuleHelper,
     private val appLogWrapper: AppLogWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val wpAppNotifierHandler: WpAppNotifierHandler,
 ) : ScopedViewModel(mainDispatcher), WpAppNotifierHandler.NotifierListener {
     private val _currentStep = MutableStateFlow<ConnectionStep?>(null)
@@ -65,6 +68,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         _buttonType.value = null
         _uiEvent.value = null
 
+        trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         wpAppNotifierHandler.addListener(this)
 
         startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -74,6 +78,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         if (wasSuccessful) {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
+            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
         } else {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
@@ -110,6 +115,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
+        trackStep(step)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -118,6 +124,21 @@ class JetpackRestConnectionViewModel @Inject constructor(
                 executeStepWithErrorHandling(step)
             }
         }
+    }
+
+    private fun trackStep(step: ConnectionStep) {
+        val event = when (step) {
+            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
+            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
+            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
+            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
+            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
+        }
+        trackEvent(event)
+    }
+
+    private fun trackEvent(event: AnalyticsTracker.Stat) {
+        analyticsTrackerWrapper.track(event)
     }
 
     /**
@@ -209,6 +230,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
+            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STA
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_FAILED
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_KEY
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STARTED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STEP_KEY
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -222,7 +223,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
+            analyticsTrackerWrapper.track(
+                stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED,
+                properties = mapOf(
+                    JETPACK_REST_CONNECT_STATE_STEP_KEY to step.toString()
+                )
+            )
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -8,6 +8,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_SOURCE_KEY
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_COMPLETED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_FAILED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_KEY
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STARTED
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -115,7 +120,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
-        trackStepStarted(step)
+        trackStepWithState(step, JETPACK_REST_CONNECT_STATE_STARTED)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -141,12 +146,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
-                trackStepFailed(step)
+                trackStepWithState(step, JETPACK_REST_CONNECT_STATE_FAILED)
                 onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
-                trackStepCompleted(step)
+                trackStepWithState(step, JETPACK_REST_CONNECT_STATE_COMPLETED)
                 if (step == ConnectionStep.Finalize) {
                     onFlowCompleted(true)
                 } else {
@@ -467,35 +472,21 @@ class JetpackRestConnectionViewModel @Inject constructor(
         startConnectionFlow()
     }
 
-    private fun trackStepStarted(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "started")
-        )
-    }
-
-    private fun trackStepCompleted(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "completed")
-        )
-    }
-
-    private fun trackStepFailed(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "failed")
-        )
-    }
-
-    private fun getStatForStep(step: ConnectionStep): AnalyticsTracker.Stat {
-        return when (step) {
+    private fun trackStepWithState(step: ConnectionStep, stateValue: String) {
+        val event = when (step) {
             ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
             ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
             ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
             ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
             ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
         }
+        analyticsTrackerWrapper.track(
+            stat = event,
+            properties = mapOf(
+                JETPACK_REST_CONNECT_STATE_KEY to stateValue,
+                JETPACK_REST_CONNECT_SOURCE_KEY to connectionSource.name
+            )
+        )
     }
 
     sealed class ConnectionStep {

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -18,6 +18,13 @@ public final class AnalyticsTracker {
     public static final String ACTIVITY_LOG_ACTIVITY_ID_KEY = "activity_id";
     public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
+    // These match iOS except for JETPACK_REST_CONNECT_SOURCE_KEY which isn't tracked on iOS
+    public static final String JETPACK_REST_CONNECT_SOURCE_KEY = "source";
+    public static final String JETPACK_REST_CONNECT_STATE_KEY = "state";
+    public static final String JETPACK_REST_CONNECT_STATE_STARTED = "started";
+    public static final String JETPACK_REST_CONNECT_STATE_COMPLETED = "completed";
+    public static final String JETPACK_REST_CONNECT_STATE_FAILED = "failed";
+
     @SuppressWarnings("LineLength")
     public enum Stat {
         // This stat is part of a funnel that provides critical information.  Before

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -18,8 +18,8 @@ public final class AnalyticsTracker {
     public static final String ACTIVITY_LOG_ACTIVITY_ID_KEY = "activity_id";
     public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
-    // These match iOS except for JETPACK_REST_CONNECT_SOURCE_KEY which isn't tracked on iOS
     public static final String JETPACK_REST_CONNECT_SOURCE_KEY = "source";
+    public static final String JETPACK_REST_CONNECT_STATE_STEP_KEY = "step";
     public static final String JETPACK_REST_CONNECT_STATE_KEY = "state";
     public static final String JETPACK_REST_CONNECT_STATE_STARTED = "started";
     public static final String JETPACK_REST_CONNECT_STATE_COMPLETED = "completed";

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -653,6 +653,16 @@ public final class AnalyticsTracker {
         SUPPORT_CHATBOT_TICKET_FAILURE,
         SUPPORT_CHATBOT_ENDED,
 
+        // Jetpack REST connection
+        JETPACK_REST_CONNECT_STARTED,
+        JETPACK_REST_CONNECT_LOGIN,
+        JETPACK_REST_CONNECT_INSTALL,
+        JETPACK_REST_CONNECT_SITE_CONNECTION,
+        JETPACK_REST_CONNECT_USER_CONNECTION,
+        JETPACK_REST_CONNECT_FINALIZE,
+        JETPACK_REST_CONNECT_COMPLETED,
+        JETPACK_REST_CONNECT_STEP_RETRIED,
+
         // these events are for the feedback form, which on iOS was originally part of the
         // in-app review feature.
         APP_REVIEWS_FEEDBACK_SCREEN_OPENED,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -653,7 +653,7 @@ public final class AnalyticsTracker {
         SUPPORT_CHATBOT_TICKET_FAILURE,
         SUPPORT_CHATBOT_ENDED,
 
-        // Jetpack REST connection
+        // Jetpack REST connection - these match iOS
         JETPACK_REST_CONNECT_STARTED,
         JETPACK_REST_CONNECT_LOGIN,
         JETPACK_REST_CONNECT_INSTALL,


### PR DESCRIPTION
This PR adds analytics tracking to the Jetpack REST connection flow. I've [matched iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/24732) with the exception of the "source" value (`JETPACK_REST_CONNECT_SOURCE_KEY`) which isn't tracked on iOS. This is used to determine where the flow was called from ("STATS" or "NOTIFS").

**To test**
* Enable "Collect information" in the app's privacy settings
* Enable application passwords and Jetpack REST connection experimental features
* Login to a self-hosted site that doesn't have Jetpack
* On My Site, click Stats and choose to install Jetpack
* Verify logcat shows the events being tracked

<img width="2046" height="780" alt="logcat" src="https://github.com/user-attachments/assets/76f75eb8-b878-455b-a473-148474fdfc33" />
