### PR TITLE
feat: GutenbergKit requires app passwords for public Atomic sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -627,11 +627,24 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     }
 
     private fun shouldRequireApplicationPassword(): Boolean {
-        return site.apiRestPasswordPlain.isNullOrEmpty() &&
-                !siteModel.isWPCom &&
-                !siteModel.isJetpackConnected &&
-                experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
-                !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        // Check if experimental block editor is enabled
+        if (!experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
+            experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)) {
+            return false
+        }
+
+        // WPCOM Simple sites rely upon bearer tokens
+        if (siteModel.isWPCom && !siteModel.isWPComAtomic) {
+            return false
+        }
+
+        // Application passwords do not support private Atomic sites currently
+        if (siteModel.isWPComAtomic && siteModel.isPrivateWPComAtomic) {
+            return false
+        }
+
+        val hasApplicationPassword = !site.apiRestPasswordPlain.isNullOrEmpty()
+        return !hasApplicationPassword
     }
 
     private fun refreshMobileEditorFromSiteSetting() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -627,24 +627,16 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     }
 
     private fun shouldRequireApplicationPassword(): Boolean {
-        // Check if experimental block editor is enabled
-        if (!experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) ||
-            experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)) {
-            return false
-        }
-
-        // WPCOM Simple sites rely upon bearer tokens
-        if (siteModel.isWPCom && !siteModel.isWPComAtomic) {
-            return false
-        }
-
-        // Application passwords do not support private Atomic sites currently
-        if (siteModel.isWPComAtomic && siteModel.isPrivateWPComAtomic) {
-            return false
-        }
-
+        val isExperimentalEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
+                !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
+        val isWPComSimpleSite = siteModel.isWPCom && !siteModel.isWPComAtomic
+        val isPrivateAtomicSite = siteModel.isWPComAtomic && siteModel.isPrivateWPComAtomic
         val hasApplicationPassword = !site.apiRestPasswordPlain.isNullOrEmpty()
-        return !hasApplicationPassword
+
+        return isExperimentalEditorEnabled &&
+                !isWPComSimpleSite && // Use bearer tokens
+                !isPrivateAtomicSite && // App passwords don't support private Atomic sites
+                !hasApplicationPassword
     }
 
     private fun refreshMobileEditorFromSiteSetting() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/GutenbergKitActivity.kt
@@ -629,14 +629,11 @@ class GutenbergKitActivity : BaseAppCompatActivity(), EditorImageSettingsListene
     private fun shouldRequireApplicationPassword(): Boolean {
         val isExperimentalEditorEnabled = experimentalFeatures.isEnabled(Feature.EXPERIMENTAL_BLOCK_EDITOR) &&
                 !experimentalFeatures.isEnabled(Feature.DISABLE_EXPERIMENTAL_BLOCK_EDITOR)
-        val isWPComSimpleSite = siteModel.isWPCom && !siteModel.isWPComAtomic
-        val isPrivateAtomicSite = siteModel.isWPComAtomic && siteModel.isPrivateWPComAtomic
-        val hasApplicationPassword = !site.apiRestPasswordPlain.isNullOrEmpty()
 
         return isExperimentalEditorEnabled &&
-                !isWPComSimpleSite && // Use bearer tokens
-                !isPrivateAtomicSite && // App passwords don't support private Atomic sites
-                !hasApplicationPassword
+                !siteModel.isWPCom && // WPCOM Simple sites use bearer tokens
+                !siteModel.isPrivateWPComAtomic && // App passwords don't support private Atomic sites
+                site.apiRestPasswordPlain.isNullOrEmpty()
     }
 
     private fun refreshMobileEditorFromSiteSetting() {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-773.

Ensure public Atomic sites leverage the remote editor with support for
WordPress.com/Jetpack blocks.

Also, match the Android behavior by requiring app passwords for 
self-hosted sites, regardless of a Jetpack connection.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
### 1. Public Atomic sites require an app password
1. Enable the _Experimental block editor_ feature.
1. Open the post editor for an WoW/Atomic site without an app password.
1. Verify you are prompted to create an application password or one is
   automatically created before revealing the editor.

### 2. Jetpack-connected self-hosted sites require an app password
1. Enable the _Experimental block editor_ feature.
1. Open the post editor for an Jetpack-connected self-hosted site without an app
   password.
1. Verify you are prompted to create an application password or one is
   automatically created before revealing the editor.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., Talkback)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

<!--

Use these emoji to improve the code review

❤️ - Praise. Compliments about great solution.
⛏ - Nitpick️. Not high importance. Usually, short one-liners.
💡 - Idea. Alternative solution or improvement.
❓ - Question. Requires some explanation or more context.
⚠️ - Warning. Should be addressed in this PR or in some follow-up PR.
🛑 - Blocker. Must be addressed before PR gets merged.

-->
