### PR TITLE
Fix: accessibility issues with media pickers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -113,7 +113,12 @@ class MediaPickerViewModel @Inject constructor(
             buildSoftAskView(softAskRequest),
             FabUiModel(mediaPickerSetup.cameraSetup != HIDDEN && selectedIds.isNullOrEmpty(), this::clickOnCamera),
             buildActionModeUiModel(selectedIds, domainModel?.domainItems),
-            buildSearchUiModel(domainModel?.emptyState == null, softAskRequest?.let { !it.show } ?: true, domainModel?.filter, searchExpanded),
+            buildSearchUiModel(
+                isContentToSearch = domainModel?.emptyState == null,
+                isVisible = softAskRequest?.let { !it.show } ?: true,
+                filter = domainModel?.filter,
+                searchExpanded = searchExpanded
+            ),
             !domainModel?.domainItems.isNullOrEmpty() && domainModel?.isLoading == true,
             buildBrowseMenuUiModel(softAskRequest, searchExpanded),
             progressDialogUiModel ?: Hidden,

--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/MediaPickerViewModel.kt
@@ -113,7 +113,7 @@ class MediaPickerViewModel @Inject constructor(
             buildSoftAskView(softAskRequest),
             FabUiModel(mediaPickerSetup.cameraSetup != HIDDEN && selectedIds.isNullOrEmpty(), this::clickOnCamera),
             buildActionModeUiModel(selectedIds, domainModel?.domainItems),
-            buildSearchUiModel(softAskRequest?.let { !it.show } ?: true, domainModel?.filter, searchExpanded),
+            buildSearchUiModel(domainModel?.emptyState == null, softAskRequest?.let { !it.show } ?: true, domainModel?.filter, searchExpanded),
             !domainModel?.domainItems.isNullOrEmpty() && domainModel?.isLoading == true,
             buildBrowseMenuUiModel(softAskRequest, searchExpanded),
             progressDialogUiModel ?: Hidden,
@@ -121,8 +121,14 @@ class MediaPickerViewModel @Inject constructor(
         )
     }
 
-    private fun buildSearchUiModel(isVisible: Boolean, filter: String?, searchExpanded: Boolean?): SearchUiModel {
+    private fun buildSearchUiModel(
+        isContentToSearch: Boolean,
+        isVisible: Boolean,
+        filter: String?,
+        searchExpanded: Boolean?
+    ): SearchUiModel {
         return when {
+            !isContentToSearch -> SearchUiModel.Hidden
             searchExpanded == true -> SearchUiModel.Expanded(filter ?: "", !mediaPickerSetup.defaultSearchView)
             isVisible -> SearchUiModel.Collapsed
             else -> SearchUiModel.Hidden

--- a/WordPress/src/main/res/layout/actionable_empty_view.xml
+++ b/WordPress/src/main/res/layout/actionable_empty_view.xml
@@ -23,7 +23,7 @@
                 android:layout_marginTop="@dimen/margin_extra_large"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 android:adjustViewBounds="true"
-                android:contentDescription="@string/content_description_person_reading_device_notification"
+                android:contentDescription="@string/content_description_empty_view"
                 android:visibility="gone"
                 tool:src="@drawable/img_illustration_empty_results_216dp"
                 tool:visibility="visible" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1582,6 +1582,7 @@
     <string name="notifications_jetpack_connection_setup_info">To get helpful notifications on your device from your WordPress site, you\'ll need to install the Jetpack plugin. Would you like to set up Jetpack?</string>
     <string name="notifications_empty_view_reader">Go to Reader</string>
     <string name="content_description_person_reading_device_notification">Person reading device with notifications</string>
+    <string name="content_description_empty_view">Image illustrating that the view is empty</string>
     <string name="older_two_days">Older than 2 days</string>
     <string name="older_last_week">Older than a week</string>
     <string name="older_month">Older than a month</string>


### PR DESCRIPTION
## Description
There were some accessibility issues with MediaPicker when the media view was empty because of connectivity issues, or just because there was no media:

1. The image alt text did not correspond with the scenario
    - Solution: Add a better alt text, specifying that there's an image indicating there's no media to show.
2. The title and button were not reachable when the search action was expanded
    - Solution: It doesn't make sense to show the search action if there's no media to search, so we have just hidden it in those scenarios.

## Testing instructions

1. Create a post
2. Cut the internet access
3. Add an image with a remote media picker
- [x] Verify you see the "no connection" message and the search action is not present
4. Enable internet access again or open a media library with images in it
- [ ] Verify you see the images and the search action


https://github.com/user-attachments/assets/59074c39-b087-4a3a-b8e7-883f0a696a80


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->