### PR TITLE
CMM 735 enable application password feature when the user accepts to use a feature that must include it

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogViewModel.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures.Feature
 import org.wordpress.android.util.AppLog
 import javax.inject.Inject
 
@@ -19,6 +21,7 @@ import javax.inject.Inject
 class ApplicationPasswordDialogViewModel @Inject constructor(
     private val applicationPasswordLoginHelper: ApplicationPasswordLoginHelper,
     private val appLogWrapper: AppLogWrapper,
+    private val experimentalFeatures: ExperimentalFeatures,
 ) : ViewModel() {
     private val _navigationEvent = MutableSharedFlow<NavigationEvent>()
     val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent.asSharedFlow()
@@ -38,6 +41,8 @@ class ApplicationPasswordDialogViewModel @Inject constructor(
             }
 
             try {
+                // Assume that the Application Password experimental feature can be enabled
+                enableApplicationPasswordIfNecessary()
                 val completeAuthUrl = applicationPasswordLoginHelper.getAuthorizationUrlComplete(authenticationUrl)
 
                 if (completeAuthUrl.isNotEmpty()) {
@@ -52,6 +57,12 @@ class ApplicationPasswordDialogViewModel @Inject constructor(
             } finally {
                 _isLoading.value = false
             }
+        }
+    }
+
+    private fun enableApplicationPasswordIfNecessary() {
+        if (!experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE)) {
+            experimentalFeatures.setEnabled(Feature.EXPERIMENTAL_APPLICATION_PASSWORD_FEATURE, true)
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordRequiredDialogActivity.kt
@@ -6,10 +6,13 @@ import org.wordpress.android.R
 @AndroidEntryPoint
 class ApplicationPasswordRequiredDialogActivity : ApplicationPasswordDialogActivity() {
     override fun getTitleResource(): Int = R.string.application_password_required
-    override fun getDescriptionString(): String =
-        intent.getStringExtra(EXTRA_FEATURE_NAME)?.let {
+    override fun getDescriptionString(): String {
+        val baseDescription = intent.getStringExtra(EXTRA_FEATURE_NAME)?.let {
             resources.getString(R.string.application_password_required_description, it)
-        } ?: resources.getString(R.string.application_password_required_description_default)
+        } ?: resources.getString(R.string.application_password_info_description_1)
+
+        return baseDescription + resources.getString(R.string.application_password_experimental_feature_note)
+    }
     override fun getButtonTextResource(): Int = R.string.get_started
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -473,7 +473,7 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         }
     }
 
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "ReturnCount")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         (application as WordPress).component().inject(this)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -109,6 +109,7 @@ import org.wordpress.android.imageeditor.preview.PreviewImageFragment.Companion.
 import org.wordpress.android.support.ZendeskHelper
 import org.wordpress.android.ui.ActivityId
 import org.wordpress.android.ui.ActivityLauncher
+import org.wordpress.android.ui.ActivityNavigator
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.dismissIfNecessary
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.isShowing
 import org.wordpress.android.ui.PrivateAtCookieRefreshProgressDialog.Companion.showIfNecessary
@@ -377,6 +378,8 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     @Inject lateinit var gutenbergKitPluginsFeature: GutenbergKitPluginsFeature
     @Inject lateinit var experimentalFeatures: ExperimentalFeatures
 
+    @Inject lateinit var activityNavigator: ActivityNavigator
+
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var storePostViewModel: StorePostViewModel
     @Inject lateinit var storageUtilsViewModel: StorageUtilsViewModel
@@ -499,6 +502,16 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
             return
         }
 
+        if (shouldRequireApplicationPassword()) {
+            activityNavigator.navigateToApplicationPasswordRequired(
+                this,
+               siteModel.url,
+               resources.getString(R.string.application_password_required_block_editor)
+            )
+            finish()
+            return
+        }
+
         isLandingEditor = intent.extras?.getBoolean(EditorConstants.EXTRA_IS_LANDING_EDITOR) ?: false
 
         refreshMobileEditorFromSiteSetting()
@@ -613,6 +626,14 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
         tempSiteModel?.let { siteModel = it }?: return false
 
         return true
+    }
+
+    private fun shouldRequireApplicationPassword(): Boolean {
+        return site.apiRestPasswordPlain.isNullOrEmpty() &&
+                !siteModel.isWPCom &&
+                !siteModel.isJetpackConnected &&
+                experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
+                !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
     }
 
     private fun refreshMobileEditorFromSiteSetting() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5062,7 +5062,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_required">Application Password Required</string>
     <string name="application_password_required_description">Application passwords are a more secure way to connect to your self-hosted site, and enable support for features like %1$s.</string>
     <string name="application_password_required_block_editor">Block Editor</string>
-    <string name="application_password_required_description_default">Application passwords are a more secure way to connect to your self-hosted site, and enable new features support.</string>
+    <string name="application_password_experimental_feature_note">\n\nNote: Application Password authentication on Android devices is an Experimental Feature.</string>
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling Application Password will remove the login for %1$s of your sites. You may need to re-add affected sites to login again.</string>
     <string name="application_password_info_title">Application Passwords</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5061,6 +5061,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password </string>
     <string name="application_password_required">Application Password Required</string>
     <string name="application_password_required_description">Application passwords are a more secure way to connect to your self-hosted site, and enable support for features like %1$s.</string>
+    <string name="application_password_required_block_editor">Block Editor</string>
     <string name="application_password_required_description_default">Application passwords are a more secure way to connect to your self-hosted site, and enable new features support.</string>
     <string name="application_password_disable_feature_title">Disable Application Password?</string>
     <string name="application_password_disable_feature_description">Disabling Application Password will remove the login for %1$s of your sites. You may need to re-add affected sites to login again.</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.whenever
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.ui.accounts.login.ApplicationPasswordLoginHelper
+import org.wordpress.android.ui.prefs.experimentalfeatures.ExperimentalFeatures
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -28,6 +29,9 @@ class ApplicationPasswordDialogViewModelTest : BaseUnitTest() {
     @Mock
     lateinit var appLogWrapper: AppLogWrapper
 
+    @Mock
+    lateinit var experimentalFeatures: ExperimentalFeatures
+
     private lateinit var viewModel: ApplicationPasswordDialogViewModel
 
     private val testAuthUrl = "https://example.com/wp-admin/authorize-application.php"
@@ -39,7 +43,8 @@ class ApplicationPasswordDialogViewModelTest : BaseUnitTest() {
         MockitoAnnotations.openMocks(this)
         viewModel = ApplicationPasswordDialogViewModel(
             applicationPasswordLoginHelper,
-            appLogWrapper
+            appLogWrapper,
+            experimentalFeatures
         )
     }
 


### PR DESCRIPTION
## Description
This PR automatically enables the Application Password Experimental feature when the user enables it from a feature that requires the new authentication method.

See [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/22194#issuecomment-3275041482) for more context

## Testing instructions

1. Add a self-hosted site, but be sure Application Password is disabled
2. Enable the Block editor feature
3. Try to add a new post
- [ ] Verify you are prompted to enable Application Password
4. Follow the flow
5. Go to "Experiemental Features" screen
- [ ] Verify Application Passwords are now enabled.


https://github.com/user-attachments/assets/f6d04ca6-aa6f-4d42-8b39-10ac00cfb8d2


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->