### PR TITLE
Fix: Opening Application Password list screen from MySite menu item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/menu/MenuActivity.kt
@@ -160,6 +160,11 @@ class MenuActivity : BaseAppCompatActivity() {
             )
 
             is SiteNavigationAction.OpenSiteMonitoring -> activityNavigator.navigateToSiteMonitoring(this, action.site)
+
+            is SiteNavigationAction.OpenApplicationPasswordsList -> {
+                ActivityLauncher.viewApplicationPasswordList(this)
+            }
+
             else -> {}
         }
     }


### PR DESCRIPTION
## Description
It was detected that clicking on the "Application Passwords" menu item inside MySite menu was not doing anything at all.
This PR is adding the logic to solve the problem and open the proper screen.

## Testing instructions
1. Log into t self-hosted site using Application Password
2. Go to MySite -> ... More -> Application Passwords
- [ ] Verify it opens the Application Passwords list screen.


https://github.com/user-attachments/assets/b0337dc2-141d-49e4-9311-0ae2ed3a6254



<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->