### PR TITLE
CMM-779 migrate add categories to wordpress-rs

### DIFF
--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -12,11 +12,13 @@ import org.wordpress.android.fluxc.network.rest.wpapi.rs.WpApiClientProvider
 import org.wordpress.android.fluxc.store.TaxonomyStore
 import org.wordpress.android.fluxc.store.TaxonomyStore.DEFAULT_TAXONOMY_TAG
 import org.wordpress.android.fluxc.store.TaxonomyStore.FetchTermsResponsePayload
+import org.wordpress.android.fluxc.store.TaxonomyStore.RemoteTermPayload
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyError
 import org.wordpress.android.fluxc.store.TaxonomyStore.TaxonomyErrorType
 import org.wordpress.android.fluxc.utils.AppLogWrapper
 import org.wordpress.android.util.AppLog
 import rs.wordpress.api.kotlin.WpRequestResult
+import uniffi.wp_api.CategoryCreateParams
 import uniffi.wp_api.CategoryListParams
 import uniffi.wp_api.TagListParams
 import javax.inject.Inject
@@ -30,6 +32,53 @@ class TaxonomyRsApiRestClient @Inject constructor(
     private val appLogWrapper: AppLogWrapper,
     private val wpApiClientProvider: WpApiClientProvider,
 ) {
+    fun createPostCategory(site: SiteModel, term: TermModel) {
+        scope.launch {
+            val client = wpApiClientProvider.getWpApiClient(site)
+
+            val categoriesResponse = client.request { requestBuilder ->
+                requestBuilder.categories().create(
+                    CategoryCreateParams(
+                        name = term.name,
+                        description = term.description,
+                        slug = term.slug,
+                        parent = term.parentRemoteId
+                    )
+                )
+            }
+
+            val termResponsePayload = when (categoriesResponse) {
+                is WpRequestResult.Success -> {
+                    val category = categoriesResponse.response.data
+                    appLogWrapper.d(AppLog.T.POSTS, "Created category: ${category.name}")
+                    RemoteTermPayload(
+                        TermModel(
+                            category.id.toInt(),
+                            site.id,
+                            category.id,
+                            TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY,
+                            category.name,
+                            category.slug,
+                            category.description,
+                            0,
+                            category.count.toInt()
+                        ),
+                        site
+                    )
+                }
+
+                else -> {
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
+                    FetchTermsResponsePayload(
+                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
+                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
+                    )
+                }
+            }
+            notifyTermCreated(termResponsePayload)
+        }
+    }
+
     fun fetchPostCategories(site: SiteModel) {
         scope.launch {
             val client = wpApiClientProvider.getWpApiClient(site)
@@ -122,6 +171,12 @@ class TaxonomyRsApiRestClient @Inject constructor(
         payload: FetchTermsResponsePayload,
     ) {
         dispatcher.dispatch(TaxonomyActionBuilder.newFetchedTermsAction(payload))
+    }
+
+    private fun notifyTermCreated(
+        payload: RemoteTermPayload,
+    ) {
+        dispatcher.dispatch(TaxonomyActionBuilder.newPushedTermAction(payload))
     }
 
     private fun createTermsResponsePayload(

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -69,7 +69,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 }
 
                 else -> {
-                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
+                    appLogWrapper.e(AppLog.T.POSTS, "Failed creating category: $categoriesResponse")
                     val payload = RemoteTermPayload(term, site)
                     payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
                     notifyTermCreated(payload)

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -60,7 +60,7 @@ class TaxonomyRsApiRestClient @Inject constructor(
                             category.name,
                             category.slug,
                             category.description,
-                            0,
+                            category.parent,
                             category.count.toInt()
                         ),
                         site

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/taxonomy/TaxonomyRsApiRestClient.kt
@@ -47,11 +47,11 @@ class TaxonomyRsApiRestClient @Inject constructor(
                 )
             }
 
-            val termResponsePayload = when (categoriesResponse) {
+            when (categoriesResponse) {
                 is WpRequestResult.Success -> {
                     val category = categoriesResponse.response.data
                     appLogWrapper.d(AppLog.T.POSTS, "Created category: ${category.name}")
-                    RemoteTermPayload(
+                    val payload = RemoteTermPayload(
                         TermModel(
                             category.id.toInt(),
                             site.id,
@@ -65,17 +65,16 @@ class TaxonomyRsApiRestClient @Inject constructor(
                         ),
                         site
                     )
+                    notifyTermCreated(payload)
                 }
 
                 else -> {
                     appLogWrapper.e(AppLog.T.POSTS, "Failed creating taxonomy: $categoriesResponse")
-                    FetchTermsResponsePayload(
-                        TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, ""),
-                        TaxonomyStore.DEFAULT_TAXONOMY_CATEGORY
-                    )
+                    val payload = RemoteTermPayload(term, site)
+                    payload.error = TaxonomyError(TaxonomyErrorType.GENERIC_ERROR, "")
+                    notifyTermCreated(payload)
                 }
             }
-            notifyTermCreated(termResponsePayload)
         }
     }
 

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.fluxc.store;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -279,8 +277,6 @@ public class TaxonomyStore extends Store {
         if (!(actionType instanceof TaxonomyAction)) {
             return;
         }
-
-        Log.d("TAX_TAG", "New action: " + actionType);
 
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -430,7 +430,7 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
-        if (payload.site.isUsingWpComRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
+        if (payload.site.isUsingSelfHostedRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
             mTaxonomyRsApiRestClient.createPostCategory(payload.site, payload.term);
         } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);

--- a/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
+++ b/libs/fluxc/src/main/java/org/wordpress/android/fluxc/store/TaxonomyStore.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.fluxc.store;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -278,6 +280,8 @@ public class TaxonomyStore extends Store {
             return;
         }
 
+        Log.d("TAX_TAG", "New action: " + actionType);
+
         switch ((TaxonomyAction) actionType) {
             case FETCH_CATEGORIES:
                 fetchTerms(((SiteModel) action.getPayload()), DEFAULT_TAXONOMY_CATEGORY);
@@ -426,10 +430,11 @@ public class TaxonomyStore extends Store {
     }
 
     private void pushTerm(@NonNull RemoteTermPayload payload) {
-        if (payload.site.isUsingWpComRestApi()) {
+        if (payload.site.isUsingWpComRestApi() && DEFAULT_TAXONOMY_CATEGORY.equals(payload.term.getTaxonomy())) {
+            mTaxonomyRsApiRestClient.createPostCategory(payload.site, payload.term);
+        } else if (payload.site.isUsingWpComRestApi()) {
             mTaxonomyRestClient.pushTerm(payload.term, payload.site);
         } else {
-            // TODO: check for WP-REST-API plugin and use it here
             mTaxonomyXMLRPCClient.pushTerm(payload.term, payload.site);
         }
     }


### PR DESCRIPTION
## Description
This PR is adding the ability to include new categories when writing a post using the `wordpress-rs` library
<!-- Describe the changes, why they are needed, and how they address the issue -->

## Testing instructions

1. Log into a self-hosted site without using Application Password
2. Create or edit a post
3. Select the categories item
4. Add a new category
- [ ] Verify the new category is added
5. Enable and set Application Password
6. Create or edit another post
5. Add a new category
- [ ] Verify the new category is added


https://github.com/user-attachments/assets/5bca1057-85aa-46c9-a631-ca80437e59f3



<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->