### PR TITLE
feat: Improve app password required dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
@@ -129,57 +129,57 @@ abstract class ApplicationPasswordDialogActivity : ComponentActivity() {
         )
     }
 
-    @Preview
-    @Preview(uiMode = UI_MODE_NIGHT_YES)
-    @Composable
-    fun ApplicationPasswordReauthenticateDialogPreview() {
-        AppThemeM3 {
-            ApplicationPasswordReauthenticateDialogPreviewContent()
-        }
-    }
-
-    @Composable
-    private fun ApplicationPasswordReauthenticateDialogPreviewContent() {
-        val isLoading = remember { mutableStateOf(false) }
-
-        AlertDialog(
-            onDismissRequest = {},
-            icon = {
-                Icon(
-                    imageVector = Icons.Outlined.Lock,
-                    contentDescription = null
-                )
-            },
-            title = { Text(text = stringResource(R.string.application_password_invalid)) },
-            text = {
-                Column(
-                    modifier = androidx.compose.ui.Modifier.verticalScroll(rememberScrollState())
-                ) {
-                    Text(text = stringResource(R.string.application_password_invalid_description))
-                }
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        isLoading.value = !isLoading.value
-                    },
-                    enabled = !isLoading.value
-                ) {
-                    if (isLoading.value) {
-                        CircularProgressIndicator(
-                            modifier = androidx.compose.ui.Modifier.size(16.dp),
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Text(text = stringResource(R.string.log_in))
-                    }
-                }
-            }
-        )
-    }
-
     companion object {
         const val EXTRA_SITE_URL = "site_url_arg"
     }
+}
+
+@Preview
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun ApplicationPasswordReauthenticateDialogPreview() {
+    AppThemeM3 {
+        ApplicationPasswordReauthenticateDialogPreviewContent()
+    }
+}
+
+@Composable
+private fun ApplicationPasswordReauthenticateDialogPreviewContent() {
+    val isLoading = remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = {},
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Lock,
+                contentDescription = null
+            )
+        },
+        title = { Text(text = stringResource(R.string.application_password_invalid)) },
+        text = {
+            Column(
+                modifier = androidx.compose.ui.Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(text = stringResource(R.string.application_password_invalid_description))
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    isLoading.value = !isLoading.value
+                },
+                enabled = !isLoading.value
+            ) {
+                if (isLoading.value) {
+                    CircularProgressIndicator(
+                        modifier = androidx.compose.ui.Modifier.size(16.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(text = stringResource(R.string.log_in))
+                }
+            }
+        }
+    )
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.TextButton
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -116,6 +117,14 @@ fun ApplicationPasswordDialog(
                 modifier = androidx.compose.ui.Modifier.verticalScroll(rememberScrollState())
             ) {
                 Text(text = description)
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isLoading
+            ) {
+                Text(text = stringResource(R.string.cancel))
             }
         },
         confirmButton = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/applicationpassword/ApplicationPasswordDialogActivity.kt
@@ -17,8 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -69,8 +67,12 @@ abstract class ApplicationPasswordDialogActivity : ComponentActivity() {
 
         setContent {
             AppThemeM3 {
-                ApplicationPasswordReauthenticateDialog(
-                    viewModel = viewModel,
+                val isLoading = viewModel.isLoading.collectAsState()
+                ApplicationPasswordDialog(
+                    title = stringResource(getTitleResource()),
+                    description = getDescriptionString(),
+                    buttonText = getButtonTextResource(),
+                    isLoading = isLoading.value,
                     onDismiss = {
                         finish()
                     },
@@ -86,100 +88,85 @@ abstract class ApplicationPasswordDialogActivity : ComponentActivity() {
     protected abstract fun getDescriptionString(): String
     protected abstract fun getButtonTextResource(): Int
 
-    @Composable
-    fun ApplicationPasswordReauthenticateDialog(
-        viewModel: ApplicationPasswordDialogViewModel,
-        onDismiss: () -> Unit,
-        onConfirm: () -> Unit,
-    ) {
-        val isLoading = viewModel.isLoading.collectAsState()
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            icon = {
-                Icon(
-                    imageVector = Icons.Outlined.Lock,
-                    contentDescription = null
-                )
-            },
-            title = { Text(text = stringResource(getTitleResource())) },
-            text = {
-                Column(
-                    modifier = androidx.compose.ui.Modifier.verticalScroll(rememberScrollState())
-                ) {
-                    Text(text = getDescriptionString())
-                }
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        onConfirm()
-                    },
-                    enabled = !isLoading.value
-                ) {
-                    if (isLoading.value) {
-                        CircularProgressIndicator(
-                            modifier = androidx.compose.ui.Modifier.size(16.dp),
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Text(text = stringResource(getButtonTextResource()))
-                    }
-                }
-            }
-        )
-    }
-
     companion object {
         const val EXTRA_SITE_URL = "site_url_arg"
     }
 }
 
-@Preview
-@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Composable
-fun ApplicationPasswordReauthenticateDialogPreview() {
-    AppThemeM3 {
-        ApplicationPasswordReauthenticateDialogPreviewContent()
-    }
-}
-
-@Composable
-private fun ApplicationPasswordReauthenticateDialogPreviewContent() {
-    val isLoading = remember { mutableStateOf(false) }
-
+fun ApplicationPasswordDialog(
+    title: String,
+    description: String,
+    buttonText: Int,
+    isLoading: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
     AlertDialog(
-        onDismissRequest = {},
+        onDismissRequest = onDismiss,
         icon = {
             Icon(
                 imageVector = Icons.Outlined.Lock,
                 contentDescription = null
             )
         },
-        title = { Text(text = stringResource(R.string.application_password_invalid)) },
+        title = { Text(text = title) },
         text = {
             Column(
                 modifier = androidx.compose.ui.Modifier.verticalScroll(rememberScrollState())
             ) {
-                Text(text = stringResource(R.string.application_password_invalid_description))
+                Text(text = description)
             }
         },
         confirmButton = {
             Button(
                 onClick = {
-                    isLoading.value = !isLoading.value
+                    onConfirm()
                 },
-                enabled = !isLoading.value
+                enabled = !isLoading
             ) {
-                if (isLoading.value) {
+                if (isLoading) {
                     CircularProgressIndicator(
                         modifier = androidx.compose.ui.Modifier.size(16.dp),
                         strokeWidth = 2.dp
                     )
                 } else {
-                    Text(text = stringResource(R.string.log_in))
+                    Text(text = stringResource(buttonText))
                 }
             }
         }
     )
 }
 
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun ApplicationPasswordDialogPreview() {
+    AppThemeM3 {
+        ApplicationPasswordDialog(
+            title = "Application Password Required",
+            description = "To use this feature, you need to create an application password. " +
+                    "This is a secure way to authenticate without using your main password.",
+            buttonText = R.string.get_started,
+            isLoading = false,
+            onDismiss = {},
+            onConfirm = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ApplicationPasswordDialogLoadingPreview() {
+    AppThemeM3 {
+        ApplicationPasswordDialog(
+            title = "Application Password Required",
+            description = "To use this feature, you need to create an application password. " +
+                    "This is a secure way to authenticate without using your main password.",
+            buttonText = R.string.get_started,
+            isLoading = true,
+            onDismiss = {},
+            onConfirm = {}
+        )
+    }
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -5058,7 +5058,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="application_password_title">Authenticate using Application Password</string>
     <string name="application_password_not_supported_error" a8c-src-lib="module:login">The provided site does not support Application Password authentication.</string>
     <string name="application_password_invalid">Invalid Application Password</string>
-    <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password </string>
+    <string name="application_password_invalid_description">Your application password no longer exists. Please sign in again to create a new application password.</string>
     <string name="application_password_required">Application Password Required</string>
     <string name="application_password_required_description">Application passwords are a more secure way to connect to your self-hosted site, and enable support for features like %1$s.</string>
     <string name="application_password_required_block_editor">Block Editor</string>


### PR DESCRIPTION
> [!tip]
> Review each commit individually to simplify comprehending the changes. 

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
- Relocate `ApplicationPasswordReauthenticateDialogPreview` to fix Jetpack
  Compose preview
- Extract `ApplicationPasswordDialog` for Jetpack Compose to preview actual UI
  composition rather than duplicate
- Add `ApplicationPasswordDialog` dismiss button to communicate ability to
  dismiss the dialog
- Use consistent punctuation for descriptions with multiple sentences

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
Jetpack Compose preview images below showcase the updated visuals. Functional testing
can be performed by following the testing plan outlined in either of the
following:

- https://github.com/wordpress-mobile/WordPress-Android/pull/22191
- https://github.com/wordpress-mobile/WordPress-Android/pull/22194

| Default | Dark mode | Loading |
| - | - | - |
| ![default](https://github.com/user-attachments/assets/437a672f-f462-42a7-8db9-f35d074c1035) | ![dark-mode](https://github.com/user-attachments/assets/623ad018-88af-4909-867f-ec79445c7bfc) | ![loading](https://github.com/user-attachments/assets/464e1ae6-462d-4682-8b6d-fa9c79764b82) |


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
