### PR TITLE
Refactor: Move GutenbergKit configuration logic to appropriate locations

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2232,14 +2232,14 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 accountUserId = accountStore.account.userId,
                 accountUserName = accountStore.account.userName,
                 userAgent = userAgent,
-                isJetpackSsoEnabled = isJetpackSsoEnabled,
-                featureConfig = featureConfig
+                isJetpackSsoEnabled = isJetpackSsoEnabled
             )
 
             val config = GutenbergKitSettingsBuilder.GutenbergKitConfig(
                 siteConfig = siteConfig,
                 postConfig = postConfig,
-                appConfig = appConfig
+                appConfig = appConfig,
+                featureConfig = featureConfig
             )
 
             return GutenbergKitEditorFragment.newInstanceWithBuilder(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2209,10 +2209,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 onXpostsSettingsCapability(isXpostsCapable)
             }
 
-            val siteConfig = GutenbergKitSettingsBuilder.SiteConfig.fromSiteModel(
-                siteModel,
-                site.siteId
-            )
+            val siteConfig = GutenbergKitSettingsBuilder.SiteConfig.fromSiteModel(siteModel)
 
             val postConfig = GutenbergKitSettingsBuilder.PostConfig.fromPostModel(
                 editPostRepository.getPost()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -65,7 +65,6 @@ import org.wordpress.android.editor.EditorImageSettingsListener
 import org.wordpress.android.editor.ExceptionLogger
 import org.wordpress.android.editor.gutenberg.DialogVisibility
 import org.wordpress.android.ui.posts.editor.GutenbergKitEditorFragment
-import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
 import org.wordpress.android.fluxc.Dispatcher
@@ -105,8 +104,6 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPrivateAtomicCookieFetched
 import org.wordpress.android.fluxc.store.UploadStore
 import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
 import org.wordpress.android.fluxc.tools.FluxCImageLoader
-import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
-import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment
 import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.EditImageData.InputData
 import org.wordpress.android.support.ZendeskHelper
@@ -2212,74 +2209,40 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 onXpostsSettingsCapability(isXpostsCapable)
             }
 
-            val isWpCom = site.isWPCom || siteModel.isWPComAtomic
-            val gutenbergWebViewAuthorizationData = createGutenbergWebViewAuthorizationData(isWpCom)
-            val settings = createGutenbergKitSettings()
-
-            return GutenbergKitEditorFragment.newInstance(
-                getContext(),
-                isNewPost,
-                gutenbergWebViewAuthorizationData,
-                jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
-                settings
-            )
-        }
-
-        private fun createGutenbergWebViewAuthorizationData(isWpCom: Boolean): GutenbergWebViewAuthorizationData {
-            return GutenbergWebViewAuthorizationData(
-                siteModel.url,
-                isWpCom,
-                accountStore.account.userId,
-                accountStore.account.userName,
-                accountStore.accessToken,
-                siteModel.selfHostedSiteId,
-                siteModel.getUserNameProcessed(),
-                siteModel.getPasswordProcessed(),
-                siteModel.isUsingWpComRestApi,
-                siteModel.webEditor,
-                userAgent.toString(),
-                isJetpackSsoEnabled
-            )
-        }
-
-        private fun createGutenbergKitSettings(): MutableMap<String, Any?> {
-            val siteConfig = GutenbergKitSettingsBuilder.SiteConfig(
-                url = siteModel.url,
-                siteId = site.siteId,
-                isWPCom = site.isWPCom,
-                isWPComAtomic = siteModel.isWPComAtomic,
-                isJetpackConnected = site.isJetpackConnected,
-                isUsingWpComRestApi = siteModel.isUsingWpComRestApi,
-                wpApiRestUrl = siteModel.wpApiRestUrl,
-                apiRestUsernamePlain = site.apiRestUsernamePlain,
-                apiRestPasswordPlain = siteModel.apiRestPasswordPlain
+            val siteConfig = GutenbergKitSettingsBuilder.SiteConfig.fromSiteModel(
+                siteModel,
+                site.siteId
             )
 
-            val postConfig = GutenbergKitSettingsBuilder.PostConfig(
-                remotePostId = editPostRepository.getPost()?.remotePostId,
-                isPage = editPostRepository.isPage,
-                title = editPostRepository.getPost()?.title,
-                content = editPostRepository.getPost()?.content
+            val postConfig = GutenbergKitSettingsBuilder.PostConfig.fromPostModel(
+                editPostRepository.getPost()
             )
 
-            val featureConfig = GutenbergKitSettingsBuilder.FeatureConfig(
+            val appConfig = GutenbergKitSettingsBuilder.AppConfig(
+                accessToken = accountStore.accessToken,
+                locale = perAppLocaleManager.getCurrentLocaleLanguageCode(),
+                cookies = editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie),
+                accountUserId = accountStore.account.userId,
+                accountUserName = accountStore.account.userName,
+                userAgent = userAgent,
+                isJetpackSsoEnabled = isJetpackSsoEnabled,
                 isPluginsFeatureEnabled = gutenbergKitPluginsFeature.isEnabled(),
                 isThemeStylesFeatureEnabled = experimentalFeatures.isEnabled(
                     Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
                 )
             )
 
-            val appConfig = GutenbergKitSettingsBuilder.AppConfig(
-                accessToken = accountStore.accessToken,
-                locale = perAppLocaleManager.getCurrentLocaleLanguageCode(),
-                cookies = editPostAuthViewModel.getCookiesForPrivateSites(site, privateAtomicCookie)
-            )
-
-            return GutenbergKitSettingsBuilder.buildSettings(
+            val config = GutenbergKitSettingsBuilder.GutenbergKitConfig(
                 siteConfig = siteConfig,
                 postConfig = postConfig,
-                appConfig = appConfig,
-                featureConfig = featureConfig
+                appConfig = appConfig
+            )
+
+            return GutenbergKitEditorFragment.newInstanceWithBuilder(
+                getContext(),
+                isNewPost,
+                jetpackFeatureRemovalPhaseHelper.shouldShowJetpackPoweredEditorFeatures(),
+                config
             )
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -2218,6 +2218,13 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 editPostRepository.getPost()
             )
 
+            val featureConfig = GutenbergKitSettingsBuilder.FeatureConfig(
+                isPluginsFeatureEnabled = gutenbergKitPluginsFeature.isEnabled(),
+                isThemeStylesFeatureEnabled = experimentalFeatures.isEnabled(
+                    Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
+                )
+            )
+
             val appConfig = GutenbergKitSettingsBuilder.AppConfig(
                 accessToken = accountStore.accessToken,
                 locale = perAppLocaleManager.getCurrentLocaleLanguageCode(),
@@ -2226,10 +2233,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
                 accountUserName = accountStore.account.userName,
                 userAgent = userAgent,
                 isJetpackSsoEnabled = isJetpackSsoEnabled,
-                isPluginsFeatureEnabled = gutenbergKitPluginsFeature.isEnabled(),
-                isThemeStylesFeatureEnabled = experimentalFeatures.isEnabled(
-                    Feature.EXPERIMENTAL_BLOCK_EDITOR_THEME_STYLES
-                )
+                featureConfig = featureConfig
             )
 
             val config = GutenbergKitSettingsBuilder.GutenbergKitConfig(

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -73,14 +73,14 @@ object GutenbergKitSettingsBuilder {
         val accountUserId: Long,
         val accountUserName: String?,
         val userAgent: UserAgent,
-        val isJetpackSsoEnabled: Boolean,
-        val featureConfig: FeatureConfig
+        val isJetpackSsoEnabled: Boolean
     )
 
     data class GutenbergKitConfig(
         val siteConfig: SiteConfig,
         val postConfig: PostConfig,
-        val appConfig: AppConfig
+        val appConfig: AppConfig,
+        val featureConfig: FeatureConfig
     )
 
     /**
@@ -94,7 +94,8 @@ object GutenbergKitSettingsBuilder {
     fun buildSettings(
         siteConfig: SiteConfig,
         postConfig: PostConfig,
-        appConfig: AppConfig
+        appConfig: AppConfig,
+        featureConfig: FeatureConfig
     ): MutableMap<String, Any?> {
         val applicationPassword = siteConfig.apiRestPasswordPlain
         val shouldUseWPComRestApi = applicationPassword.isNullOrEmpty() && siteConfig.isUsingWpComRestApi
@@ -125,9 +126,9 @@ object GutenbergKitSettingsBuilder {
             "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
             "authHeader" to authHeader,
             "siteApiNamespace" to siteApiNamespace,
-            "themeStyles" to appConfig.featureConfig.isThemeStylesFeatureEnabled,
+            "themeStyles" to featureConfig.isThemeStylesFeatureEnabled,
             "plugins" to shouldUsePlugins(
-                isFeatureEnabled = appConfig.featureConfig.isPluginsFeatureEnabled,
+                isFeatureEnabled = featureConfig.isPluginsFeatureEnabled,
                 isWPComSite = siteConfig.isWPCom,
                 isJetpackConnected = siteConfig.isJetpackConnected,
                 applicationPassword = applicationPassword

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -61,6 +61,10 @@ object GutenbergKitSettingsBuilder {
         }
     }
 
+    data class FeatureConfig(
+        val isPluginsFeatureEnabled: Boolean,
+        val isThemeStylesFeatureEnabled: Boolean
+    )
 
     data class AppConfig(
         val accessToken: String?,
@@ -70,8 +74,7 @@ object GutenbergKitSettingsBuilder {
         val accountUserName: String?,
         val userAgent: UserAgent,
         val isJetpackSsoEnabled: Boolean,
-        val isPluginsFeatureEnabled: Boolean,
-        val isThemeStylesFeatureEnabled: Boolean
+        val featureConfig: FeatureConfig
     )
 
     data class GutenbergKitConfig(
@@ -122,9 +125,9 @@ object GutenbergKitSettingsBuilder {
             "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
             "authHeader" to authHeader,
             "siteApiNamespace" to siteApiNamespace,
-            "themeStyles" to appConfig.isThemeStylesFeatureEnabled,
+            "themeStyles" to appConfig.featureConfig.isThemeStylesFeatureEnabled,
             "plugins" to shouldUsePlugins(
-                isFeatureEnabled = appConfig.isPluginsFeatureEnabled,
+                isFeatureEnabled = appConfig.featureConfig.isPluginsFeatureEnabled,
                 isWPComSite = siteConfig.isWPCom,
                 isJetpackConnected = siteConfig.isJetpackConnected,
                 applicationPassword = applicationPassword

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -21,7 +21,9 @@ object GutenbergKitSettingsBuilder {
         val isUsingWpComRestApi: Boolean,
         val wpApiRestUrl: String?,
         val apiRestUsernamePlain: String?,
-        val apiRestPasswordPlain: String?
+        val apiRestPasswordPlain: String?,
+        val selfHostedSiteId: Long,
+        val webEditor: String
     ) {
         companion object {
             fun fromSiteModel(site: SiteModel): SiteConfig {
@@ -34,7 +36,9 @@ object GutenbergKitSettingsBuilder {
                     isUsingWpComRestApi = site.isUsingWpComRestApi,
                     wpApiRestUrl = site.wpApiRestUrl,
                     apiRestUsernamePlain = site.apiRestUsernamePlain,
-                    apiRestPasswordPlain = site.apiRestPasswordPlain
+                    apiRestPasswordPlain = site.apiRestPasswordPlain,
+                    selfHostedSiteId = site.selfHostedSiteId,
+                    webEditor = site.webEditor
                 )
             }
         }
@@ -203,11 +207,11 @@ object GutenbergKitSettingsBuilder {
             appConfig.accountUserId,
             appConfig.accountUserName,
             appConfig.accessToken,
-            if (siteConfig.isWPCom) 0 else siteConfig.siteId,
+            siteConfig.selfHostedSiteId,
             siteConfig.apiRestUsernamePlain,
             siteConfig.apiRestPasswordPlain,
             siteConfig.isUsingWpComRestApi,
-            "", // webEditor - not used in current implementation
+            siteConfig.webEditor,
             appConfig.userAgent.toString(),
             appConfig.isJetpackSsoEnabled
         )

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -1,6 +1,10 @@
 package org.wordpress.android.ui.posts
 
 import android.util.Base64
+import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
+import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
+import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 
@@ -18,24 +22,62 @@ object GutenbergKitSettingsBuilder {
         val wpApiRestUrl: String?,
         val apiRestUsernamePlain: String?,
         val apiRestPasswordPlain: String?
-    )
+    ) {
+        companion object {
+            fun fromSiteModel(
+                site: org.wordpress.android.fluxc.model.SiteModel,
+                siteId: Long
+            ): SiteConfig {
+                return SiteConfig(
+                    url = site.url,
+                    siteId = siteId,
+                    isWPCom = site.isWPCom,
+                    isWPComAtomic = site.isWPComAtomic,
+                    isJetpackConnected = site.isJetpackConnected,
+                    isUsingWpComRestApi = site.isUsingWpComRestApi,
+                    wpApiRestUrl = site.wpApiRestUrl,
+                    apiRestUsernamePlain = site.getUserNameProcessed(),
+                    apiRestPasswordPlain = site.getPasswordProcessed()
+                )
+            }
+        }
+    }
 
     data class PostConfig(
         val remotePostId: Long?,
         val isPage: Boolean,
         val title: String?,
         val content: String?
-    )
+    ) {
+        companion object {
+            fun fromPostModel(postModel: org.wordpress.android.fluxc.model.PostImmutableModel?): PostConfig {
+                return PostConfig(
+                    remotePostId = postModel?.remotePostId,
+                    isPage = postModel?.isPage ?: false,
+                    title = postModel?.title,
+                    content = postModel?.content
+                )
+            }
+        }
+    }
 
-    data class FeatureConfig(
-        val isPluginsFeatureEnabled: Boolean,
-        val isThemeStylesFeatureEnabled: Boolean
-    )
 
     data class AppConfig(
         val accessToken: String?,
         val locale: String,
-        val cookies: Any?
+        val cookies: Any?,
+        val accountUserId: Long,
+        val accountUserName: String?,
+        val userAgent: UserAgent,
+        val isJetpackSsoEnabled: Boolean,
+        val isPluginsFeatureEnabled: Boolean,
+        val isThemeStylesFeatureEnabled: Boolean
+    )
+
+    data class GutenbergKitConfig(
+        val siteConfig: SiteConfig,
+        val postConfig: PostConfig,
+        val appConfig: AppConfig
     )
 
     /**
@@ -49,8 +91,7 @@ object GutenbergKitSettingsBuilder {
     fun buildSettings(
         siteConfig: SiteConfig,
         postConfig: PostConfig,
-        appConfig: AppConfig,
-        featureConfig: FeatureConfig
+        appConfig: AppConfig
     ): MutableMap<String, Any?> {
         val applicationPassword = siteConfig.apiRestPasswordPlain
         val shouldUseWPComRestApi = applicationPassword.isNullOrEmpty() && siteConfig.isUsingWpComRestApi
@@ -81,9 +122,9 @@ object GutenbergKitSettingsBuilder {
             "namespaceExcludedPaths" to arrayOf("/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"),
             "authHeader" to authHeader,
             "siteApiNamespace" to siteApiNamespace,
-            "themeStyles" to featureConfig.isThemeStylesFeatureEnabled,
+            "themeStyles" to appConfig.isThemeStylesFeatureEnabled,
             "plugins" to shouldUsePlugins(
-                isFeatureEnabled = featureConfig.isPluginsFeatureEnabled,
+                isFeatureEnabled = appConfig.isPluginsFeatureEnabled,
                 isWPComSite = siteConfig.isWPCom,
                 isJetpackConnected = siteConfig.isJetpackConnected,
                 applicationPassword = applicationPassword
@@ -146,5 +187,28 @@ object GutenbergKitSettingsBuilder {
         // 2. Jetpack-connected sites with application passwords (when feature is enabled)
         return isFeatureEnabled &&
                 (isWPComSite || (isJetpackConnected && !applicationPassword.isNullOrEmpty()))
+    }
+
+    /**
+     * Builds Gutenberg WebView authorization data for the fragment.
+     */
+    fun buildAuthorizationData(
+        siteConfig: SiteConfig,
+        appConfig: AppConfig
+    ): GutenbergWebViewAuthorizationData {
+        return GutenbergWebViewAuthorizationData(
+            siteConfig.url,
+            siteConfig.isWPCom || siteConfig.isWPComAtomic,
+            appConfig.accountUserId,
+            appConfig.accountUserName,
+            appConfig.accessToken,
+            if (siteConfig.isWPCom) 0 else siteConfig.siteId,
+            siteConfig.apiRestUsernamePlain,
+            siteConfig.apiRestPasswordPlain,
+            siteConfig.isUsingWpComRestApi,
+            "", // webEditor - not used in current implementation
+            appConfig.userAgent.toString(),
+            appConfig.isJetpackSsoEnabled
+        )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.posts
 
 import android.util.Base64
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
+import org.wordpress.android.fluxc.model.PostImmutableModel
+import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
-import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
-import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 
@@ -24,20 +24,17 @@ object GutenbergKitSettingsBuilder {
         val apiRestPasswordPlain: String?
     ) {
         companion object {
-            fun fromSiteModel(
-                site: org.wordpress.android.fluxc.model.SiteModel,
-                siteId: Long
-            ): SiteConfig {
+            fun fromSiteModel(site: SiteModel): SiteConfig {
                 return SiteConfig(
                     url = site.url,
-                    siteId = siteId,
+                    siteId = site.siteId,
                     isWPCom = site.isWPCom,
                     isWPComAtomic = site.isWPComAtomic,
                     isJetpackConnected = site.isJetpackConnected,
                     isUsingWpComRestApi = site.isUsingWpComRestApi,
                     wpApiRestUrl = site.wpApiRestUrl,
-                    apiRestUsernamePlain = site.getUserNameProcessed(),
-                    apiRestPasswordPlain = site.getPasswordProcessed()
+                    apiRestUsernamePlain = site.apiRestUsernamePlain,
+                    apiRestPasswordPlain = site.apiRestPasswordPlain
                 )
             }
         }
@@ -50,7 +47,7 @@ object GutenbergKitSettingsBuilder {
         val content: String?
     ) {
         companion object {
-            fun fromPostModel(postModel: org.wordpress.android.fluxc.model.PostImmutableModel?): PostConfig {
+            fun fromPostModel(postModel: PostImmutableModel?): PostConfig {
                 return PostConfig(
                     remotePostId = postModel?.remotePostId,
                     isPage = postModel?.isPage ?: false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -5,6 +5,8 @@ import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.fluxc.model.PostImmutableModel
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.fluxc.network.UserAgent
+import org.wordpress.android.fluxc.utils.extensions.getPasswordProcessed
+import org.wordpress.android.fluxc.utils.extensions.getUserNameProcessed
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.UrlUtils
 
@@ -23,7 +25,9 @@ object GutenbergKitSettingsBuilder {
         val apiRestUsernamePlain: String?,
         val apiRestPasswordPlain: String?,
         val selfHostedSiteId: Long,
-        val webEditor: String
+        val webEditor: String,
+        val apiRestUsernameProcessed: String?,
+        val apiRestPasswordProcessed: String?
     ) {
         companion object {
             fun fromSiteModel(site: SiteModel): SiteConfig {
@@ -38,7 +42,9 @@ object GutenbergKitSettingsBuilder {
                     apiRestUsernamePlain = site.apiRestUsernamePlain,
                     apiRestPasswordPlain = site.apiRestPasswordPlain,
                     selfHostedSiteId = site.selfHostedSiteId,
-                    webEditor = site.webEditor
+                    webEditor = site.webEditor,
+                    apiRestUsernameProcessed = site.getUserNameProcessed(),
+                    apiRestPasswordProcessed = site.getPasswordProcessed()
                 )
             }
         }
@@ -208,8 +214,8 @@ object GutenbergKitSettingsBuilder {
             appConfig.accountUserName,
             appConfig.accessToken,
             siteConfig.selfHostedSiteId,
-            siteConfig.apiRestUsernamePlain,
-            siteConfig.apiRestPasswordPlain,
+            siteConfig.apiRestUsernameProcessed,
+            siteConfig.apiRestPasswordProcessed,
             siteConfig.isUsingWpComRestApi,
             siteConfig.webEditor,
             appConfig.userAgent.toString(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -25,6 +25,7 @@ import org.wordpress.android.editor.EditorImagePreviewListener
 import org.wordpress.android.editor.LiveTextWatcher
 import org.wordpress.android.editor.gutenberg.GutenbergWebViewAuthorizationData
 import org.wordpress.android.editor.savedinstance.SavedInstanceDatabase.Companion.getDatabase
+import org.wordpress.android.ui.posts.GutenbergKitSettingsBuilder
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ProfilingUtils
@@ -537,6 +538,36 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
             GutenbergKitEditorFragment.settings = settings
             db?.addParcel(ARG_GUTENBERG_WEB_VIEW_AUTH_DATA, webViewAuthorizationData)
             return fragment
+        }
+
+        /**
+         * Simplified factory method that uses GutenbergKitSettingsBuilder for configuration.
+         * This reduces the activity's responsibility for detailed fragment setup.
+         */
+        fun newInstanceWithBuilder(
+            context: Context,
+            isNewPost: Boolean,
+            jetpackFeaturesEnabled: Boolean,
+            config: GutenbergKitSettingsBuilder.GutenbergKitConfig
+        ): GutenbergKitEditorFragment {
+            val authorizationData = GutenbergKitSettingsBuilder.buildAuthorizationData(
+                siteConfig = config.siteConfig,
+                appConfig = config.appConfig
+            )
+
+            val settings = GutenbergKitSettingsBuilder.buildSettings(
+                siteConfig = config.siteConfig,
+                postConfig = config.postConfig,
+                appConfig = config.appConfig
+            )
+
+            return newInstance(
+                context,
+                isNewPost,
+                authorizationData,
+                jetpackFeaturesEnabled,
+                settings
+            )
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/editor/GutenbergKitEditorFragment.kt
@@ -558,7 +558,8 @@ class GutenbergKitEditorFragment : GutenbergKitEditorFragmentBase() {
             val settings = GutenbergKitSettingsBuilder.buildSettings(
                 siteConfig = config.siteConfig,
                 postConfig = config.postConfig,
-                appConfig = config.appConfig
+                appConfig = config.appConfig,
+                featureConfig = config.featureConfig
             )
 
             return newInstance(

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
+import org.wordpress.android.fluxc.network.UserAgent
 
 @RunWith(MockitoJUnitRunner::class)
 @Suppress("LargeClass")
@@ -612,7 +613,7 @@ class GutenbergKitSettingsBuilderTest {
         cookies = cookies,
         accountUserId = 123L,
         accountUserName = "testuser",
-        userAgent = org.wordpress.android.fluxc.network.UserAgent("test"),
+        userAgent = UserAgent(appContext = null, appName = "foo"),
         isJetpackSsoEnabled = false
     )
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilderTest.kt
@@ -393,7 +393,11 @@ class GutenbergKitSettingsBuilderTest {
             isUsingWpComRestApi = true,
             wpApiRestUrl = null,
             apiRestUsernamePlain = null,
-            apiRestPasswordPlain = null
+            apiRestPasswordPlain = null,
+            selfHostedSiteId = 0,
+            webEditor = "gutenberg",
+            apiRestUsernameProcessed = null,
+            apiRestPasswordProcessed = null
         )
 
         val postConfig = GutenbergKitSettingsBuilder.PostConfig(
@@ -441,7 +445,11 @@ class GutenbergKitSettingsBuilderTest {
             isUsingWpComRestApi = false,
             wpApiRestUrl = "https://jetpack-site.com/wp-json/",
             apiRestUsernamePlain = "admin",
-            apiRestPasswordPlain = "securepass"
+            apiRestPasswordPlain = "securepass",
+            selfHostedSiteId = 999,
+            webEditor = "gutenberg",
+            apiRestUsernameProcessed = "admin",
+            apiRestPasswordProcessed = "securepass"
         )
 
         val postConfig = GutenbergKitSettingsBuilder.PostConfig(
@@ -601,7 +609,11 @@ class GutenbergKitSettingsBuilderTest {
     ) = GutenbergKitSettingsBuilder.AppConfig(
         accessToken = accessToken,
         locale = locale,
-        cookies = cookies
+        cookies = cookies,
+        accountUserId = 123L,
+        accountUserName = "testuser",
+        userAgent = org.wordpress.android.fluxc.network.UserAgent("test"),
+        isJetpackSsoEnabled = false
     )
 
     private fun createSiteConfig(
@@ -623,7 +635,11 @@ class GutenbergKitSettingsBuilderTest {
         isUsingWpComRestApi = isUsingWpComRestApi,
         wpApiRestUrl = wpApiRestUrl,
         apiRestUsernamePlain = apiRestUsernamePlain,
-        apiRestPasswordPlain = apiRestPasswordPlain
+        apiRestPasswordPlain = apiRestPasswordPlain,
+        selfHostedSiteId = siteId,
+        webEditor = "gutenberg",
+        apiRestUsernameProcessed = apiRestUsernamePlain,
+        apiRestPasswordProcessed = apiRestPasswordPlain
     )
 
     private fun createPostConfig(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/UserAgent.kt
@@ -16,20 +16,25 @@ class UserAgent(appContext: Context?, appName: String) {
         // E.g.:
         //   "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //   AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36"
-        val defaultUserAgent = try {
-            WebSettings.getDefaultUserAgent(appContext)
-        } catch (e: RuntimeException) {
-            // `getDefaultUserAgent()` can throw an Exception
-            // see: https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187
-            ""
-        }
+        val defaultUserAgent = appContext?.let {
+            try {
+                WebSettings.getDefaultUserAgent(appContext)
+            } catch (_: RuntimeException) {
+                // `getDefaultUserAgent()` can throw an Exception
+                // see: https://github.com/wordpress-mobile/WordPress-Android/issues/20147#issuecomment-1961238187
+                ""
+            }
+        } ?: ""
         // User-Agent string when making HTTP connections, for both API traffic and WebViews.
         // Appends "wp-android/version" to WebView's default User-Agent string for the webservers
         // to get the full feature list of the browser and serve content accordingly, e.g.:
         //    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
         //    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
         //    wp-android/4.7"
-        val appWithVersion = "$appName/${PackageUtils.getVersionName(appContext)}"
+        val versionName = appContext?.let {
+            PackageUtils.getVersionName(appContext)
+        } ?: "0" // PackageUtils.getVersionName will also return "0" if it can't find packageInfo
+        val appWithVersion = "$appName/$versionName"
         userAgent = if (defaultUserAgent.isNotEmpty()) "$defaultUserAgent $appWithVersion" else appWithVersion
     }
 


### PR DESCRIPTION
## Summary

Continues refactoring `GutenbergKitActivity` by moving configuration building logic to the appropriate classes. This further reduces activity responsibilities and improves separation of concerns.

## Changes

- **Added companion factory methods**: 
  - `SiteConfig.fromSiteModel()` - creates configuration from site models
  - `PostConfig.fromPostModel()` - creates configuration from post model
- **Moved configuration building**: `buildAuthorizationData()` method moved from activity to `GutenbergKitSettingsBuilder`
- **Enhanced fragment factory**: Added `newInstanceWithBuilder()` method that handles its own configuration
- **Consolidated parameters**: Created `GutenbergKitConfig` wrapper to group related configuration objects