### PR TITLE
CMM-736: Incorrect subscriber details open when tapping on subscribers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/subscribers/SubscribersViewModel.kt
@@ -55,6 +55,7 @@ class SubscribersViewModel @Inject constructor(
     private val _subscriberStats = MutableStateFlow<IndividualSubscriberStats?>(null)
     val subscriberStats = _subscriberStats.asStateFlow()
 
+    private var selectedSubscriber: Subscriber? = null
     private var statsJob: Job? = null
 
     override val emptyView = DataViewEmptyView(
@@ -212,6 +213,20 @@ class SubscribersViewModel @Inject constructor(
     fun getSubscriber(userId: Long): Subscriber? {
         val item = uiState.value.items.firstOrNull { it.id == userId }
         return item?.data as? Subscriber
+    }
+
+    /**
+     * Sets the currently selected subscriber for detail view navigation
+     */
+    fun setSelectedSubscriber(subscriber: Subscriber) {
+        selectedSubscriber = subscriber
+    }
+
+    /**
+     * Returns the currently selected subscriber
+     */
+    fun getSelectedSubscriber(): Subscriber? {
+        return selectedSubscriber
     }
 
     private suspend fun fetchSubscriberStats(subscriptionId: ULong): IndividualSubscriberStats? =


### PR DESCRIPTION
## Description
This PR fixes a bug where tapping on a subscriber in the Stats → Subscribers list would sometimes open details for the wrong subscriber (usually the first in the current sort order).

The issue occurred because the detail screen navigation relied on looking up subscribers by ID after navigation using getSubscriber(userId). This method searched through the current UI state list, but if the list had been reloaded or modyfied between the click and detail screen loading, it could return the wrong subscriber.

  So:
  - Added direct subscriber storage to SubscribersViewModel with setSelectedSubscriber() and getSelectedSubscriber() methods
  - Modified the click handler to store the full subscriber object before navigation instead of relying on ID lookup
  - Updated both Detail and Plan screens to use the stored subscriber directly


## Testing instructions
1. Open a site with a big list of suibscribers. You can use this [CSV](https://github.com/user-attachments/files/22276518/email.csv) to import them through wp-admin
2. Open different subscribers form the list
- [ ] Verify the correct subscriber is opened when tapped on it
- [ ] Verify removing a subscriber actually removes it

https://github.com/user-attachments/assets/1d018e93-1cb5-41a8-aeab-dadf827547e7


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->