### PR TITLE
Jetpack REST connection tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -68,7 +68,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         _buttonType.value = null
         _uiEvent.value = null
 
-        trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
+        analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         wpAppNotifierHandler.addListener(this)
 
         startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -78,7 +78,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         if (wasSuccessful) {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
-            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
+            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
         } else {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
@@ -115,7 +115,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
-        trackStep(step)
+        trackStepStarted(step)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -124,21 +124,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
                 executeStepWithErrorHandling(step)
             }
         }
-    }
-
-    private fun trackStep(step: ConnectionStep) {
-        val event = when (step) {
-            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
-            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
-            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
-            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
-            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
-        }
-        trackEvent(event)
-    }
-
-    private fun trackEvent(event: AnalyticsTracker.Stat) {
-        analyticsTrackerWrapper.track(event)
     }
 
     /**
@@ -156,10 +141,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
+                trackStepFailed(step)
                 onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
+                trackStepCompleted(step)
                 if (step == ConnectionStep.Finalize) {
                     onFlowCompleted(true)
                 } else {
@@ -230,7 +217,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
+            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found
@@ -478,6 +465,37 @@ class JetpackRestConnectionViewModel @Inject constructor(
         accountStore.resetAccessToken()
         clearValues()
         startConnectionFlow()
+    }
+
+    private fun trackStepStarted(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "started")
+        )
+    }
+
+    private fun trackStepCompleted(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "completed")
+        )
+    }
+
+    private fun trackStepFailed(step: ConnectionStep) {
+        analyticsTrackerWrapper.track(
+            stat = getStatForStep(step),
+            properties = mapOf("state" to "failed")
+        )
+    }
+
+    private fun getStatForStep(step: ConnectionStep): AnalyticsTracker.Stat {
+        return when (step) {
+            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
+            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
+            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
+            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
+            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
+        }
     }
 
     sealed class ConnectionStep {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -549,7 +549,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "JetpackRestConnectionViewModel"
-        private const val LIMIT_VERSION = "14.2"
+        private const val JETPACK_LIMIT_VERSION = "14.2"
         private const val STEP_TIMEOUT_MS = 45 * 1000L
         private const val UI_DELAY_MS = 1000L
         val DEFAULT_CONNECTION_SOURCE = ConnectionSource.STATS
@@ -564,7 +564,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             return site.isUsingSelfHostedRestApi
                     && !site.wpApiRestUrl.isNullOrEmpty()
                     && !site.isJetpackConnected
-                    && (!site.isJetpackInstalled || checkMinimalVersion(site.jetpackVersion, LIMIT_VERSION))
+                    && (!site.isJetpackInstalled || checkMinimalVersion(site.jetpackVersion, JETPACK_LIMIT_VERSION))
         }
 
         private val initialStepStates = mapOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpackrestconnection
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,7 +45,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val _stepStates = MutableStateFlow(initialStepStates)
     val stepStates = _stepStates
 
-    private var job: Job? = null
     private var isWaitingForWPComLogin = false
 
     private var connectionSource: ConnectionSource = DEFAULT_CONNECTION_SOURCE
@@ -60,34 +58,29 @@ class JetpackRestConnectionViewModel @Inject constructor(
         appLogWrapper.d(AppLog.T.API, "$TAG: Connection source set to: $source")
     }
 
-    private fun startConnectionJob(fromStep: ConnectionStep? = null) {
+    private fun startConnectionFlow(fromStep: ConnectionStep? = null) {
         val stepInfo = fromStep?.let { " from step: $it" } ?: ""
-        appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection job$stepInfo")
+        appLogWrapper.d(AppLog.T.API, "$TAG: Starting Jetpack connection flow $stepInfo")
 
         _buttonType.value = null
         _uiEvent.value = null
 
         wpAppNotifierHandler.addListener(this)
 
-        job?.cancel()
-        job = launch {
-            startStep(fromStep ?: ConnectionStep.LoginWpCom)
-        }
+        startStep(fromStep ?: ConnectionStep.LoginWpCom)
     }
 
-    private fun onJobCompleted(wasSuccessful: Boolean) {
+    private fun onFlowCompleted(wasSuccessful: Boolean) {
         if (wasSuccessful) {
-            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection job completed successfully")
+            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
         } else {
-            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection job failed")
+            appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
         }
 
         wpAppNotifierHandler.removeListener(this)
-
         _currentStep.value = null
-        job?.cancel()
     }
 
     private fun getNextStep(): ConnectionStep? = when (currentStep.value) {
@@ -142,12 +135,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
-                onJobCompleted(false)
+                onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
                 if (step == ConnectionStep.Finalize) {
-                    onJobCompleted(true)
+                    onFlowCompleted(true)
                 } else {
                     startNextStep()
                 }
@@ -162,7 +155,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
      */
     fun onStartClick() {
         appLogWrapper.d(AppLog.T.API, "$TAG: Start clicked")
-        startConnectionJob()
+        startConnectionFlow()
     }
 
     /**
@@ -191,7 +184,6 @@ class JetpackRestConnectionViewModel @Inject constructor(
      */
     fun onCancelConfirmed() {
         appLogWrapper.d(AppLog.T.API, "$TAG: Cancel confirmed")
-        job?.cancel()
         setUiEvent(UiEvent.Close)
     }
 
@@ -217,11 +209,11 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            startConnectionJob(fromStep = step)
+            startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found
             clearValues()
-            startConnectionJob()
+            startConnectionFlow()
         }
     }
 
@@ -233,9 +225,9 @@ class JetpackRestConnectionViewModel @Inject constructor(
     }
 
     /**
-     * Returns true if the connection job is active
+     * Returns true if the connection flow is active
      */
-    private fun isActive(): Boolean = job?.isActive == true || run {
+    private fun isActive(): Boolean = run {
         val step = currentStep.value
         step != null && _stepStates.value[step]?.status != ConnectionStatus.Failed
     }
@@ -463,7 +455,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         wpAppNotifierHandler.removeListener(this)
         accountStore.resetAccessToken()
         clearValues()
-        startConnectionJob()
+        startConnectionFlow()
     }
 
     sealed class ConnectionStep {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -16,6 +17,7 @@ import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.mysite.SelectedSiteRepository
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.VersionUtils.checkMinimalVersion
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 import org.wordpress.android.viewmodel.ScopedViewModel
 import uniffi.wp_api.PluginStatus
 import javax.inject.Inject
@@ -31,6 +33,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val jetpackConnector: JetpackConnector,
     private val jetpackModuleHelper: JetpackStatsModuleHelper,
     private val appLogWrapper: AppLogWrapper,
+    private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val wpAppNotifierHandler: WpAppNotifierHandler,
 ) : ScopedViewModel(mainDispatcher), WpAppNotifierHandler.NotifierListener {
     private val _currentStep = MutableStateFlow<ConnectionStep?>(null)
@@ -65,6 +68,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         _buttonType.value = null
         _uiEvent.value = null
 
+        trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         wpAppNotifierHandler.addListener(this)
 
         startStep(fromStep ?: ConnectionStep.LoginWpCom)
@@ -74,6 +78,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
         if (wasSuccessful) {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow completed successfully")
             _buttonType.value = ButtonType.Done
+            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
         } else {
             appLogWrapper.d(AppLog.T.API, "$TAG: Jetpack connection flow failed")
             _buttonType.value = ButtonType.Retry
@@ -110,6 +115,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
+        trackStep(step)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -118,6 +124,21 @@ class JetpackRestConnectionViewModel @Inject constructor(
                 executeStepWithErrorHandling(step)
             }
         }
+    }
+
+    private fun trackStep(step: ConnectionStep) {
+        val event = when (step) {
+            ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
+            ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
+            ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
+            ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
+            ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
+        }
+        trackEvent(event)
+    }
+
+    private fun trackEvent(event: AnalyticsTracker.Stat) {
+        analyticsTrackerWrapper.track(event)
     }
 
     /**
@@ -209,6 +230,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
+            trackEvent(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -42,8 +42,9 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val wpAppNotifierHandler: WpAppNotifierHandler,
 ) : ScopedViewModel(mainDispatcher), WpAppNotifierHandler.NotifierListener {
-    // Internal variable that can be overridden for testing
+    // Internal variables that can be overridden for testing
     internal var uiDelayMs: Long = UI_DELAY_MS
+    internal var stepTimeoutMs: Long = STEP_TIMEOUT_MS
     
     private val _currentStep = MutableStateFlow<ConnectionStep?>(null)
     val currentStep = _currentStep
@@ -269,7 +270,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private suspend fun executeStepWithErrorHandling(step: ConnectionStep) {
         try {
             withContext(bgDispatcher) {
-                withTimeout(STEP_TIMEOUT_MS) {
+                withTimeout(stepTimeoutMs) {
                     executeStep(step)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -13,6 +13,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STA
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_FAILED
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_KEY
 import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STARTED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STEP_KEY
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -222,7 +223,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
             _stepStates.value = _stepStates.value.toMutableMap().apply {
                 this[step] = StepState()
             }
-            analyticsTrackerWrapper.track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED)
+            analyticsTrackerWrapper.track(
+                stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED,
+                properties = mapOf(
+                    JETPACK_REST_CONNECT_STATE_STEP_KEY to step.toString()
+                )
+            )
             startConnectionFlow(fromStep = step)
         } ?: run {
             // Fallback to original behavior if no failed step found

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -42,6 +42,9 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private val analyticsTrackerWrapper: AnalyticsTrackerWrapper,
     private val wpAppNotifierHandler: WpAppNotifierHandler,
 ) : ScopedViewModel(mainDispatcher), WpAppNotifierHandler.NotifierListener {
+    // Internal variable that can be overridden for testing
+    internal var uiDelayMs: Long = UI_DELAY_MS
+    
     private val _currentStep = MutableStateFlow<ConnectionStep?>(null)
     val currentStep = _currentStep
 
@@ -320,7 +323,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
             // User is already logged in, add a short delay before marking the step completed
             appLogWrapper.d(AppLog.T.API, "$TAG: WordPress.com access token already exists")
             launch {
-                delay(UI_DELAY_MS)
+                delay(uiDelayMs)
                 updateStepStatus(ConnectionStep.LoginWpCom, ConnectionStatus.Completed)
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModel.kt
@@ -8,6 +8,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_SOURCE_KEY
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_COMPLETED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_FAILED
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_KEY
+import org.wordpress.android.analytics.AnalyticsTracker.JETPACK_REST_CONNECT_STATE_STARTED
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
@@ -115,7 +120,7 @@ class JetpackRestConnectionViewModel @Inject constructor(
     private fun startStep(step: ConnectionStep) {
         appLogWrapper.d(AppLog.T.API, "$TAG: Starting step: $step")
         _currentStep.value = step
-        trackStepStarted(step)
+        trackStepWithState(step, JETPACK_REST_CONNECT_STATE_STARTED)
         updateStepStatus(step, ConnectionStatus.InProgress)
         if (step == ConnectionStep.LoginWpCom) {
             loginWpCom()
@@ -141,12 +146,12 @@ class JetpackRestConnectionViewModel @Inject constructor(
 
         when (status) {
             ConnectionStatus.Failed -> {
-                trackStepFailed(step)
+                trackStepWithState(step, JETPACK_REST_CONNECT_STATE_FAILED)
                 onFlowCompleted(false)
             }
 
             ConnectionStatus.Completed -> {
-                trackStepCompleted(step)
+                trackStepWithState(step, JETPACK_REST_CONNECT_STATE_COMPLETED)
                 if (step == ConnectionStep.Finalize) {
                     onFlowCompleted(true)
                 } else {
@@ -467,35 +472,21 @@ class JetpackRestConnectionViewModel @Inject constructor(
         startConnectionFlow()
     }
 
-    private fun trackStepStarted(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "started")
-        )
-    }
-
-    private fun trackStepCompleted(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "completed")
-        )
-    }
-
-    private fun trackStepFailed(step: ConnectionStep) {
-        analyticsTrackerWrapper.track(
-            stat = getStatForStep(step),
-            properties = mapOf("state" to "failed")
-        )
-    }
-
-    private fun getStatForStep(step: ConnectionStep): AnalyticsTracker.Stat {
-        return when (step) {
+    private fun trackStepWithState(step: ConnectionStep, stateValue: String) {
+        val event = when (step) {
             ConnectionStep.LoginWpCom -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN
             ConnectionStep.InstallJetpack -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL
             ConnectionStep.ConnectSite -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_SITE_CONNECTION
             ConnectionStep.ConnectUser -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_USER_CONNECTION
             ConnectionStep.Finalize -> AnalyticsTracker.Stat.JETPACK_REST_CONNECT_FINALIZE
         }
+        analyticsTrackerWrapper.track(
+            stat = event,
+            properties = mapOf(
+                JETPACK_REST_CONNECT_STATE_KEY to stateValue,
+                JETPACK_REST_CONNECT_SOURCE_KEY to connectionSource.name
+            )
+        )
     }
 
     sealed class ConnectionStep {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -1,0 +1,559 @@
+package org.wordpress.android.ui.jetpackrestconnection
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.analytics.AnalyticsTracker
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
+import org.wordpress.android.fluxc.store.AccountStore
+import org.wordpress.android.fluxc.utils.AppLogWrapper
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ButtonType
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionSource
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStatus
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStep
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ErrorType
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.StepState
+import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.UiEvent
+import org.wordpress.android.ui.mysite.SelectedSiteRepository
+import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
+import uniffi.wp_api.PluginStatus
+
+@ExperimentalCoroutinesApi
+class JetpackRestConnectionViewModelTest : BaseUnitTest() {
+    @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Mock lateinit var accountStore: AccountStore
+    @Mock lateinit var jetpackInstaller: JetpackInstaller
+    @Mock lateinit var jetpackConnector: JetpackConnector
+    @Mock lateinit var jetpackModuleHelper: JetpackStatsModuleHelper
+    @Mock lateinit var appLogWrapper: AppLogWrapper
+    @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock lateinit var wpAppNotifierHandler: WpAppNotifierHandler
+    @Mock lateinit var siteModel: SiteModel
+
+    private lateinit var viewModel: JetpackRestConnectionViewModel
+
+    @Before
+    fun setup() {
+        whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
+        
+        viewModel = JetpackRestConnectionViewModel(
+            mainDispatcher = UnconfinedTestDispatcher(),
+            bgDispatcher = UnconfinedTestDispatcher(),
+            selectedSiteRepository = selectedSiteRepository,
+            accountStore = accountStore,
+            jetpackInstaller = jetpackInstaller,
+            jetpackConnector = jetpackConnector,
+            jetpackModuleHelper = jetpackModuleHelper,
+            appLogWrapper = appLogWrapper,
+            analyticsTrackerWrapper = analyticsTrackerWrapper,
+            wpAppNotifierHandler = wpAppNotifierHandler,
+        )
+    }
+
+    @Test
+    fun `setConnectionSource updates connection source`() {
+        viewModel.setConnectionSource(ConnectionSource.NOTIFS)
+        
+        verify(appLogWrapper).d(any(), argThat { contains("Connection source set to: NOTIFS") })
+    }
+
+    @Test
+    fun `onStartClick starts connection flow`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
+        verify(wpAppNotifierHandler).addListener(viewModel)
+        // The buttonType should be Retry since the InstallJetpack step failed
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
+        // After login completes, it should move to InstallJetpack
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+    }
+
+    @Test
+    fun `onDoneClick sets Done UI event`() = runTest {
+        viewModel.onDoneClick()
+        
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
+    }
+
+    @Test
+    fun `onCloseClick shows confirmation when connection is active`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        
+        viewModel.onStartClick()
+        viewModel.onCloseClick()
+        
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.ShowCancelConfirmation)
+    }
+
+    @Test
+    fun `onCloseClick closes immediately when connection is not active`() = runTest {
+        viewModel.onCloseClick()
+        
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
+    }
+
+    @Test
+    fun `onCancelConfirmed sets Close UI event`() = runTest {
+        viewModel.onCancelConfirmed()
+        
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
+    }
+
+    @Test
+    fun `onCancelDismissed continues connection`() {
+        viewModel.onCancelDismissed()
+        
+        verify(appLogWrapper).d(any(), argThat { contains("Cancel dismissed, continuing connection") })
+    }
+
+    @Test
+    fun `onRetryClick retries from failed step`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Failed")))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        
+        viewModel.onRetryClick()
+        
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED,
+            properties = mapOf("step" to "InstallJetpack")
+        )
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+    }
+
+    @Test
+    fun `loginWpCom step completes immediately when already logged in`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        // After InstallJetpack fails, currentStep becomes null
+        assertThat(viewModel.currentStep.value).isNull()
+        // But we should have attempted InstallJetpack and it failed
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+    }
+
+    @Test
+    fun `loginWpCom step triggers login when not logged in`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        
+        viewModel.onStartClick()
+        
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.StartWPComLogin)
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
+            .isEqualTo(ConnectionStatus.InProgress)
+    }
+
+    @Test
+    fun `onWPComLoginCompleted with success completes login step`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
+        
+        viewModel.onStartClick()
+        viewModel.onWPComLoginCompleted(true)
+        advanceUntilIdle()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        // After login completes, flow should continue but fail at InstallJetpack
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+    }
+
+    @Test
+    fun `onWPComLoginCompleted with failure marks login step as failed`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        
+        viewModel.onStartClick()
+        viewModel.onWPComLoginCompleted(false)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.errorType)
+            .isEqualTo(ErrorType.LoginWpComFailed)
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
+    }
+
+    @Test
+    fun `installJetpack step succeeds with active plugin`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Stop here")))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        // After InstallJetpack completes, flow should continue but fail at ConnectSite
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+    }
+
+    @Test
+    fun `installJetpack step succeeds with network active plugin`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.NETWORK_ACTIVE))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+    }
+
+    @Test
+    fun `installJetpack step fails with inactive plugin`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.INACTIVE))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
+            .isEqualTo(ErrorType.InstallJetpackInactive)
+    }
+
+    @Test
+    fun `installJetpack step fails on exception`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Install failed")))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
+            .isEqualTo(ErrorType.InstallJetpackFailed)
+    }
+
+    @Test
+    fun `connectSite step succeeds and updates site ID`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        verify(siteModel).siteId = 12345L
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        // After ConnectSite completes, flow should continue but fail at ConnectUser
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+    }
+
+    @Test
+    fun `connectSite step fails on exception`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Connect failed")))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.errorType)
+            .isEqualTo(ErrorType.ConnectSiteFailed)
+    }
+
+    @Test
+    fun `connectUser step fails without access token`() = runTest {
+        whenever(accountStore.hasAccessToken())
+            .thenReturn(true) // Initial check for LoginWpCom
+            .thenReturn(false) // Check in ConnectUser step
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
+            .isEqualTo(ErrorType.MissingAccessToken)
+    }
+
+    @Test
+    fun `connectUser step succeeds with access token`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stop here")))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        verify(jetpackConnector).connectUser(eq(siteModel), eq("test_token"))
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        // After ConnectUser completes, flow should continue but fail at Finalize
+        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+    }
+
+    @Test
+    fun `connectUser step fails on exception`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.failure(Exception("User connect failed")))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
+            .isEqualTo(ErrorType.ConnectUserFailed)
+    }
+
+    @Test
+    fun `finalize step succeeds and completes flow`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
+        verify(wpAppNotifierHandler).removeListener(viewModel)
+    }
+
+    @Test
+    fun `finalize step fails on exception`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stats failed")))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.errorType)
+            .isEqualTo(ErrorType.ActivateStatsFailed)
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
+    }
+
+    @Test
+    fun `onRequestedWithInvalidAuthentication resets and restarts flow`() = runTest {
+        viewModel.onRequestedWithInvalidAuthentication("https://example.com")
+        
+        verify(wpAppNotifierHandler).removeListener(viewModel)
+        verify(accountStore).resetAccessToken()
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
+        assertThat(viewModel.currentStep.value).isEqualTo(ConnectionStep.LoginWpCom)
+    }
+
+    @Test
+    fun `step timeout triggers timeout error`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).doSuspendableAnswer {
+            delay(50000)
+            Result.success(PluginStatus.ACTIVE)
+        }
+        
+        viewModel.onStartClick()
+        advanceTimeBy(46000)
+        advanceUntilIdle()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Failed)
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
+            .isEqualTo(ErrorType.Timeout)
+    }
+
+    @Test
+    fun `canInitiateJetpackRestConnection returns true for valid self-hosted site`() {
+        val site = mock<SiteModel> {
+            on { isUsingSelfHostedRestApi } doReturn true
+            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
+            on { isJetpackConnected } doReturn false
+            on { isJetpackInstalled } doReturn false
+        }
+        
+        assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isTrue
+    }
+
+    @Test
+    fun `canInitiateJetpackRestConnection returns true for site with valid Jetpack version`() {
+        val site = mock<SiteModel> {
+            on { isUsingSelfHostedRestApi } doReturn true
+            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
+            on { isJetpackConnected } doReturn false
+            on { isJetpackInstalled } doReturn true
+            on { jetpackVersion } doReturn "14.3"
+        }
+        
+        assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isTrue
+    }
+
+    @Test
+    fun `canInitiateJetpackRestConnection returns false for non-self-hosted site`() {
+        val site = mock<SiteModel> {
+            on { isUsingSelfHostedRestApi } doReturn false
+            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
+            on { isJetpackConnected } doReturn false
+            on { isJetpackInstalled } doReturn false
+        }
+        
+        assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
+    }
+
+    @Test
+    fun `canInitiateJetpackRestConnection returns false for already connected site`() {
+        val site = mock<SiteModel> {
+            on { isUsingSelfHostedRestApi } doReturn true
+            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
+            on { isJetpackConnected } doReturn true
+            on { isJetpackInstalled } doReturn true
+        }
+        
+        assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
+    }
+
+    @Test
+    fun `canInitiateJetpackRestConnection returns false for old Jetpack version`() {
+        val site = mock<SiteModel> {
+            on { isUsingSelfHostedRestApi } doReturn true
+            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
+            on { isJetpackConnected } doReturn false
+            on { isJetpackInstalled } doReturn true
+            on { jetpackVersion } doReturn "14.0"
+        }
+        
+        assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
+    }
+
+    @Test
+    fun `tracks analytics for each step state transition`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
+        
+        viewModel.setConnectionSource(ConnectionSource.NOTIFS)
+        viewModel.onStartClick()
+        
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
+            properties = mapOf(
+                "state" to "started",
+                "source" to "NOTIFS"
+            )
+        )
+        
+        viewModel.onWPComLoginCompleted(true)
+        
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
+            properties = mapOf(
+                "state" to "completed",
+                "source" to "NOTIFS"
+            )
+        )
+    }
+
+    @Test
+    fun `multiple retries maintain correct step states`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any()))
+            .thenReturn(Result.failure(Exception("First failure")))
+            .thenReturn(Result.failure(Exception("Second failure")))
+            .thenReturn(Result.success(PluginStatus.ACTIVE))
+        
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+        
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
+        
+        viewModel.onRetryClick()
+        
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
+        
+        viewModel.onRetryClick()
+        
+        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
+            .isEqualTo(ConnectionStatus.Completed)
+        
+        verify(jetpackInstaller, times(3)).installJetpack(any())
+    }
+
+    @Test
+    fun `UI events are properly reset before setting new value`() = runTest {
+        viewModel.onDoneClick()
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
+        
+        viewModel.onCloseClick()
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
+        
+        viewModel.onCloseClick()
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
+    }
+
+    @Test
+    fun `step states are initialized correctly`() {
+        val initialStates = viewModel.stepStates.value
+        
+        assertThat(initialStates).hasSize(5)
+        assertThat(initialStates[ConnectionStep.LoginWpCom]).isEqualTo(StepState())
+        assertThat(initialStates[ConnectionStep.InstallJetpack]).isEqualTo(StepState())
+        assertThat(initialStates[ConnectionStep.ConnectSite]).isEqualTo(StepState())
+        assertThat(initialStates[ConnectionStep.ConnectUser]).isEqualTo(StepState())
+        assertThat(initialStates[ConnectionStep.Finalize]).isEqualTo(StepState())
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -98,6 +98,14 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.uiDelayMs = TEST_UI_DELAY_MS
         viewModel.stepTimeoutMs = TEST_STEP_TIMEOUT_MS
     }
+    
+    // Helper to assert step status
+    private fun assertStepStatus(step: ConnectionStep, expectedStatus: ConnectionStatus, expectedError: ErrorType? = null) {
+        assertThat(viewModel.stepStates.value[step]?.status).isEqualTo(expectedStatus)
+        expectedError?.let { 
+            assertThat(viewModel.stepStates.value[step]?.errorType).isEqualTo(it)
+        }
+    }
 
     @Test
     fun `onDoneClick sets Done UI event`() = runTest {
@@ -202,8 +210,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.onStartClick()
         advanceUntilIdle()
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
+        assertStepStatus(ConnectionStep.InstallJetpack, ConnectionStatus.Completed)
     }
 
 
@@ -215,10 +222,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.onStartClick()
         advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
-            .isEqualTo(ErrorType.InstallJetpackInactive)
+        assertStepStatus(ConnectionStep.InstallJetpack, ConnectionStatus.Failed, ErrorType.InstallJetpackInactive)
     }
 
 
@@ -232,8 +236,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         verify(siteModel).siteId = TEST_SITE_ID.toLong()
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
+        assertStepStatus(ConnectionStep.ConnectSite, ConnectionStatus.Completed)
     }
 
 
@@ -248,10 +251,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.onStartClick()
         advanceUntilIdle()
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
-            .isEqualTo(ErrorType.MissingAccessToken)
+        assertStepStatus(ConnectionStep.ConnectUser, ConnectionStatus.Failed, ErrorType.MissingAccessToken)
     }
 
     @Test
@@ -266,8 +266,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         advanceUntilIdle()
 
         verify(jetpackConnector).connectUser(eq(siteModel), eq(TEST_ACCESS_TOKEN))
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
+        assertStepStatus(ConnectionStep.ConnectUser, ConnectionStatus.Completed)
     }
 
 
@@ -283,8 +282,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.onStartClick()
         advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
+        assertStepStatus(ConnectionStep.Finalize, ConnectionStatus.Completed)
     }
 
     @Test
@@ -299,10 +297,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.onStartClick()
         advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.errorType)
-            .isEqualTo(ErrorType.ActivateStatsFailed)
+        assertStepStatus(ConnectionStep.Finalize, ConnectionStatus.Failed, ErrorType.ActivateStatsFailed)
     }
 
     @Test
@@ -326,10 +321,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         advanceTimeBy(TEST_TIMEOUT_ADVANCE_MS)
         advanceUntilIdle()
 
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
-            .isEqualTo(ErrorType.Timeout)
+        assertStepStatus(ConnectionStep.InstallJetpack, ConnectionStatus.Failed, ErrorType.Timeout)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -19,13 +19,11 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
-import org.wordpress.android.analytics.AnalyticsTracker
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.rest.wpapi.applicationpasswords.WpAppNotifierHandler
 import org.wordpress.android.fluxc.store.AccountStore
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ButtonType
-import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionSource
 import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStatus
 import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ConnectionStep
 import org.wordpress.android.ui.jetpackrestconnection.JetpackRestConnectionViewModel.ErrorType
@@ -68,35 +66,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `setConnectionSource updates connection source for analytics`() = runTest {
-        viewModel.setConnectionSource(ConnectionSource.NOTIFS)
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        
-        viewModel.onStartClick()
-        advanceUntilIdle()
-        
-        // Verify the connection source is used in analytics for the install step
-        verify(analyticsTrackerWrapper).track(
-            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL,
-            properties = mapOf(
-                "state" to "started",
-                "source" to "NOTIFS"
-            )
-        )
-    }
-
-    @Test
-    fun `onStartClick tracks analytics and adds listener`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(false)
-
-        viewModel.onStartClick()
-
-        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
-        verify(wpAppNotifierHandler).addListener(viewModel)
-    }
-
-    @Test
     fun `onDoneClick sets Done UI event`() = runTest {
         viewModel.onDoneClick()
 
@@ -105,8 +74,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
     @Test
     fun `onCloseClick shows confirmation when connection is active`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(false)
-
         viewModel.onStartClick()
         viewModel.onCloseClick()
 
@@ -132,10 +99,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         // Set up a UI event first
         viewModel.onDoneClick()
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
-        
+
         // Cancel dismissed should not change the UI event
         viewModel.onCancelDismissed()
-        
+
         // UI event should remain unchanged
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
     }
@@ -155,10 +122,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         viewModel.onRetryClick()
 
-        verify(analyticsTrackerWrapper).track(
-            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED,
-            properties = mapOf("step" to "InstallJetpack")
-        )
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Completed)
     }
@@ -332,7 +295,9 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(accountStore.accessToken).thenReturn("test_token")
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.failure(Exception("User connect failed")))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(
+            Result.failure(Exception("User connect failed"))
+        )
 
         viewModel.onStartClick()
         advanceTimeBy(1100)
@@ -383,7 +348,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         verify(wpAppNotifierHandler).removeListener(viewModel)
         verify(accountStore).resetAccessToken()
-        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         assertThat(viewModel.currentStep.value).isEqualTo(ConnectionStep.LoginWpCom)
     }
 
@@ -463,31 +427,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
     }
 
-    @Test
-    fun `tracks analytics for each step state transition`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(false)
-
-        viewModel.setConnectionSource(ConnectionSource.NOTIFS)
-        viewModel.onStartClick()
-
-        verify(analyticsTrackerWrapper).track(
-            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
-            properties = mapOf(
-                "state" to "started",
-                "source" to "NOTIFS"
-            )
-        )
-
-        viewModel.onWPComLoginCompleted(true)
-
-        verify(analyticsTrackerWrapper).track(
-            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
-            properties = mapOf(
-                "state" to "completed",
-                "source" to "NOTIFS"
-            )
-        )
-    }
 
     @Test
     fun `multiple retries maintain correct step states`() = runTest {
@@ -527,7 +466,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `successful flow completion sets Done button and tracks analytics`() = runTest {
+    fun `successful flow completion sets Done button and removes listener`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(accountStore.accessToken).thenReturn("test_token")
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
@@ -539,7 +478,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         advanceTimeBy(1100)
 
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
-        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
         verify(wpAppNotifierHandler).removeListener(viewModel)
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -36,20 +36,28 @@ import uniffi.wp_api.PluginStatus
 class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var selectedSiteRepository: SelectedSiteRepository
+
     @Mock
     lateinit var accountStore: AccountStore
+
     @Mock
     lateinit var jetpackInstaller: JetpackInstaller
+
     @Mock
     lateinit var jetpackConnector: JetpackConnector
+
     @Mock
     lateinit var jetpackModuleHelper: JetpackStatsModuleHelper
+
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
+
     @Mock
     lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+
     @Mock
     lateinit var wpAppNotifierHandler: WpAppNotifierHandler
+
     @Mock
     lateinit var siteModel: SiteModel
 
@@ -61,11 +69,12 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         private const val TEST_ACCESS_TOKEN = "test_token"
         private const val VALID_JETPACK_VERSION = "14.3" // Above JETPACK_LIMIT_VERSION
         private const val INVALID_JETPACK_VERSION = "14.0" // Below JETPACK_LIMIT_VERSION
-        
+
         // Test timing constants
-        private const val TEST_UI_DELAY_MS = 10L // Fast UI delay for tests
-        private const val TEST_ADVANCE_TIME_MS = 50L // Time to advance for UI delay tests
-        private const val TEST_STEP_TIMEOUT_MS = 46000L // Near STEP_TIMEOUT_MS for timeout testing
+        private const val TEST_UI_DELAY_MS = 10L        // Fast UI delay for tests
+        private const val TEST_ADVANCE_TIME_MS = 50L    // Time to advance for UI delay tests
+        private const val TEST_STEP_TIMEOUT_MS = 100L   // Fast timeout for tests
+        private const val TEST_TIMEOUT_ADVANCE_MS = 150L // Time to advance for timeout tests
     }
 
     @Before
@@ -84,9 +93,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             analyticsTrackerWrapper = analyticsTrackerWrapper,
             wpAppNotifierHandler = wpAppNotifierHandler,
         )
-        
-        // Override UI delay for faster tests
+
+        // Override delays for faster tests
         viewModel.uiDelayMs = TEST_UI_DELAY_MS
+        viewModel.stepTimeoutMs = TEST_STEP_TIMEOUT_MS
     }
 
     @Test
@@ -308,12 +318,12 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `step timeout triggers timeout error`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).doSuspendableAnswer {
-            delay(50000)
+            delay(200L) // Longer than TEST_STEP_TIMEOUT_MS to trigger timeout
             Result.success(PluginStatus.ACTIVE)
         }
 
         viewModel.onStartClick()
-        advanceTimeBy(TEST_STEP_TIMEOUT_MS)
+        advanceTimeBy(TEST_TIMEOUT_ADVANCE_MS)
         advanceUntilIdle()
 
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -61,6 +61,11 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         private const val TEST_ACCESS_TOKEN = "test_token"
         private const val VALID_JETPACK_VERSION = "14.3" // Above JETPACK_LIMIT_VERSION
         private const val INVALID_JETPACK_VERSION = "14.0" // Below JETPACK_LIMIT_VERSION
+        
+        // Test timing constants
+        private const val TEST_UI_DELAY_MS = 10L // Fast UI delay for tests
+        private const val TEST_ADVANCE_TIME_MS = 50L // Time to advance for UI delay tests
+        private const val TEST_STEP_TIMEOUT_MS = 46000L // Near STEP_TIMEOUT_MS for timeout testing
     }
 
     @Before
@@ -79,6 +84,9 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             analyticsTrackerWrapper = analyticsTrackerWrapper,
             wpAppNotifierHandler = wpAppNotifierHandler,
         )
+        
+        // Override UI delay for faster tests
+        viewModel.uiDelayMs = TEST_UI_DELAY_MS
     }
 
     @Test
@@ -117,7 +125,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Failed")))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
@@ -195,7 +203,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.INACTIVE))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
@@ -263,7 +271,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
             .isEqualTo(ConnectionStatus.Completed)
@@ -279,7 +287,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stats failed")))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
             .isEqualTo(ConnectionStatus.Failed)
@@ -305,7 +313,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         }
 
         viewModel.onStartClick()
-        advanceTimeBy(46000)
+        advanceTimeBy(TEST_STEP_TIMEOUT_MS)
         advanceUntilIdle()
 
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
@@ -382,7 +390,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
         verify(wpAppNotifierHandler).removeListener(viewModel)
@@ -394,7 +402,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Failed")))
 
         viewModel.onStartClick()
-        advanceTimeBy(1100)
+        advanceTimeBy(TEST_ADVANCE_TIME_MS)
 
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
@@ -94,18 +93,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
     }
 
-    @Test
-    fun `onCancelDismissed does not change UI state`() = runTest {
-        // Set up a UI event first
-        viewModel.onDoneClick()
-        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
-
-        // Cancel dismissed should not change the UI event
-        viewModel.onCancelDismissed()
-
-        // UI event should remain unchanged
-        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
-    }
 
     @Test
     fun `onRetryClick retries from failed step`() = runTest {
@@ -186,17 +173,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ConnectionStatus.Completed)
     }
 
-    @Test
-    fun `installJetpack step succeeds with network active plugin`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.NETWORK_ACTIVE))
-
-        viewModel.onStartClick()
-        advanceTimeBy(1100)
-
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
-    }
 
     @Test
     fun `installJetpack step fails with inactive plugin`() = runTest {
@@ -212,19 +188,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ErrorType.InstallJetpackInactive)
     }
 
-    @Test
-    fun `installJetpack step fails on exception`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Install failed")))
-
-        viewModel.onStartClick()
-        advanceTimeBy(1100)
-
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
-            .isEqualTo(ErrorType.InstallJetpackFailed)
-    }
 
     @Test
     fun `connectSite step succeeds and updates site ID`() = runTest {
@@ -240,20 +203,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ConnectionStatus.Completed)
     }
 
-    @Test
-    fun `connectSite step fails on exception`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Connect failed")))
-
-        viewModel.onStartClick()
-        advanceTimeBy(1100)
-
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.errorType)
-            .isEqualTo(ErrorType.ConnectSiteFailed)
-    }
 
     @Test
     fun `connectUser step fails without access token`() = runTest {
@@ -289,24 +238,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ConnectionStatus.Completed)
     }
 
-    @Test
-    fun `connectUser step fails on exception`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn("test_token")
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(
-            Result.failure(Exception("User connect failed"))
-        )
-
-        viewModel.onStartClick()
-        advanceTimeBy(1100)
-
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
-            .isEqualTo(ErrorType.ConnectUserFailed)
-    }
 
     @Test
     fun `finalize step succeeds and completes step`() = runTest {
@@ -428,42 +359,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
 
-    @Test
-    fun `multiple retries maintain correct step states`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any()))
-            .thenReturn(Result.failure(Exception("First failure")))
-            .thenReturn(Result.failure(Exception("Second failure")))
-            .thenReturn(Result.success(PluginStatus.ACTIVE))
 
-        viewModel.onStartClick()
-        advanceTimeBy(1100)
-
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
-
-        viewModel.onRetryClick()
-
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
-
-        viewModel.onRetryClick()
-
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
-
-        verify(jetpackInstaller, times(3)).installJetpack(any())
-    }
-
-    @Test
-    fun `UI events are properly reset before setting new value`() = runTest {
-        viewModel.onDoneClick()
-        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
-
-        viewModel.onCloseClick()
-        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
-
-        viewModel.onCloseClick()
-        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
-    }
 
     @Test
     fun `successful flow completion sets Done button and removes listener`() = runTest {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -98,11 +98,11 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         viewModel.uiDelayMs = TEST_UI_DELAY_MS
         viewModel.stepTimeoutMs = TEST_STEP_TIMEOUT_MS
     }
-    
+
     // Helper to assert step status
     private fun assertStepStatus(step: ConnectionStep, expectedStatus: ConnectionStatus, expectedError: ErrorType? = null) {
         assertThat(viewModel.stepStates.value[step]?.status).isEqualTo(expectedStatus)
-        expectedError?.let { 
+        expectedError?.let {
             assertThat(viewModel.stepStates.value[step]?.errorType).isEqualTo(it)
         }
     }
@@ -313,7 +313,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `step timeout triggers timeout error`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).doSuspendableAnswer {
-            delay(200L) // Longer than TEST_STEP_TIMEOUT_MS to trigger timeout
+            delay(TEST_STEP_TIMEOUT_MS + 10L) // Longer than TEST_STEP_TIMEOUT_MS to trigger timeout
             Result.success(PluginStatus.ACTIVE)
         }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -67,7 +67,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         private const val TEST_SITE_ID = 12345UL
         private const val TEST_USER_ID = 67890UL
         private const val TEST_ACCESS_TOKEN = "test_token"
-        private const val VALID_JETPACK_VERSION = "14.3" // Above JETPACK_LIMIT_VERSION
+        private const val VALID_JETPACK_VERSION = "14.3"   // Above JETPACK_LIMIT_VERSION
         private const val INVALID_JETPACK_VERSION = "14.0" // Below JETPACK_LIMIT_VERSION
 
         // Test timing constants
@@ -100,7 +100,11 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     // Helper to assert step status
-    private fun assertStepStatus(step: ConnectionStep, expectedStatus: ConnectionStatus, expectedError: ErrorType? = null) {
+    private fun assertStepStatus(
+        step: ConnectionStep,
+        expectedStatus: ConnectionStatus,
+        expectedError: ErrorType? = null
+    ) {
         assertThat(viewModel.stepStates.value[step]?.status).isEqualTo(expectedStatus)
         expectedError?.let {
             assertThat(viewModel.stepStates.value[step]?.errorType).isEqualTo(it)

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -125,7 +125,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `loginWpCom step completes immediately when already logged in`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
 
         viewModel.onStartClick()
         advanceUntilIdle()
@@ -173,7 +172,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `installJetpack step succeeds with active plugin`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Stop here")))
 
         viewModel.onStartClick()
         advanceUntilIdle()
@@ -237,7 +235,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
         whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
-        whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stop here")))
 
         viewModel.onStartClick()
         advanceUntilIdle()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -11,7 +11,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
@@ -69,27 +68,32 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `setConnectionSource updates connection source`() {
+    fun `setConnectionSource updates connection source for analytics`() = runTest {
         viewModel.setConnectionSource(ConnectionSource.NOTIFS)
-
-        verify(appLogWrapper).d(any(), argThat { contains("Connection source set to: NOTIFS") })
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        
+        viewModel.onStartClick()
+        advanceUntilIdle()
+        
+        // Verify the connection source is used in analytics for the install step
+        verify(analyticsTrackerWrapper).track(
+            stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_INSTALL,
+            properties = mapOf(
+                "state" to "started",
+                "source" to "NOTIFS"
+            )
+        )
     }
 
     @Test
-    fun `onStartClick starts connection flow`() = runTest {
-        whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
+    fun `onStartClick tracks analytics and adds listener`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(false)
 
         viewModel.onStartClick()
-        advanceUntilIdle()
 
         verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         verify(wpAppNotifierHandler).addListener(viewModel)
-        // The buttonType should be Retry since the InstallJetpack step failed
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
-        // After login completes, it should move to InstallJetpack
-        assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
-            .isEqualTo(ConnectionStatus.Completed)
     }
 
     @Test
@@ -124,10 +128,16 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `onCancelDismissed continues connection`() {
+    fun `onCancelDismissed does not change UI state`() = runTest {
+        // Set up a UI event first
+        viewModel.onDoneClick()
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
+        
+        // Cancel dismissed should not change the UI event
         viewModel.onCancelDismissed()
-
-        verify(appLogWrapper).d(any(), argThat { contains("Cancel dismissed, continuing connection") })
+        
+        // UI event should remain unchanged
+        assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
     }
 
     @Test
@@ -163,11 +173,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        // After InstallJetpack fails, currentStep becomes null
-        assertThat(viewModel.currentStep.value).isNull()
-        // But we should have attempted InstallJetpack and it failed
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
     }
 
     @Test
@@ -184,17 +189,12 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `onWPComLoginCompleted with success completes login step`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
 
         viewModel.onStartClick()
         viewModel.onWPComLoginCompleted(true)
-        advanceUntilIdle()
 
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        // After login completes, flow should continue but fail at InstallJetpack
-        assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
     }
 
     @Test
@@ -208,7 +208,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.errorType)
             .isEqualTo(ErrorType.LoginWpComFailed)
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
     }
 
     @Test
@@ -222,9 +221,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        // After InstallJetpack completes, flow should continue but fail at ConnectSite
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
     }
 
     @Test
@@ -279,9 +275,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         verify(siteModel).siteId = 12345L
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        // After ConnectSite completes, flow should continue but fail at ConnectUser
-        assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
     }
 
     @Test
@@ -331,9 +324,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         verify(jetpackConnector).connectUser(eq(siteModel), eq("test_token"))
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        // After ConnectUser completes, flow should continue but fail at Finalize
-        assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
-            .isEqualTo(ConnectionStatus.Failed)
     }
 
     @Test
@@ -354,7 +344,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     }
 
     @Test
-    fun `finalize step succeeds and completes flow`() = runTest {
+    fun `finalize step succeeds and completes step`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(accountStore.accessToken).thenReturn("test_token")
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
@@ -367,9 +357,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
-        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
-        verify(wpAppNotifierHandler).removeListener(viewModel)
     }
 
     @Test
@@ -388,7 +375,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.errorType)
             .isEqualTo(ErrorType.ActivateStatsFailed)
-        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
     }
 
     @Test
@@ -538,6 +524,34 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         viewModel.onCloseClick()
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
+    }
+
+    @Test
+    fun `successful flow completion sets Done button and tracks analytics`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
+
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
+        verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_COMPLETED)
+        verify(wpAppNotifierHandler).removeListener(viewModel)
+    }
+
+    @Test
+    fun `failed flow completion sets Retry button`() = runTest {
+        whenever(accountStore.hasAccessToken()).thenReturn(true)
+        whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Failed")))
+
+        viewModel.onStartClick()
+        advanceTimeBy(1100)
+
+        assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
     }
 
     @Test

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -59,6 +59,8 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         private const val TEST_SITE_ID = 12345UL
         private const val TEST_USER_ID = 67890UL
         private const val TEST_ACCESS_TOKEN = "test_token"
+        private const val VALID_JETPACK_VERSION = "14.3" // Above JETPACK_LIMIT_VERSION
+        private const val INVALID_JETPACK_VERSION = "14.0" // Below JETPACK_LIMIT_VERSION
     }
 
     @Before
@@ -331,7 +333,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { wpApiRestUrl } doReturn "https://example.com/wp-json"
             on { isJetpackConnected } doReturn false
             on { isJetpackInstalled } doReturn true
-            on { jetpackVersion } doReturn "14.3"
+            on { jetpackVersion } doReturn VALID_JETPACK_VERSION
         }
 
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isTrue
@@ -364,7 +366,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { wpApiRestUrl } doReturn "https://example.com/wp-json"
             on { isJetpackConnected } doReturn false
             on { isJetpackInstalled } doReturn true
-            on { jetpackVersion } doReturn "14.0"
+            on { jetpackVersion } doReturn INVALID_JETPACK_VERSION
         }
 
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -55,6 +55,12 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
     private lateinit var viewModel: JetpackRestConnectionViewModel
 
+    companion object {
+        private const val TEST_SITE_ID = 12345UL
+        private const val TEST_USER_ID = 67890UL
+        private const val TEST_ACCESS_TOKEN = "test_token"
+    }
+
     @Before
     fun setup() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
@@ -200,12 +206,12 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `connectSite step succeeds and updates site ID`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
 
         viewModel.onStartClick()
         advanceUntilIdle()
 
-        verify(siteModel).siteId = 12345L
+        verify(siteModel).siteId = TEST_SITE_ID.toLong()
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
             .isEqualTo(ConnectionStatus.Completed)
     }
@@ -217,7 +223,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .thenReturn(true) // Initial check for LoginWpCom
             .thenReturn(false) // Check in ConnectUser step
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
 
         viewModel.onStartClick()
         advanceUntilIdle()
@@ -231,15 +237,15 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `connectUser step succeeds with access token`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(accountStore.accessToken).thenReturn(TEST_ACCESS_TOKEN)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(TEST_USER_ID))
 
         viewModel.onStartClick()
         advanceUntilIdle()
 
-        verify(jetpackConnector).connectUser(eq(siteModel), eq("test_token"))
+        verify(jetpackConnector).connectUser(eq(siteModel), eq(TEST_ACCESS_TOKEN))
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
             .isEqualTo(ConnectionStatus.Completed)
     }
@@ -248,10 +254,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `finalize step succeeds and completes step`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(accountStore.accessToken).thenReturn(TEST_ACCESS_TOKEN)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(TEST_USER_ID))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
 
         viewModel.onStartClick()
@@ -264,10 +270,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `finalize step fails on exception`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(accountStore.accessToken).thenReturn(TEST_ACCESS_TOKEN)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(TEST_USER_ID))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stats failed")))
 
         viewModel.onStartClick()
@@ -367,10 +373,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `successful flow completion sets Done button and removes listener`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
-        whenever(accountStore.accessToken).thenReturn("test_token")
+        whenever(accountStore.accessToken).thenReturn(TEST_ACCESS_TOKEN)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
+        whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(TEST_SITE_ID))
+        whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(TEST_USER_ID))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
 
         viewModel.onStartClick()

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.jetpackrestconnection
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -54,7 +53,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Before
     fun setup() {
         whenever(selectedSiteRepository.getSelectedSite()).thenReturn(siteModel)
-        
+
         viewModel = JetpackRestConnectionViewModel(
             mainDispatcher = UnconfinedTestDispatcher(),
             bgDispatcher = UnconfinedTestDispatcher(),
@@ -72,7 +71,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `setConnectionSource updates connection source`() {
         viewModel.setConnectionSource(ConnectionSource.NOTIFS)
-        
+
         verify(appLogWrapper).d(any(), argThat { contains("Connection source set to: NOTIFS") })
     }
 
@@ -80,10 +79,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `onStartClick starts connection flow`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
         verify(wpAppNotifierHandler).addListener(viewModel)
         // The buttonType should be Retry since the InstallJetpack step failed
@@ -96,38 +95,38 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `onDoneClick sets Done UI event`() = runTest {
         viewModel.onDoneClick()
-        
+
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
     }
 
     @Test
     fun `onCloseClick shows confirmation when connection is active`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        
+
         viewModel.onStartClick()
         viewModel.onCloseClick()
-        
+
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.ShowCancelConfirmation)
     }
 
     @Test
     fun `onCloseClick closes immediately when connection is not active`() = runTest {
         viewModel.onCloseClick()
-        
+
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
     }
 
     @Test
     fun `onCancelConfirmed sets Close UI event`() = runTest {
         viewModel.onCancelConfirmed()
-        
+
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
     }
 
     @Test
     fun `onCancelDismissed continues connection`() {
         viewModel.onCancelDismissed()
-        
+
         verify(appLogWrapper).d(any(), argThat { contains("Cancel dismissed, continuing connection") })
     }
 
@@ -135,17 +134,17 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `onRetryClick retries from failed step`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Failed")))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
-        
+
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
-        
+
         viewModel.onRetryClick()
-        
+
         verify(analyticsTrackerWrapper).track(
             stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STEP_RETRIED,
             properties = mapOf("step" to "InstallJetpack")
@@ -158,10 +157,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `loginWpCom step completes immediately when already logged in`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.Completed)
         // After InstallJetpack fails, currentStep becomes null
@@ -174,9 +173,9 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `loginWpCom step triggers login when not logged in`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        
+
         viewModel.onStartClick()
-        
+
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.StartWPComLogin)
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.InProgress)
@@ -186,11 +185,11 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `onWPComLoginCompleted with success completes login step`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Stop here")))
-        
+
         viewModel.onStartClick()
         viewModel.onWPComLoginCompleted(true)
         advanceUntilIdle()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.Completed)
         // After login completes, flow should continue but fail at InstallJetpack
@@ -201,10 +200,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `onWPComLoginCompleted with failure marks login step as failed`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        
+
         viewModel.onStartClick()
         viewModel.onWPComLoginCompleted(false)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.LoginWpCom]?.errorType)
@@ -217,10 +216,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Stop here")))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Completed)
         // After InstallJetpack completes, flow should continue but fail at ConnectSite
@@ -232,10 +231,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `installJetpack step succeeds with network active plugin`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.NETWORK_ACTIVE))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Completed)
     }
@@ -244,10 +243,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `installJetpack step fails with inactive plugin`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.INACTIVE))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
@@ -258,10 +257,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `installJetpack step fails on exception`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.failure(Exception("Install failed")))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
@@ -273,10 +272,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         verify(siteModel).siteId = 12345L
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
             .isEqualTo(ConnectionStatus.Completed)
@@ -290,10 +289,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(accountStore.hasAccessToken()).thenReturn(true)
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.failure(Exception("Connect failed")))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectSite]?.errorType)
@@ -307,10 +306,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .thenReturn(false) // Check in ConnectUser step
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
@@ -325,10 +324,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
         whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stop here")))
-        
+
         viewModel.onStartClick()
         advanceUntilIdle()
-        
+
         verify(jetpackConnector).connectUser(eq(siteModel), eq("test_token"))
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
             .isEqualTo(ConnectionStatus.Completed)
@@ -344,10 +343,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackInstaller.installJetpack(any())).thenReturn(Result.success(PluginStatus.ACTIVE))
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
         whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.failure(Exception("User connect failed")))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.ConnectUser]?.errorType)
@@ -362,10 +361,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
         whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.success(Unit))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
             .isEqualTo(ConnectionStatus.Completed)
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Done)
@@ -381,10 +380,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         whenever(jetpackConnector.connectSite(any())).thenReturn(Result.success(12345UL))
         whenever(jetpackConnector.connectUser(any(), any())).thenReturn(Result.success(67890UL))
         whenever(jetpackModuleHelper.activateStatsModule(any())).thenReturn(Result.failure(Exception("Stats failed")))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.Finalize]?.errorType)
@@ -395,7 +394,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `onRequestedWithInvalidAuthentication resets and restarts flow`() = runTest {
         viewModel.onRequestedWithInvalidAuthentication("https://example.com")
-        
+
         verify(wpAppNotifierHandler).removeListener(viewModel)
         verify(accountStore).resetAccessToken()
         verify(analyticsTrackerWrapper).track(AnalyticsTracker.Stat.JETPACK_REST_CONNECT_STARTED)
@@ -409,11 +408,11 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             delay(50000)
             Result.success(PluginStatus.ACTIVE)
         }
-        
+
         viewModel.onStartClick()
         advanceTimeBy(46000)
         advanceUntilIdle()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Failed)
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.errorType)
@@ -428,7 +427,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isJetpackConnected } doReturn false
             on { isJetpackInstalled } doReturn false
         }
-        
+
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isTrue
     }
 
@@ -441,7 +440,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isJetpackInstalled } doReturn true
             on { jetpackVersion } doReturn "14.3"
         }
-        
+
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isTrue
     }
 
@@ -453,7 +452,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isJetpackConnected } doReturn false
             on { isJetpackInstalled } doReturn false
         }
-        
+
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
     }
 
@@ -465,7 +464,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isJetpackConnected } doReturn true
             on { isJetpackInstalled } doReturn true
         }
-        
+
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
     }
 
@@ -478,17 +477,17 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isJetpackInstalled } doReturn true
             on { jetpackVersion } doReturn "14.0"
         }
-        
+
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
     }
 
     @Test
     fun `tracks analytics for each step state transition`() = runTest {
         whenever(accountStore.hasAccessToken()).thenReturn(false)
-        
+
         viewModel.setConnectionSource(ConnectionSource.NOTIFS)
         viewModel.onStartClick()
-        
+
         verify(analyticsTrackerWrapper).track(
             stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
             properties = mapOf(
@@ -496,9 +495,9 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
                 "source" to "NOTIFS"
             )
         )
-        
+
         viewModel.onWPComLoginCompleted(true)
-        
+
         verify(analyticsTrackerWrapper).track(
             stat = AnalyticsTracker.Stat.JETPACK_REST_CONNECT_LOGIN,
             properties = mapOf(
@@ -515,21 +514,21 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             .thenReturn(Result.failure(Exception("First failure")))
             .thenReturn(Result.failure(Exception("Second failure")))
             .thenReturn(Result.success(PluginStatus.ACTIVE))
-        
+
         viewModel.onStartClick()
         advanceTimeBy(1100)
-        
+
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
-        
+
         viewModel.onRetryClick()
-        
+
         assertThat(viewModel.buttonType.value).isEqualTo(ButtonType.Retry)
-        
+
         viewModel.onRetryClick()
-        
+
         assertThat(viewModel.stepStates.value[ConnectionStep.InstallJetpack]?.status)
             .isEqualTo(ConnectionStatus.Completed)
-        
+
         verify(jetpackInstaller, times(3)).installJetpack(any())
     }
 
@@ -537,10 +536,10 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `UI events are properly reset before setting new value`() = runTest {
         viewModel.onDoneClick()
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Done)
-        
+
         viewModel.onCloseClick()
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
-        
+
         viewModel.onCloseClick()
         assertThat(viewModel.uiEvent.value).isEqualTo(UiEvent.Close)
     }
@@ -548,7 +547,7 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     @Test
     fun `step states are initialized correctly`() {
         val initialStates = viewModel.stepStates.value
-        
+
         assertThat(initialStates).hasSize(5)
         assertThat(initialStates[ConnectionStep.LoginWpCom]).isEqualTo(StepState())
         assertThat(initialStates[ConnectionStep.InstallJetpack]).isEqualTo(StepState())

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -34,15 +34,24 @@ import uniffi.wp_api.PluginStatus
 
 @ExperimentalCoroutinesApi
 class JetpackRestConnectionViewModelTest : BaseUnitTest() {
-    @Mock lateinit var selectedSiteRepository: SelectedSiteRepository
-    @Mock lateinit var accountStore: AccountStore
-    @Mock lateinit var jetpackInstaller: JetpackInstaller
-    @Mock lateinit var jetpackConnector: JetpackConnector
-    @Mock lateinit var jetpackModuleHelper: JetpackStatsModuleHelper
-    @Mock lateinit var appLogWrapper: AppLogWrapper
-    @Mock lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
-    @Mock lateinit var wpAppNotifierHandler: WpAppNotifierHandler
-    @Mock lateinit var siteModel: SiteModel
+    @Mock
+    lateinit var selectedSiteRepository: SelectedSiteRepository
+    @Mock
+    lateinit var accountStore: AccountStore
+    @Mock
+    lateinit var jetpackInstaller: JetpackInstaller
+    @Mock
+    lateinit var jetpackConnector: JetpackConnector
+    @Mock
+    lateinit var jetpackModuleHelper: JetpackStatsModuleHelper
+    @Mock
+    lateinit var appLogWrapper: AppLogWrapper
+    @Mock
+    lateinit var analyticsTrackerWrapper: AnalyticsTrackerWrapper
+    @Mock
+    lateinit var wpAppNotifierHandler: WpAppNotifierHandler
+    @Mock
+    lateinit var siteModel: SiteModel
 
     private lateinit var viewModel: JetpackRestConnectionViewModel
 
@@ -357,9 +366,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
 
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
     }
-
-
-
 
     @Test
     fun `successful flow completion sets Done button and removes listener`() = runTest {

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -71,9 +71,9 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
         private const val INVALID_JETPACK_VERSION = "14.0" // Below JETPACK_LIMIT_VERSION
 
         // Test timing constants
-        private const val TEST_UI_DELAY_MS = 10L        // Fast UI delay for tests
-        private const val TEST_ADVANCE_TIME_MS = 50L    // Time to advance for UI delay tests
-        private const val TEST_STEP_TIMEOUT_MS = 100L   // Fast timeout for tests
+        private const val TEST_UI_DELAY_MS = 10L         // Fast UI delay for tests
+        private const val TEST_ADVANCE_TIME_MS = 50L     // Time to advance for UI delay tests
+        private const val TEST_STEP_TIMEOUT_MS = 100L    // Fast timeout for tests
         private const val TEST_TIMEOUT_ADVANCE_MS = 150L // Time to advance for timeout tests
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/jetpackrestconnection/JetpackRestConnectionViewModelTest.kt
@@ -448,9 +448,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
     fun `canInitiateJetpackRestConnection returns false for non-self-hosted site`() {
         val site = mock<SiteModel> {
             on { isUsingSelfHostedRestApi } doReturn false
-            on { wpApiRestUrl } doReturn "https://example.com/wp-json"
-            on { isJetpackConnected } doReturn false
-            on { isJetpackInstalled } doReturn false
         }
 
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse
@@ -462,7 +459,6 @@ class JetpackRestConnectionViewModelTest : BaseUnitTest() {
             on { isUsingSelfHostedRestApi } doReturn true
             on { wpApiRestUrl } doReturn "https://example.com/wp-json"
             on { isJetpackConnected } doReturn true
-            on { isJetpackInstalled } doReturn true
         }
 
         assertThat(JetpackRestConnectionViewModel.canInitiateJetpackRestConnection(site)).isFalse

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -18,6 +18,13 @@ public final class AnalyticsTracker {
     public static final String ACTIVITY_LOG_ACTIVITY_ID_KEY = "activity_id";
     public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
+    // These match iOS except for JETPACK_REST_CONNECT_SOURCE_KEY which isn't tracked on iOS
+    public static final String JETPACK_REST_CONNECT_SOURCE_KEY = "source";
+    public static final String JETPACK_REST_CONNECT_STATE_KEY = "state";
+    public static final String JETPACK_REST_CONNECT_STATE_STARTED = "started";
+    public static final String JETPACK_REST_CONNECT_STATE_COMPLETED = "completed";
+    public static final String JETPACK_REST_CONNECT_STATE_FAILED = "failed";
+
     @SuppressWarnings("LineLength")
     public enum Stat {
         // This stat is part of a funnel that provides critical information.  Before

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -18,8 +18,8 @@ public final class AnalyticsTracker {
     public static final String ACTIVITY_LOG_ACTIVITY_ID_KEY = "activity_id";
     public static final String NOTIFICATIONS_SELECTED_FILTER = "selected_filter";
 
-    // These match iOS except for JETPACK_REST_CONNECT_SOURCE_KEY which isn't tracked on iOS
     public static final String JETPACK_REST_CONNECT_SOURCE_KEY = "source";
+    public static final String JETPACK_REST_CONNECT_STATE_STEP_KEY = "step";
     public static final String JETPACK_REST_CONNECT_STATE_KEY = "state";
     public static final String JETPACK_REST_CONNECT_STATE_STARTED = "started";
     public static final String JETPACK_REST_CONNECT_STATE_COMPLETED = "completed";

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -653,6 +653,16 @@ public final class AnalyticsTracker {
         SUPPORT_CHATBOT_TICKET_FAILURE,
         SUPPORT_CHATBOT_ENDED,
 
+        // Jetpack REST connection
+        JETPACK_REST_CONNECT_STARTED,
+        JETPACK_REST_CONNECT_LOGIN,
+        JETPACK_REST_CONNECT_INSTALL,
+        JETPACK_REST_CONNECT_SITE_CONNECTION,
+        JETPACK_REST_CONNECT_USER_CONNECTION,
+        JETPACK_REST_CONNECT_FINALIZE,
+        JETPACK_REST_CONNECT_COMPLETED,
+        JETPACK_REST_CONNECT_STEP_RETRIED,
+
         // these events are for the feedback form, which on iOS was originally part of the
         // in-app review feature.
         APP_REVIEWS_FEEDBACK_SCREEN_OPENED,

--- a/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -653,7 +653,7 @@ public final class AnalyticsTracker {
         SUPPORT_CHATBOT_TICKET_FAILURE,
         SUPPORT_CHATBOT_ENDED,
 
-        // Jetpack REST connection
+        // Jetpack REST connection - these match iOS
         JETPACK_REST_CONNECT_STARTED,
         JETPACK_REST_CONNECT_LOGIN,
         JETPACK_REST_CONNECT_INSTALL,


### PR DESCRIPTION
This PR adds tests for `JetpackRestConnectionViewModel`.

To test, verify CI passes then run through the usual Jetpack REST connection flow steps and verify they still work as expected.