### PR TITLE
feat: GutenbergKit requires app password for self-hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -473,7 +473,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
     }
 
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "ReturnCount")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -109,6 +109,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.dismissIfNecessary
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.isShowing
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.showIfNecessary
@@ -377,6 +378,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
     @Inject lateinit var experimentalFeatures: ExperimentalFeatures
 
+    @Inject lateinit var activityNavigator: ActivityNavigator
+
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var storePostViewModel: StorePostViewModel
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
@@ -499,6 +502,16 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
             return
         }
 
+        if (shouldRequireApplicationPassword()) {
+            activityNavigator.navigateToApplicationPasswordRequired(
+                this,
+               siteModel.url,
+               resources.getString(R.string.application_password_required_block_editor)
+            )
+            finish()
+            return
+        }
+
         isLandingEditor = intent.extras?.getBoolean(EditorConstants.EXTRA_IS_LANDING_EDITOR) ?: false
 
         refreshMobileEditorFromSiteSetting()
@@ -613,6 +626,14 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         tempSiteModel?.let { siteModel = it }?: return false
 
         return true
+    }
+
+    private fun shouldRequireApplicationPassword(): Boolean {
+        return site.apiRestPasswordPlain.isNullOrEmpty() &&
+                !siteModel.isWPCom &&
+                !siteModel.isJetpackConnected &&
+                experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
+                !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
     }
 
     private fun refreshMobileEditorFromSiteSetting() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5061,6 +5061,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password </string>
     <string name="application_password_required">Application Password Required</string>
     <string name="application_password_required_description">Application passwords are a more secure way to connect to your self-hosted site, and enable support for features like %1$s.</string>
+    <string name="application_password_required_block_editor">Block Editor</string>
     <string name="application_password_required_description_default">Application passwords are a more secure way to connect to your self-hosted site, and enable new features support.</string>
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling Application Password will remove the login for %1$s of your sites. You may need to re-add affected sites to login again.</string>


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-724.

Prompt users to create an application password before opening the GutenbergKit
editor for self-hosted sites. This is necessary to authenticate REST API
requests in the editor, as we do not support cookie authentication.

<img alt="GutebergKit prompts for app password" src="https://github.com/user-attachments/assets/f7d25caa-310f-4101-b4ba-0c7626ea77ad" width="300" />

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
### 1. WPCOM sites are not prompted for an app password
1. Select a WPCOM site.
1. Open the GutenbergKit editor.
1. Verify the editor opens without a prompt.

### 2. Sites with the block editor disabled are not prompted for an app password
1. Select a self-hosted site without an app password.
1. Navigate to _My Site_ → _Site Settings_.
1. Disable _Use block editor_.
1. Create a new post with the editor.
1. Verify the editor opens without a prompt.

### 3. Sites with the GutenbergKit disabled are not prompted for an app password
1. Select a self-hosted site without an app password.
1. Disable _Experimental block editor_ feature flag.
1. Open the editor.
1. Verify the editor opens without a prompt.

### 4. Sites without an app password are prompted
1. Select a self-hosted site without an app password.
1. Open the GutenbergKit editor.
1. Verify the editor opens without a prompt.

### 5. Sites with an app password are not prompted
1. Select a self-hosted site without an app password.
1. Open the GutenbergKit editor.
1. Verify the editor opens without a prompt.
1. Continue the authentication process.
1. Verify the editor launches.
1. Close and re-open the editor.
1. Verify the editor launches.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
