### PR TITLE
fix: Prevent Media Library null pointer exceptions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mediapicker/loader/MediaLibraryDataSource.kt
@@ -131,7 +131,7 @@ class MediaLibraryDataSource(
                 mediaModel.title,
                 mediaType,
                 mediaModel.mimeType,
-                mediaModel.uploadDate?.let { dateTimeUtilsWrapper.dateFromIso8601(it).time } ?: 0L
+                mediaModel.uploadDate?.let { dateTimeUtilsWrapper.dateFromIso8601(it)?.time } ?: 0L
             )
         }
     }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Specific reproduction steps were elusive, but opening the media library
in the GutenbergKit editor sometimes led to a crash. Specifically, it
occurred after running the app on a newly-created emulator.

This change also updates the logic to align with guard logic found in
other portions of the codebase—e.g., PublishSettingsViewModel.

```
FATAL EXCEPTION: main (Ask Gemini)
Process: com.jetpack.android.beta, PID: 2916
java.lang.NullPointerException: Attempt to invoke virtual method 'long java.util.Date.getTime()' on a null object reference
	at org.wordpress.android.ui.mediapicker.loader.MediaLibraryDataSource.toMediaItems(MediaLibraryDataSource.kt:134)
	at org.wordpress.android.ui.mediapicker.loader.MediaLibraryDataSource.getFromDatabase(MediaLibraryDataSource.kt:145)
	at org.wordpress.android.ui.mediapicker.loader.MediaLibraryDataSource.access$getFromDatabase(MediaLibraryDataSource.kt:39)
	at org.wordpress.android.ui.mediapicker.loader.MediaLibraryDataSource$get$2$1$1.invokeSuspend(MediaLibraryDataSource.kt:114)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Insert a media block into the editor.
1. Open the media library.
1. Verify:
    1. The app does not crash;
    1. That media can be inserted;
    1. That the media library can be dismissed without selection.

Other areas worth smoke testing:

  - Browsing the WordPress media library
  - Searching for media in the library
  - Adding media to posts/pages from the WordPress library
  - Setting featured images from the library
  - Upload/manage site icons

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
