### PR TITLE
Fix: #21432: Prevent voice-to-content BottomSheet overlap with navigation bar…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/voicetocontent/VoiceToContentScreen.kt
@@ -18,6 +18,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -82,7 +86,9 @@ fun VoiceToContentScreen(
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .nestedScroll(rememberNestedScrollInteropConnection()) // Enable nested scrolling for the bottom sheet
-                .verticalScroll(rememberScrollState()) // Enable vertical scrolling for the bottom sheet
+                .windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)) // Only bottom insets
+                .imePadding() // Add IME (keyboard) padding if needed
+                .navigationBarsPadding() // Prevent overlap with system navigation bars
         ) {
             VoiceToContentView(state, recordingUpdate, isRecording)
         }


### PR DESCRIPTION
Prevent voice-to-content BottomSheet overlap with navigation bar and keyboard (closes #21432)

- Use windowInsetsPadding(WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)) and imePadding for robust system UI handling in Compose
- Ensures BottomSheet is not obscured on small screens or with keyboard open

Refs: #21432

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->