### PR TITLE
fix: Group notifications older then 2 days by date

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.annotation.StringRes
 import androidx.core.text.BidiFormatter
 import androidx.core.text.trimmedLength
 import androidx.core.view.isVisible
@@ -26,11 +25,15 @@ import org.wordpress.android.ui.comments.CommentUtils
 import org.wordpress.android.ui.notifications.NotificationsListViewModel
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan
 import org.wordpress.android.ui.notifications.utils.NotificationsUtilsWrapper
+import org.wordpress.android.util.DateUtils.isSameDay
 import org.wordpress.android.util.GravatarUtils
 import org.wordpress.android.util.RtlUtils
 import org.wordpress.android.util.extensions.getColorFromAttribute
 import org.wordpress.android.util.image.ImageManager
 import org.wordpress.android.util.image.ImageType
+import java.text.DateFormat
+import java.util.Calendar
+import java.util.Date
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
@@ -141,24 +144,26 @@ class NoteViewHolder(
             binding.root.context.getString(if (liked) R.string.mnu_comment_liked else R.string.reader_label_like)
     }
 
-    @StringRes
-    private fun timeGroupHeaderText(note: Note, previousNote: Note?) =
-        previousNote?.timeGroup.let { previousTimeGroup ->
-            val timeGroup = note.timeGroup
-            if (previousTimeGroup?.let { it == timeGroup } == true) {
-                // If the previous time group exists and is the same, we don't need a new one
-                null
-            } else {
-                // Otherwise, we create a new one
-                when (timeGroup) {
-                    Note.NoteTimeGroup.GROUP_TODAY -> R.string.stats_timeframe_today
-                    Note.NoteTimeGroup.GROUP_YESTERDAY -> R.string.stats_timeframe_yesterday
-                    Note.NoteTimeGroup.GROUP_OLDER_TWO_DAYS -> R.string.older_two_days
-                    Note.NoteTimeGroup.GROUP_OLDER_WEEK -> R.string.older_last_week
-                    Note.NoteTimeGroup.GROUP_OLDER_MONTH -> R.string.older_month
-                }
+    private fun timeGroupHeaderText(note: Note, previousNote: Note?): String? {
+        val noteDate = Date(note.timestamp * MILLISECOND)
+
+        // If we have a previous note, check if it's from the same calendar day
+        previousNote?.let { prevNote ->
+            val prevNoteDate = Date(prevNote.timestamp * MILLISECOND)
+            if (isSameDay(noteDate, prevNoteDate)) {
+                // Same day as previous note, don't show a header
+                return null
             }
         }
+
+        return when (note.timeGroup) {
+            Note.NoteTimeGroup.GROUP_TODAY -> binding.root.context.getString(R.string.stats_timeframe_today)
+            Note.NoteTimeGroup.GROUP_YESTERDAY -> binding.root.context.getString(R.string.stats_timeframe_yesterday)
+            Note.NoteTimeGroup.GROUP_OLDER_TWO_DAYS,
+            Note.NoteTimeGroup.GROUP_OLDER_WEEK,
+            Note.NoteTimeGroup.GROUP_OLDER_MONTH -> timeGroupHeaderDate(noteDate)
+        }
+    }
 
     fun bindSubject(note: Note) {
         // Subject is stored in db as html to preserve text formatting
@@ -269,4 +274,22 @@ class NoteViewHolder(
 
     private val Note.timeGroup
         get() = Note.getTimeGroupForTimestamp(timestamp)
+}
+
+private const val MILLISECOND = 1000
+
+/**
+ * Get formatted date string for display in notification headers
+ */
+private fun timeGroupHeaderDate(date: Date): String {
+    val calendar = Calendar.getInstance()
+    val currentYear = calendar.get(Calendar.YEAR)
+    calendar.time = date
+    val noteYear = calendar.get(Calendar.YEAR)
+
+    val text = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
+    return when (noteYear) {
+        currentYear -> text.replace(", $noteYear", "")
+        else -> text
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteViewHolder.kt
@@ -283,9 +283,9 @@ private const val MILLISECOND = 1000
  */
 private fun timeGroupHeaderDate(date: Date): String {
     val calendar = Calendar.getInstance()
-    val currentYear = calendar.get(Calendar.YEAR)
+    val currentYear = calendar[Calendar.YEAR]
     calendar.time = date
-    val noteYear = calendar.get(Calendar.YEAR)
+    val noteYear = calendar[Calendar.YEAR]
 
     val text = DateFormat.getDateInstance(DateFormat.MEDIUM).format(date)
     return when (noteYear) {


### PR DESCRIPTION
## Description
In Jetpack app Notifications older then two days stays in one group and it's hard to separate them. To do so, I group such items by date using data as the header of the group. I used localized date formatting with DateFormat.getDateInstance().

I can't handle testing because have "Enable Jetpack" message on notification screen. I set up temporary site with jurassic.ninja with Jetpack Enabled. Down the enable Jetpack flow in app I stuck at the step with log in step:

<img width="290" height="600" alt="Screenshot_20250916_110114" src="https://github.com/user-attachments/assets/58a41336-dd98-405d-aaa5-36aac2b72022" />

<img width="290" height="600" alt="Screenshot_20250916_104603" src="https://github.com/user-attachments/assets/c3248a84-70f8-459e-91d6-6aa19f6b8398" />

I confirmed my emain on WordPress.com but flow doesn't go forward.

Also, I didn't find the way to test notifications list UI with prepopulated data localy.

## Testing instructions
Someone need to test it against data source that generate notifications older then 2 days, since there are no documentation to work with Jetpack-speciefic issues:

> @Anubhav8176 I checked with the team and unfortunately the problem is that our documentation is incomplete, in that it's missing instructions for Jetpack builds. We'll resolve this but it's unlikely to happen soon. For that reason, if you still wish to contribute, I recommend choosing something that's not Jetpack-specific. 

 _Originally posted by @nbradbury in [#21191](https://github.com/wordpress-mobile/WordPress-Android/issues/21191#issuecomment-2598315541)_ 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->