### PR TITLE
fix: Mitigate pending editor content loss

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -288,8 +288,7 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.EditPostActivity"
-            android:configChanges="screenLayout|orientation|screenSize
-      |keyboard|keyboardHidden|smallestScreenSize"
+            android:configChanges="locale|orientation|screenSize"
             android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -299,8 +299,7 @@
         </activity>
         <activity
             android:name=".ui.posts.GutenbergKitActivity"
-            android:configChanges="screenLayout|orientation|screenSize
-      |keyboard|keyboardHidden|smallestScreenSize"
+            android:configChanges="locale|screenLayout|orientation|screenSize|keyboard|keyboardHidden|smallestScreenSize|uiMode"
             android:theme="@style/WordPress.NoActionBar.NoEdgeToEdge"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:exported="false">


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Mitigate pending content loss in the editor when configuration changes
occur—e.g., toggling dark mode, rotating the device.

The approach taken for the `GutenbergKitActivity` follows that of 
Google's recommendations for [managing WebView state](https://developer.android.com/develop/ui/compose/quick-guides/content/manage-webview-state).

Close CMM-689. 

> [!note]
> There is a UI oddity that occurs when toggling dark mode and also interacting with the undo/redo buttons. It leads to incorrect UI colors for these buttons. I consider this far less disruptive than potential content loss, we can look to address this later. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the editor.
1. Type some text.
1. Perform an action triggering configuration changes—e.g., toggle dark mode,
   rotate the device.
1. Verify the pending content remains present and the scroll position is
   preserved.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
