### PR TITLE
feat: Enable GutenbergKit remote editor for Jetpack-connected sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2278,7 +2278,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
 
             val isWpCom = site.isWPCom || siteModel.isWPComAtomic
             val gutenbergWebViewAuthorizationData = createGutenbergWebViewAuthorizationData(isWpCom)
-            val settings = createGutenbergKitSettings(isWpCom)
+            val settings = createGutenbergKitSettings()
 
             return GutenbergKitEditorFragment.newInstance(
                 getContext(),
@@ -2306,7 +2306,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
             )
         }
 
-        private fun createGutenbergKitSettings(isWpCom: Boolean): MutableMap<String, Any?> {
+        private fun createGutenbergKitSettings(): MutableMap<String, Any?> {
             val postType = if (editPostRepository.isPage) "page" else "post"
             val siteURL = siteModel.url
             val applicationPassword = siteModel.apiRestPasswordPlain

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2335,9 +2335,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 "authHeader" to authHeader,
                 "siteApiNamespace" to siteApiNamespace,
                 "themeStyles" to experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES),
-                // Limited to Jetpack-connected sites until editor assets endpoint is available in WordPress core
-                "plugins" to (gutenbergKitPluginsFeature.isEnabled() &&
-                    (site.isWPCom || (site.isJetpackConnected && !applicationPassword.isNullOrEmpty()))),
+                "plugins" to shouldUsePlugins(applicationPassword),
                 "locale" to wpcomLocaleSlug,
                 "cookies" to editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
                 "webViewGlobals" to listOf(
@@ -2351,6 +2349,17 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                     )
                 )
             )
+        }
+
+        // Returns true if the plugins should be enabled for the given blog.
+        // This is used to determine if the editor should load third-party
+        // plugins providing blocks.
+        private fun shouldUsePlugins(applicationPassword: String?): Boolean {
+            // Requires a Jetpack until editor assets endpoint is available in WordPress core.
+            // Requires a WP.com Simple site or an application password to authenticate all REST
+            // API requests, including those originating from non-core blocks.
+            return gutenbergKitPluginsFeature.isEnabled() &&
+                (site.isWPCom || (site.isJetpackConnected && !applicationPassword.isNullOrEmpty()))
         }
 
         override fun instantiateItem(container: ViewGroup, position: Int): Any {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -12,6 +12,7 @@ import android.os.Handler
 import android.os.Looper
 import android.preference.PreferenceManager
 import android.text.Editable
+import android.util.Base64
 import android.text.TextUtils
 import android.view.Menu
 import android.view.MenuItem
@@ -2308,11 +2309,15 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
         private fun createGutenbergKitSettings(isWpCom: Boolean): MutableMap<String, Any?> {
             val postType = if (editPostRepository.isPage) "page" else "post"
             val siteURL = siteModel.url
-            val siteApiRoot = if (isWpCom) "https://public-api.wordpress.com/"
+            val applicationPassword = siteModel.apiRestPasswordPlain
+            val shouldUseWPComRestApi = applicationPassword.isNullOrEmpty() && siteModel.isUsingWpComRestApi
+
+            val siteApiRoot = if (shouldUseWPComRestApi) "https://public-api.wordpress.com/"
                 else siteModel.wpApiRestUrl ?: "$siteURL/wp-json/"
-            // Use the application password for self-hosted sites when available
-            val authHeader = if (isWpCom) "Bearer ${accountStore.accessToken}" else "Basic "
-            val siteApiNamespace = if (isWpCom)
+            val authHeader = if
+                (shouldUseWPComRestApi) "Bearer ${accountStore.accessToken}"
+                else "Basic ${Base64.encodeToString("${site.apiRestUsernamePlain}:${applicationPassword}".toByteArray(), Base64.NO_WRAP)}"
+            val siteApiNamespace = if (shouldUseWPComRestApi)
                 arrayOf("sites/${site.siteId}/", "sites/${UrlUtils.removeScheme(siteURL)}/")
                 else arrayOf()
 
@@ -2330,8 +2335,9 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 "authHeader" to authHeader,
                 "siteApiNamespace" to siteApiNamespace,
                 "themeStyles" to experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES),
-                // Limited to Simple sites until application passwords are supported
-                "plugins" to (gutenbergKitPluginsFeature.isEnabled() && site.isWPCom),
+                // Limited to Jetpack-connected sites until editor assets endpoint is available in WordPress core
+                "plugins" to (gutenbergKitPluginsFeature.isEnabled() &&
+                    (site.isWPCom || (site.isJetpackConnected && !applicationPassword.isNullOrEmpty()))),
                 "locale" to wpcomLocaleSlug,
                 "cookies" to editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
                 "webViewGlobals" to listOf(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2316,7 +2316,10 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorFragmentActivity, Ed
                 else siteModel.wpApiRestUrl ?: "$siteURL/wp-json/"
             val authHeader = if
                 (shouldUseWPComRestApi) "Bearer ${accountStore.accessToken}"
-                else "Basic ${Base64.encodeToString("${site.apiRestUsernamePlain}:${applicationPassword}".toByteArray(), Base64.NO_WRAP)}"
+                else {
+                    val credentials = "${site.apiRestUsernamePlain}:${applicationPassword}"
+                    "Basic ${Base64.encodeToString(credentials.toByteArray(), Base64.NO_WRAP)}"
+                }
             val siteApiNamespace = if (shouldUseWPComRestApi)
                 arrayOf("sites/${site.siteId}/", "sites/${UrlUtils.removeScheme(siteURL)}/")
                 else arrayOf()


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-673. 

Enable the remote editor (non-core block support) for all Jetpack-connected sites that either (A) are a WP.com Simple site or (B) have an application password. A Jetpack connection is required until the editor assets endpoint is available in WordPress Core. A WP.com Simple site or application password is required for authenticating all REST API requests, including those originating from non-core blocks. 

Mirrors WP-iOS changes in https://github.com/wordpress-mobile/WordPress-iOS/pull/24751. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
> [!tip]
> Use a fresh app install to avoid lingering application passwords. 

### 1. Plugins disabled for unsupported site types
1. Enable the _Experimental block editor_ experimental features toggle. 
2. Enable the _Experimental block editor plugins_ debug feature flag. 
3. Use an Atomic (WoW) site **without an application password.** 
4. Open the editor. 
5. Verify non-core blocks are unavailable. 
6. Repeat steps 3–4 for a Jetpack-connected, self-hosted site (e.g., JN site) **without an application password.** 

### 2. Plugins enabled for supported site types
1. Enable the _Experimental block editor_ experimental features toggle. 
2. Enable the _Experimental block Editor plugins_ debug feature flag. 
3. Use an Atomic (WoW) site. 
4. Create an application password for the site. 
5. Open the editor. 
6. Verify non-core blocks are available. 
7. Repeat steps 3–5 for a Jetpack-connected, self-hosted site (e.g., JN site). 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
