### PR TITLE
fix: Handle possible null web editor values

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitSettingsBuilder.kt
@@ -25,7 +25,7 @@ object GutenbergKitSettingsBuilder {
         val apiRestUsernamePlain: String?,
         val apiRestPasswordPlain: String?,
         val selfHostedSiteId: Long,
-        val webEditor: String,
+        val webEditor: String?,
         val apiRestUsernameProcessed: String?,
         val apiRestPasswordProcessed: String?
     ) {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
The Kotlin `webEditor` type contradicted the null-ability of the Java
`mWebEditor` value. Null values led to a crash when opening the
GutenbergKit editor for self-hosted sites without a Jetpack connection.

<details><summary>Stack trace</summary>

```
java.lang.NullPointerException: getWebEditor(...) must not be null
	at org.wordpress.android.ui.posts.GutenbergKitSettingsBuilder$SiteConfig$Companion.fromSiteModel(GutenbergKitSettingsBuilder.kt:45)
	at org.wordpress.android.ui.posts.GutenbergKitActivity$SectionsPagerAdapter.createGutenbergKitEditorFragment(GutenbergKitActivity.kt:2212)
	at org.wordpress.android.ui.posts.GutenbergKitActivity$SectionsPagerAdapter.getItem(GutenbergKitActivity.kt:2196)
	at androidx.fragment.app.FragmentPagerAdapter.instantiateItem(FragmentPagerAdapter.java:174)
	at org.wordpress.android.ui.posts.GutenbergKitActivity$SectionsPagerAdapter.instantiateItem(GutenbergKitActivity.kt:2251)
	at androidx.viewpager.widget.ViewPager.addNewItem(ViewPager.java:1010)
	at androidx.viewpager.widget.ViewPager.populate(ViewPager.java:1158)
	at androidx.viewpager.widget.ViewPager.populate(ViewPager.java:1092)
	at androidx.viewpager.widget.ViewPager.onMeasure(ViewPager.java:1622)
	at android.view.View.measure(View.java:28407)
	at android.widget.RelativeLayout.measureChildHorizontal(RelativeLayout.java:735)
	at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:481)
	at android.view.View.measure(View.java:28407)
	at androidx.constraintlayout.widget.ConstraintLayout$Measurer.measure(ConstraintLayout.java:861)
	at androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.measure(BasicMeasure.java:491)
	at androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.measureChildren(BasicMeasure.java:140)
	at androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.solverMeasure(BasicMeasure.java:285)
	at androidx.constraintlayout.core.widgets.ConstraintWidgetContainer.measure(ConstraintWidgetContainer.java:119)
	at androidx.constraintlayout.widget.ConstraintLayout.resolveSystem(ConstraintLayout.java:1634)
	at androidx.constraintlayout.widget.ConstraintLayout.onMeasure(ConstraintLayout.java:1777)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at androidx.coordinatorlayout.widget.CoordinatorLayout.onMeasureChild(CoordinatorLayout.java:795)
	at com.google.android.material.appbar.HeaderScrollingViewBehavior.onMeasureChild(HeaderScrollingViewBehavior.java:100)
	at com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior.onMeasureChild(AppBarLayout.java:2365)
	at androidx.coordinatorlayout.widget.CoordinatorLayout.onMeasure(CoordinatorLayout.java:866)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at android.widget.FrameLayout.onMeasure(FrameLayout.java:194)
	at androidx.appcompat.widget.ContentFrameLayout.onMeasure(ContentFrameLayout.java:141)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at android.widget.FrameLayout.onMeasure(FrameLayout.java:194)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at android.widget.FrameLayout.onMeasure(FrameLayout.java:194)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1608)
	at android.widget.LinearLayout.measureVertical(LinearLayout.java:878)
	at android.widget.LinearLayout.onMeasure(LinearLayout.java:721)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:7028)
	at android.widget.FrameLayout.onMeasure(FrameLayout.java:194)
	at com.android.internal.policy.DecorView.onMeasure(DecorView.java:736)
	at android.view.View.measure(View.java:28407)
	at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:4998)
	at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:3391)
	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3699)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:3076) (Ask Gemini)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:10643)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1570)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1579)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1179)
	at android.view.Choreographer.doFrame(Choreographer.java:1108)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1553)
	at android.os.Handler.handleCallback(Handler.java:995)
	at android.os.Handler.dispatchMessage(Handler.java:103)
	at android.os.Looper.loopOnce(Looper.java:248)
	at android.os.Looper.loop(Looper.java:338)
	at android.app.ActivityThread.main(ActivityThread.java:9067)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```

</details>


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Enable the experimental editor.
1. Add a self-hosted site without a Jetpack connection.
1. Open the post editor.
1. Verify the app does not crash.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
